### PR TITLE
Hot fix cache key

### DIFF
--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -189,11 +189,14 @@ class TensorAdaptor:
     def __fly_ptrs__(self):
         return self.tensor_adaptor.get_c_pointers()
 
+    @staticmethod
+    def raw_cache_signature(tensor: torch.Tensor):
+        """Lightweight cache sig from a raw tensor, no DLPack overhead."""
+        return (tensor.dtype,)
+
     def __cache_signature__(self):
         return (
             self._orig_dtype,
-            # tuple(self._orig_shape),
-            # tuple(self._orig_strides),
             self.assumed_align,
             self.use_32bit_stride,
         )

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -667,7 +667,8 @@ class JitFunction:
            identity (e.g. TensorAdaptor includes assumed_align).
         2. Python scalars — value in key when not runtime; type only when
            runtime (annotated as Int32/Stream/etc.).
-        3. Tensor-like (dtype+shape) — fallback for bare torch.Tensor.
+        3. Registry raw_cache_signature — lightweight sig from raw arg
+           without full JitArgument construction overhead.
         4. Everything else — type only.
         """
         if hasattr(arg, "__cache_signature__"):
@@ -676,10 +677,11 @@ class JitFunction:
             if runtime:
                 return type(arg)
             return (type(arg), arg)
-        # elif hasattr(arg, "dtype") and hasattr(arg, "shape"):
-        #     strides = tuple(arg.stride()) if hasattr(arg, "stride") else ()
-        #     return (arg.dtype, tuple(arg.shape), strides)
         else:
+            from .jit_argument import JitArgumentRegistry
+            constructor, _ = JitArgumentRegistry.get(type(arg))
+            if constructor is not None and hasattr(constructor, 'raw_cache_signature'):
+                return constructor.raw_cache_signature(arg)
             return type(arg)
 
     def _make_cache_key(self, bound_args):


### PR DESCRIPTION
remove tensor shape from cache signature which results in recompile in runtime.