### PR TITLE
CI: add network speed test workflow

### DIFF
--- a/.github/workflows/network-test.yaml
+++ b/.github/workflows/network-test.yaml
@@ -2,10 +2,19 @@ name: Network Speed Test
 
 on:
   workflow_dispatch:
+    inputs:
+      runner:
+        description: 'Runner label'
+        required: true
+        default: 'linux-flydsl-mi355-1'
+        type: choice
+        options:
+          - linux-flydsl-mi355-1
+          - linux-flydsl-mi325-1
 
 jobs:
   network-test:
-    runs-on: linux-flydsl-mi355-1
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Install speedtest-cli
         run: pip install speedtest-cli


### PR DESCRIPTION
Add a manually triggered workflow to test network speed on self-hosted runners.

- Run speedtest to measure overall network bandwidth
- Git clone ROCm/aiter to benchmark clone speed
- Supports runner selection via workflow_dispatch input (mi355, mi325)