### PR TITLE
[FLYDSL]: dsl and/or ast rewrite dynamic process

### DIFF
--- a/python/flydsl/compiler/ast_rewriter.py
+++ b/python/flydsl/compiler/ast_rewriter.py
@@ -263,17 +263,22 @@ class ReplaceIfWithDispatch(Transformer):
             "scf_if_dispatch": cls.scf_if_dispatch,
         }
 
-    _REWRITE_HELPER_NAMES = {"dsl_not_", "dsl_and_", "dsl_or_",
-                              "scf_if_dispatch", "const_expr", "type",
-                              "bool", "isinstance", "hasattr"}
+    _REWRITE_HELPER_NAMES = {
+        "scf_if_dispatch",
+        "const_expr",
+        "type",
+        "bool",
+        "isinstance",
+        "hasattr",
+    }
 
     @staticmethod
     def _could_be_dynamic(test_node):
         """Check if an if-condition AST could produce an MLIR Value at runtime.
 
-        Calls to RewriteBoolOps helpers (dsl_not_, dsl_and_, dsl_or_) and
-        Python builtins are NOT considered dynamic — they just wrap Python-level
-        boolean logic. Only calls to user/MLIR functions can produce Values.
+        Calls to Python builtins are NOT considered dynamic. BoolOp helpers like
+        dsl_and_/dsl_or_ may still produce dynamic predicates, so they should
+        not be filtered out here.
         """
         for child in ast.walk(test_node):
             if isinstance(child, ast.Call):


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

#!/usr/bin/env python3
"""Vector Abs - C = |A| element-wise using FlyDSL"""

import sys
import torch
import flydsl.compiler as flyc
import flydsl.expr as fx
from flydsl.expr import arith


@flyc.kernel
def vecAbsKernel(
    A: fx.Tensor,
    C: fx.Tensor,
    block_dim: fx.Constexpr[int],
    vec_width: fx.Constexpr[int],
    print_debug: fx.Constexpr[bool] = True,
):
    bid = fx.block_idx.x
    tid = fx.thread_idx.x
    if print_debug and bid == 0 and tid <= 2:
        fx.printf("[kernel] bid={}, tid={}", bid, tid)

@flyc.jit
def vecAbs(
    A: fx.Tensor,
    C,
    n: fx.Int32,
    const_n: fx.Constexpr[int],
    block_dim: fx.Constexpr[int],
    vec_width: fx.Constexpr[int],
    stream: fx.Stream = fx.Stream(None),
):
    tile_elems = block_dim * vec_width
    grid_x = (n + tile_elems - 1) // tile_elems
    vecAbsKernel(A, C, block_dim, vec_width).launch(
        grid=(grid_x, 1, 1), block=(block_dim, 1, 1), stream=stream
    )


if __name__ == "__main__":
    THREADS = 256
    VEC = 4
    TILE = THREADS * VEC
    SIZE = TILE * 1000

    A = torch.randn(SIZE, device="cuda", dtype=torch.float32)
    C = torch.empty_like(A)

    stream = torch.cuda.Stream()
    tA = flyc.from_dlpack(A).mark_layout_dynamic(leading_dim=0, divisibility=VEC)

    vecAbs(tA, C, SIZE, SIZE, THREADS, VEC, stream=stream)
    torch.cuda.synchronize()

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
