### PR TITLE
[Bug] Fix missing stream_ptr parameter in MoeGemm2ReduceWrapper

### DIFF
--- a/kernels/moe_gemm_2stage.py
+++ b/kernels/moe_gemm_2stage.py
@@ -2567,6 +2567,7 @@ class _MoeGemm2ReduceWrapper:
         n_in,
         k_in,
         size_expert_ids_in,
+        stream_ptr,
     ):
         """Execute GEMM2 + reduce.
 
@@ -2580,11 +2581,12 @@ class _MoeGemm2ReduceWrapper:
             arg_x, arg_w, arg_scale_x, arg_scale_w,
             arg_sorted_token_ids, arg_expert_ids, arg_sorted_weights,
             arg_num_valid_ids, tokens_in, n_in, k_in, size_expert_ids_in,
+            stream_ptr,
         )
         # Phase 2: Reduce over topk -> [tokens, model_dim]
         X = intermediate.view(tokens_in, self._topk, self._model_dim)
         Y = arg_out.view(tokens_in, self._model_dim)
-        self._reduce_exe(X, Y, tokens_in)
+        self._reduce_exe(X, Y, tokens_in, stream_ptr)
 
     @property
     def mode(self) -> str:


### PR DESCRIPTION
## Motivation

Fix `TypeError` failures introduced by other PR in `test_moe_stage2_standalone` tests when using the reduce mode (`moe_gemm2_reduce_torch`) for MoE GEMM2 kernel. The wrapper class `_MoeGemm2ReduceWrapper` was missing the `stream_ptr` parameter, causing argument count mismatches during kernel execution.

## Technical Details

The `_MoeGemm2ReduceWrapper` class wraps GEMM2 (non-atomic) with a reduction kernel. Three issues were identified and fixed:

1. **Missing `stream_ptr` in `__call__` signature**: Added `stream_ptr` parameter to match the expected kernel interface (14 positional arguments).

2. **Missing `stream_ptr` in `_gemm2_exe` call**: Added `stream_ptr` as the last argument when invoking the underlying GEMM2 executor.

3. **Missing `stream_ptr` in `_reduce_exe` call**: Added `stream_ptr` to match `compile_moe_reduction` kernel signature.

## Test Plan

Run MoE stage2 standalone tests with reduce mode enabled:
```bash
pytest test_moe_gemm.py::test_moe_stage2_standalone -v -s
```

## Test Result

All 7 test cases in `test_moe_stage2_standalone` now pass:
<img width="3808" height="1365" alt="image" src="https://github.com/user-attachments/assets/3229f1f8-2f3a-4210-9f5e-90acac9c8d97" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.