### PR TITLE
fix(jit): prevent use-after-free SIGSEGV when FLYDSL_RUNTIME_ENABLE_CACHE=0

### DIFF
--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -828,16 +828,20 @@ class JitFunction:
 
             result = compiled_func(*jit_args)
 
-            # Build CallState so subsequent calls skip DLPack
-            try:
-                state = _build_call_state(
-                    sig, args_tuple,
-                    compiled_func._get_func_exe(),
-                )
-                if state is not None:
-                    self._call_state_cache[cache_key] = state
-            except Exception:
-                pass
+            # Build CallState so subsequent calls skip DLPack.
+            # Only when caching is enabled -- otherwise compiled_func will be
+            # GC'd and the function pointer inside CallState becomes dangling,
+            # causing a SIGSEGV on the next call with the same cache_key.
+            if use_cache:
+                try:
+                    state = _build_call_state(
+                        sig, args_tuple,
+                        compiled_func._get_func_exe(),
+                    )
+                    if state is not None:
+                        self._call_state_cache[cache_key] = state
+                except Exception:
+                    pass
 
             return result
 


### PR DESCRIPTION
## Motivation

When `FLYDSL_RUNTIME_ENABLE_CACHE=0`, calling a `@flyc.jit` kernel **twice with the same arguments** causes a SIGSEGV (exit code 139) on the second call. This makes iterative development and debugging impossible without caching enabled.

## Root Cause

`_call_state_cache` was populated unconditionally (regardless of `use_cache`) with a `CallState` holding a **raw ctypes function pointer** (`func_exe`) obtained from `CompiledArtifact._get_func_exe()`. This pointer points into native code memory managed by the MLIR `ExecutionEngine` inside the `CompiledArtifact`.

When `use_cache=False`:
1. **First call**: compiles the kernel, creates `CompiledArtifact`, builds `CallState` with `func_exe`, stores `CallState` in `_call_state_cache`. But `CompiledArtifact` is NOT stored in `_mem_cache` (because `use_cache` is False).
2. After `__call__` returns, `compiled_func` (a local variable) goes out of scope and gets **garbage collected** — destroying the `ExecutionEngine` and **freeing the native code memory**.
3. **Second call** with the same `cache_key`: hits the fast path (`_call_state_cache.get(cache_key)`), finds the cached `CallState`, calls `func_exe(packed_args)` — **dereferencing a dangling pointer** → SIGSEGV.

## Technical Details

Only populate `_call_state_cache` when `use_cache` is True. When caching is disabled, every call goes through the full compilation path, which is slow but correct. This is the expected behavior — `FLYDSL_RUNTIME_ENABLE_CACHE=0` is a debug/development flag, not a production setting.

```python
# Before (buggy): always caches CallState — dangling pointer when compiled_func is GC'd
try:
    state = _build_call_state(sig, args_tuple, compiled_func._get_func_exe())
    if state is not None:
        self._call_state_cache[cache_key] = state
except Exception:
    pass

# After (fixed): only cache when compiled_func will also be held in _mem_cache
if use_cache:
    try:
        state = _build_call_state(sig, args_tuple, compiled_func._get_func_exe())
        if state is not None:
            self._call_state_cache[cache_key] = state
    except Exception:
        pass
```

The two-phase compilation (`compile_hints` support) has been split out to a separate PR per review feedback.

## Test Plan

- [x] Reproduce SIGSEGV: `FLYDSL_RUNTIME_ENABLE_CACHE=0 python3 test_pa_decode_gluon3.py` (calls kernel 10x in a loop) — crashes with exit code 139 on 2nd call before fix
- [x] Verify fix: same command completes all 10 calls without crash after fix
- [x] Verify caching path unchanged: `FLYDSL_RUNTIME_ENABLE_CACHE=1` (default) — kernel compiles once, subsequent calls use fast `CallState` path as before

## Test Result

- Before fix: exit code 139 (SIGSEGV) on second kernel invocation with `FLYDSL_RUNTIME_ENABLE_CACHE=0`
- After fix: all invocations complete successfully (each call recompiles as expected when cache is disabled)
- No regression on default cache-enabled path

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.