### PR TITLE
feat: support explicit kernel name in @flyc.kernel for profiler visib…

### DIFF
--- a/kernels/blockscale_preshuffle_gemm.py
+++ b/kernels/blockscale_preshuffle_gemm.py
@@ -126,6 +126,11 @@ def compile_blockscale_preshuffle_gemm(
 
     epilog_tag = "cshuffle" if use_cshuffle_epilog else "direct"
 
+    module_name = (
+        f"bs_gemm_{out_dtype}_{epilog_tag}"
+        f"_t{tile_m}x{tile_n}x{tile_k}"
+    ).replace("-", "_")
+
     # ── LDS sizing (pure Python, no MLIR ops) ────────────────────────────
     lds_tile_bytes = tile_m * lds_stride_bytes
     lds_out_bytes = 2 * tile_m * tile_n if use_cshuffle_epilog else 0
@@ -153,7 +158,7 @@ def compile_blockscale_preshuffle_gemm(
     num_acc_n = n_per_wave // 16
 
     # ── Kernel function ───────────────────────────────────────────────────
-    @flyc.kernel
+    @flyc.kernel(name=module_name)
     def kernel_gemm(
         arg_c: fx.Tensor,
         arg_a: fx.Tensor,

--- a/kernels/moe_blockscale_2stage.py
+++ b/kernels/moe_blockscale_2stage.py
@@ -203,7 +203,7 @@ def compile_moe_blockscale_gemm1(
     lds_alloc_offset = allocator._align(allocator.ptr, 16)
     allocator.ptr = lds_alloc_offset + lds_alloc_bytes
 
-    @flyc.kernel
+    @flyc.kernel(name=module_name)
     def moe_blockscale_gemm1(
             arg_out: fx.Tensor,
             arg_x: fx.Tensor,
@@ -1158,7 +1158,7 @@ def compile_moe_blockscale_gemm1(
                     bx_m=bx_m,
                     body_row=_stage1_store_row,
                 )
-    
+
     # ── Host launcher (flyc.jit + .launch) ────────────────────────────────
     @flyc.jit
     def launch_moe_blockscale_gemm1(
@@ -1382,7 +1382,7 @@ def compile_moe_blockscale_gemm2(
             )
 
     if True:
-        @flyc.kernel
+        @flyc.kernel(name=module_name)
         def moe_blockscale_gemm2(
             arg_out: fx.Tensor,
             arg_x: fx.Tensor,
@@ -2388,6 +2388,7 @@ def compile_moe_blockscale_gemm2(
             _if_blk = scf.IfOp(blk_valid)
             with _if_then(_if_blk):
                 _moe_gemm2_then_body()
+
     # ── Host launcher (flyc.jit + .launch) ────────────────────────────────
     @flyc.jit
     def launch_moe_blockscale_gemm2(
@@ -2474,6 +2475,8 @@ def compile_moe_reduction(
 
     masked = "masked" if use_mask else ""
 
+    module_name = f"bs_moe_reduce_topk{topk}_{dtype_str}{masked}"
+
     if dtype_str == "f32":
         elem_type_tag = "f32"
     elif dtype_str == "f16":
@@ -2491,7 +2494,7 @@ def compile_moe_reduction(
         return ty() if callable(ty) else ty
 
     if True:
-        @flyc.kernel
+        @flyc.kernel(name=module_name)
         def moe_reduction_kernel(
             X: fx.Tensor,
             Y: fx.Tensor,

--- a/python/flydsl/compiler/kernel_function.py
+++ b/python/flydsl/compiler/kernel_function.py
@@ -336,9 +336,10 @@ class KernelFunction:
     configuring and launching the kernel.
     """
 
-    def __init__(self, func: Callable, some_args=None):
+    def __init__(self, func: Callable, some_args=None, name: Optional[str] = None):
         self._func = ASTRewriter.transform(func)
         self._some_args = some_args
+        self._name = name
         self._kernel_name: Optional[str] = None
         self._location_tracker = FuncLocationTracker(func)
 
@@ -376,7 +377,10 @@ class KernelFunction:
             kernel_arg_types.extend(fly_types(value))
 
         kernel_id = ctx.next_kernel_id()
-        self._kernel_name = f"{self._func.__name__}_{kernel_id}"
+        if self._name is not None:
+            self._kernel_name = self._name
+        else:
+            self._kernel_name = f"{self._func.__name__}_{kernel_id}"
 
         ctx.register_kernel_tracker(self._kernel_name, self._location_tracker)
 
@@ -421,7 +425,7 @@ class KernelFunction:
 # =============================================================================
 
 
-def kernel(func: Optional[Callable] = None, *, some_args=None) -> KernelFunction:
+def kernel(func: Optional[Callable] = None, *, some_args=None, name: Optional[str] = None) -> KernelFunction:
     """Decorator for GPU kernel functions.
 
     Usage:
@@ -430,8 +434,8 @@ def kernel(func: Optional[Callable] = None, *, some_args=None) -> KernelFunction
             # kernel body
             ...
 
-        # Or with arguments
-        @kernel(some_args=value)
+        # With explicit kernel name (visible in profiler):
+        @kernel(name="gemm_m16n128k128_bf16")
         def my_kernel(a: Tensor):
             ...
 
@@ -441,10 +445,12 @@ def kernel(func: Optional[Callable] = None, *, some_args=None) -> KernelFunction
     Args:
         func: Function to decorate
         some_args: Optional kernel-specific arguments
+        name: Optional kernel name override; shown in profiler instead of the
+              Python function name. Tile/dtype info can be embedded here.
 
     Returns:
         KernelFunction wrapper
     """
     if func is None:
-        return lambda f: KernelFunction(f, some_args=some_args)
-    return KernelFunction(func, some_args=some_args)
+        return lambda f: KernelFunction(f, some_args=some_args, name=name)
+    return KernelFunction(func, some_args=some_args, name=name)


### PR DESCRIPTION
…ility

Add `name` parameter to `@flyc.kernel` decorator so kernels can embed tile/dtype configuration in their profiler-visible name without touching internal framework attributes.

Changes:
- kernel_function.py: add `name` kwarg to `KernelFunction.__init__` and `kernel()` decorator; when `name` is provided it is used verbatim as the kernel symbol (no `_{kernel_id}` suffix); otherwise falls back to the existing `{func.__name__}_{kernel_id}` scheme
- blockscale_preshuffle_gemm.py: add `module_name`, pass to `@flyc.kernel(name=module_name)` → e.g. `bs_gemm_bf16_direct_t16x128x128`
- moe_blockscale_2stage.py: pass existing `module_name` to `@flyc.kernel(name=module_name)` for gemm1, gemm2, and reduction kernels
