### PR TITLE
[Fix] Fix/python310 compat

### DIFF
--- a/python/flydsl/expr/utils/arith.py
+++ b/python/flydsl/expr/utils/arith.py
@@ -46,7 +46,7 @@ def arith_const(value, ty=None, *, loc=None, ip=None):
         else:
             raise ValueError(f"unsupported constant type: {type(value)}")
 
-    if ir.VectorType.isinstance(ty):
+    if isinstance(ty, ir.VectorType):
         elem_ty = element_type(ty)
         if isinstance(elem_ty, ir.IntegerType):
             attr = ir.IntegerAttr.get(elem_ty, int(value))


### PR DESCRIPTION

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

After upgrading to LLVM 23 with nanobind-based MLIR Python bindings (`pre_v0.1`), FlyDSL examples (`01-vectorAdd.py`) crash at runtime on Python 3.10 environments with two distinct `AttributeError`s. This PR restores compatibility with Python 3.10 while preserving full functionality on Python 3.11+.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

**1. `python/flydsl/expr/meta.py` — `frameInfo.positions` not available on Python < 3.11**

The `dsl_api_wrapper` used `frameInfo.positions.lineno` and `frameInfo.positions.col_offset` to construct MLIR source locations. The `positions` attribute on `Traceback` objects was introduced in [PEP 657](https://peps.python.org/pep-0657/) (Python 3.11). On Python 3.10, this raises:

```
AttributeError: 'Traceback' object has no attribute 'positions'
```

Fix: Use `hasattr` to detect `positions` availability. On Python 3.11+, fine-grained column info is preserved; on 3.10, fall back to `frameInfo.lineno` with column offset `0`.

**2. `python/flydsl/expr/utils/arith.py` — `VectorType.isinstance()` removed in nanobind bindings**

The old pybind11-based MLIR Python bindings provided a per-class static `isinstance()` method (e.g. `ir.VectorType.isinstance(ty)`). The new nanobind-based bindings removed this method, causing:

```
AttributeError: type object 'VectorType' has no attribute 'isinstance'
```

Fix: Replace `ir.VectorType.isinstance(ty)` with the standard Python `isinstance(ty, ir.VectorType)`, which is the idiomatic pattern for the nanobind bindings.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- [x] Run `examples/01-vectorAdd.py` end-to-end on Python 3.10.12 with ROCm 7.1 (MI308X / gfx942)
- [x] Verify JIT compilation, GPU kernel launch, and result correctness

## Test Result

<!-- Briefly summarize test outcomes. -->

```
> Compile: n={} const_n={} ? 129
Result correct: True
Hello, Fly!
> Runtime: n=128 const_n=129
```

Both errors are resolved. The vector-add kernel compiles, executes on GPU, and produces correct results on Python 3.10.

## Submission Checklist
