### PR TITLE
compile: return compiled module in FLYDSL_COMPILE_ONLY mode

### DIFF
--- a/flydsl/src/flydsl/compiler/compiler.py
+++ b/flydsl/src/flydsl/compiler/compiler.py
@@ -356,7 +356,7 @@ def compile(
                         if compile_only:
                             if dump_enabled or print_final_module:
                                 print(f"[flir.compile] FLYDSL_COMPILE_ONLY=1, skipping executor creation (arch={chip})")
-                            return None
+                            return cached_mod
                         from .executor import ExecutionEngineExecutor as Executor
                         if shared_libs is None:
                             shared_libs = default_shared_libs().as_list()
@@ -430,11 +430,11 @@ def compile(
                 except Exception:
                     pass
 
-    # In compile-only mode, skip executor creation and return None
+    # In compile-only mode, skip executor creation and return the compiled module.
     if compile_only:
         if dump_enabled or print_final_module:
             print(f"[flir.compile] FLYDSL_COMPILE_ONLY=1, skipping executor creation (arch={chip})")
-        return None
+        return module
 
     from .executor import ExecutionEngineExecutor as Executor
 


### PR DESCRIPTION

## Motivation

Found this while working on jax-flydsl, a JAX integration for FlyDSL kernels on AMD ROCm. Embedders that run the compilation pipeline but want to handle execution themselves (e.g. via JAX/XLA instead of PyTorch) have no way to get the compiled module back.


## Technical Details

Two return sites in compile() where compile_only=True previously returned None. Both now return the compiled ir.Module (cached_mod on the cache-hit path, module on the fresh-compile path). No behavior change for normal usage — FLYDSL_COMPILE_ONLY is not set by default.


## Test Result

Compilation and HSACO extraction succeed. jax-flydsl vec_add test passes end-to-end on MI355X (gfx950).


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
