### PR TITLE
Register Python float to fx.Float32 and bool to fx.Boolean

### DIFF
--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -9,7 +9,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Type, get_origin
 import torch
 
 from .._mlir._mlir_libs._fly import DLTensorAdaptor
-from ..expr.typing import Constexpr, Float32, Int32, Stream, Tensor
+from ..expr.typing import Boolean, Constexpr, Float32, Int32, Stream, Tensor
 from .protocol import DslType, JitArgument
 
 
@@ -214,6 +214,7 @@ def from_dlpack(
     return TensorAdaptor(tensor, assumed_align, use_32bit_stride)
 
 
+JitArgumentRegistry.register(bool)(Boolean)
 JitArgumentRegistry.register(int)(Int32)
 JitArgumentRegistry.register(float)(Float32)
 JitArgumentRegistry.register(torch.cuda.Stream)(Stream)


### PR DESCRIPTION
For passing dynamic float (e.g. softmax scale) to kernel. It can automatically convert a python float to fx.Float32.

There's no natural Python type to map other dtype like int8, fp16, etc. So just add float here.