### PR TITLE
feat(compiler): auto-detect constexpr range() arguments

### DIFF
--- a/python/flydsl/compiler/ast_rewriter.py
+++ b/python/flydsl/compiler/ast_rewriter.py
@@ -403,6 +403,71 @@ class InsertEmptyYieldForSCFFor(Transformer):
     def _is_range(cls, iter_node):
         return cls._iter_call_name(iter_node) == "range"
 
+    _CONSTEXPR_ANNOTATIONS = {"Constexpr", "fx.Constexpr", "const_expr"}
+    _dynamic_params = frozenset()  # Default: no dynamic params known
+
+    def _extract_dynamic_params(self, func_node):
+        """Extract non-Constexpr parameter names from a FunctionDef node."""
+        params = set()
+        for arg in func_node.args.args + func_node.args.posonlyargs + func_node.args.kwonlyargs:
+            annotation = arg.annotation
+            if annotation is None:
+                params.add(arg.arg)
+                continue
+            ann_str = ast.unparse(annotation) if annotation else ""
+            if any(ce in ann_str for ce in self._CONSTEXPR_ANNOTATIONS):
+                continue
+            if "Stream" in ann_str:
+                continue
+            params.add(arg.arg)
+        return frozenset(params)
+
+    def generic_visit(self, node):
+        """Override to extract dynamic params from FunctionDef before visiting children."""
+        if isinstance(node, ast.FunctionDef) and not getattr(node, _ASTREWRITE_MARKER, False):
+            self._dynamic_params = self._extract_dynamic_params(node)
+        return super().generic_visit(node)
+
+    def _is_constexpr_arg(self, node):
+        """Check if a range() argument is statically evaluable at AST level.
+
+        Returns True for expressions that can only produce Python values
+        (never MLIR Values): literals, variable names, and arithmetic on
+        those.  Returns False for function calls, attribute accesses, and
+        subscripts which may produce MLIR Values at runtime.
+
+        For ast.Name, returns False if the name is a function parameter
+        without Constexpr type annotation (it will be an MLIR value).
+        """
+        if isinstance(node, ast.Constant):
+            return True
+        if isinstance(node, ast.Name):
+            # Exclude names that are known dynamic parameters (non-Constexpr
+            # function arguments become MLIR values at JIT time).
+            if node.id in self._dynamic_params:
+                return False
+            return True
+        if isinstance(node, ast.UnaryOp):
+            return self._is_constexpr_arg(node.operand)
+        if isinstance(node, ast.BinOp):
+            return (self._is_constexpr_arg(node.left)
+                    and self._is_constexpr_arg(node.right))
+        # ast.Call, ast.Attribute, ast.Subscript, etc. -> could produce MLIR Values
+        return False
+
+    def _is_auto_constexpr_range(self, call_node):
+        """Check if a range() call can be auto-promoted to constexpr.
+
+        A range() is auto-constexpr when:
+        1. All positional arguments are statically evaluable
+        2. No `init=` keyword argument (loop-carried values require scf.for)
+        """
+        # init= keyword means loop-carried values -> must be scf.for
+        for kw in call_node.keywords:
+            if kw.arg == "init":
+                return False
+        return all(self._is_constexpr_arg(a) for a in call_node.args)
+
     def visit_For(self, node: ast.For) -> ast.For:
         if self._is_range_constexpr(node.iter):
             node.iter.func = ast.Name(id="range", ctx=ast.Load())
@@ -410,6 +475,12 @@ class InsertEmptyYieldForSCFFor(Transformer):
             node = ast.fix_missing_locations(node)
             return node
         if self._is_range(node.iter):
+            if self._is_auto_constexpr_range(node.iter):
+                # All arguments are compile-time constants -> unroll like range_constexpr
+                node.iter.func = ast.Name(id="range", ctx=ast.Load())
+                node = self.generic_visit(node)
+                node = ast.fix_missing_locations(node)
+                return node
             node.iter.func = ast.Name(id="scf_range", ctx=ast.Load())
         line = ast.dump(node.iter)
         if "for_" in line or "scf.for_" in line or "scf_range" in line:

--- a/tests/unit/test_auto_constexpr_range.py
+++ b/tests/unit/test_auto_constexpr_range.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Tests for automatic constexpr range detection in AST rewriter."""
+
+import ast
+import pytest
+from flydsl.compiler.ast_rewriter import InsertEmptyYieldForSCFFor
+
+
+def _make_rewriter(func_code=None):
+    """Create an InsertEmptyYieldForSCFFor with dynamic params from a function."""
+    rewriter = InsertEmptyYieldForSCFFor(context=None, first_lineno=0)
+    rewriter._dynamic_params = set()
+    if func_code:
+        tree = ast.parse(func_code.strip())
+        func_node = tree.body[0]
+        rewriter.visit_FunctionDef(func_node)
+    return rewriter
+
+
+class TestIsConstexprArg:
+    """Unit tests for _is_constexpr_arg."""
+
+    def test_integer_literal(self):
+        r = _make_rewriter()
+        node = ast.parse("4").body[0].value
+        assert r._is_constexpr_arg(node) is True
+
+    def test_string_literal(self):
+        r = _make_rewriter()
+        node = ast.parse("'hello'").body[0].value
+        assert r._is_constexpr_arg(node) is True
+
+    def test_name_variable(self):
+        r = _make_rewriter()
+        node = ast.parse("TLOOP").body[0].value
+        assert r._is_constexpr_arg(node) is True
+
+    def test_name_dynamic_param(self):
+        """A function parameter without Constexpr annotation is dynamic."""
+        r = _make_rewriter("def f(n: Int32): pass")
+        node = ast.parse("n").body[0].value
+        assert r._is_constexpr_arg(node) is False
+
+    def test_name_constexpr_param(self):
+        """A function parameter with Constexpr annotation is constexpr."""
+        r = _make_rewriter("def f(n: Constexpr[int]): pass")
+        node = ast.parse("n").body[0].value
+        assert r._is_constexpr_arg(node) is True
+
+    def test_binop_constants(self):
+        r = _make_rewriter()
+        node = ast.parse("TLOOP * 2").body[0].value
+        assert r._is_constexpr_arg(node) is True
+
+    def test_binop_with_dynamic_param(self):
+        """BinOp involving a dynamic parameter is not constexpr."""
+        r = _make_rewriter("def f(n: Int32): pass")
+        node = ast.parse("n + 1").body[0].value
+        assert r._is_constexpr_arg(node) is False
+
+    def test_binop_nested(self):
+        r = _make_rewriter()
+        node = ast.parse("HEAD_SIZE // MFMA_N // NUM_WARPS").body[0].value
+        assert r._is_constexpr_arg(node) is True
+
+    def test_unaryop(self):
+        r = _make_rewriter()
+        node = ast.parse("-N").body[0].value
+        assert r._is_constexpr_arg(node) is True
+
+    def test_function_call_not_constexpr(self):
+        r = _make_rewriter()
+        node = ast.parse("arith.constant(4)").body[0].value
+        assert r._is_constexpr_arg(node) is False
+
+    def test_attribute_not_constexpr(self):
+        r = _make_rewriter()
+        node = ast.parse("obj.attr").body[0].value
+        assert r._is_constexpr_arg(node) is False
+
+    def test_subscript_not_constexpr(self):
+        r = _make_rewriter()
+        node = ast.parse("arr[0]").body[0].value
+        assert r._is_constexpr_arg(node) is False
+
+    def test_binop_with_call_not_constexpr(self):
+        r = _make_rewriter()
+        node = ast.parse("func() + 1").body[0].value
+        assert r._is_constexpr_arg(node) is False
+
+
+class TestIsAutoConstexprRange:
+    """Unit tests for _is_auto_constexpr_range."""
+
+    def test_literal_arg(self):
+        """range(4) -> constexpr"""
+        r = _make_rewriter()
+        node = ast.parse("range(4)").body[0].value
+        assert r._is_auto_constexpr_range(node) is True
+
+    def test_name_arg(self):
+        """range(TLOOP) -> constexpr (module-level constant)"""
+        r = _make_rewriter()
+        node = ast.parse("range(TLOOP)").body[0].value
+        assert r._is_auto_constexpr_range(node) is True
+
+    def test_dynamic_param_arg(self):
+        """range(loop_count) -> NOT constexpr when loop_count is dynamic param"""
+        r = _make_rewriter("def f(loop_count: Int32): pass")
+        node = ast.parse("range(loop_count)").body[0].value
+        assert r._is_auto_constexpr_range(node) is False
+
+    def test_arithmetic_args(self):
+        """range(TLOOP * 2) -> constexpr"""
+        r = _make_rewriter()
+        node = ast.parse("range(TLOOP * 2)").body[0].value
+        assert r._is_auto_constexpr_range(node) is True
+
+    def test_two_literal_args(self):
+        """range(0, 4) -> constexpr"""
+        r = _make_rewriter()
+        node = ast.parse("range(0, 4)").body[0].value
+        assert r._is_auto_constexpr_range(node) is True
+
+    def test_three_args_all_constexpr(self):
+        """range(0, N, 2) -> constexpr when N is not a dynamic param"""
+        r = _make_rewriter()
+        node = ast.parse("range(0, N, 2)").body[0].value
+        assert r._is_auto_constexpr_range(node) is True
+
+    def test_call_arg_not_constexpr(self):
+        """range(arith.index_cast(x)) -> NOT constexpr"""
+        r = _make_rewriter()
+        node = ast.parse("range(arith.index_cast(x))").body[0].value
+        assert r._is_auto_constexpr_range(node) is False
+
+    def test_mixed_args_one_call(self):
+        """range(0, func()) -> NOT constexpr"""
+        r = _make_rewriter()
+        node = ast.parse("range(0, func())").body[0].value
+        assert r._is_auto_constexpr_range(node) is False
+
+    def test_init_keyword_not_constexpr(self):
+        """range(0, N, 1, init=[...]) -> NOT constexpr (loop-carried)"""
+        r = _make_rewriter()
+        node = ast.parse("range(0, N, 1, init=vals)").body[0].value
+        assert r._is_auto_constexpr_range(node) is False
+
+    def test_init_keyword_with_literal_args(self):
+        """range(0, 4, init=[...]) -> NOT constexpr despite literal args"""
+        r = _make_rewriter()
+        node = ast.parse("range(0, 4, init=vals)").body[0].value
+        assert r._is_auto_constexpr_range(node) is False
+
+
+class TestVisitForAutoConstexpr:
+    """Integration: verify visit_For correctly routes constexpr vs dynamic."""
+
+    def _get_rewritten_iter_name(self, for_code, func_code=None):
+        """Parse code, apply visit_For, return the iter function name."""
+        r = _make_rewriter(func_code)
+        tree = ast.parse(for_code.strip())
+        for_node = tree.body[0]
+        assert isinstance(for_node, ast.For)
+        result = r.visit_For(for_node)
+        if isinstance(result, ast.For):
+            call = result.iter
+            if isinstance(call, ast.Call):
+                func = call.func
+                return getattr(func, 'id', None) or getattr(func, 'attr', None)
+        return None
+
+    def test_literal_becomes_range(self):
+        name = self._get_rewritten_iter_name("for i in range(4): pass")
+        assert name == "range"
+
+    def test_name_becomes_range(self):
+        name = self._get_rewritten_iter_name("for i in range(TLOOP): pass")
+        assert name == "range"
+
+    def test_arithmetic_becomes_range(self):
+        name = self._get_rewritten_iter_name("for i in range(N * 2): pass")
+        assert name == "range"
+
+    def test_dynamic_param_becomes_scf_range(self):
+        """range(loop_count) where loop_count is a dynamic param -> scf_range"""
+        name = self._get_rewritten_iter_name(
+            "for i in range(loop_count): pass",
+            "def f(loop_count: Int32): pass")
+        assert name == "scf_range"
+
+    def test_call_arg_becomes_scf_range(self):
+        name = self._get_rewritten_iter_name("for i in range(func()): pass")
+        assert name == "scf_range"
+
+    def test_attribute_call_becomes_scf_range(self):
+        name = self._get_rewritten_iter_name("for i in range(obj.method()): pass")
+        assert name == "scf_range"
+
+    def test_range_constexpr_still_works(self):
+        name = self._get_rewritten_iter_name("for i in range_constexpr(4): pass")
+        assert name == "range"
+
+    def test_no_yield_added_for_constexpr(self):
+        """Auto-constexpr range should NOT get yield appended."""
+        code = "for i in range(4):\n    x = i"
+        r = _make_rewriter()
+        tree = ast.parse(code)
+        result = r.visit_For(tree.body[0])
+        body_unparsed = [ast.unparse(s) for s in result.body]
+        assert not any("yield" in s for s in body_unparsed), \
+            f"Constexpr range should not have yield, got: {body_unparsed}"
+
+    def test_yield_added_for_dynamic(self):
+        """Dynamic range should get yield appended."""
+        code = "for i in range(func()):\n    x = i"
+        r = _make_rewriter()
+        tree = ast.parse(code)
+        result = r.visit_For(tree.body[0])
+        body_unparsed = [ast.unparse(s) for s in result.body]
+        assert any("yield" in s for s in body_unparsed), \
+            f"Dynamic range should have yield, got: {body_unparsed}"
+
+
+class TestDynamicParamDetection:
+    """Test that visit_FunctionDef correctly identifies dynamic parameters."""
+
+    def test_int32_param_is_dynamic(self):
+        r = _make_rewriter("def f(n: Int32): pass")
+        assert "n" in r._dynamic_params
+
+    def test_constexpr_param_is_not_dynamic(self):
+        r = _make_rewriter("def f(n: Constexpr[int]): pass")
+        assert "n" not in r._dynamic_params
+
+    def test_fx_constexpr_param_is_not_dynamic(self):
+        r = _make_rewriter("def f(n: fx.Constexpr[int]): pass")
+        assert "n" not in r._dynamic_params
+
+    def test_stream_param_is_not_dynamic(self):
+        r = _make_rewriter("def f(s: Stream): pass")
+        assert "s" not in r._dynamic_params
+
+    def test_tensor_param_is_dynamic(self):
+        r = _make_rewriter("def f(out: Tensor): pass")
+        assert "out" in r._dynamic_params
+
+    def test_no_annotation_is_dynamic(self):
+        r = _make_rewriter("def f(x): pass")
+        assert "x" in r._dynamic_params
+
+    def test_mixed_params(self):
+        r = _make_rewriter("def f(out: Tensor, n: Constexpr[int], scale: Int32): pass")
+        assert "out" in r._dynamic_params
+        assert "n" not in r._dynamic_params
+        assert "scale" in r._dynamic_params
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Automatically detect whether `range()` arguments in FlyDSL kernels are compile-time constants (constexpr) or dynamic MLIR values, eliminating the need for users to manually write `range_constexpr()`
- `range(4)`, `range(N)` where `N: Constexpr[int]`, `range(N * 2)` → Python `range()` (compile-time unrolled)
- `range(x)` where `x: fx.Int32` or `x: fx.Tensor` → `scf_range()` (MLIR `scf.for` loop)
- `range(..., init=...)` → always `scf_range()` (loop-carried values require `scf.for`)

## Implementation

Adds three methods to `InsertEmptyYieldForSCFFor`:

1. **`_extract_dynamic_params(func_node)`** — scans the kernel function signature to identify parameters with non-Constexpr type annotations (these become MLIR values at JIT time)
2. **`_is_constexpr_arg(node)`** — recursively checks if an AST expression is statically evaluable: `ast.Constant` ✓, `ast.Name` of Constexpr param ✓, `ast.BinOp`/`ast.UnaryOp` of constexpr operands ✓, `ast.Call`/`ast.Attribute`/`ast.Subscript` ✗ (conservative)
3. **`_is_auto_constexpr_range(call_node)`** — returns True when all `range()` args are constexpr and no `init=` keyword is present

Overrides `generic_visit` to intercept the FunctionDef node and extract dynamic params before visiting children (necessary because `ASTRewriter.transform` calls `generic_visit(func_node)` which skips `visit_FunctionDef` on the root node).

## Test plan

- [x] 39 new unit tests covering all detection branches (`tests/unit/test_auto_constexpr_range.py`)
- [x] Existing `test_kernel_range_dynamic_upper_bound` regression test passes AST transform (confirms `range(loop_count)` where `loop_count: fx.Int32` correctly maps to `scf_range`)
- [x] Manual verification: `range(loop_count)` → `scf_range(loop_count)`, `range(N)` with `N: Constexpr[int]` → `range(N)`, `range(4)` → `range(4)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)