### PR TITLE
Support moe gemm2 bf16 output atomics on gfx942

### DIFF
--- a/kernels/moe_blockscale_2stage.py
+++ b/kernels/moe_blockscale_2stage.py
@@ -1318,6 +1318,10 @@ def compile_moe_blockscale_gemm2(
     _ck_lds128 = os.environ.get("FLYDSL_CK_LDS128", "1") in ("1", "true", "True", "YES", "yes")
     pad_k = 0 if _ck_lds128 else 8
     lds_stride = tile_k + pad_k
+    # gfx950+ has buffer_atomic_pk_add_bf16 → bf16 can use buffer atomics (same as f16).
+    # gfx942 only has global_atomic_pk_add_bf16 → must use global atomics with raw pointer.
+    _has_buffer_atomic_bf16 = str(gpu_arch).startswith(("gfx95", "gfx12"))
+    _needs_global_atomic_bf16 = out_is_bf16 and not _has_buffer_atomic_bf16
     if out_is_bf16:
         if not (gpu_arch.startswith("gfx942") or gpu_arch.startswith("gfx950") or gpu_arch.startswith("gfx12")):
             raise ValueError(f"out_dtype='bf16' requires bf16 global atomics (gfx942/gfx950/gfx12), got arch={gpu_arch!r}")
@@ -2268,12 +2272,11 @@ def compile_moe_blockscale_gemm2(
                             "FLYDSL_MOE_STAGE2_CSHUFFLE=1 but lds_out is not allocated/aliased."
                         )
 
-                    # For bf16 global atomics, precompute the output base address once.
-                    # (We still need an inttoptr per atomic unless we can rely on GEPOp; keep the
-                    # stable path here.)
+                    # For bf16 global atomics (gfx942 only), precompute the output base address.
+                    # gfx950+ has buffer_atomic_pk_add_bf16, so bf16 uses buffer atomics there.
                     out_base_idx = None
-                    if out_is_bf16:
-                        out_base_idx = buffer_ops.extract_memref_base_index(arg_out)
+                    if _needs_global_atomic_bf16:
+                        out_base_idx = buffer_ops.extract_base_index(arg_out)
 
                     def write_row_to_lds(
                         *,
@@ -2330,10 +2333,9 @@ def compile_moe_blockscale_gemm2(
                         col_i32 = arith.index_cast(T.i32, col_g0)
                         idx_elem = idx0 + col_i32
                         idx_elem_even = idx_elem & mask_even_i32
-                        if out_is_bf16:
+                        if _needs_global_atomic_bf16:
+                            # gfx942: no buffer_atomic_pk_add_bf16, use global atomicrmw fadd
                             if bool(accumulate):
-                                # Use global atomicrmw fadd on <2 x bf16> (CK path).
-                                # Row-valid gating is handled at the row level by c_shuffle_epilog via `precompute_row`.
                                 byte_off = idx_elem_even * c2_i32
                                 byte_off_idx = arith.index_cast(T.index, byte_off)
                                 ptr_addr_idx = out_base_idx + byte_off_idx
@@ -2349,9 +2351,9 @@ def compile_moe_blockscale_gemm2(
                                     alignment=4,
                                 )
                             else:
-                                # Scatter store (no atomic): store bf16x(e_vec) directly via buffer store.
                                 buffer_ops.buffer_store(frag, out_rsrc, idx_elem_even)
                         else:
+                            # f16, or bf16 on gfx950+ (has buffer_atomic_pk_add_bf16)
                             byte_off = idx_elem_even * c2_i32
                             if bool(accumulate):
                                 atomic_add_f16x2(frag, byte_off)

--- a/kernels/moe_gemm_2stage.py
+++ b/kernels/moe_gemm_2stage.py
@@ -1371,6 +1371,10 @@ def compile_moe_gemm2(
     _ck_lds128 = os.environ.get("FLYDSL_CK_LDS128", "1") in ("1", "true", "True", "YES", "yes")
     pad_k = 0 if _ck_lds128 else 8
     lds_stride = tile_k + pad_k
+    # gfx950+ has buffer_atomic_pk_add_bf16 → bf16 can use buffer atomics (same as f16).
+    # gfx942 only has global_atomic_pk_add_bf16 → must use global atomics with raw pointer.
+    _has_buffer_atomic_bf16 = str(gpu_arch).startswith(("gfx95", "gfx12"))
+    _needs_global_atomic_bf16 = out_is_bf16 and not _has_buffer_atomic_bf16
     if out_is_bf16:
         if not supports_bf16_global_atomics(gpu_arch):
             raise ValueError(
@@ -2281,12 +2285,11 @@ def compile_moe_gemm2(
                             "FLYDSL_MOE_STAGE2_CSHUFFLE=1 but lds_out is not allocated/aliased."
                         )
 
-                    # For bf16 global atomics, precompute the output base address once.
-                    # (We still need an inttoptr per atomic unless we can rely on GEPOp; keep the
-                    # stable path here.)
+                    # For bf16 global atomics (gfx942 only), precompute the output base address.
+                    # gfx950+ has buffer_atomic_pk_add_bf16, so bf16 uses buffer atomics there.
                     out_base_idx = None
-                    if out_is_bf16:
-                        out_base_idx = buffer_ops.extract_memref_base_index(arg_out)
+                    if _needs_global_atomic_bf16:
+                        out_base_idx = buffer_ops.extract_base_index(arg_out)
 
                     def write_row_to_lds(
                         *,
@@ -2370,10 +2373,9 @@ def compile_moe_gemm2(
                         col_i32 = arith.index_cast(T.i32, col_g0)
                         idx_elem = idx0 + col_i32
                         idx_elem_even = idx_elem & mask_even_i32
-                        if out_is_bf16:
+                        if _needs_global_atomic_bf16:
+                            # gfx942: no buffer_atomic_pk_add_bf16, use global atomicrmw fadd
                             if bool(accumulate):
-                                # Use global atomicrmw fadd on <2 x bf16> (CK path).
-                                # Row-valid gating is handled at the row level by c_shuffle_epilog via `precompute_row`.
                                 byte_off = idx_elem_even * c2_i32
                                 byte_off_idx = arith.index_cast(T.index, byte_off)
                                 ptr_addr_idx = out_base_idx + byte_off_idx
@@ -2389,9 +2391,9 @@ def compile_moe_gemm2(
                                     alignment=4,
                                 )
                             else:
-                                # Scatter store (no atomic): store bf16x(e_vec) directly via buffer store.
                                 buffer_ops.buffer_store(frag, out_rsrc, idx_elem_even)
                         else:
+                            # f16, or bf16 on gfx950+ (has buffer_atomic_pk_add_bf16)
                             byte_off = idx_elem_even * c2_i32
                             if bool(accumulate):
                                 atomic_add_f16x2(frag, byte_off)

--- a/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
+++ b/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
@@ -817,32 +817,13 @@ public:
   LogicalResult matchAndRewrite(ExtractAlignedPointerAsIndexOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     // fly.memref is a bare pointer; after type conversion the operand is llvm.ptr<AS>.
-    // Convert to the result type requested by the op.
+    // Cast to the result type (e.g. llvm.ptr<0>) if address spaces differ.
     Value src = adaptor.getSource();
     Type resultType = getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
       resultType = op.getResult().getType();
-    if (src.getType() != resultType) {
-      if (isa<LLVM::LLVMPointerType>(src.getType()) &&
-          (isa<IntegerType>(resultType) || isa<IndexType>(resultType))) {
-        // ptr -> integer/index: needed when kernel code requires a numeric base
-        // address for pointer arithmetic (e.g. bf16 global atomics on gfx942,
-        // which lacks buffer_atomic_pk_add_bf16 and must use
-        // global_atomic_pk_add_bf16 with a raw pointer).
-        //
-        // PtrToIntOp requires an integer result, so for IndexType we lower
-        // through i64 and insert an index_cast.
-        Type intType = isa<IndexType>(resultType) ? rewriter.getI64Type()
-                                                  : resultType;
-        src = LLVM::PtrToIntOp::create(rewriter, op.getLoc(), intType, src);
-        if (isa<IndexType>(resultType))
-          src = arith::IndexCastOp::create(rewriter, op.getLoc(), resultType,
-                                           src);
-      } else {
-        // ptr -> ptr (different address space): cast between address spaces.
-        src = LLVM::AddrSpaceCastOp::create(rewriter, op.getLoc(), resultType, src);
-      }
-    }
+    if (src.getType() != resultType)
+      src = LLVM::AddrSpaceCastOp::create(rewriter, op.getLoc(), resultType, src);
     rewriter.replaceOp(op, src);
     return success();
   }

--- a/python/flydsl/expr/buffer_ops.py
+++ b/python/flydsl/expr/buffer_ops.py
@@ -75,7 +75,7 @@ __all__ = [
     'buffer_load',
     'buffer_store',
     'BufferResourceDescriptor',
-    'extract_memref_base_index',
+    'extract_base_index',
 ]
 
 
@@ -139,20 +139,19 @@ def create_llvm_ptr(value, address_space: int = 0) -> ir.Value:
     return llvm.IntToPtrOp(ptr_type, value).result
 
 
-def extract_memref_base_index(memref_val) -> ir.Value:
+def extract_base_index(tensor, address_space: int = 1) -> ir.Value:
     """Extract the base address of a fly.memref as an index value.
 
-    On gfx942 the ISA has global_atomic_pk_add_bf16 but NOT
-    buffer_atomic_pk_add_bf16, so bf16 output atomics must use
-    llvm.atomicrmw with a raw pointer instead of buffer atomics.
-    This helper returns the base address as an index so kernel
-    code can compute the target pointer with normal arithmetic.
+    Inverse of :func:`create_llvm_ptr` (index -> ptr). Useful when ISA
+    requires a raw pointer instead of a buffer resource descriptor
+    (e.g. global_atomic_pk_add_bf16 on gfx942).
     """
-    raw_val = _unwrap_value(memref_val)
     from .._mlir.dialects import fly as _fly
-    return _unwrap_value(
-        _fly.extract_aligned_pointer_as_index(ir.IndexType.get(), raw_val)
-    )
+    raw = _unwrap_value(tensor)
+    ptr_type = ir.Type.parse(f'!llvm.ptr<{address_space}>')
+    ptr = _fly.extract_aligned_pointer_as_index(ptr_type, raw)
+    i64_val = llvm.PtrToIntOp(ir.IntegerType.get_signless(64), ptr).result
+    return _unwrap_value(std_arith.IndexCastOp(ir.IndexType.get(), i64_val).result)
 
 
 def get_element_ptr(

--- a/tests/kernels/test_moe_gemm.py
+++ b/tests/kernels/test_moe_gemm.py
@@ -1476,6 +1476,18 @@ class _TorchReduceWrapper:
         return self._mode
 
 
+@pytest.mark.parametrize("use_reduce", [False, True], ids=["atomic", "reduce"])
+def test_moe_gemm_2stage_bf16_out(use_reduce):
+    """Smoke test for bf16 output atomics (gfx942: global atomic, gfx950+: buffer atomic)."""
+    test_moe_gemm_2stage(
+        tokens=64, model_dim=256, inter_dim=128, experts=4, topk=2,
+        tile_m=16, tile_n1=64, tile_k1=128, tile_n2=64, tile_k2=128,
+        doweight_stage1=False, in_dtype="fp8", out_dtype="bf16",
+        use_reduce=use_reduce, use_valid_mask=False, test_graph=False,
+        group_size=-1, num_iters=2, num_warmup=1,
+    )
+
+
 @pytest.mark.parametrize(
     "tokens, model_dim, inter_dim, experts, topk, tile_m, tile_n, tile_k",
     [


### PR DESCRIPTION
gfx942 (MI300) has buffer_atomic_pk_add_f16 but NOT buffer_atomic_pk_add_bf16 - the bf16 variant only exists on gfx950+. Therefore bf16 output atomics must use global_atomic_pk_add_bf16, which requires a raw pointer address instead of a buffer resource descriptor.

The bf16 codepath extracted the output base address via the standard memref.extract_aligned_pointer_as_index, but kernel arguments are !fly.memref (not standard memref), causing an MLIR verification error.

Fix:
- Extend ExtractAlignedPointerAsIndexLowering (FlyToROCDL.cpp) to support integer/index result types via ptrtoint + index_cast, so fly.extract_aligned_pointer_as_index can return index directly. Previously the lowering only handled ptr-to-ptr (addrspacecast).
- Add buffer_ops.extract_memref_base_index() helper that calls fly.extract_aligned_pointer_as_index with IndexType result.
- Use the new helper in moe_gemm_2stage and moe_blockscale_2stage.
- Enable bf16 in the test harness out_dtype mapping and CLI.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
