### PR TITLE
fix all copyright & license headers & add lint

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Fly DSL test
 
 on:

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: REUSE compliance check
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_REPO_NAME }}
+          ref: ${{ env.GITHUB_COMMIT_SHA }}
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v6

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Build outputs
 build/
 .flydsl*/

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/LLVM-exception.txt
+++ b/LICENSES/LLVM-exception.txt
@@ -1,0 +1,15 @@
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+   As an exception, if, as a result of your compiling your source code, portions
+   of this Software are embedded into an Object form of such source code, you
+   may redistribute such embedded portions in such Object form without complying
+   with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+   In addition, if you combine or link compiled forms of this Software with
+   software that is licensed under the GPLv2 ("Combined Software") and if a
+   court of competent jurisdiction determines that the patent provision (Section
+   3), the indemnity provision (Section 9) or other Section of the License
+   conflicts with the conditions of the GPLv2, you may retroactively and
+   prospectively choose to deem waived or otherwise exclude such Section(s) of
+   the License, but only in their entirety and only with respect to the Combined
+   Software.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 include LICENSE
 include README.md
 include pyproject.toml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # FlyDSL (<span style="color:#2f81f7"><strong>F</strong></span>lexible <span style="color:#2f81f7"><strong>l</strong></span>ayout p<span style="color:#2f81f7"><strong>y</strong></span>thon DSL)
 > A Python DSL and a MLIR stack for authoring high‑performance GPU kernels with explicit layouts and tiling. 
 

--- a/docs/architecture_guide.md
+++ b/docs/architecture_guide.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Architecture & Compilation Pipeline Guide
 
 > FlyDSL project structure, compilation stages, key abstractions, and configuration.

--- a/docs/kernel_authoring_guide.md
+++ b/docs/kernel_authoring_guide.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Kernel Authoring Guide
 
 > Writing GPU kernels with FlyDSL: MlirModule, thread hierarchy, TensorView, tiled copies, MFMA, shared memory, and synchronization.

--- a/docs/layout_system_guide.md
+++ b/docs/layout_system_guide.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # FLIR Layout Algebra Guide
 
 > Core types, construction, coordinate mapping, algebra operations, and swizzling in the FLIR layout system.

--- a/docs/prebuilt_kernels_guide.md
+++ b/docs/prebuilt_kernels_guide.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Pre-built Kernel Library Guide
 
 > Available FlyDSL kernels: Normalization, Softmax, GEMM, Mixed-precision GEMM, MoE GEMM -- configuration, data types, pipelines, and shared utilities.

--- a/docs/testing_benchmarking_guide.md
+++ b/docs/testing_benchmarking_guide.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Testing & Benchmarking Guide
 
 > Test infrastructure, running tests, benchmark harness, writing new tests, and performance comparison with AIter.

--- a/flir/CMakeLists.txt
+++ b/flir/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.18)
 project(FLIR VERSION 0.1.0 LANGUAGES C CXX)
 

--- a/flir/build.sh
+++ b/flir/build.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -ex
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/flir/include/flir/CMakeLists.txt
+++ b/flir/include/flir/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Simplified CMakeLists for modern MLIR
 
 set(LLVM_TARGET_DEFINITIONS FlirDialect.td)

--- a/flir/include/flir/FlirAttrDefs.td
+++ b/flir/include/flir/FlirAttrDefs.td
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef FLIR_ATTRDEFS
 #define FLIR_ATTRDEFS
 

--- a/flir/include/flir/FlirDialect.h
+++ b/flir/include/flir/FlirDialect.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef FLIR_DIALECT_H
 #define FLIR_DIALECT_H
 

--- a/flir/include/flir/FlirDialect.td
+++ b/flir/include/flir/FlirDialect.td
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirDialect.td - Flir dialect definition ---------*- tablegen -*-===//
 
 #ifndef FLIR_DIALECT

--- a/flir/include/flir/FlirLayoutAlgebra.h
+++ b/flir/include/flir/FlirLayoutAlgebra.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 //===- FlirLayoutAlgebra.h - Type-level layout algebra helpers -----------===//
 //
 //

--- a/flir/include/flir/FlirOps.h
+++ b/flir/include/flir/FlirOps.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef FLIR_OPS_H
 #define FLIR_OPS_H
 

--- a/flir/include/flir/FlirOps.td
+++ b/flir/include/flir/FlirOps.td
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirOps.td - flir operation definitions ------------*- tablegen -*-===//
 
 #ifndef FLIR_OPS

--- a/flir/include/flir/FlirPasses.h
+++ b/flir/include/flir/FlirPasses.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef FLIR_PASSES_H
 #define FLIR_PASSES_H
 

--- a/flir/include/flir/FlirPasses.td
+++ b/flir/include/flir/FlirPasses.td
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirPasses.td - Layout IR Lowering Passes ----------*- tablegen -*-===//
 //
 // Lowering passes for Flir IR dialects

--- a/flir/include/flir/FlirPatternAttr.h
+++ b/flir/include/flir/FlirPatternAttr.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef FLIR_PATTERN_ATTR_H
 #define FLIR_PATTERN_ATTR_H
 

--- a/flir/include/flir/FlirPython.td
+++ b/flir/include/flir/FlirPython.td
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirPython.td - Python Bindings Definition ---------*- tablegen -*-===//
 //
 // Combined definition file for generating Python bindings

--- a/flir/include/flir/FlirRocmDialect.h
+++ b/flir/include/flir/FlirRocmDialect.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef FLIR_ROCM_DIALECT_H
 #define FLIR_ROCM_DIALECT_H
 

--- a/flir/include/flir/FlirRocmDialect.td
+++ b/flir/include/flir/FlirRocmDialect.td
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirRocmDialect.td - Flir ROCm Dialect Definition -*- tablegen -*-===//
 //
 // Flir AMD GPU Hardware-Aware Dialect for GFX942

--- a/flir/include/flir/FlirRocmOps.h
+++ b/flir/include/flir/FlirRocmOps.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef FLIR_ROCM_OPS_H
 #define FLIR_ROCM_OPS_H
 

--- a/flir/include/flir/FlirRocmOps.td
+++ b/flir/include/flir/FlirRocmOps.td
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirRocmOps.td - Flir ROCm Operations Definition --*- tablegen -*-===//
 //
 // Flir AMD GPU operations for GFX942

--- a/flir/include/flir/FlirTypeDefs.td
+++ b/flir/include/flir/FlirTypeDefs.td
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef FLIR_TYPEDEFS
 #define FLIR_TYPEDEFS
 

--- a/flir/lib/CMakeLists.txt
+++ b/flir/lib/CMakeLists.txt
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(Dialect)
 add_subdirectory(Transforms)

--- a/flir/lib/Dialect/CMakeLists.txt
+++ b/flir/lib/Dialect/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(Flir)
 # FlirRocm temporarily disabled for build fixes
 # add_subdirectory(FlirRocm)

--- a/flir/lib/Dialect/Flir/CMakeLists.txt
+++ b/flir/lib/Dialect/Flir/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 add_mlir_dialect_library(FlirDialect
   FlirDialect.cpp
   FlirOps.cpp

--- a/flir/lib/Dialect/Flir/FlirDialect.cpp
+++ b/flir/lib/Dialect/Flir/FlirDialect.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirDialect.cpp - Flir Dialect Implementation --------------------===//
 
 #include "llvm/ADT/SmallVector.h"

--- a/flir/lib/Dialect/Flir/FlirLayoutAlgebra.cpp
+++ b/flir/lib/Dialect/Flir/FlirLayoutAlgebra.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirLayoutAlgebra.cpp - Type-level layout algebra helpers ---------===//
 
 #include "flir/FlirLayoutAlgebra.h"

--- a/flir/lib/Dialect/Flir/FlirOps.cpp
+++ b/flir/lib/Dialect/Flir/FlirOps.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirOps.cpp - Flir Operations Implementation --------------------===//
 //
 // Implementation of Flir operation verification and methods

--- a/flir/lib/Dialect/FlirRocm/CMakeLists.txt
+++ b/flir/lib/Dialect/FlirRocm/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 add_mlir_dialect_library(FlirRocmDialect
   FlirRocmDialect.cpp
   FlirRocmOps.cpp

--- a/flir/lib/Dialect/FlirRocm/FlirRocmDialect.cpp
+++ b/flir/lib/Dialect/FlirRocm/FlirRocmDialect.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "flir/FlirRocmDialect.h"
 #include "flir/FlirRocmDialect.cpp.inc"
 

--- a/flir/lib/Dialect/FlirRocm/FlirRocmOps.cpp
+++ b/flir/lib/Dialect/FlirRocm/FlirRocmOps.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirRocmOps.cpp - Flir ROCm Operations Implementation -----------===//
 //
 // Implementation of Flir ROCm dialect operations

--- a/flir/lib/Transforms/CMakeLists.txt
+++ b/flir/lib/Transforms/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 add_mlir_library(FlirTransforms
   FlirToStandard.cpp
   FlirDCE.cpp

--- a/flir/lib/Transforms/FlirDCE.cpp
+++ b/flir/lib/Transforms/FlirDCE.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirDCE.cpp - Trivial DCE (standalone) ----------------------------===//
 //
 // Provides a general dead-code elimination pass for our embedded MLIR

--- a/flir/lib/Transforms/FlirToStandard.cpp
+++ b/flir/lib/Transforms/FlirToStandard.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "flir/FlirDialect.h"
 #include "flir/FlirOps.h"
 #include "flir/FlirPasses.h"

--- a/flir/python_bindings/CMakeLists.txt
+++ b/flir/python_bindings/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 include(AddMLIRPython)
 
 # Use the embedded MLIR package name prefix (`_mlir.*`), matching the install

--- a/flir/python_bindings/FlirRegisterPasses.cpp
+++ b/flir/python_bindings/FlirRegisterPasses.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirRegisterPasses.cpp - Flir Passes Registration ----------------===//
 
 #include "mlir-c/RegisterEverything.h"

--- a/flir/python_bindings/dialects/FlirOps.td
+++ b/flir/python_bindings/dialects/FlirOps.td
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //===- FlirOps.td - Entry point for Flir python bindings -*- tablegen -*-===//
 //
 // This file is the entry point for generating Python op bindings for the Flir

--- a/flir/python_bindings/dialects/flir.py
+++ b/flir/python_bindings/dialects/flir.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Flir dialect Python bindings."""
 
 from ._flir_ops_gen import *

--- a/flir/python_bindings/flir.py
+++ b/flir/python_bindings/flir.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Flir Dialect for MLIR Python Bindings"""
 
 from _mlir import ir

--- a/flir/python_bindings/runtime/FlirRocmRuntimeWrappers.cpp
+++ b/flir/python_bindings/runtime/FlirRocmRuntimeWrappers.cpp
@@ -6,6 +6,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 //===----------------------------------------------------------------------===//
 //

--- a/flir/tools/CMakeLists.txt
+++ b/flir/tools/CMakeLists.txt
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(flir-opt)

--- a/flir/tools/flir-opt/CMakeLists.txt
+++ b/flir/tools/flir-opt/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(LIBS
   FlirDialect
   FlirTransforms

--- a/flir/tools/flir-opt/flir-opt.cpp
+++ b/flir/tools/flir-opt/flir-opt.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/InitAllDialects.h"

--- a/flydsl/requirements.txt
+++ b/flydsl/requirements.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # FLIR Python package runtime dependencies.
 
 numpy

--- a/flydsl/src/flydsl/__init__.py
+++ b/flydsl/src/flydsl/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """FLIR - ROCm Domain Specific Language for layout algebra"""
 
 # Base version - git commit is appended at build time by setup.py

--- a/flydsl/src/flydsl/compiler/__init__.py
+++ b/flydsl/src/flydsl/compiler/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .context import *
 from .pipeline import *
 

--- a/flydsl/src/flydsl/compiler/cache.py
+++ b/flydsl/src/flydsl/compiler/cache.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Simple on-disk cache for compiled FLIR modules (inspired by Triton cache).
 
 This is intentionally minimal:

--- a/flydsl/src/flydsl/compiler/compiler.py
+++ b/flydsl/src/flydsl/compiler/compiler.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """High-level compilation entrypoint for FLIR modules."""
 
 from __future__ import annotations

--- a/flydsl/src/flydsl/compiler/context.py
+++ b/flydsl/src/flydsl/compiler/context.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import contextlib
 import importlib
 import sys

--- a/flydsl/src/flydsl/compiler/executor.py
+++ b/flydsl/src/flydsl/compiler/executor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Executor for FLIR via MLIR ExecutionEngine."""
 
 from __future__ import annotations

--- a/flydsl/src/flydsl/compiler/flir_opt_helper.py
+++ b/flydsl/src/flydsl/compiler/flir_opt_helper.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Helper utilities to run Flir lowering via the MLIR Python API.
 
 This module is maintained for backward compatibility. New code should use

--- a/flydsl/src/flydsl/compiler/pipeline.py
+++ b/flydsl/src/flydsl/compiler/pipeline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Pass pipeline builder for FLIR compiler transformations.
 
 This module provides a fluent API for constructing MLIR pass pipelines

--- a/flydsl/src/flydsl/dialects/__init__.py
+++ b/flydsl/src/flydsl/dialects/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """FLIR dialects"""
 
 # Dialects are available via `flydsl.dialects.ext` and `_mlir.dialects`.

--- a/flydsl/src/flydsl/dialects/ext/__init__.py
+++ b/flydsl/src/flydsl/dialects/ext/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Extended dialect wrappers for more Pythonic MLIR programming.
 
 This package is intentionally **lazy-imported** to keep import side effects small.

--- a/flydsl/src/flydsl/dialects/ext/_loc.py
+++ b/flydsl/src/flydsl/dialects/ext/_loc.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared location utilities for FLIR/Python wrappers.
 
 We want IR dumps to be debuggable, but also avoid paying stack-inspection costs

--- a/flydsl/src/flydsl/dialects/ext/arith.py
+++ b/flydsl/src/flydsl/dialects/ext/arith.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Arith dialect extensions with operator overloading for Pythonic syntax."""
 
 from functools import partialmethod

--- a/flydsl/src/flydsl/dialects/ext/block_reduce_ops.py
+++ b/flydsl/src/flydsl/dialects/ext/block_reduce_ops.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 High-level collective operations for GPU programming.
 

--- a/flydsl/src/flydsl/dialects/ext/buffer_ops.py
+++ b/flydsl/src/flydsl/dialects/ext/buffer_ops.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """AMD Buffer Load/Store Operations - High-level Python API
 
 This module provides high-level Python wrappers for AMD CDNA3/CDNA4 buffer operations.

--- a/flydsl/src/flydsl/dialects/ext/flir.py
+++ b/flydsl/src/flydsl/dialects/ext/flir.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Python bindings for Flir dialect operations.
 
 This module provides Python wrappers for Flir layout algebra operations,

--- a/flydsl/src/flydsl/dialects/ext/func.py
+++ b/flydsl/src/flydsl/dialects/ext/func.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import copy
 import inspect
 import sys

--- a/flydsl/src/flydsl/dialects/ext/gpu.py
+++ b/flydsl/src/flydsl/dialects/ext/gpu.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import inspect
 from functools import partial
 import sys

--- a/flydsl/src/flydsl/dialects/ext/llvm.py
+++ b/flydsl/src/flydsl/dialects/ext/llvm.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """LLVM dialect re-export for FLIR tests."""
 
 from _mlir.dialects.llvm import *  # noqa: F401,F403

--- a/flydsl/src/flydsl/dialects/ext/math.py
+++ b/flydsl/src/flydsl/dialects/ext/math.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Math dialect re-export for FLIR tests."""
 
 from _mlir.dialects.math import *  # noqa: F401,F403

--- a/flydsl/src/flydsl/dialects/ext/memref.py
+++ b/flydsl/src/flydsl/dialects/ext/memref.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MemRef dialect helpers with better default debug locations.
 
 When IR dumping is enabled, it is useful for common ops like `memref.load/store/view`

--- a/flydsl/src/flydsl/dialects/ext/mlir_extras/__init__.py
+++ b/flydsl/src/flydsl/dialects/ext/mlir_extras/__init__.py
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # mlir-python-extras compatibility

--- a/flydsl/src/flydsl/dialects/ext/mlir_extras/_shaped_value.py
+++ b/flydsl/src/flydsl/dialects/ext/mlir_extras/_shaped_value.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass
 from functools import cached_property, reduce
 import numpy as np

--- a/flydsl/src/flydsl/dialects/ext/mlir_extras/arith.py
+++ b/flydsl/src/flydsl/dialects/ext/mlir_extras/arith.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import ast
 import copy
 import os

--- a/flydsl/src/flydsl/dialects/ext/mlir_extras/scf.py
+++ b/flydsl/src/flydsl/dialects/ext/mlir_extras/scf.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import ast
 import logging
 from contextlib import contextmanager

--- a/flydsl/src/flydsl/dialects/ext/mlir_extras/util.py
+++ b/flydsl/src/flydsl/dialects/ext/mlir_extras/util.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import contextlib
 import ctypes
 import inspect

--- a/flydsl/src/flydsl/dialects/ext/python_control_flow.py
+++ b/flydsl/src/flydsl/dialects/ext/python_control_flow.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Python control-flow lowering helpers.
 
 FLIR executes Python code to build MLIR IR. A plain Python loop like:

--- a/flydsl/src/flydsl/dialects/ext/rocdl.py
+++ b/flydsl/src/flydsl/dialects/ext/rocdl.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """ROCDL dialect extension for ROCm/AMD GPU programming.
 
 This module provides access to ROCm-specific GPU operations including:

--- a/flydsl/src/flydsl/dialects/ext/rocm.py
+++ b/flydsl/src/flydsl/dialects/ext/rocm.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Python bindings for Flir ROCm dialect operations.
 
 This module provides Python wrappers for AMD GPU-specific operations

--- a/flydsl/src/flydsl/dialects/ext/scf.py
+++ b/flydsl/src/flydsl/dialects/ext/scf.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Extended scf dialect with convenience wrappers.
 
 This module intentionally provides context-manager wrappers that manage

--- a/flydsl/src/flydsl/dialects/ext/vector.py
+++ b/flydsl/src/flydsl/dialects/ext/vector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Vector dialect helpers with better default debug locations.
 
 This module exists so tests can import vector ops through `flydsl.dialects.ext`

--- a/flydsl/src/flydsl/lang/__init__.py
+++ b/flydsl/src/flydsl/lang/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .ir import *  
 
 

--- a/flydsl/src/flydsl/lang/ir/__init__.py
+++ b/flydsl/src/flydsl/lang/ir/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .module import MlirModule, kernel, jit
 from .types import Types, T
 

--- a/flydsl/src/flydsl/lang/ir/module.py
+++ b/flydsl/src/flydsl/lang/ir/module.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import inspect

--- a/flydsl/src/flydsl/lang/ir/types.py
+++ b/flydsl/src/flydsl/lang/ir/types.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared MLIR IR type helpers for flydsl kernels."""
 
 from __future__ import annotations

--- a/flydsl/src/flydsl/passes.py
+++ b/flydsl/src/flydsl/passes.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Pass management for FLIR compiler.
 
 This module provides the main interface for defining and running

--- a/flydsl/src/flydsl/runtime/__init__.py
+++ b/flydsl/src/flydsl/runtime/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Runtime utilities for flir GPU execution"""
 
 from .device import get_rocm_arch

--- a/flydsl/src/flydsl/runtime/device.py
+++ b/flydsl/src/flydsl/runtime/device.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from typing import Optional
 

--- a/flydsl/src/flydsl/utils/__init__.py
+++ b/flydsl/src/flydsl/utils/__init__.py
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .smem_allocator import SmemAllocator, SmemPtr, SmemStructInstance

--- a/flydsl/src/flydsl/utils/smem_allocator.py
+++ b/flydsl/src/flydsl/utils/smem_allocator.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import sys
 import math
 from dataclasses import dataclass, fields, is_dataclass

--- a/kernels/__init__.py
+++ b/kernels/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Reusable FLIR Python examples and kernel builders.
 
 This directory is a Python package so tests can import kernel builders via:

--- a/kernels/kernels_common.py
+++ b/kernels/kernels_common.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from _mlir.dialects import builtin, gpu as _gpu
 from flydsl.dialects.ext import buffer_ops
 

--- a/kernels/layernorm_kernel.py
+++ b/kernels/layernorm_kernel.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """LayerNorm kernel builder used by tests.
 
 This file intentionally keeps the kernel builder logic identical to the version

--- a/kernels/mfma_epilogues.py
+++ b/kernels/mfma_epilogues.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Reusable epilogue helpers for MFMA 16x16-based kernels.
 
 This module provides:

--- a/kernels/mfma_preshuffle_pipeline.py
+++ b/kernels/mfma_preshuffle_pipeline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared MFMA preshuffle helpers (used by preshuffle GEMM + MoE kernels).
 
 This module consolidates the common building blocks that were previously duplicated

--- a/kernels/mixed_moe_gemm_2stage.py
+++ b/kernels/mixed_moe_gemm_2stage.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MoE GEMM stage1/stage2 kernel implementations (FLIR MFMA FP8/FP16).
 
 This module intentionally contains the **kernel builder code** for:

--- a/kernels/mixed_preshuffle_gemm.py
+++ b/kernels/mixed_preshuffle_gemm.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Preshuffle GEMM kernel implementations (FLIR MFMA FP8/INT8).
 
 This module intentionally contains the **kernel builder code** for the preshuffle GEMM,

--- a/kernels/moe_gemm_2stage.py
+++ b/kernels/moe_gemm_2stage.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MoE GEMM stage1/stage2 kernel implementations (FLIR MFMA FP8).
 
 This module intentionally contains the **kernel builder code** for:

--- a/kernels/preshuffle_gemm.py
+++ b/kernels/preshuffle_gemm.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Preshuffle GEMM kernel implementations (FLIR MFMA FP8/INT8).
 
 This module intentionally contains the **kernel builder code** for the preshuffle GEMM,

--- a/kernels/reduce.py
+++ b/kernels/reduce.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared reduction helpers for FLIR example kernels.
 
 These helpers build MLIR ops (flir/gpu/scf/vector/etc). They are extracted from

--- a/kernels/rmsnorm_kernel.py
+++ b/kernels/rmsnorm_kernel.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """RMSNorm kernel builder used by tests.
 
 This file intentionally keeps the kernel builder logic identical to the version

--- a/kernels/softmax_kernel.py
+++ b/kernels/softmax_kernel.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Softmax kernel builder used by tests.
 
 This file intentionally keeps the kernel builder logic identical to the version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
 requires = [
   "setuptools>=64",

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 # Default to downloading llvm-project in the parent directory of flir

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/dumpir.sh
+++ b/scripts/dumpir.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # dumpir.sh <script> <arguments>
 # Example: bash scripts/dumpir.sh python tests/kernels/benchmark/matrixTranspose.py
 export FLIR_DUMP_IR=1

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # POSIX sh compatible (also works in bash).
 set -eu
 # Enable pipefail when supported (bash/ksh/zsh); ignore if unavailable (dash/posix sh).

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Flir Test Suite - Organized by test type
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)

--- a/scripts/upload_wheels.sh
+++ b/scripts/upload_wheels.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 python -m twine upload $@

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import os

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """FLIR tests package"""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Pytest configuration for FLIR tests.
 
 This test suite now uses FLIR's embedded MLIR Python bindings (the `_mlir`

--- a/tests/kernels/__init__.py
+++ b/tests/kernels/__init__.py
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # GPU-focused FLIR/ROCIR tests.
 #

--- a/tests/kernels/benchmark_common.py
+++ b/tests/kernels/benchmark_common.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared helpers for optional perf comparison in GPU operator tests.
 
 These tests are primarily correctness tests. Performance comparison (FLIR vs AIter)

--- a/tests/kernels/test_eltwise_add.py
+++ b/tests/kernels/test_eltwise_add.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Elementwise Addition Example using FLIR
 This example demonstrates the FLIR API pattern
 - make_ordered_layout, make_layout_tv

--- a/tests/kernels/test_gpu_layout.py
+++ b/tests/kernels/test_gpu_layout.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """GPU kernel tests using flir layout algebra API
 
 These are compilation-only smoke tests: they build GPU kernels with layout-based

--- a/tests/kernels/test_gpu_rocdsl.py
+++ b/tests/kernels/test_gpu_rocdsl.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """GPU kernel tests demonstrating Flir layout/coord concepts.
 
 These are compilation-focused tests: they emit GPU kernels with flir ops and

--- a/tests/kernels/test_gpu_simple.py
+++ b/tests/kernels/test_gpu_simple.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Simple GPU kernel tests using flir Python API
 Vector addition test with clean, readable syntax

--- a/tests/kernels/test_gpu_with_rocir_coords.py
+++ b/tests/kernels/test_gpu_with_rocir_coords.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """GPU kernel test demonstrating Flir coordinate operations.
 
 This test is meant to be stable under the ExecutionEngine backend: we keep the

--- a/tests/kernels/test_layernorm.py
+++ b/tests/kernels/test_layernorm.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 LayerNorm Operator Test
 Implementation of a Block-wise LayerNorm:

--- a/tests/kernels/test_matrix_trans.py
+++ b/tests/kernels/test_matrix_trans.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Matrix Transpose Benchmark - GPU kernel with Shared Memory + Vec2 Vectorization"""
 
 import sys

--- a/tests/kernels/test_moe_gemm.py
+++ b/tests/kernels/test_moe_gemm.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import logging
 import math

--- a/tests/kernels/test_preshuffle_gemm.py
+++ b/tests/kernels/test_preshuffle_gemm.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MFMA FP8/INT8 GEMM Test using flir with B preshuffle.
 
 NOTE:

--- a/tests/kernels/test_quant.py
+++ b/tests/kernels/test_quant.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Benchmark: Per-Token Quantization Kernel
 

--- a/tests/kernels/test_ref.py
+++ b/tests/kernels/test_ref.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import torch.nn.functional as F
 

--- a/tests/kernels/test_rmsnorm.py
+++ b/tests/kernels/test_rmsnorm.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 RMSNorm Operator Test
 Implementation of a Block-wise RMSNorm:

--- a/tests/kernels/test_shared_working.py
+++ b/tests/kernels/test_shared_working.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared memory matmul - correctness smoke test.
 
 This used to execute at import time; it is now a proper pytest test and is

--- a/tests/kernels/test_softmax.py
+++ b/tests/kernels/test_softmax.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Softmax Operator Test with Manual Vectorization and Register Buffering
 Implementation based on high-performance C++ kernel logic:

--- a/tests/kernels/test_vec_add.py
+++ b/tests/kernels/test_vec_add.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Vector Addition Benchmark - GPU kernel with Flir Layout integration"""
 
 import sys

--- a/tests/mlir/comprehensive_test.mlir
+++ b/tests/mlir/comprehensive_test.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Comprehensive test of all working Flir operations
 
 // Test 1: size - Product of shape dimensions

--- a/tests/mlir/test_all_ops.mlir
+++ b/tests/mlir/test_all_ops.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // RUN: flir-opt %s --flir-to-standard | FileCheck %s
 
 // Comprehensive test covering all layout operations and lowering

--- a/tests/mlir/test_all_product_divide.mlir
+++ b/tests/mlir/test_all_product_divide.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test all product and divide operations
 
 func.func @test_tiled_product() -> index {

--- a/tests/mlir/test_basic.mlir
+++ b/tests/mlir/test_basic.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test basic type parsing and printing
 
 module {

--- a/tests/mlir/test_chained.mlir
+++ b/tests/mlir/test_chained.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 func.func @test1() {
   %c8 = arith.constant 8 : index
   %c16 = arith.constant 16 : index

--- a/tests/mlir/test_chained_operations.mlir
+++ b/tests/mlir/test_chained_operations.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test chained operations: get_shape -> size, get_stride -> get
 // This tests the value tracking fix
 

--- a/tests/mlir/test_composition.mlir
+++ b/tests/mlir/test_composition.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test flir.composition operation
 func.func @test_composition() -> index {
   %c8 = arith.constant 8 : index

--- a/tests/mlir/test_coord_lowering.mlir
+++ b/tests/mlir/test_coord_lowering.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // RUN: flir-opt %s --flir-to-standard | FileCheck %s
 
 module {

--- a/tests/mlir/test_coord_lowering_dynamic.mlir
+++ b/tests/mlir/test_coord_lowering_dynamic.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test coordinate lowering with dynamic values (no constant folding)
 
 module {

--- a/tests/mlir/test_cosize.mlir
+++ b/tests/mlir/test_cosize.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test flir.cosize operation
 func.func @test_cosize() -> index {
   %c8 = arith.constant 8 : index

--- a/tests/mlir/test_crd2idx.mlir
+++ b/tests/mlir/test_crd2idx.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test crd2idx lowering
 module {
   func.func @test_crd2idx() -> index {

--- a/tests/mlir/test_get.mlir
+++ b/tests/mlir/test_get.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test flir.get operation
 func.func @test_get() -> index {
   %c8 = arith.constant 8 : index

--- a/tests/mlir/test_idx2crd.mlir
+++ b/tests/mlir/test_idx2crd.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test flir.idx2crd operation (inverse of crd2idx)
 func.func @test_idx2crd() {
   %c50 = arith.constant 50 : index

--- a/tests/mlir/test_layout.mlir
+++ b/tests/mlir/test_layout.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test basic layout creation and manipulation
 
 module {

--- a/tests/mlir/test_layout_amd.mlir
+++ b/tests/mlir/test_layout_amd.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test layout operations for AMD GFX942
 
 module attributes {

--- a/tests/mlir/test_local_ops.mlir
+++ b/tests/mlir/test_local_ops.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test local_partition and local_tile operations
 
 func.func @test_local_partition() -> index {

--- a/tests/mlir/test_ops.mlir
+++ b/tests/mlir/test_ops.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module {
   func.func @test_flir_ops(%i1: index, %i2: index, %i3: index) {
     %s = flir.make_shape %i1, %i2, %i3 : (index, index, index) -> !flir.shape<(?,?,?)>

--- a/tests/mlir/test_pass.mlir
+++ b/tests/mlir/test_pass.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test partial pass lowering (crd2idx only)
 module {
   func.func @test_crd2idx_simple(%c: !flir.coord<(?,?)>, %l: !flir.layout<(?,?):(?,?)>) {

--- a/tests/mlir/test_product_divide.mlir
+++ b/tests/mlir/test_product_divide.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // RUN: flir-opt %s --flir-to-standard | FileCheck %s
 
 // Test logical_product operation

--- a/tests/mlir/test_rank.mlir
+++ b/tests/mlir/test_rank.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test flir.rank operation
 func.func @test_rank() -> index {
   %c8 = arith.constant 8 : index

--- a/tests/mlir/test_simple.mlir
+++ b/tests/mlir/test_simple.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 func.func @test_idx2crd() {
   %c50 = arith.constant 50 : index
   %c8 = arith.constant 8 : index

--- a/tests/mlir/test_size.mlir
+++ b/tests/mlir/test_size.mlir
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Test flir.size operation
 func.func @test_size() -> index {
   %c8 = arith.constant 8 : index

--- a/tests/pyir/test_arith_operators.py
+++ b/tests/pyir/test_arith_operators.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test operator overloading for elegant Pythonic syntax."""
 
 import pytest

--- a/tests/pyir/test_basic_ops.py
+++ b/tests/pyir/test_basic_ops.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test basic Flir operations: make_shape, make_stride, make_layout, size, rank, etc."""
 
 import pytest

--- a/tests/pyir/test_lang_module_descriptors.py
+++ b/tests/pyir/test_lang_module_descriptors.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Sanity test: MlirModule + @kernel/@jit re-exported under `flir.*`."""
 
 from flydsl.dialects.ext import flir, memref

--- a/tests/pyir/test_layout_algebra.py
+++ b/tests/pyir/test_layout_algebra.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Complete tests for Flir layout algebra operations.
 These tests follow a reference notebook for layout-algebra behavior.

--- a/tests/pyir/test_local_ops.py
+++ b/tests/pyir/test_local_ops.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test local operations: local_partition and local_tile with Pythonic operators."""
 
 import pytest

--- a/tests/pyir/test_nested_layouts.py
+++ b/tests/pyir/test_nested_layouts.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from _mlir.ir import IntegerAttr

--- a/tests/pyir/test_passes.py
+++ b/tests/pyir/test_passes.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test pass pipelines and lowering transformations."""
 
 import pytest

--- a/tests/pyir/test_product_divide.py
+++ b/tests/pyir/test_product_divide.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test product (tiling) and divide (partitioning) operations with Pythonic operators."""
 
 import pytest

--- a/tests/pyir/test_rocdl_ops.py
+++ b/tests/pyir/test_rocdl_ops.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test ROCDL dialect operations."""
 
 from flydsl.dialects.ext import rocdl, flir

--- a/tests/pyir/test_rocir_basic.py
+++ b/tests/pyir/test_rocir_basic.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for core Flir operations: make_shape, make_stride, make_layout, size, rank."""
 
 import pytest

--- a/tests/pyir/test_rocir_coord_ops.py
+++ b/tests/pyir/test_rocir_coord_ops.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test the new flir coordinate operations (make_coord, crd2idx, idx2crd)"""
 
 from flydsl.dialects.ext import arith, flir

--- a/tests/pyir/test_rocir_divide.py
+++ b/tests/pyir/test_rocir_divide.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for Flir divide operations (partitioning)."""
 
 import flydsl.dialects.ext.flir as flir

--- a/tests/pyir/test_rocir_local.py
+++ b/tests/pyir/test_rocir_local.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from flydsl.dialects.ext import flir, arith
 from flydsl.dialects.ext.arith import Index
 

--- a/tests/pyir/test_rocir_print.py
+++ b/tests/pyir/test_rocir_print.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Test flir.print and flir.printf functionality.
 

--- a/tests/pyir/test_rocir_product.py
+++ b/tests/pyir/test_rocir_product.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from flydsl.dialects.ext import flir, arith
 from flydsl.dialects.ext.arith import Index
 

--- a/tests/pyir/test_static_vs_dynamic.py
+++ b/tests/pyir/test_static_vs_dynamic.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Static vs dynamic layout types test (mirrors a reference notebook Cell 11)"""
 
 from flydsl.compiler.pipeline import Pipeline, run_pipeline

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,3 +1,7 @@
+; SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+;
+; SPDX-License-Identifier: Apache-2.0
+
 [pytest]
 testpaths = .
 python_files = test_*.py

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared utilities for GPU testing, compilation, and benchmarking."""
 
 from flydsl.compiler.pipeline import Pipeline, run_pipeline


### PR DESCRIPTION
## Motivation

Thank you for contributing FlyDSL to the open source community. To ensure the licensing is comprehensive & unambiguous, this commit makes the project REUSE-compliant (https://reuse.software/faq/) and adds a lint which will catch future regressions with GitHub Actions by using https://github.com/marketplace/actions/reuse-compliance-check.

## Technical Details

The commit was assembled with the `reuse` tool available through PyPI (https://reuse.readthedocs.io/en/stable/readme.html).

```sh
$ reuse download Apache-2.0 LLVM-exception MIT
$ reuse annotate . \
    --copyright "Advanced Micro Devices, Inc. All rights reserved." \
    --exclude-year \
    --license "Apache-2.0" \
    --recursive \
    --skip-existing \
    --skip-unrecognised
# MLIR & Tablegen files were skipped, as they are not recognized by reuse, so run again with cpp style
$ reuse annotate . \
    --copyright "Advanced Micro Devices, Inc. All rights reserved." \
    --exclude-year \
    --license "Apache-2.0" \
    --recursive \
    --skip-existing \
    --style cpp
$ reuse lint
```

## Test Plan

* Run `reuse lint` on a local clone
* Look at the outcome of the GitHub Action for REUSE compliance check (`.github/workflows/reuse.yaml`)

## Test Result

* Check for a compliance message (e.g. "Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)")

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.