### PR TITLE
refactor(Conversion): per-backend TableGen for FlyToROCDL

### DIFF
--- a/include/flydsl/Conversion/CMakeLists.txt
+++ b/include/flydsl/Conversion/CMakeLists.txt
@@ -1,8 +1,1 @@
-set(LLVM_TARGET_DEFINITIONS Passes.td)
-mlir_tablegen(Passes.h.inc -gen-pass-decls -name Conversion)
-mlir_tablegen(Passes.capi.h.inc -gen-pass-capi-header --prefix Conversion)
-mlir_tablegen(Passes.capi.cpp.inc -gen-pass-capi-impl --prefix Conversion)
-
-add_mlir_generic_tablegen_target(FlyConversionPassIncGen)
-
-
+add_subdirectory(FlyToROCDL)

--- a/include/flydsl/Conversion/FlyToROCDL/CMakeLists.txt
+++ b/include/flydsl/Conversion/FlyToROCDL/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name FlyToROCDL)
+mlir_tablegen(Passes.capi.h.inc -gen-pass-capi-header --prefix FlyToROCDL)
+mlir_tablegen(Passes.capi.cpp.inc -gen-pass-capi-impl --prefix FlyToROCDL)
+
+add_mlir_generic_tablegen_target(FlyToROCDLPassIncGen)

--- a/include/flydsl/Conversion/FlyToROCDL/FlyToROCDL.h
+++ b/include/flydsl/Conversion/FlyToROCDL/FlyToROCDL.h
@@ -9,7 +9,7 @@
 namespace mlir {
 #define GEN_PASS_DECL_FLYTOROCDLCONVERSIONPASS
 #define GEN_PASS_DECL_FLYROCDLCLUSTERATTRPASS
-#include "flydsl/Conversion/Passes.h.inc"
+#include "flydsl/Conversion/FlyToROCDL/Passes.h.inc"
 } // namespace mlir
 
 #endif // CONVERSION_FLYTOROCDL_FLYTOROCDL_H

--- a/include/flydsl/Conversion/FlyToROCDL/Passes.td
+++ b/include/flydsl/Conversion/FlyToROCDL/Passes.td
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 FlyDSL Project Contributors
 
-#ifndef FLYDSL_CONVERSION_PASSES
-#define FLYDSL_CONVERSION_PASSES
-
 include "mlir/Pass/PassBase.td"
 
 def FlyToROCDLConversionPass : Pass<"convert-fly-to-rocdl"> {
@@ -31,5 +28,3 @@ def FlyROCDLClusterAttrPass : Pass<"fly-rocdl-cluster-attr"> {
     "LLVM::LLVMDialect"
   ];
 }
-
-#endif // FLYDSL_CONVERSION_PASSES

--- a/include/flydsl/Conversion/Passes.h
+++ b/include/flydsl/Conversion/Passes.h
@@ -10,7 +10,7 @@
 namespace mlir {
 
 #define GEN_PASS_REGISTRATION
-#include "flydsl/Conversion/Passes.h.inc"
+#include "flydsl/Conversion/FlyToROCDL/Passes.h.inc"
 
 } // namespace mlir
 

--- a/lib/Conversion/FlyToROCDL/CMakeLists.txt
+++ b/lib/Conversion/FlyToROCDL/CMakeLists.txt
@@ -4,7 +4,7 @@ add_mlir_conversion_library(MLIRFlyToROCDL
   DEPENDS
   MLIRFlyIncGen
   MLIRFlyROCDLIncGen
-  FlyConversionPassIncGen
+  FlyToROCDLPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRFlyDialect

--- a/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
+++ b/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
@@ -27,7 +27,7 @@
 namespace mlir {
 #define GEN_PASS_DEF_FLYTOROCDLCONVERSIONPASS
 #define GEN_PASS_DEF_FLYROCDLCLUSTERATTRPASS
-#include "flydsl/Conversion/Passes.h.inc"
+#include "flydsl/Conversion/FlyToROCDL/Passes.h.inc"
 } // namespace mlir
 
 using namespace mlir;


### PR DESCRIPTION
Move Fly conversion passes from shared Conversion/Passes.td into include/flydsl/Conversion/FlyToROCDL/ with a dedicated FlyToROCDLPassIncGen target. Central Passes.h registers via FlyToROCDL/Passes.h.inc.

Implements the layout proposed in https://github.com/ROCm/FlyDSL/issues/240 for easier addition of future backends without editing a global Passes.td.

Made-with: Cursor
