### PR TITLE
test: roll out tier markers and test docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,8 @@ bash scripts/run_benchmark.sh
 pytest tests/ -k "test_name" -v
 ```
 
+Tiered pytest markers, env vars, and examples: **[`tests/README.md`](tests/README.md)**.
+
 ### Adding Tests
 
 When adding new features or fixing bugs, include tests that cover the changes:

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ bash scripts/run_tests.sh
 bash scripts/run_benchmark.sh
 ```
 
+**Test layout, pytest markers, and environment variables** used by the suite are documented in [**`tests/README.md`**](tests/README.md) .
+
 ### Quick reference
 
 ```bash

--- a/docs/cute_layout_algebra_guide.md
+++ b/docs/cute_layout_algebra_guide.md
@@ -410,11 +410,12 @@ launch(A_torch, B_torch, C_torch, ..., stream=torch.cuda.Stream())
 
 | Variable | Description |
 |---|---|
+| `FLYDSL_COMPILE_BACKEND=rocm` | Compile backend id |
 | `ARCH` | Target architecture (e.g., `gfx942`, `gfx950`) |
 | `FLYDSL_DUMP_IR=1` | Dump intermediate MLIR IR |
 | `FLYDSL_DUMP_DIR=/path` | IR dump location |
-| `FLYDSL_COMPILE_ONLY=1` | Skip execution, compile only |
-| `FLYDSL_NO_CACHE=1` | Disable compilation cache |
+| `COMPILE_ONLY=1` | Skip execution, compile only |
+| `FLYDSL_RUNTIME_ENABLE_CACHE=0` | Disable compilation cache |
 | `FLYDSL_RUNTIME_CACHE_DIR=/path` | Cache directory (default: `~/.flydsl/cache/`) |
 
 ---

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,93 @@
+# FlyDSL tests
+
+Pytest configuration lives in [`pytest.ini`](pytest.ini) in this directory. Run pytest from the **repository root** (or pass `-c tests/pytest.ini`) so this file is picked up.
+
+## Test tiering (RFC 0003)
+
+The project uses a **layered model** so CI and contributors can select tests by dependency (CPU-only vs MLIR with ROCDL vs real GPU). The full specification is [**RFC 0003: Test tiering and multi-backend CI matrix**](../rfc/0003-test-tiering-and-backend-matrix.md).
+
+| Tier | Meaning |
+|------|---------|
+| **L0** | Backend-agnostic: no `FLYDSL_COMPILE_BACKEND` / device-runtime assumption; no vendor target dialect (`rocdl`, …). |
+| **L1a** | Compile-tier, **no** vendor target dialect; portable Fly + upstream dialects only. |
+| **L1b** | Compile-tier with **target-specific** lowering (e.g. Fly→ROCDL); still **no** GPU execution for correctness. |
+| **L2** | Device-tier: needs GPU, driver, and runtime (often PyTorch) for launch and checks. |
+
+**Pytest markers** (registered in `pytest.ini`) mirror these tiers:
+
+| Marker | Typical tier |
+|--------|----------------|
+| `l0_backend_agnostic` | L0 |
+| `l1a_compile_no_target_dialect` | L1a |
+| `l1b_target_dialect` | L1b |
+| `l2_device` | L2 |
+| `rocm_lower` | Use **with** `l1b_target_dialect` or `l2_device` when the test assumes the ROCDL stack. |
+
+**Legacy:** `large_shape` — used for slow/large kernel shapes; `scripts/run_tests.sh` skips it unless `RUN_TESTS_FULL=1`.
+
+### Rollout status
+
+First-pass annotations now cover `tests/unit` and `tests/kernels` for clearly classified files (L0/L1a/L1b/L2).
+
+Current high-traffic mapping:
+
+- `tests/kernels/*.py`: `l2_device` + `rocm_lower`
+- `tests/unit/*`: mixed by file (`l0_backend_agnostic`, `l1a_compile_no_target_dialect`, `l1b_target_dialect + rocm_lower`, `l2_device + rocm_lower`)
+- `tests/mlir/Conversion/*.mlir`: treated as L1b + ROCm-lowering coverage (selected by FileCheck runner, not pytest markers)
+- `tests/mlir/LayoutAlgebra/*.mlir`: treated as L1a compile-tier coverage where applicable (FileCheck, not pytest markers)
+
+## Environment variables (source of truth: `env.py`)
+
+Use the same names as [`python/flydsl/utils/env.py`](../python/flydsl/utils/env.py). Do not introduce alternate spellings in scripts or docs.
+
+| Purpose | Variable |
+|---------|----------|
+| Compile backend id | `FLYDSL_COMPILE_BACKEND` (default `rocm`) |
+| Override GPU arch for compile | `ARCH` |
+| Compile without execution | `COMPILE_ONLY` |
+| JIT cache directory | `FLYDSL_RUNTIME_CACHE_DIR` |
+| Enable/disable JIT cache | `FLYDSL_RUNTIME_ENABLE_CACHE` (`0` / `false` to disable) |
+| IR dump | `FLYDSL_DUMP_IR`, `FLYDSL_DUMP_DIR` |
+| Device runtime kind | `FLYDSL_RUNTIME_KIND` |
+| ROCm arch hints (detection helpers) | `FLYDSL_GPU_ARCH`, `HSA_OVERRIDE_GFX_VERSION` |
+
+Session-level pytest options are supported in `tests/conftest.py`:
+
+- `--flydsl-compile-backend` -> sets `FLYDSL_COMPILE_BACKEND`
+- `--flydsl-compile-arch` -> sets `ARCH`
+
+When these options are unset, default environment behavior remains unchanged.
+
+## Running pytest
+
+From the repo root after a successful build / `pip install -e .`:
+
+```bash
+export PYTHONPATH="${PWD}/build-fly/python_packages:${PWD}:${PYTHONPATH}"
+export LD_LIBRARY_PATH="${PWD}/build-fly/python_packages/flydsl/_mlir/_mlir_libs:${LD_LIBRARY_PATH}"
+```
+
+Examples:
+
+```bash
+# Default: full pytest areas (same idea as scripts/run_tests.sh pytest step)
+python3 -m pytest tests/kernels/ tests/unit/ tests/python/examples/ -v
+
+# Exclude large shapes (matches run_tests.sh when RUN_TESTS_FULL is unset)
+python3 -m pytest tests/kernels/ tests/unit/ tests/python/examples/ -m "not large_shape" -v
+
+# When tests are annotated — examples (forward-looking)
+# python3 -m pytest tests/ -m "l0_backend_agnostic or l1a_compile_no_target_dialect" -v
+# python3 -m pytest tests/ -m "l2_device" -v
+```
+
+Disable JIT cache while iterating:
+
+```bash
+export FLYDSL_RUNTIME_ENABLE_CACHE=0
+```
+
+## MLIR FileCheck tests
+
+`tests/mlir/**/*.mlir` checks are driven by **`scripts/run_tests.sh`** (FileCheck + `fly-opt`), not by pytest. Tiering for those may be documented in parallel in this README as the RFC rollout continues; see RFC open questions.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,12 +91,35 @@ def insert_point(ctx):
         yield InsertionPoint.current
 
 
+def pytest_addoption(parser):
+    """Add FlyDSL test-session options that map to env variables."""
+    group = parser.getgroup("flydsl")
+    group.addoption(
+        "--flydsl-compile-backend",
+        action="store",
+        default=None,
+        help="Set FLYDSL_COMPILE_BACKEND for this pytest session.",
+    )
+    group.addoption(
+        "--flydsl-compile-arch",
+        action="store",
+        default=None,
+        help="Set ARCH for this pytest session.",
+    )
+
+
 def pytest_configure(config):
-    """Register custom markers."""
+    """Register custom markers and apply FlyDSL env overrides."""
     config.addinivalue_line(
         "markers",
         "large_shape: marks tests with large shapes that are slow to run (deselect with '-m \"not large_shape\"')",
     )
+    backend = config.getoption("--flydsl-compile-backend")
+    arch = config.getoption("--flydsl-compile-arch")
+    if backend:
+        os.environ["FLYDSL_COMPILE_BACKEND"] = backend
+    if arch:
+        os.environ["ARCH"] = arch
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/kernels/test_blockscale_preshuffle_gemm.py
+++ b/tests/kernels/test_blockscale_preshuffle_gemm.py
@@ -14,6 +14,8 @@ import torch
 import torch.nn.functional as F
 import pytest
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))

--- a/tests/kernels/test_layernorm.py
+++ b/tests/kernels/test_layernorm.py
@@ -23,6 +23,8 @@ from tests.kernels.benchmark_common import (
     print_perf_table,
 )
 import pytest
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 try:
     import torch
 except ImportError:

--- a/tests/kernels/test_moe_blockscale.py
+++ b/tests/kernels/test_moe_blockscale.py
@@ -23,6 +23,8 @@ import torch
 import torch.nn.functional as F
 import pytest
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 _PYTHON_CANDIDATES = [
     os.path.join(_REPO_ROOT, "build", "python_packages"),

--- a/tests/kernels/test_moe_gemm.py
+++ b/tests/kernels/test_moe_gemm.py
@@ -14,6 +14,8 @@ import flydsl.compiler as flyc
 import pytest
 import torch
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 # -----------------------------------------------------------------------------
 # Ensure we use the repo-local `flydsl` when running this file directly.
 #

--- a/tests/kernels/test_moe_reduce.py
+++ b/tests/kernels/test_moe_reduce.py
@@ -22,6 +22,8 @@ from typing import Tuple
 import pytest
 import torch
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 _PYTHON_CANDIDATES = [
     os.path.join(_REPO_ROOT, "build", "python_packages"),

--- a/tests/kernels/test_mxfp4_gemm_gfx1250.py
+++ b/tests/kernels/test_mxfp4_gemm_gfx1250.py
@@ -20,6 +20,8 @@ import flydsl  # noqa: E402,F401 -- preload system comgr before torch/HIP loads 
 import pytest
 import torch
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 from flydsl.runtime.device import get_rocm_arch
 from kernels.mxfp4_gemm_gfx1250 import compile_mxfp4_gemm
 from tests.kernels.utils import fp4_utils

--- a/tests/kernels/test_pa.py
+++ b/tests/kernels/test_pa.py
@@ -5,6 +5,8 @@
 import sys, os, torch, math, logging, random, gc
 import pytest
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 sys.path.insert(0, 'build-fly/python_packages'); sys.path.insert(1, '.')
 os.environ['FLYDSL_RUNTIME_ENABLE_CACHE'] = '1'
 logging.basicConfig(level=logging.INFO, format='%(message)s')

--- a/tests/kernels/test_preshuffle_gemm.py
+++ b/tests/kernels/test_preshuffle_gemm.py
@@ -18,6 +18,8 @@ import torch
 import torch.nn.functional as F
 import pytest
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 _PYFLYDSL_SRC = os.path.join(_REPO_ROOT, "flydsl", "src")
 if _REPO_ROOT not in sys.path:

--- a/tests/kernels/test_quant.py
+++ b/tests/kernels/test_quant.py
@@ -22,6 +22,8 @@ import argparse
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 _RUN_QUANT = os.environ.get("FLYDSL_RUN_QUANT", "").strip().lower() in ("1", "true", "yes", "on")
 if not _RUN_QUANT:
     _reason = "Per-token quant benchmark temporarily disabled (set FLYDSL_RUN_QUANT=1 to enable)."

--- a/tests/kernels/test_rdna_gemm.py
+++ b/tests/kernels/test_rdna_gemm.py
@@ -13,6 +13,8 @@ import logging
 import torch
 import pytest
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)

--- a/tests/kernels/test_rmsnorm.py
+++ b/tests/kernels/test_rmsnorm.py
@@ -23,6 +23,8 @@ from tests.kernels.benchmark_common import (
     print_perf_table,
 )
 import pytest
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 try:
     import torch
 except ImportError:

--- a/tests/kernels/test_softmax.py
+++ b/tests/kernels/test_softmax.py
@@ -15,6 +15,8 @@ Implementation based on high-performance C++ kernel logic:
 import os
 
 import pytest
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 try:
     import torch
 except ImportError:

--- a/tests/kernels/test_vec_add.py
+++ b/tests/kernels/test_vec_add.py
@@ -10,6 +10,8 @@ import os
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 try:
     import torch
 except ImportError:

--- a/tests/kernels/test_wmma_gemm_gfx1250.py
+++ b/tests/kernels/test_wmma_gemm_gfx1250.py
@@ -21,6 +21,8 @@ import flydsl  # noqa: E402,F401 -- preload system comgr before torch/HIP loads 
 import pytest
 import torch
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 from flydsl.runtime.device import get_rocm_arch
 from kernels.wmma_gemm_gfx1250 import compile_wmma_gemm_tdm
 from tests.test_common import verify_output

--- a/tests/kernels/test_wmma_gemm_simple.py
+++ b/tests/kernels/test_wmma_gemm_simple.py
@@ -11,6 +11,8 @@ import sys
 import pytest
 import torch
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 _PYFLIR_SRC = os.path.join(_REPO_ROOT, "flydsl", "src")
 if _REPO_ROOT not in sys.path:

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -6,3 +6,8 @@ python_functions = test_*
 addopts = -v --tb=short
 markers =
     large_shape: marks tests with large problem sizes (deselect with '-m "not large_shape"')
+    l0_backend_agnostic: no compile/runtime backend assumption; no vendor target dialect
+    l1a_compile_no_target_dialect: MLIR compile path without vendor target dialects (see tests/README.md)
+    l1b_target_dialect: requires a target lowering stack; pair with rocm_lower (or future backend markers)
+    l2_device: requires GPU and full runtime stack for execution/correctness
+    rocm_lower: L1b/L2 tests that assume the ROCDL lowering path

--- a/tests/unit/test_async_object_vs_deps.py
+++ b/tests/unit/test_async_object_vs_deps.py
@@ -12,6 +12,8 @@ import textwrap
 
 import pytest
 
+pytestmark = [pytest.mark.l1b_target_dialect, pytest.mark.rocm_lower]
+
 
 def _find_fly_opt():
     if "FLY_OPT" in os.environ:

--- a/tests/unit/test_device_runtime.py
+++ b/tests/unit/test_device_runtime.py
@@ -7,6 +7,8 @@ import pytest
 
 import flydsl.runtime.device_runtime as dr
 
+pytestmark = [pytest.mark.l0_backend_agnostic]
+
 
 @pytest.fixture(autouse=True)
 def _reset_device_runtime_singleton():

--- a/tests/unit/test_jit_stream_param.py
+++ b/tests/unit/test_jit_stream_param.py
@@ -10,6 +10,8 @@ Validates end-to-end that:
 """
 import pytest
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 try:
     import torch
 except ImportError:

--- a/tests/unit/test_kernel_dynamic_smem_types.py
+++ b/tests/unit/test_kernel_dynamic_smem_types.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 try:
     import torch
 except ImportError:

--- a/tests/unit/test_kernel_known_block_size.py
+++ b/tests/unit/test_kernel_known_block_size.py
@@ -4,6 +4,8 @@ import re
 
 import pytest
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 try:
     import torch
 except ImportError:

--- a/tests/unit/test_kernel_range_dynamic_upper_bound.py
+++ b/tests/unit/test_kernel_range_dynamic_upper_bound.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 try:
     import torch
 except ImportError:

--- a/tests/unit/test_launch_overhead.py
+++ b/tests/unit/test_launch_overhead.py
@@ -15,6 +15,10 @@ Usage:
 import time
 import torch
 
+import pytest
+
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 # ─────────────────────────────────────────────────────────────────
 # 1. FlyDSL vec_add
 # ─────────────────────────────────────────────────────────────────

--- a/tests/unit/test_layout_algebra.py
+++ b/tests/unit/test_layout_algebra.py
@@ -22,6 +22,8 @@ from flydsl._mlir.dialects.fly import IntTupleType
 from flydsl._mlir.dialects import fly, arith, func
 import flydsl.expr as fx
 
+pytestmark = [pytest.mark.l1b_target_dialect, pytest.mark.rocm_lower]
+
 
 FLY_PIPELINE = (
     "builtin.module("

--- a/tests/unit/test_multi_stream_launch.py
+++ b/tests/unit/test_multi_stream_launch.py
@@ -14,6 +14,8 @@ Covers:
 """
 import pytest
 
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
 try:
     import torch
 except ImportError:

--- a/tests/unit/test_rocir_print.py
+++ b/tests/unit/test_rocir_print.py
@@ -13,6 +13,9 @@ from flydsl._mlir.dialects import arith, func, gpu
 from flydsl._mlir.passmanager import PassManager
 from flydsl.compiler.kernel_function import create_gpu_module, get_gpu_module_body, create_gpu_func
 import flydsl.expr as fx
+import pytest
+
+pytestmark = [pytest.mark.l1a_compile_no_target_dialect]
 
 
 def _build_cpu_module(build_fn):

--- a/tests/unit/test_static_vs_dynamic.py
+++ b/tests/unit/test_static_vs_dynamic.py
@@ -18,6 +18,8 @@ from flydsl._mlir.ir import (
 from flydsl._mlir.dialects.fly import IntTupleType
 from flydsl._mlir.dialects import fly, arith, func
 
+pytestmark = [pytest.mark.l1b_target_dialect, pytest.mark.rocm_lower]
+
 
 FLY_PIPELINE = (
     "builtin.module("


### PR DESCRIPTION
Establishes an RFC-aligned test tiering baseline by registering L0/L1a/L1b/L2 markers, annotating high-traffic unit/kernel suites, and aligning contributor docs with env.py naming and pytest session options for consistent test selection.

Made-with: Cursor
