### PR TITLE
[Compiler][CacheKey] improve JIT cache key to hash entire compiler to…

### DIFF
--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -2,6 +2,7 @@ import hashlib
 import inspect
 import os
 import pickle
+import pkgutil
 import types
 from functools import lru_cache
 from pathlib import Path
@@ -27,21 +28,72 @@ from .kernel_function import (
 from .protocol import fly_types, fly_construct
 from flydsl.runtime.device import get_rocm_arch
 
-@lru_cache(maxsize=1)
-def _get_llvm_version() -> str:
-    _FLYDSL_ROOT = Path(__file__).resolve().parents[4]
-    llvm_hash_file = _FLYDSL_ROOT / "thirdparty" / "llvm-hash.txt"
-    if llvm_hash_file.exists():
-        llvm_hash = llvm_hash_file.read_text()
-    else:
-        llvm_hash = "release_version"
-    log().debug(f"LLVM version: {llvm_hash}")
-    return llvm_hash
-
 
 @lru_cache(maxsize=1)
-def _flydsl_verison_key() -> str:
-    return f"flydsl:{flydsl.__version__}|llvm:{_get_llvm_version()}"
+def _flydsl_key() -> str:
+    """Compute a hash fingerprint of the entire FlyDSL compiler toolchain.
+
+    Covers:
+      1. All Python source files under flydsl.compiler.*, flydsl.expr.*,
+         flydsl.runtime.*, flydsl.lang.*, flydsl.utils.*
+      2. Native shared libraries (_fly*.so, libFly*.so, libfly_jit_runtime.so,
+         libmlir_rocm_runtime.so)
+      3. flydsl.__version__
+
+    Any change to compiler code, pass pipeline, runtime wrappers, or C++
+    bindings will produce a different key, invalidating stale disk caches.
+    """
+    contents = []
+
+    flydsl_root = Path(flydsl.__file__).resolve().parent
+
+    # 1) Hash all Python source files in key sub-packages.
+    pkg_prefixes = [
+        (str(flydsl_root / "compiler"), "flydsl.compiler."),
+        (str(flydsl_root / "expr"), "flydsl.expr."),
+        (str(flydsl_root / "runtime"), "flydsl.runtime."),
+        (str(flydsl_root / "lang"), "flydsl.lang."),
+        (str(flydsl_root / "utils"), "flydsl.utils."),
+    ]
+    for pkg_path, prefix in pkg_prefixes:
+        if not os.path.isdir(pkg_path):
+            continue
+        for lib in pkgutil.walk_packages([pkg_path], prefix=prefix):
+            try:
+                spec = lib.module_finder.find_spec(lib.name)
+                if spec and spec.origin and os.path.isfile(spec.origin):
+                    with open(spec.origin, "rb") as f:
+                        contents.append(hashlib.sha256(f.read()).hexdigest())
+            except Exception:
+                pass
+
+    # Also hash flydsl/__init__.py and _version.py.
+    for name in ("__init__.py", "_version.py"):
+        p = flydsl_root / name
+        if p.is_file():
+            with open(p, "rb") as f:
+                contents.append(hashlib.sha256(f.read()).hexdigest())
+
+    # 2) Hash native shared libraries (C++ passes, runtime wrappers, bindings).
+    mlir_libs_dir = flydsl_root / "_mlir" / "_mlir_libs"
+    if mlir_libs_dir.is_dir():
+        so_patterns = ["_fly*.so", "_fly_rocdl*.so", "libFly*.so",
+                       "libfly_jit_runtime.so", "libmlir_rocm_runtime.so",
+                       "_mlirRegisterEverything*.so"]
+        for pattern in so_patterns:
+            for so_file in sorted(mlir_libs_dir.glob(pattern)):
+                h = hashlib.sha256()
+                with open(so_file, "rb") as f:
+                    while True:
+                        chunk = f.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        h.update(chunk)
+                contents.append(h.hexdigest())
+
+    key = f"flydsl:{flydsl.__version__}-" + "-".join(contents)
+    log().debug(f"flydsl_key: {hashlib.sha256(key.encode()).hexdigest()[:16]}")
+    return key
 
 
 def _get_underlying_func(obj):
@@ -85,7 +137,7 @@ def _collect_dependency_sources(func, rootFile, visited: Optional[Set[int]] = No
 
 def _jit_function_cache_key(func: Callable) -> str:
     parts = []
-    parts.append(_flydsl_verison_key())
+    parts.append(_flydsl_key())
     try:
         source = inspect.getsource(func)
     except OSError:


### PR DESCRIPTION
## Motivation

The old JIT cache key (`_flydsl_verison_key`) was based solely on `flydsl.__version__` and `llvm-hash.txt`, making it unable to detect changes to compiler source code, MLIR pass pipeline configuration, or C++ runtime libraries. This meant that after modifying pass logic or runtime wrappers during development, stale cached artifacts would not be automatically invalidated — users had to manually `rm -rf ~/.flydsl/cache/` for new code to take effect. This was particularly problematic during the `gpu-to-llvm` → `fly-gpu-to-llvm` pass transition, where stale cache entries directly caused CUDA Graph Capture failures.

## Technical Details

Inspired by Triton's `triton_key()` mechanism (which uses `pkgutil.walk_packages` to hash all compiler module sources + `libtriton.so`), replaced `_flydsl_verison_key()` with `_flydsl_key()`:

1. **Python source hashing**: Uses `pkgutil.walk_packages` to traverse all `.py` files under `flydsl.compiler.*`, `flydsl.expr.*`, `flydsl.runtime.*`, `flydsl.lang.*`, `flydsl.utils.*`, plus `__init__.py` and `_version.py`. Each file's content is SHA256-hashed.

2. **Native .so library hashing**: SHA256-hashes key shared libraries under `_mlir_libs/` (`_fly*.so`, `libFly*.so`, `libfly_jit_runtime.so`, `libmlir_rocm_runtime.so`, `_mlirRegisterEverything*.so`) using 1MB chunked reads.

3. **Cache key integration**: `_jit_function_cache_key()` now uses `_flydsl_key()` as the toolchain fingerprint prefix, combined with user function source, dependency sources, and closure values to produce the final 32-char hex cache key.

4. **Performance**: `_flydsl_key()` is decorated with `@lru_cache(maxsize=1)`, computed only once per process lifetime.

**Changed files**: `python/flydsl/compiler/jit_function.py` 

## Test Plan


## Test Result

## Submission Checklist
