### PR TITLE
feat(runtime): implement device runtime layer (Python)

### DIFF
--- a/python/flydsl/compiler/backends/__init__.py
+++ b/python/flydsl/compiler/backends/__init__.py
@@ -68,6 +68,12 @@ def get_backend(name: Optional[str] = None, *, arch: str = "") -> BaseBackend:
 
     *name* defaults to ``FLYDSL_COMPILE_BACKEND`` env var (or ``'rocm'``).
     *arch* overrides the auto-detected architecture when non-empty.
+
+    Compile/runtime pairing (``FLYDSL_COMPILE_BACKEND`` vs ``FLYDSL_RUNTIME_KIND``)
+    is validated on each :class:`~flydsl.compiler.jit_function.JitFunction` call
+    (via :func:`flydsl.runtime.device_runtime.ensure_compile_runtime_pairing_from_env`)
+    and again on first :func:`flydsl.runtime.device_runtime.get_device_runtime`,
+    not here.
     """
     if name is None:
         name = compile_backend_name()

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -19,7 +19,7 @@ from .._mlir.passmanager import PassManager
 from ..expr.typing import Stream
 from ..utils import env, log
 from .ast_rewriter import ASTRewriter
-from .backends import get_backend
+from .backends import compile_backend_name, get_backend
 from .jit_argument import convert_to_jit_arguments
 from .jit_executor import CompiledArtifact
 from .kernel_function import (
@@ -727,6 +727,11 @@ class JitFunction:
         cache_key = self._make_cache_key(bound.arguments)
 
         args_tuple = tuple(bound.arguments.values())
+
+        # Compile/runtime pairing at JIT entry (not in CompiledArtifact / ExecutionEngine init).
+        from ..runtime.device_runtime import ensure_compile_runtime_pairing_from_env
+
+        ensure_compile_runtime_pairing_from_env(compile_backend_name())
 
         # Fast path: reuse pre-built CallState (no ctypes alloc, no DLPack)
         call_state = self._call_state_cache.get(cache_key)

--- a/python/flydsl/expr/typing.py
+++ b/python/flydsl/expr/typing.py
@@ -300,6 +300,13 @@ class Tensor:
 
 
 class Stream:
+    """Opaque async queue handle for kernel launch.
+
+    ``None`` is the default queue; an :class:`int` is a raw pointer. Any other
+    value is interpreted by the active device runtime
+    (:mod:`flydsl.runtime.device_runtime`).
+    """
+
     _is_stream_param = True
 
     def __init__(self, value=None):

--- a/python/flydsl/runtime/__init__.py
+++ b/python/flydsl/runtime/__init__.py
@@ -1,3 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
+"""FlyDSL runtime: device runtime, GPU detection helpers, etc."""
+
+from .device_runtime import (
+    COMPILE_BACKEND_TO_RUNTIME_KIND,
+    DeviceRuntime,
+    RocmDeviceRuntime,
+    ensure_compile_runtime_compatible,
+    ensure_compile_runtime_pairing_from_env,
+    get_device_runtime,
+    register_compile_runtime_mapping,
+    register_device_runtime,
+)
+
+__all__ = [
+    "COMPILE_BACKEND_TO_RUNTIME_KIND",
+    "DeviceRuntime",
+    "RocmDeviceRuntime",
+    "ensure_compile_runtime_compatible",
+    "ensure_compile_runtime_pairing_from_env",
+    "get_device_runtime",
+    "register_compile_runtime_mapping",
+    "register_device_runtime",
+]

--- a/python/flydsl/runtime/device.py
+++ b/python/flydsl/runtime/device.py
@@ -43,6 +43,30 @@ def get_rocm_arch() -> str:
     return "gfx942"
 
 
+@functools.lru_cache(maxsize=None)
+def get_rocm_device_count() -> int:
+    """Best-effort ROCm visible GPU count via ``rocm_agent_enumerator`` (standard ROCm tool).
+
+    Uses the same invocation as :func:`_arch_from_rocm_agent_enumerator`. Returns 0
+    when the tool is unavailable or no discrete GPU agents are reported.
+    """
+    try:
+        out = subprocess.check_output(
+            ["rocm_agent_enumerator", "-name"],
+            text=True,
+            timeout=5,
+            stderr=subprocess.DEVNULL,
+        )
+        n = 0
+        for line in out.splitlines():
+            name = line.strip()
+            if name.startswith("gfx") and name != "gfx000":
+                n += 1
+        return n
+    except Exception:
+        return 0
+
+
 def is_rdna_arch(arch: Optional[str] = None) -> bool:
     """Check if architecture is RDNA-based (gfx10/11/12, wave32).
 

--- a/python/flydsl/runtime/device_runtime/__init__.py
+++ b/python/flydsl/runtime/device_runtime/__init__.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Per-process GPU device runtime.
+
+Exactly one :class:`DeviceRuntime` implementation is active per process.
+It must match the selected compile backend (e.g. ``rocm`` compile backend ↔
+``rocm`` runtime / HIP).
+
+Environment:
+
+* ``FLYDSL_RUNTIME_KIND`` — selects the built-in runtime implementation
+  (default: ``rocm``). Must agree with ``FLYDSL_COMPILE_BACKEND`` via
+  :data:`COMPILE_BACKEND_TO_RUNTIME_KIND` (and optional extension mappings).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Type
+
+from ...utils import env
+from .base import DeviceRuntime
+from .rocm import RocmDeviceRuntime
+
+# Compile-backend id -> device-runtime kind (single string namespace).
+COMPILE_BACKEND_TO_RUNTIME_KIND: Dict[str, str] = {
+    "rocm": "rocm",
+}
+
+_EXTRA_MAPPINGS: Dict[str, str] = {}
+
+_builtin_runtimes: Dict[str, Type[DeviceRuntime]] = {
+    "rocm": RocmDeviceRuntime,
+}
+
+_runtime_cls_override: Optional[Type[DeviceRuntime]] = None
+_instance: Optional[DeviceRuntime] = None
+
+
+def register_compile_runtime_mapping(compile_backend: str, runtime_kind: str) -> None:
+    """Map a compile-backend id to a device-runtime *kind*.
+
+    Use when a third-party :func:`flydsl.compiler.backends.register_backend`
+    targets an existing runtime stack (e.g. custom name → ``rocm``).
+    """
+    _EXTRA_MAPPINGS[compile_backend.strip().lower()] = runtime_kind.strip().lower()
+
+
+def register_device_runtime(
+    cls: Type[DeviceRuntime],
+    *,
+    kind: Optional[str] = None,
+    force: bool = False,
+) -> None:
+    """Register a custom :class:`DeviceRuntime` class for the whole process.
+
+    Must be called before the first :func:`get_device_runtime` if replacing the
+    default. Raises if a runtime instance already exists, unless ``force=True``.
+
+    If *kind* is set, the class is also registered under that runtime *kind* for
+    ``FLYDSL_RUNTIME_KIND`` (and should match the compile-backend mapping).
+    """
+    global _runtime_cls_override, _instance
+    if _instance is not None and not force:
+        raise RuntimeError(
+            "Cannot register a device runtime after get_device_runtime() "
+            "has been called (unless force=True)."
+        )
+    if _runtime_cls_override is not None and not force:
+        raise ValueError(
+            "A custom device runtime class is already registered "
+            "(use force=True to replace)."
+        )
+    _runtime_cls_override = cls
+    if kind is not None:
+        _builtin_runtimes[kind.strip().lower()] = cls
+
+
+def _expected_runtime_kind_for_compile_backend(compile_backend_id: str) -> str:
+    key = compile_backend_id.strip().lower()
+    if key in _EXTRA_MAPPINGS:
+        return _EXTRA_MAPPINGS[key]
+    if key in COMPILE_BACKEND_TO_RUNTIME_KIND:
+        return COMPILE_BACKEND_TO_RUNTIME_KIND[key]
+    raise ValueError(
+        f"No device-runtime kind mapped for compile backend {compile_backend_id!r}. "
+        "Register a mapping with register_compile_runtime_mapping()."
+    )
+
+
+def _resolve_runtime_class() -> Type[DeviceRuntime]:
+    if _runtime_cls_override is not None:
+        return _runtime_cls_override
+    kind = (env.runtime.kind or "rocm").strip().lower()
+    cls = _builtin_runtimes.get(kind)
+    if cls is None:
+        known = ", ".join(sorted(_builtin_runtimes)) or "(none)"
+        raise ValueError(
+            f"Unknown FLYDSL_RUNTIME_KIND={kind!r}. Built-in kinds: {known}"
+        )
+    return cls
+
+
+def _selected_runtime_kind_from_env() -> str:
+    """Runtime kind implied by env / registration, without instantiating :class:`DeviceRuntime`."""
+    if _runtime_cls_override is not None:
+        return str(_runtime_cls_override.kind)
+    return (env.runtime.kind or "rocm").strip().lower()
+
+
+def ensure_compile_runtime_pairing_from_env(compile_backend_id: str) -> None:
+    """Raise if *compile_backend_id* does not match the configured runtime kind.
+
+    Uses only environment and registration state — does not construct
+    :class:`DeviceRuntime`. Suitable for compiler paths (e.g. ``COMPILE_ONLY``)
+    where initializing the runtime is unnecessary.
+    """
+    expected = _expected_runtime_kind_for_compile_backend(compile_backend_id)
+    actual = _selected_runtime_kind_from_env()
+    if actual != expected:
+        raise RuntimeError(
+            f"Compile backend {compile_backend_id!r} requires device runtime kind "
+            f"{expected!r}, but FLYDSL_RUNTIME_KIND (and registration) resolve to "
+            f"{actual!r}. "
+            f"Align FLYDSL_COMPILE_BACKEND with FLYDSL_RUNTIME_KIND (and extension "
+            f"mappings), or use a matching pair of register_backend / "
+            f"register_device_runtime."
+        )
+
+
+def ensure_compile_runtime_compatible(
+    compile_backend_id: str,
+    *,
+    runtime: Optional[DeviceRuntime] = None,
+) -> None:
+    """Raise if *compile_backend_id* does not match the active runtime kind."""
+    expected = _expected_runtime_kind_for_compile_backend(compile_backend_id)
+    rt = runtime if runtime is not None else get_device_runtime()
+    if rt.kind != expected:
+        raise RuntimeError(
+            f"Compile backend {compile_backend_id!r} requires device runtime kind "
+            f"{expected!r}, but the active runtime is {rt.kind!r}. "
+            f"Align FLYDSL_COMPILE_BACKEND with FLYDSL_RUNTIME_KIND (and extension "
+            f"mappings), or use a matching pair of register_backend / "
+            f"register_device_runtime."
+        )
+
+
+def _active_compile_backend_id() -> str:
+    """Mirror :func:`flydsl.compiler.backends.compile_backend_name` without importing ``compiler``."""
+    return (env.compile.backend or "rocm").lower()
+
+
+def get_device_runtime() -> DeviceRuntime:
+    """Return the single process-wide :class:`DeviceRuntime` instance.
+
+    Compile/runtime pairing runs once when the singleton is first created (see
+    :func:`ensure_compile_runtime_pairing_from_env`), not on every call — the
+    active backend and runtime kind are treated as fixed for the process after
+    that point.
+    """
+    global _instance
+    if _instance is None:
+        ensure_compile_runtime_pairing_from_env(_active_compile_backend_id())
+        cls = _resolve_runtime_class()
+        _instance = cls()
+    return _instance
+
+
+__all__ = [
+    "COMPILE_BACKEND_TO_RUNTIME_KIND",
+    "DeviceRuntime",
+    "RocmDeviceRuntime",
+    "ensure_compile_runtime_compatible",
+    "ensure_compile_runtime_pairing_from_env",
+    "get_device_runtime",
+    "register_compile_runtime_mapping",
+    "register_device_runtime",
+]

--- a/python/flydsl/runtime/device_runtime/base.py
+++ b/python/flydsl/runtime/device_runtime/base.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Abstract device runtime : single native GPU stack per process."""
+
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+from typing import ClassVar
+
+
+class DeviceRuntime(metaclass=ABCMeta):
+    """Vendor-neutral runtime: one implementation per process (HIP, CUDA, …).
+
+    Opaque stream handles live in :mod:`flydsl.expr.typing` at the DSL boundary;
+    concrete APIs stay in native glue (e.g. ROCm wrappers).
+    """
+
+    kind: ClassVar[str]
+    """Stable runtime identifier (e.g. ``\"rocm\"`` for HIP/ROCm)."""
+
+    @abstractmethod
+    def device_count(self) -> int:
+        """Number of visible devices for this runtime."""

--- a/python/flydsl/runtime/device_runtime/rocm.py
+++ b/python/flydsl/runtime/device_runtime/rocm.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""ROCm / HIP device runtime (default FlyDSL GPU stack)."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from ..device import get_rocm_device_count
+from .base import DeviceRuntime
+
+
+class RocmDeviceRuntime(DeviceRuntime):
+    """HIP-based runtime; matches compile backend ``rocm``.
+
+    ``device_count()`` delegates to :func:`get_rocm_device_count` in ``device.py``
+    (``@lru_cache``; ``rocm_agent_enumerator``, same style as arch detection there).
+    """
+
+    kind: ClassVar[str] = "rocm"
+
+    def device_count(self) -> int:
+        return get_rocm_device_count()

--- a/python/flydsl/utils/env.py
+++ b/python/flydsl/utils/env.py
@@ -255,6 +255,10 @@ class RuntimeEnvManager(EnvManager):
 
     env_prefix = "RUNTIME"
 
+    kind = OptStr(
+        "rocm",
+        description="Device runtime kind (must match FLYDSL_COMPILE_BACKEND; e.g. rocm for HIP)",
+    )
     cache_dir = OptStr(str(Path.home() / ".flydsl" / "cache"), description="Directory for caching compiled kernels")
     enable_cache = OptBool(True, description="Enable kernel caching")
 

--- a/tests/unit/test_device_runtime.py
+++ b/tests/unit/test_device_runtime.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""device runtime registry and compile-backend pairing."""
+
+import pytest
+
+import flydsl.runtime.device_runtime as dr
+
+
+@pytest.fixture(autouse=True)
+def _reset_device_runtime_singleton():
+    """Each test starts without a cached DeviceRuntime instance."""
+    dr._instance = None
+    dr._runtime_cls_override = None
+    dr._EXTRA_MAPPINGS.clear()
+    yield
+    dr._instance = None
+    dr._runtime_cls_override = None
+    dr._EXTRA_MAPPINGS.clear()
+
+
+class _FakeCudaRuntime(dr.DeviceRuntime):
+    kind = "cuda"
+
+    def device_count(self) -> int:
+        return 1
+
+
+def test_rocm_runtime_kind_matches_compile_backend(monkeypatch):
+    monkeypatch.delenv("FLYDSL_RUNTIME_KIND", raising=False)
+    monkeypatch.setenv("FLYDSL_COMPILE_BACKEND", "rocm")
+    rt = dr.get_device_runtime()
+    assert rt.kind == "rocm"
+    dr.ensure_compile_runtime_compatible("rocm", runtime=rt)
+
+
+def test_ensure_mismatch_raises():
+    bad = _FakeCudaRuntime()
+    with pytest.raises(RuntimeError, match="requires device runtime kind"):
+        dr.ensure_compile_runtime_compatible("rocm", runtime=bad)
+
+
+def test_unknown_runtime_kind_env(monkeypatch):
+    """Invalid FLYDSL_RUNTIME_KIND fails at compile/runtime pairing first."""
+    monkeypatch.setenv("FLYDSL_RUNTIME_KIND", "not_a_real_kind")
+    monkeypatch.setenv("FLYDSL_COMPILE_BACKEND", "rocm")
+    with pytest.raises(RuntimeError, match="requires device runtime kind"):
+        dr.get_device_runtime()
+
+
+def test_unknown_runtime_kind_after_pairing_passes(monkeypatch):
+    """When env strings agree with mapping, unknown kind fails in class lookup."""
+    dr.register_compile_runtime_mapping("custom", "weird_kind")
+    monkeypatch.setenv("FLYDSL_COMPILE_BACKEND", "custom")
+    monkeypatch.setenv("FLYDSL_RUNTIME_KIND", "weird_kind")
+    try:
+        with pytest.raises(ValueError, match="Unknown FLYDSL_RUNTIME_KIND"):
+            dr.get_device_runtime()
+    finally:
+        dr._EXTRA_MAPPINGS.pop("custom", None)
+
+
+def test_register_compile_runtime_mapping():
+    dr.register_compile_runtime_mapping("foo", "rocm")
+    try:
+        dr.ensure_compile_runtime_compatible("foo", runtime=dr.RocmDeviceRuntime())
+    finally:
+        dr._EXTRA_MAPPINGS.pop("foo", None)
+
+
+def test_pairing_from_env_no_singleton(monkeypatch):
+    """Pairing check used on compile path must not create DeviceRuntime."""
+    monkeypatch.delenv("FLYDSL_RUNTIME_KIND", raising=False)
+    monkeypatch.setenv("FLYDSL_COMPILE_BACKEND", "rocm")
+    dr.ensure_compile_runtime_pairing_from_env("rocm")
+    assert dr._instance is None
+
+
+def test_pairing_from_env_mismatch_raises(monkeypatch):
+    monkeypatch.setenv("FLYDSL_COMPILE_BACKEND", "rocm")
+    monkeypatch.setenv("FLYDSL_RUNTIME_KIND", "not_a_registered_kind")
+    with pytest.raises(RuntimeError, match="requires device runtime kind"):
+        dr.ensure_compile_runtime_pairing_from_env("rocm")


### PR DESCRIPTION
- Add flydsl.runtime.device_runtime: Device/DeviceRuntime/Event, RocmDeviceRuntime
- FLYDSL_RUNTIME_KIND (env.runtime.kind), compile/runtime pairing validation
- get_backend() triggers get_device_runtime() for single-stack invariant
- register_device_runtime, register_compile_runtime_mapping for extensions
- Unit tests.

code with cursor