### PR TITLE
feat(debug): dump LLVM IR when FLYDSL_DUMP_IR=1

### DIFF
--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -342,13 +342,11 @@ def _dump_llvmir(*, dump_dir: Path, asm: str, stage_name: str = "16_llvm_ir"):
 
         mlir_translate = shutil.which("mlir-translate")
         if mlir_translate is None:
-            for candidate in [
-                "/llvm-project/mlir_install/bin/mlir-translate",
-                "/llvm-project/mlir_install_v23/bin/mlir-translate",
-            ]:
-                if Path(candidate).exists():
-                    mlir_translate = candidate
-                    break
+            # Search within the Python package's _mlir_libs directory
+            _mlir_libs = Path(__file__).resolve().parent.parent / "_mlir" / "_mlir_libs"
+            pkg_candidate = _mlir_libs / "mlir-translate"
+            if pkg_candidate.exists():
+                mlir_translate = str(pkg_candidate)
 
         if mlir_translate is None:
             log().debug("[dump_llvmir] mlir-translate not found")

--- a/python/mlir_flydsl/CMakeLists.txt
+++ b/python/mlir_flydsl/CMakeLists.txt
@@ -215,6 +215,9 @@ add_custom_target(CopyFlyPythonSources ALL
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
     "$<TARGET_FILE:mlir_float16_utils>"
     "${_MLIR_LIBS_DIR}/$<TARGET_FILE_NAME:mlir_float16_utils>"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${MLIR_INSTALL_PREFIX}/bin/mlir-translate"
+    "${_MLIR_LIBS_DIR}/mlir-translate"
   COMMENT "Copying python/flydsl sources to build/python_packages/flydsl"
   DEPENDS FlyPythonModules
 )


### PR DESCRIPTION
## Summary

Dump LLVM IR alongside MLIR stages when `FLYDSL_DUMP_IR=1` is set.

Adds `_dump_llvmir()` that extracts the `gpu.module` kernel from the reconcile-unrealized-casts MLIR, wraps it as a standalone LLVM dialect module, and invokes `mlir-translate --mlir-to-llvmir` to produce a `.ll` file alongside the existing ISA dump. No C++ changes required.

### Changes
- **jit_function.py**: Add `_dump_llvmir()` function and call site after ISA dump
- **jit_function.py**: Replace 3x local `import re as _re` with single top-level `import re`

### Usage
```bash
FLYDSL_DUMP_IR=1 python3 your_kernel.py
# Output: $FLYDSL_DUMP_DIR/<kernel>/16_llvm_ir.ll
```