### PR TITLE
【3/N】add RDNA4 PA decode FP8 kernel, refactor shared reduce code

### DIFF
--- a/kernels/pa_common.py
+++ b/kernels/pa_common.py
@@ -1,0 +1,416 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Shared code for paged-attention FP8 decode kernels (CDNA + RDNA).
+
+Contains:
+  - Constants (QUERY_GROUP_SIZE, HEAD_SIZE, etc.)
+  - Stride computation (compute_pa_strides)
+  - Reduce kernels (build_ps_reduce_kernel, build_v2_reduce_kernel)
+"""
+
+from __future__ import annotations
+import math as _math
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import arith, gpu, buffer_ops
+from flydsl.expr.typing import T, Int32
+
+# ============================================================================
+# Shared constants
+# ============================================================================
+
+QUERY_GROUP_SIZE = 16
+HEAD_SIZE = 128
+KV_BLOCK_SIZE = 16
+KV_COMPUTE_BLOCK = 256
+FP8_MAX = 240.0
+LOG2E = 1.4426950408889634
+
+
+# ============================================================================
+# Stride computation
+# ============================================================================
+
+def compute_pa_strides(
+    num_kv_heads,
+    num_partitions,
+    max_blocks_per_seq,
+    kv_block_size=16,
+    trans_v=False,
+    one_shot=False,
+    ps_num_splits=0,
+):
+    """Compute all strides needed by the PA decode dot kernel.
+
+    Returns a dict with stride values and derived parameters.
+    """
+    _bs = kv_block_size
+    _num_heads = num_kv_heads * QUERY_GROUP_SIZE
+
+    s = dict(
+        stride_q_seq=_num_heads * HEAD_SIZE,
+        stride_q_head=HEAD_SIZE,
+        stride_k_block=num_kv_heads * (HEAD_SIZE // 16) * _bs * 16,
+        stride_k_head=(HEAD_SIZE // 16) * _bs * 16,
+        stride_bt_seq=max_blocks_per_seq,
+    )
+
+    if trans_v:
+        s["stride_v_block"] = num_kv_heads * (_bs // 16) * HEAD_SIZE * 16
+        s["stride_v_head"] = (_bs // 16) * HEAD_SIZE * 16
+    else:
+        s["stride_v_block"] = num_kv_heads * HEAD_SIZE * _bs
+        s["stride_v_head"] = HEAD_SIZE * _bs
+
+    _direct_output = one_shot or (ps_num_splits > 0)
+    if _direct_output:
+        s["stride_out_part"] = 0
+        s["stride_out_head"] = QUERY_GROUP_SIZE * HEAD_SIZE
+        s["stride_out_seq"] = num_kv_heads * QUERY_GROUP_SIZE * HEAD_SIZE
+    else:
+        s["stride_out_part"] = QUERY_GROUP_SIZE * HEAD_SIZE
+        s["stride_out_head"] = num_partitions * QUERY_GROUP_SIZE * HEAD_SIZE
+        s["stride_out_seq"] = num_kv_heads * num_partitions * QUERY_GROUP_SIZE * HEAD_SIZE
+
+    s["stride_es_seq"] = num_kv_heads * num_partitions * QUERY_GROUP_SIZE
+    s["stride_ml_seq"] = num_kv_heads * num_partitions * QUERY_GROUP_SIZE
+
+    # Derived
+    s["use_large_block"] = _bs > KV_BLOCK_SIZE
+    s["partitions_per_block"] = _bs // KV_COMPUTE_BLOCK if s["use_large_block"] else 1
+    s["blocks_per_partition"] = KV_COMPUTE_BLOCK // _bs if not s["use_large_block"] else 1
+    s["ps_mode"] = ps_num_splits > 0
+    s["max_pps"] = _math.ceil(num_partitions / ps_num_splits) if s["ps_mode"] else 1
+
+    return s
+
+
+# ============================================================================
+# Reduce kernels (architecture-independent scalar code)
+# ============================================================================
+
+NEG_INF_VAL = float("-inf")
+
+
+def _exp_f32(x, log2e_const):
+    """Compute exp(x) = exp2(x * LOG2E) using hardware exp2."""
+    return (x * log2e_const).exp2(fastmath=arith.FastMathFlags.fast)
+
+
+def build_ps_reduce_kernel(
+    head_size: int,
+    query_group_size: int,
+    query_seq_len: int,
+    max_context_partition_num: int,
+    use_sinks: bool = False,
+):
+    """Build the ps_reduce kernel (fixed MAX_CONTEXT_PARTITION_NUM, single-pass)."""
+    qg_total = query_seq_len * query_group_size
+
+    @flyc.kernel
+    def ps_reduce_kernel(
+        output_ptr: fx.Tensor,
+        exp_sums_ptr: fx.Tensor,
+        max_logits_ptr: fx.Tensor,
+        partial_output_ptr: fx.Tensor,
+        sink_token_ptr: fx.Tensor,
+        context_partition_num: Int32,
+        stride_output_bs: Int32,
+        stride_output_len: Int32,
+        stride_output_kv_head: Int32,
+        stride_output_group: Int32,
+        stride_es_seq: Int32,
+        stride_es_head: Int32,
+        stride_es_part: Int32,
+        stride_po_seq: Int32,
+        stride_po_head: Int32,
+        stride_po_part: Int32,
+        stride_po_group: Int32,
+    ):
+        seq_idx = gpu.block_idx.x
+        kv_head_idx = gpu.block_idx.y
+
+        es_rsrc = buffer_ops.create_buffer_resource(exp_sums_ptr, max_size=True)
+        ml_rsrc = buffer_ops.create_buffer_resource(max_logits_ptr, max_size=True)
+        po_rsrc = buffer_ops.create_buffer_resource(partial_output_ptr, max_size=True)
+        out_rsrc = buffer_ops.create_buffer_resource(output_ptr, max_size=True)
+
+        LOG2E_C = arith.constant(LOG2E, type=T.f32)
+        NEG_INF = arith.constant(NEG_INF_VAL, type=T.f32)
+        ZERO_F = fx.Float32(0.0)
+
+        tid = gpu.thread_idx.x
+
+        for qg in range(qg_total):
+            qg_i32 = fx.Int32(qg)
+            ql_idx = fx.Int32(qg // query_group_size)
+            gr_idx = fx.Int32(qg % query_group_size)
+
+            global_max = NEG_INF
+            for p in range(max_context_partition_num):
+                p_i32 = fx.Int32(p)
+                p_valid = p_i32 < context_partition_num
+                es_off = seq_idx * stride_es_seq + kv_head_idx * stride_es_head + p_i32 * stride_es_part + qg_i32
+                ml_val = buffer_ops.buffer_load(ml_rsrc, es_off, vec_width=1, dtype=T.f32)
+                ml_val = p_valid.select(ml_val, NEG_INF)
+                global_max = global_max.maximumf(ml_val)
+
+            total_exp_sum = ZERO_F
+            for p in range(max_context_partition_num):
+                p_i32 = fx.Int32(p)
+                p_valid = p_i32 < context_partition_num
+                es_off = seq_idx * stride_es_seq + kv_head_idx * stride_es_head + p_i32 * stride_es_part + qg_i32
+                ml_val = buffer_ops.buffer_load(ml_rsrc, es_off, vec_width=1, dtype=T.f32)
+                ml_val = p_valid.select(ml_val, NEG_INF)
+                es_val = buffer_ops.buffer_load(es_rsrc, es_off, vec_width=1, dtype=T.f32)
+                es_val = p_valid.select(es_val, ZERO_F)
+                rescaled = es_val * _exp_f32(ml_val - global_max, LOG2E_C)
+                total_exp_sum = total_exp_sum + rescaled
+
+            if use_sinks:
+                sink_rsrc = buffer_ops.create_buffer_resource(sink_token_ptr, max_size=True)
+                sink_off = kv_head_idx * fx.Int32(query_group_size) + gr_idx
+                sink_val = buffer_ops.buffer_load(sink_rsrc, sink_off, vec_width=1, dtype=T.f32)
+                sink_contrib = _exp_f32(sink_val - global_max, LOG2E_C)
+                total_exp_sum = total_exp_sum + sink_contrib
+
+            for h in range(head_size):
+                h_i32 = fx.Int32(h)
+                acc = ZERO_F
+                for p in range(max_context_partition_num):
+                    p_i32 = fx.Int32(p)
+                    p_valid = p_i32 < context_partition_num
+                    es_off = seq_idx * stride_es_seq + kv_head_idx * stride_es_head + p_i32 * stride_es_part + qg_i32
+                    ml_val = buffer_ops.buffer_load(ml_rsrc, es_off, vec_width=1, dtype=T.f32)
+                    ml_val = p_valid.select(ml_val, NEG_INF)
+                    es_val = buffer_ops.buffer_load(es_rsrc, es_off, vec_width=1, dtype=T.f32)
+                    es_val = p_valid.select(es_val, ZERO_F)
+                    rescaled = es_val * _exp_f32(ml_val - global_max, LOG2E_C)
+                    attn_prob = rescaled / total_exp_sum
+                    po_off = (
+                        seq_idx * stride_po_seq
+                        + kv_head_idx * stride_po_head
+                        + p_i32 * stride_po_part
+                        + qg_i32 * stride_po_group
+                        + h_i32
+                    )
+                    po_val = buffer_ops.buffer_load(po_rsrc, po_off, vec_width=1, dtype=T.f32)
+                    po_val = p_valid.select(po_val, ZERO_F)
+                    acc = acc + po_val * attn_prob
+
+                out_off = (
+                    seq_idx * stride_output_bs
+                    + ql_idx * stride_output_len
+                    + kv_head_idx * stride_output_kv_head
+                    + gr_idx * stride_output_group
+                    + h_i32
+                )
+                buffer_ops.buffer_store(acc, out_rsrc, out_off)
+
+    @flyc.jit
+    def launch_ps_reduce(
+        output: fx.Tensor,
+        exp_sums: fx.Tensor,
+        max_logits: fx.Tensor,
+        partial_output: fx.Tensor,
+        sink_token: fx.Tensor,
+        context_partition_num: Int32,
+        stride_output_bs: Int32,
+        stride_output_len: Int32,
+        stride_output_kv_head: Int32,
+        stride_output_group: Int32,
+        stride_es_seq: Int32,
+        stride_es_head: Int32,
+        stride_es_part: Int32,
+        stride_po_seq: Int32,
+        stride_po_head: Int32,
+        stride_po_part: Int32,
+        stride_po_group: Int32,
+        num_seqs: Int32,
+        num_kv_heads: Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        ps_reduce_kernel(
+            output, exp_sums, max_logits, partial_output, sink_token,
+            context_partition_num,
+            stride_output_bs, stride_output_len,
+            stride_output_kv_head, stride_output_group,
+            stride_es_seq, stride_es_head, stride_es_part,
+            stride_po_seq, stride_po_head, stride_po_part, stride_po_group,
+        ).launch(
+            grid=(num_seqs, num_kv_heads),
+            block=(1,),
+            stream=stream,
+        )
+
+    return ps_reduce_kernel, launch_ps_reduce
+
+
+def build_v2_reduce_kernel(
+    head_size: int,
+    query_group_size: int,
+    query_seq_len: int,
+    context_partition_size: int,
+    max_chunk_size: int = 16,
+    use_sinks: bool = False,
+):
+    """Build the v2_reduce kernel (dynamic partition count, two-pass loop)."""
+    qg_total = query_seq_len * query_group_size
+
+    @flyc.kernel
+    def v2_reduce_kernel(
+        output_ptr: fx.Tensor,
+        exp_sums_ptr: fx.Tensor,
+        max_logits_ptr: fx.Tensor,
+        partial_output_ptr: fx.Tensor,
+        context_lengths_ptr: fx.Tensor,
+        sink_token_ptr: fx.Tensor,
+        stride_output_bs: Int32,
+        stride_output_len: Int32,
+        stride_output_kv_head: Int32,
+        stride_output_group: Int32,
+        stride_es_seq: Int32,
+        stride_es_head: Int32,
+        stride_es_part: Int32,
+        stride_po_seq: Int32,
+        stride_po_head: Int32,
+        stride_po_part: Int32,
+        stride_po_group: Int32,
+    ):
+        seq_idx = gpu.block_idx.x
+        kv_head_idx = gpu.block_idx.y
+
+        cl_rsrc = buffer_ops.create_buffer_resource(context_lengths_ptr, max_size=True)
+        ctx_len = buffer_ops.buffer_load(cl_rsrc, seq_idx, vec_width=1, dtype=T.i32)
+        cps_const = fx.Int32(context_partition_size)
+        context_partition_num = (ctx_len + cps_const - 1) / cps_const
+
+        es_rsrc = buffer_ops.create_buffer_resource(exp_sums_ptr, max_size=True)
+        ml_rsrc = buffer_ops.create_buffer_resource(max_logits_ptr, max_size=True)
+        po_rsrc = buffer_ops.create_buffer_resource(partial_output_ptr, max_size=True)
+        out_rsrc = buffer_ops.create_buffer_resource(output_ptr, max_size=True)
+
+        LOG2E_C = arith.constant(LOG2E, type=T.f32)
+        NEG_INF = arith.constant(NEG_INF_VAL, type=T.f32)
+        ZERO_F = fx.Float32(0.0)
+        ONE_F = fx.Float32(1.0)
+        CHUNK = fx.Int32(max_chunk_size)
+
+        for qg in range(qg_total):
+            qg_i32 = fx.Int32(qg)
+            ql_idx = fx.Int32(qg // query_group_size)
+            gr_idx = fx.Int32(qg % query_group_size)
+
+            global_max = NEG_INF
+            global_exp_sum = ZERO_F
+
+            for chunk_base in range(0, max_chunk_size * 64, max_chunk_size):
+                chunk_base_i32 = fx.Int32(chunk_base)
+                chunk_active = chunk_base_i32 < context_partition_num
+                prev_global_max = global_max
+
+                for p_in_chunk in range(max_chunk_size):
+                    p_i32 = chunk_base_i32 + fx.Int32(p_in_chunk)
+                    p_valid = p_i32 < context_partition_num
+                    es_off = seq_idx * stride_es_seq + kv_head_idx * stride_es_head + p_i32 * stride_es_part + qg_i32
+                    ml_val = buffer_ops.buffer_load(ml_rsrc, es_off, vec_width=1, dtype=T.f32)
+                    ml_val = p_valid.select(ml_val, NEG_INF)
+                    global_max = global_max.maximumf(ml_val)
+
+                update_scale = _exp_f32(prev_global_max - global_max, LOG2E_C)
+                global_exp_sum = global_exp_sum * update_scale
+
+                for p_in_chunk in range(max_chunk_size):
+                    p_i32 = chunk_base_i32 + fx.Int32(p_in_chunk)
+                    p_valid = p_i32 < context_partition_num
+                    es_off = seq_idx * stride_es_seq + kv_head_idx * stride_es_head + p_i32 * stride_es_part + qg_i32
+                    ml_val = buffer_ops.buffer_load(ml_rsrc, es_off, vec_width=1, dtype=T.f32)
+                    ml_val = p_valid.select(ml_val, NEG_INF)
+                    es_val = buffer_ops.buffer_load(es_rsrc, es_off, vec_width=1, dtype=T.f32)
+                    es_val = p_valid.select(es_val, ZERO_F)
+                    rescaled = es_val * _exp_f32(ml_val - global_max, LOG2E_C)
+                    global_exp_sum = global_exp_sum + rescaled
+
+            if use_sinks:
+                sink_rsrc = buffer_ops.create_buffer_resource(sink_token_ptr, max_size=True)
+                sink_off = kv_head_idx * fx.Int32(query_seq_len * query_group_size) + qg_i32
+                sink_val = buffer_ops.buffer_load(sink_rsrc, sink_off, vec_width=1, dtype=T.f32)
+                sink_contrib = _exp_f32(sink_val - global_max, LOG2E_C)
+                global_exp_sum = global_exp_sum + sink_contrib
+
+            for h in range(head_size):
+                h_i32 = fx.Int32(h)
+                acc = ZERO_F
+
+                for chunk_base in range(0, max_chunk_size * 64, max_chunk_size):
+                    chunk_base_i32 = fx.Int32(chunk_base)
+                    for p_in_chunk in range(max_chunk_size):
+                        p_i32 = chunk_base_i32 + fx.Int32(p_in_chunk)
+                        p_valid = p_i32 < context_partition_num
+                        es_off = (
+                            seq_idx * stride_es_seq + kv_head_idx * stride_es_head + p_i32 * stride_es_part + qg_i32
+                        )
+                        ml_val = buffer_ops.buffer_load(ml_rsrc, es_off, vec_width=1, dtype=T.f32)
+                        ml_val = p_valid.select(ml_val, NEG_INF)
+                        es_val = buffer_ops.buffer_load(es_rsrc, es_off, vec_width=1, dtype=T.f32)
+                        es_val = p_valid.select(es_val, ZERO_F)
+                        rescaled = es_val * _exp_f32(ml_val - global_max, LOG2E_C)
+                        attn_prob = rescaled / global_exp_sum
+                        po_off = (
+                            seq_idx * stride_po_seq
+                            + kv_head_idx * stride_po_head
+                            + p_i32 * stride_po_part
+                            + qg_i32 * stride_po_group
+                            + h_i32
+                        )
+                        po_val = buffer_ops.buffer_load(po_rsrc, po_off, vec_width=1, dtype=T.f32)
+                        po_val = p_valid.select(po_val, ZERO_F)
+                        acc = acc + po_val * attn_prob
+
+                out_off = (
+                    seq_idx * stride_output_bs
+                    + ql_idx * stride_output_len
+                    + kv_head_idx * stride_output_kv_head
+                    + gr_idx * stride_output_group
+                    + h_i32
+                )
+                buffer_ops.buffer_store(acc, out_rsrc, out_off)
+
+    @flyc.jit
+    def launch_v2_reduce(
+        output: fx.Tensor,
+        exp_sums: fx.Tensor,
+        max_logits: fx.Tensor,
+        partial_output: fx.Tensor,
+        context_lengths: fx.Tensor,
+        sink_token: fx.Tensor,
+        stride_output_bs: Int32,
+        stride_output_len: Int32,
+        stride_output_kv_head: Int32,
+        stride_output_group: Int32,
+        stride_es_seq: Int32,
+        stride_es_head: Int32,
+        stride_es_part: Int32,
+        stride_po_seq: Int32,
+        stride_po_head: Int32,
+        stride_po_part: Int32,
+        stride_po_group: Int32,
+        num_seqs: Int32,
+        num_kv_heads: Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        v2_reduce_kernel(
+            output, exp_sums, max_logits, partial_output, context_lengths, sink_token,
+            stride_output_bs, stride_output_len,
+            stride_output_kv_head, stride_output_group,
+            stride_es_seq, stride_es_head, stride_es_part,
+            stride_po_seq, stride_po_head, stride_po_part, stride_po_group,
+        ).launch(
+            grid=(num_seqs, num_kv_heads),
+            block=(1,),
+            stream=stream,
+        )
+
+    return v2_reduce_kernel, launch_v2_reduce

--- a/kernels/pa_decode_fp8.py
+++ b/kernels/pa_decode_fp8.py
@@ -2,12 +2,10 @@
 # Copyright (c) 2025 FlyDSL Project Contributors
 
 """
-Supports kv_block_size=16 (original) and kv_block_size=1024 (trans_v required).
+CDNA paged-attention FP8 decode kernel using MFMA instructions (wave64).
 
-Contains:
-  - build_pa_decode_module(): main decode dot-product kernel
-  - build_ps_reduce_kernel(): fixed-partition-count reduce kernel
-  - build_v2_reduce_kernel(): dynamic-partition-count reduce kernel
+Supports kv_block_size=16 (original) and kv_block_size=1024 (trans_v required).
+Reduce kernels are in pa_common.py (shared with RDNA).
 """
 
 from __future__ import annotations
@@ -21,11 +19,12 @@ from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl._mlir import ir
 
+from kernels.pa_common import (
+    QUERY_GROUP_SIZE, HEAD_SIZE, KV_BLOCK_SIZE, KV_COMPUTE_BLOCK,
+    FP8_MAX, LOG2E, compute_pa_strides,
+    build_ps_reduce_kernel, build_v2_reduce_kernel,  # re-export
+)
 
-QUERY_GROUP_SIZE = 16
-HEAD_SIZE = 128
-KV_BLOCK_SIZE = 16
-KV_COMPUTE_BLOCK = 256
 NUM_WARPS = 4
 WARP_SIZE = 64
 BLOCK_THREADS = NUM_WARPS * WARP_SIZE
@@ -39,8 +38,6 @@ Q_LDS_BYTES = BLOCK_THREADS * 8
 PROB_LDS_BYTES = BLOCK_THREADS * 16
 BT_LDS_BYTES = NUM_WARPS * 16
 RED_SLOTS = NUM_WARPS
-FP8_MAX = 240.0
-LOG2E = 1.4426950408889634
 
 
 def _vsplat_mul(vec, scalar):
@@ -80,38 +77,26 @@ def build_pa_decode_module(
     _prob_scale = float(value_scale / FP8_MAX)
 
     _bs = kv_block_size
-    _num_heads = num_kv_heads * QUERY_GROUP_SIZE
-    _stride_q_seq = _num_heads * HEAD_SIZE
-    _stride_q_head = HEAD_SIZE
-    _stride_k_block = num_kv_heads * (HEAD_SIZE // 16) * _bs * 16
-    _stride_k_head = (HEAD_SIZE // 16) * _bs * 16
-    _stride_bt_seq = max_blocks_per_seq
-
-    if trans_v:
-        _stride_v_block = num_kv_heads * (_bs // 16) * HEAD_SIZE * 16
-        _stride_v_head = (_bs // 16) * HEAD_SIZE * 16
-    else:
-        _stride_v_block = num_kv_heads * HEAD_SIZE * _bs
-        _stride_v_head = HEAD_SIZE * _bs
-
-    _direct_output = one_shot or (ps_num_splits > 0)
-    if _direct_output:
-        _stride_out_part = 0
-        _stride_out_head = QUERY_GROUP_SIZE * HEAD_SIZE
-        _stride_out_seq = num_kv_heads * QUERY_GROUP_SIZE * HEAD_SIZE
-    else:
-        _stride_out_part = QUERY_GROUP_SIZE * HEAD_SIZE
-        _stride_out_head = num_partitions * QUERY_GROUP_SIZE * HEAD_SIZE
-        _stride_out_seq = num_kv_heads * num_partitions * QUERY_GROUP_SIZE * HEAD_SIZE
-    _stride_es_seq = num_kv_heads * num_partitions * QUERY_GROUP_SIZE
-    _stride_ml_seq = num_kv_heads * num_partitions * QUERY_GROUP_SIZE
-
-    _use_large_block = _bs > KV_BLOCK_SIZE
-    _partitions_per_block = _bs // KV_COMPUTE_BLOCK if _use_large_block else 1
-    _blocks_per_partition = KV_COMPUTE_BLOCK // _bs if not _use_large_block else 1
-
-    _ps_mode = ps_num_splits > 0
-    _max_pps = _math.ceil(num_partitions / ps_num_splits) if _ps_mode else 1
+    _S = compute_pa_strides(num_kv_heads, num_partitions, max_blocks_per_seq,
+                            kv_block_size=kv_block_size, trans_v=trans_v,
+                            one_shot=one_shot, ps_num_splits=ps_num_splits)
+    _stride_q_seq = _S["stride_q_seq"]
+    _stride_q_head = _S["stride_q_head"]
+    _stride_k_block = _S["stride_k_block"]
+    _stride_k_head = _S["stride_k_head"]
+    _stride_bt_seq = _S["stride_bt_seq"]
+    _stride_v_block = _S["stride_v_block"]
+    _stride_v_head = _S["stride_v_head"]
+    _stride_out_part = _S["stride_out_part"]
+    _stride_out_head = _S["stride_out_head"]
+    _stride_out_seq = _S["stride_out_seq"]
+    _stride_es_seq = _S["stride_es_seq"]
+    _stride_ml_seq = _S["stride_ml_seq"]
+    _use_large_block = _S["use_large_block"]
+    _partitions_per_block = _S["partitions_per_block"]
+    _blocks_per_partition = _S["blocks_per_partition"]
+    _ps_mode = _S["ps_mode"]
+    _max_pps = _S["max_pps"]
 
     allocator = SmemAllocator(None, arch=arch, global_sym_name="pa_smem")
     q_off = 0
@@ -539,372 +524,3 @@ def build_pa_decode_module(
                         buffer_ops.buffer_store(out_i32, out_rsrc, out_off * 2, offset_is_bytes=True)
 
     return pa_decode_dot_kernel
-
-
-# ============================================================================
-# Reduce kernels
-# ============================================================================
-
-NEG_INF_VAL = float("-inf")
-
-
-def _exp_f32(x, log2e_const):
-    """Compute exp(x) = exp2(x * LOG2E) using hardware exp2."""
-    return (x * log2e_const).exp2(fastmath=arith.FastMathFlags.fast)
-
-
-def build_ps_reduce_kernel(
-    head_size: int,
-    query_group_size: int,
-    query_seq_len: int,
-    max_context_partition_num: int,
-    use_sinks: bool = False,
-):
-    """Build the ps_reduce kernel (fixed MAX_CONTEXT_PARTITION_NUM, single-pass)."""
-    qg_total = query_seq_len * query_group_size
-
-    @flyc.kernel
-    def ps_reduce_kernel(
-        output_ptr: fx.Tensor,
-        exp_sums_ptr: fx.Tensor,
-        max_logits_ptr: fx.Tensor,
-        partial_output_ptr: fx.Tensor,
-        sink_token_ptr: fx.Tensor,
-        context_partition_num: Int32,
-        stride_output_bs: Int32,
-        stride_output_len: Int32,
-        stride_output_kv_head: Int32,
-        stride_output_group: Int32,
-        stride_es_seq: Int32,
-        stride_es_head: Int32,
-        stride_es_part: Int32,
-        stride_po_seq: Int32,
-        stride_po_head: Int32,
-        stride_po_part: Int32,
-        stride_po_group: Int32,
-    ):
-        seq_idx = gpu.block_idx.x
-        kv_head_idx = gpu.block_idx.y
-
-        es_rsrc = buffer_ops.create_buffer_resource(exp_sums_ptr, max_size=True)
-        ml_rsrc = buffer_ops.create_buffer_resource(max_logits_ptr, max_size=True)
-        po_rsrc = buffer_ops.create_buffer_resource(partial_output_ptr, max_size=True)
-        out_rsrc = buffer_ops.create_buffer_resource(output_ptr, max_size=True)
-
-        LOG2E_C = arith.constant(LOG2E, type=T.f32)
-        NEG_INF = arith.constant(NEG_INF_VAL, type=T.f32)
-        ZERO_F = fx.Float32(0.0)
-
-        tid = gpu.thread_idx.x
-
-        for qg in range(qg_total):
-            qg_i32 = fx.Int32(qg)
-            ql_idx = fx.Int32(qg // query_group_size)
-            gr_idx = fx.Int32(qg % query_group_size)
-
-            global_max = NEG_INF
-            for p in range(max_context_partition_num):
-                p_i32 = fx.Int32(p)
-                p_valid = p_i32 < context_partition_num
-
-                es_off = seq_idx * stride_es_seq + kv_head_idx * stride_es_head + p_i32 * stride_es_part + qg_i32
-                ml_val = buffer_ops.buffer_load(ml_rsrc, es_off, vec_width=1, dtype=T.f32)
-                ml_val = p_valid.select(ml_val, NEG_INF)
-                global_max = global_max.maximumf(ml_val)
-
-            total_exp_sum = ZERO_F
-            for p in range(max_context_partition_num):
-                p_i32 = fx.Int32(p)
-                p_valid = p_i32 < context_partition_num
-
-                es_off = seq_idx * stride_es_seq + kv_head_idx * stride_es_head + p_i32 * stride_es_part + qg_i32
-                ml_val = buffer_ops.buffer_load(ml_rsrc, es_off, vec_width=1, dtype=T.f32)
-                ml_val = p_valid.select(ml_val, NEG_INF)
-                es_val = buffer_ops.buffer_load(es_rsrc, es_off, vec_width=1, dtype=T.f32)
-                es_val = p_valid.select(es_val, ZERO_F)
-
-                rescaled = es_val * _exp_f32(ml_val - global_max, LOG2E_C)
-                total_exp_sum = total_exp_sum + rescaled
-
-            if use_sinks:
-                sink_rsrc = buffer_ops.create_buffer_resource(sink_token_ptr, max_size=True)
-                sink_off = kv_head_idx * fx.Int32(query_group_size) + gr_idx
-                sink_val = buffer_ops.buffer_load(sink_rsrc, sink_off, vec_width=1, dtype=T.f32)
-                sink_contrib = _exp_f32(sink_val - global_max, LOG2E_C)
-                total_exp_sum = total_exp_sum + sink_contrib
-
-            for h in range(head_size):
-                h_i32 = fx.Int32(h)
-                acc = ZERO_F
-
-                for p in range(max_context_partition_num):
-                    p_i32 = fx.Int32(p)
-                    p_valid = p_i32 < context_partition_num
-
-                    es_off = seq_idx * stride_es_seq + kv_head_idx * stride_es_head + p_i32 * stride_es_part + qg_i32
-                    ml_val = buffer_ops.buffer_load(ml_rsrc, es_off, vec_width=1, dtype=T.f32)
-                    ml_val = p_valid.select(ml_val, NEG_INF)
-                    es_val = buffer_ops.buffer_load(es_rsrc, es_off, vec_width=1, dtype=T.f32)
-                    es_val = p_valid.select(es_val, ZERO_F)
-
-                    rescaled = es_val * _exp_f32(ml_val - global_max, LOG2E_C)
-                    attn_prob = rescaled / total_exp_sum
-
-                    po_off = (
-                        seq_idx * stride_po_seq
-                        + kv_head_idx * stride_po_head
-                        + p_i32 * stride_po_part
-                        + qg_i32 * stride_po_group
-                        + h_i32
-                    )
-                    po_val = buffer_ops.buffer_load(po_rsrc, po_off, vec_width=1, dtype=T.f32)
-                    po_val = p_valid.select(po_val, ZERO_F)
-
-                    acc = acc + po_val * attn_prob
-
-                out_off = (
-                    seq_idx * stride_output_bs
-                    + ql_idx * stride_output_len
-                    + kv_head_idx * stride_output_kv_head
-                    + gr_idx * stride_output_group
-                    + h_i32
-                )
-                buffer_ops.buffer_store(acc, out_rsrc, out_off)
-
-    @flyc.jit
-    def launch_ps_reduce(
-        output: fx.Tensor,
-        exp_sums: fx.Tensor,
-        max_logits: fx.Tensor,
-        partial_output: fx.Tensor,
-        sink_token: fx.Tensor,
-        context_partition_num: Int32,
-        stride_output_bs: Int32,
-        stride_output_len: Int32,
-        stride_output_kv_head: Int32,
-        stride_output_group: Int32,
-        stride_es_seq: Int32,
-        stride_es_head: Int32,
-        stride_es_part: Int32,
-        stride_po_seq: Int32,
-        stride_po_head: Int32,
-        stride_po_part: Int32,
-        stride_po_group: Int32,
-        num_seqs: Int32,
-        num_kv_heads: Int32,
-        stream: fx.Stream = fx.Stream(None),
-    ):
-        ps_reduce_kernel(
-            output,
-            exp_sums,
-            max_logits,
-            partial_output,
-            sink_token,
-            context_partition_num,
-            stride_output_bs,
-            stride_output_len,
-            stride_output_kv_head,
-            stride_output_group,
-            stride_es_seq,
-            stride_es_head,
-            stride_es_part,
-            stride_po_seq,
-            stride_po_head,
-            stride_po_part,
-            stride_po_group,
-        ).launch(
-            grid=(num_seqs, num_kv_heads),
-            block=(1,),
-            stream=stream,
-        )
-
-    return ps_reduce_kernel, launch_ps_reduce
-
-
-def build_v2_reduce_kernel(
-    head_size: int,
-    query_group_size: int,
-    query_seq_len: int,
-    context_partition_size: int,
-    max_chunk_size: int = 16,
-    use_sinks: bool = False,
-):
-    """Build the v2_reduce kernel (dynamic partition count, two-pass loop)."""
-    qg_total = query_seq_len * query_group_size
-
-    @flyc.kernel
-    def v2_reduce_kernel(
-        output_ptr: fx.Tensor,
-        exp_sums_ptr: fx.Tensor,
-        max_logits_ptr: fx.Tensor,
-        partial_output_ptr: fx.Tensor,
-        context_lengths_ptr: fx.Tensor,
-        sink_token_ptr: fx.Tensor,
-        stride_output_bs: Int32,
-        stride_output_len: Int32,
-        stride_output_kv_head: Int32,
-        stride_output_group: Int32,
-        stride_es_seq: Int32,
-        stride_es_head: Int32,
-        stride_es_part: Int32,
-        stride_po_seq: Int32,
-        stride_po_head: Int32,
-        stride_po_part: Int32,
-        stride_po_group: Int32,
-    ):
-        seq_idx = gpu.block_idx.x
-        kv_head_idx = gpu.block_idx.y
-
-        cl_rsrc = buffer_ops.create_buffer_resource(context_lengths_ptr, max_size=True)
-        ctx_len = buffer_ops.buffer_load(cl_rsrc, seq_idx, vec_width=1, dtype=T.i32)
-        cps_const = fx.Int32(context_partition_size)
-        context_partition_num = (ctx_len + cps_const - 1) / cps_const
-
-        es_rsrc = buffer_ops.create_buffer_resource(exp_sums_ptr, max_size=True)
-        ml_rsrc = buffer_ops.create_buffer_resource(max_logits_ptr, max_size=True)
-        po_rsrc = buffer_ops.create_buffer_resource(partial_output_ptr, max_size=True)
-        out_rsrc = buffer_ops.create_buffer_resource(output_ptr, max_size=True)
-
-        LOG2E_C = arith.constant(LOG2E, type=T.f32)
-        NEG_INF = arith.constant(NEG_INF_VAL, type=T.f32)
-        ZERO_F = fx.Float32(0.0)
-        ONE_F = fx.Float32(1.0)
-        CHUNK = fx.Int32(max_chunk_size)
-
-        for qg in range(qg_total):
-            qg_i32 = fx.Int32(qg)
-            ql_idx = fx.Int32(qg // query_group_size)
-            gr_idx = fx.Int32(qg % query_group_size)
-
-            global_max = NEG_INF
-            global_exp_sum = ZERO_F
-
-            for chunk_base in range(0, max_chunk_size * 64, max_chunk_size):
-                chunk_base_i32 = fx.Int32(chunk_base)
-                chunk_active = chunk_base_i32 < context_partition_num
-
-                prev_global_max = global_max
-
-                for p_in_chunk in range(max_chunk_size):
-                    p_i32 = chunk_base_i32 + fx.Int32(p_in_chunk)
-                    p_valid = p_i32 < context_partition_num
-
-                    es_off = seq_idx * stride_es_seq + kv_head_idx * stride_es_head + p_i32 * stride_es_part + qg_i32
-                    ml_val = buffer_ops.buffer_load(ml_rsrc, es_off, vec_width=1, dtype=T.f32)
-                    ml_val = p_valid.select(ml_val, NEG_INF)
-                    global_max = global_max.maximumf(ml_val)
-
-                update_scale = _exp_f32(prev_global_max - global_max, LOG2E_C)
-                global_exp_sum = global_exp_sum * update_scale
-
-                for p_in_chunk in range(max_chunk_size):
-                    p_i32 = chunk_base_i32 + fx.Int32(p_in_chunk)
-                    p_valid = p_i32 < context_partition_num
-
-                    es_off = seq_idx * stride_es_seq + kv_head_idx * stride_es_head + p_i32 * stride_es_part + qg_i32
-                    ml_val = buffer_ops.buffer_load(ml_rsrc, es_off, vec_width=1, dtype=T.f32)
-                    ml_val = p_valid.select(ml_val, NEG_INF)
-                    es_val = buffer_ops.buffer_load(es_rsrc, es_off, vec_width=1, dtype=T.f32)
-                    es_val = p_valid.select(es_val, ZERO_F)
-
-                    rescaled = es_val * _exp_f32(ml_val - global_max, LOG2E_C)
-                    global_exp_sum = global_exp_sum + rescaled
-
-            if use_sinks:
-                sink_rsrc = buffer_ops.create_buffer_resource(sink_token_ptr, max_size=True)
-                sink_off = kv_head_idx * fx.Int32(query_seq_len * query_group_size) + qg_i32
-                sink_val = buffer_ops.buffer_load(sink_rsrc, sink_off, vec_width=1, dtype=T.f32)
-                sink_contrib = _exp_f32(sink_val - global_max, LOG2E_C)
-                global_exp_sum = global_exp_sum + sink_contrib
-
-            for h in range(head_size):
-                h_i32 = fx.Int32(h)
-                acc = ZERO_F
-
-                for chunk_base in range(0, max_chunk_size * 64, max_chunk_size):
-                    chunk_base_i32 = fx.Int32(chunk_base)
-
-                    for p_in_chunk in range(max_chunk_size):
-                        p_i32 = chunk_base_i32 + fx.Int32(p_in_chunk)
-                        p_valid = p_i32 < context_partition_num
-
-                        es_off = (
-                            seq_idx * stride_es_seq + kv_head_idx * stride_es_head + p_i32 * stride_es_part + qg_i32
-                        )
-                        ml_val = buffer_ops.buffer_load(ml_rsrc, es_off, vec_width=1, dtype=T.f32)
-                        ml_val = p_valid.select(ml_val, NEG_INF)
-                        es_val = buffer_ops.buffer_load(es_rsrc, es_off, vec_width=1, dtype=T.f32)
-                        es_val = p_valid.select(es_val, ZERO_F)
-
-                        rescaled = es_val * _exp_f32(ml_val - global_max, LOG2E_C)
-                        attn_prob = rescaled / global_exp_sum
-
-                        po_off = (
-                            seq_idx * stride_po_seq
-                            + kv_head_idx * stride_po_head
-                            + p_i32 * stride_po_part
-                            + qg_i32 * stride_po_group
-                            + h_i32
-                        )
-                        po_val = buffer_ops.buffer_load(po_rsrc, po_off, vec_width=1, dtype=T.f32)
-                        po_val = p_valid.select(po_val, ZERO_F)
-
-                        acc = acc + po_val * attn_prob
-
-                out_off = (
-                    seq_idx * stride_output_bs
-                    + ql_idx * stride_output_len
-                    + kv_head_idx * stride_output_kv_head
-                    + gr_idx * stride_output_group
-                    + h_i32
-                )
-                buffer_ops.buffer_store(acc, out_rsrc, out_off)
-
-    @flyc.jit
-    def launch_v2_reduce(
-        output: fx.Tensor,
-        exp_sums: fx.Tensor,
-        max_logits: fx.Tensor,
-        partial_output: fx.Tensor,
-        context_lengths: fx.Tensor,
-        sink_token: fx.Tensor,
-        stride_output_bs: Int32,
-        stride_output_len: Int32,
-        stride_output_kv_head: Int32,
-        stride_output_group: Int32,
-        stride_es_seq: Int32,
-        stride_es_head: Int32,
-        stride_es_part: Int32,
-        stride_po_seq: Int32,
-        stride_po_head: Int32,
-        stride_po_part: Int32,
-        stride_po_group: Int32,
-        num_seqs: Int32,
-        num_kv_heads: Int32,
-        stream: fx.Stream = fx.Stream(None),
-    ):
-        v2_reduce_kernel(
-            output,
-            exp_sums,
-            max_logits,
-            partial_output,
-            context_lengths,
-            sink_token,
-            stride_output_bs,
-            stride_output_len,
-            stride_output_kv_head,
-            stride_output_group,
-            stride_es_seq,
-            stride_es_head,
-            stride_es_part,
-            stride_po_seq,
-            stride_po_head,
-            stride_po_part,
-            stride_po_group,
-        ).launch(
-            grid=(num_seqs, num_kv_heads),
-            block=(1,),
-            stream=stream,
-        )
-
-    return v2_reduce_kernel, launch_v2_reduce

--- a/kernels/rdna_pa_decode_fp8.py
+++ b/kernels/rdna_pa_decode_fp8.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""
+RDNA4 paged-attention FP8 decode kernel using WMMA instructions.
+
+Ported from CDNA MFMA-based kernel (pa_decode_fp8.py) to RDNA4 wave32 WMMA.
+
+Architecture:
+  - 8 warps x 32 lanes = 256 threads per workgroup
+  - WMMA f32_16x16x16_fp8_fp8 for both QK and PV dot products
+  - QK: each warp handles 2 N-tiles (32 KV tokens), 8 K-steps (128 head dim)
+  - PV: each warp handles 1 N-tile (16 head dims), 16 K-steps (256 tokens)
+  - Softmax P staged through LDS as f32 for PV consumption
+
+WMMA 16x16x16 FP8 lane mapping (wave32):
+  - A operand (v2i32 = 8 FP8 bytes): lane16 selects M-row, klane selects K-half
+  - B operand (v2i32 = 8 FP8 bytes): lane16 selects N-col, klane selects K-half
+  - C/D accumulator (v8f32): element i -> row = klane*8+i, col = lane16
+
+Current scope (minimal supported subset for bring-up):
+  - kv_block_size=16 only
+  - trans_v=False only
+  - one_shot=False only
+  - ps_num_splits=0 only
+"""
+
+from __future__ import annotations
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import arith, vector, gpu, rocdl, buffer_ops
+from flydsl.expr.typing import T, Int32
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl._mlir import ir
+
+from kernels.pa_common import (
+    QUERY_GROUP_SIZE, HEAD_SIZE, KV_BLOCK_SIZE, KV_COMPUTE_BLOCK,
+    FP8_MAX, LOG2E, compute_pa_strides,
+    build_ps_reduce_kernel, build_v2_reduce_kernel,  # re-export
+)
+
+WMMA_M = WMMA_N = WMMA_K = 16
+WARP_SIZE = 32
+NUM_WARPS = 8
+BLOCK_THREADS = NUM_WARPS * WARP_SIZE
+QK_N_TILES_WARP = 2
+QK_K_STEPS = HEAD_SIZE // WMMA_K
+PV_K_STEPS = KV_COMPUTE_BLOCK // WMMA_K
+BLOCKS_PER_PARTITION = KV_COMPUTE_BLOCK // KV_BLOCK_SIZE
+
+P_LDS_F32_COUNT = BLOCKS_PER_PARTITION * QUERY_GROUP_SIZE * KV_BLOCK_SIZE
+P_LDS_BYTES = P_LDS_F32_COUNT * 4
+RED_SLOTS = NUM_WARPS
+
+
+allocator = None
+
+
+def build_pa_decode_module(
+    num_seqs,
+    num_kv_heads,
+    num_partitions,
+    max_blocks_per_seq=256,
+    softmax_scale=None,
+    query_scale=1.0,
+    key_scale=1.0,
+    value_scale=1.0,
+    kv_block_size=16,
+    trans_v=False,
+    one_shot=False,
+    ps_num_splits=0,
+):
+    global allocator
+    arch = get_hip_arch()
+    if softmax_scale is None:
+        softmax_scale = 1.0 / (HEAD_SIZE ** 0.5)
+    _qk_scale = float(softmax_scale * query_scale * key_scale)
+    _prob_scale = float(value_scale / FP8_MAX)
+
+    assert kv_block_size == KV_BLOCK_SIZE, "Only kv_block_size=16 supported for RDNA"
+    assert not trans_v, "trans_v not yet supported for RDNA"
+
+    _bs = kv_block_size
+    _S = compute_pa_strides(num_kv_heads, num_partitions, max_blocks_per_seq,
+                            kv_block_size=kv_block_size, trans_v=trans_v,
+                            one_shot=one_shot, ps_num_splits=ps_num_splits)
+    _stride_q_seq = _S["stride_q_seq"]
+    _stride_q_head = _S["stride_q_head"]
+    _stride_k_block = _S["stride_k_block"]
+    _stride_k_head = _S["stride_k_head"]
+    _stride_bt_seq = _S["stride_bt_seq"]
+    _stride_v_block = _S["stride_v_block"]
+    _stride_v_head = _S["stride_v_head"]
+    _stride_out_part = _S["stride_out_part"]
+    _stride_out_head = _S["stride_out_head"]
+    _stride_out_seq = _S["stride_out_seq"]
+    _stride_es_seq = _S["stride_es_seq"]
+    _stride_ml_seq = _S["stride_ml_seq"]
+    _blocks_per_partition = _S["blocks_per_partition"]
+    _ps_mode = _S["ps_mode"]
+    _max_pps = _S["max_pps"]
+
+    # -- LDS allocation --
+    allocator = SmemAllocator(None, arch=arch, global_sym_name="pa_smem")
+    p_off = 0
+    allocator.ptr = P_LDS_BYTES
+    rmax_off = P_LDS_BYTES
+    allocator.ptr += RED_SLOTS * 4
+    rsum_off = rmax_off + RED_SLOTS * 4
+    allocator.ptr += RED_SLOTS * 4
+
+    @flyc.kernel
+    def pa_decode_dot_kernel(
+        out_ptr: fx.Tensor,
+        exp_sums_ptr: fx.Tensor,
+        max_logits_ptr: fx.Tensor,
+        query_ptr: fx.Tensor,
+        key_cache_ptr: fx.Tensor,
+        value_cache_ptr: fx.Tensor,
+        block_tables_ptr: fx.Tensor,
+        context_length_i32: Int32,
+    ):
+        v8f32 = T.vec(8, T.f32)
+        v2i32 = T.i32x2
+
+        def _vsplat_mul_8(vec, scalar):
+            s = scalar.ir_value() if hasattr(scalar, "ir_value") else scalar
+            return vec * vector.broadcast(v8f32, s)
+
+        tid = gpu.thread_idx.x
+        seq = gpu.block_idx.x
+        kv_h = gpu.block_idx.y
+        part_z = gpu.block_idx.z
+
+        warp_id = tid >> 5
+        lane = tid & 31
+        lane16 = lane & 15
+        klane = lane >> 4
+        c_w = fx.Int32(WARP_SIZE)
+
+        q_rsrc = buffer_ops.create_buffer_resource(query_ptr, max_size=True)
+        bt_rsrc = buffer_ops.create_buffer_resource(block_tables_ptr, max_size=True)
+        k_rsrc = buffer_ops.create_buffer_resource(key_cache_ptr, max_size=True)
+        v_rsrc = buffer_ops.create_buffer_resource(value_cache_ptr, max_size=True)
+        out_rsrc = buffer_ops.create_buffer_resource(out_ptr, max_size=True)
+        es_rsrc = buffer_ops.create_buffer_resource(exp_sums_ptr, max_size=True)
+        ml_rsrc = buffer_ops.create_buffer_resource(max_logits_ptr, max_size=True)
+
+        base = allocator.get_base()
+        p_smem = SmemPtr(base, p_off, T.f32, shape=(P_LDS_F32_COUNT,))
+        p_lds_f32 = p_smem.get()
+        s_max_p = SmemPtr(base, rmax_off, T.f32, shape=(RED_SLOTS,))
+        s_sum_p = SmemPtr(base, rsum_off, T.f32, shape=(RED_SLOTS,))
+
+        c_kb = fx.Int32(_stride_k_block)
+        c_kh = fx.Int32(_stride_k_head)
+        c_vb = fx.Int32(_stride_v_block)
+        c_vh = fx.Int32(_stride_v_head)
+        c_sq = fx.Int32(_stride_q_seq)
+        c_qh = fx.Int32(_stride_q_head)
+        c_bt = fx.Int32(_stride_bt_seq)
+        wave_idx = arith.index_cast(T.index, warp_id)
+
+        _q_byte_base = seq * c_sq + kv_h * fx.Int32(QUERY_GROUP_SIZE) * c_qh
+        _k_head_off = kv_h * c_kh
+        _v_head_off = kv_h * c_vh
+
+        NEG_INF = arith.constant(float("-inf"), type=T.f32)
+        ZERO_F = fx.Float32(0.0)
+        LOG2E_C = arith.constant(LOG2E, type=T.f32)
+        QK_SCALE = arith.constant(_qk_scale, type=T.f32)
+        F_FP8MAX = arith.constant(FP8_MAX, type=T.f32)
+        PROB_SCALE_C = arith.constant(_prob_scale, type=T.f32)
+
+        _mi0 = arith.index_cast(T.index, fx.Int32(0))
+        _mi1 = arith.index_cast(T.index, fx.Int32(1))
+        _mi2 = arith.index_cast(T.index, fx.Int32(2))
+        _mi3 = arith.index_cast(T.index, fx.Int32(3))
+        _mi4 = arith.index_cast(T.index, fx.Int32(4))
+        _mi5 = arith.index_cast(T.index, fx.Int32(5))
+        _mi6 = arith.index_cast(T.index, fx.Int32(6))
+        _mi7 = arith.index_cast(T.index, fx.Int32(7))
+
+        # -- wave-level reductions for 32-lane waves --
+        def _wave_max(x):
+            w = x
+            for sh in [16, 8, 4, 2, 1]:
+                w = w.maximumf(w.shuffle_xor(fx.Int32(sh), c_w))
+            return w
+
+        def _wave_add(x):
+            w = x
+            for sh in [16, 8, 4, 2, 1]:
+                w = w + w.shuffle_xor(fx.Int32(sh), c_w)
+            return w
+
+        def _load_q(rk):
+            """Q WMMA-A operand for K-step rk.  v2i32 = 8 FP8 bytes."""
+            off = _q_byte_base // 4 + lane16 * fx.Int32(HEAD_SIZE // 4) + fx.Int32(rk * (WMMA_K // 4)) + klane * fx.Int32(2)
+            return buffer_ops.buffer_load(q_rsrc, off, vec_width=2, dtype=T.i32)
+
+        def _load_k(phys_block, rk):
+            """K WMMA-B operand.  v2i32 = 8 FP8 bytes."""
+            k_base = (phys_block * c_kb + _k_head_off) // 4
+            off = k_base + fx.Int32(rk * (_bs * 16 // 4)) + lane16 * fx.Int32(16 // 4) + klane * fx.Int32(2)
+            return buffer_ops.buffer_load(k_rsrc, off, vec_width=2, dtype=T.i32)
+
+        def _load_v(phys_block, warp_hd_base):
+            """V WMMA-B operand.  V cache is [head_dim, token] within (block,head)."""
+            v_base = (phys_block * c_vb + _v_head_off) // 4
+            off = v_base + (warp_hd_base + lane16) * fx.Int32(_bs // 4) + klane * fx.Int32(2)
+            return buffer_ops.buffer_load(v_rsrc, off, vec_width=2, dtype=T.i32)
+
+        def _bt_load(part_val, idx):
+            """Load block-table entry idx for partition part_val."""
+            bt_start = part_val * fx.Int32(_blocks_per_partition)
+            return buffer_ops.buffer_load(bt_rsrc, seq * c_bt + bt_start + idx, vec_width=1, dtype=T.i32)
+
+        def _f32x8_to_fp8(vals):
+            """Pack 8 scaled-f32 values into v2i32 (WMMA FP8 operand)."""
+            lo = rocdl.cvt_pk_fp8_f32(T.i32, vals[0], vals[1], fx.Int32(0), False)
+            lo = rocdl.cvt_pk_fp8_f32(T.i32, vals[2], vals[3], lo, True)
+            hi = rocdl.cvt_pk_fp8_f32(T.i32, vals[4], vals[5], fx.Int32(0), False)
+            hi = rocdl.cvt_pk_fp8_f32(T.i32, vals[6], vals[7], hi, True)
+            return vector.from_elements(v2i32, [lo, hi])
+
+        # -- online softmax state --
+        running_max = NEG_INF
+        running_sum = ZERO_F
+        acc_pv = arith.constant_vector(0.0, v8f32)
+
+        # -- partition loop --
+        for _pi in range(int(_max_pps)):
+            if _ps_mode:
+                _pi_i32 = arith.index_cast(T.i32, _pi)
+                part = part_z * int(_max_pps) + _pi_i32
+            else:
+                part = part_z
+
+            partition_start = part * fx.Int32(KV_COMPUTE_BLOCK)
+
+            # == QK: Q[16,128] x K^T[128,256] -> S[16,256] ==
+            zero_acc = arith.constant_vector(0.0, v8f32)
+            acc_qk = [zero_acc, zero_acc]
+
+            for nt in [0, 1]:
+                bt_idx = warp_id * fx.Int32(2) + fx.Int32(nt)
+                phys_block = _bt_load(part, bt_idx)
+                acc = zero_acc
+                for rk in [0, 1, 2, 3, 4, 5, 6, 7]:
+                    q_op = _load_q(rk)
+                    k_op = _load_k(phys_block, rk)
+                    acc = rocdl.wmma_f32_16x16x16_fp8_fp8(
+                        v8f32, q_op, k_op, arith.unwrap(acc)
+                    ).result
+                acc_qk[nt] = acc
+
+            # -- scale + mask --
+            ctx_len = context_length_i32
+            for nt in [0, 1]:
+                acc_qk[nt] = _vsplat_mul_8(acc_qk[nt], QK_SCALE)
+                kv_tok = partition_start + warp_id * fx.Int32(32) + fx.Int32(nt * 16) + lane16
+                in_b = kv_tok < ctx_len
+                for elem in [0, 1, 2, 3, 4, 5, 6, 7]:
+                    v = vector.extract(acc_qk[nt], static_position=[elem], dynamic_position=[])
+                    acc_qk[nt] = vector.insert(
+                        in_b.select(v, NEG_INF), acc_qk[nt],
+                        static_position=[elem], dynamic_position=[],
+                    )
+
+            # == online softmax ==
+            local_max = NEG_INF
+            for nt in [0, 1]:
+                local_max = local_max.maximumf(vector.reduction(T.f32, "maxnumf", acc_qk[nt]))
+            wmax = _wave_max(local_max)
+            s_max_p.store(wmax, [wave_idx])
+            gpu.barrier()
+            global_max_new = (
+                s_max_p.load([_mi0]).maximumf(s_max_p.load([_mi1]))
+                .maximumf(s_max_p.load([_mi2])).maximumf(s_max_p.load([_mi3]))
+                .maximumf(s_max_p.load([_mi4])).maximumf(s_max_p.load([_mi5]))
+                .maximumf(s_max_p.load([_mi6])).maximumf(s_max_p.load([_mi7]))
+            )
+
+            if _ps_mode:
+                rescale = ((running_max - global_max_new) * LOG2E_C).exp2(fastmath=arith.FastMathFlags.fast)
+                acc_pv = _vsplat_mul_8(acc_pv, rescale)
+                running_sum = running_sum * rescale
+                running_max = global_max_new
+            else:
+                running_max = global_max_new
+
+            local_sum = ZERO_F
+            for nt in [0, 1]:
+                for elem in [0, 1, 2, 3, 4, 5, 6, 7]:
+                    s = vector.extract(acc_qk[nt], static_position=[elem], dynamic_position=[])
+                    p = ((s - running_max) * LOG2E_C).exp2(fastmath=arith.FastMathFlags.fast)
+                    local_sum = local_sum + p
+                    acc_qk[nt] = vector.insert(p, acc_qk[nt], static_position=[elem], dynamic_position=[])
+            wsum = _wave_add(local_sum)
+            s_sum_p.store(wsum, [wave_idx])
+            gpu.barrier()
+            iter_sum = (
+                s_sum_p.load([_mi0]) + s_sum_p.load([_mi1])
+                + s_sum_p.load([_mi2]) + s_sum_p.load([_mi3])
+                + s_sum_p.load([_mi4]) + s_sum_p.load([_mi5])
+                + s_sum_p.load([_mi6]) + s_sum_p.load([_mi7])
+            )
+            running_sum = running_sum + iter_sum
+
+            # == store P (f32) to LDS ==
+            # Layout: P_lds[tile_abs][query][token_in_tile], f32 index =
+            #   tile_abs*256 + query*16 + token_in_tile
+            # tile_abs = warp_id*2+nt, query = klane*8+elem, token = lane16
+            gpu.barrier()
+            for nt in [0, 1]:
+                tile_abs = warp_id * fx.Int32(2) + fx.Int32(nt)
+                for elem in [0, 1, 2, 3, 4, 5, 6, 7]:
+                    q_idx = klane * fx.Int32(8) + fx.Int32(elem)
+                    p_idx = tile_abs * fx.Int32(256) + q_idx * fx.Int32(16) + lane16
+                    p_val = vector.extract(acc_qk[nt], static_position=[elem], dynamic_position=[])
+                    p_smem.store(p_val, [arith.index_cast(T.index, p_idx)])
+            gpu.barrier()
+
+            # == PV: P[16,256] x V[256,128] -> O[16,128] ==
+            warp_hd_base = warp_id * fx.Int32(WMMA_N)
+            for s in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]:
+                # P from LDS: 8 contiguous f32 -> query=lane16, tokens=klane*8..+7
+                p_lds_idx = fx.Int32(s * 256) + lane16 * fx.Int32(16) + klane * fx.Int32(8)
+                p_f32 = vector.load_op(v8f32, p_lds_f32, [arith.index_cast(T.index, p_lds_idx)])
+                p_scaled = [
+                    vector.extract(p_f32, static_position=[i], dynamic_position=[]) * F_FP8MAX
+                    for i in [0, 1, 2, 3, 4, 5, 6, 7]
+                ]
+                p_fp8 = _f32x8_to_fp8(p_scaled)
+
+                phys_v = _bt_load(part, fx.Int32(s))
+                v_fp8 = _load_v(phys_v, warp_hd_base)
+
+                acc_pv = rocdl.wmma_f32_16x16x16_fp8_fp8(
+                    v8f32, p_fp8, v_fp8, arith.unwrap(acc_pv)
+                ).result
+
+            # == output ==
+            _is_last_iter = _pi == int(_max_pps) - 1
+            if not _ps_mode or _is_last_iter:
+                rcp = fx.Float32(1.0) / running_sum
+                pv_out = _vsplat_mul_8(_vsplat_mul_8(acc_pv, PROB_SCALE_C), rcp)
+
+                if one_shot or _ps_mode:
+                    c_os = fx.Int32(_stride_out_seq)
+                    c_oh = fx.Int32(_stride_out_head)
+                    for elem in [0, 1, 2, 3, 4, 5, 6, 7]:
+                        q = klane * fx.Int32(8) + fx.Int32(elem)
+                        out_off = seq * c_os + kv_h * c_oh + q * fx.Int32(HEAD_SIZE) + warp_hd_base + lane16
+                        val = arith.trunc_f(T.bf16, vector.extract(pv_out, static_position=[elem], dynamic_position=[]))
+                        buffer_ops.buffer_store(val, out_rsrc, out_off)
+                else:
+                    c_np_qg = fx.Int32(num_partitions * QUERY_GROUP_SIZE)
+                    c_qg = fx.Int32(QUERY_GROUP_SIZE)
+                    for elem in [0, 1, 2, 3, 4, 5, 6, 7]:
+                        q = klane * fx.Int32(8) + fx.Int32(elem)
+                        ml_off = seq * fx.Int32(_stride_ml_seq) + kv_h * c_np_qg + part * c_qg + q
+                        es_off = seq * fx.Int32(_stride_es_seq) + kv_h * c_np_qg + part * c_qg + q
+                        buffer_ops.buffer_store(running_max, ml_rsrc, ml_off)
+                        buffer_ops.buffer_store(running_sum, es_rsrc, es_off)
+
+                    c_os = fx.Int32(_stride_out_seq)
+                    c_oh = fx.Int32(_stride_out_head)
+                    c_op = fx.Int32(_stride_out_part)
+                    for elem in [0, 1, 2, 3, 4, 5, 6, 7]:
+                        q = klane * fx.Int32(8) + fx.Int32(elem)
+                        out_off = (
+                            seq * c_os + kv_h * c_oh + part * c_op
+                            + q * fx.Int32(HEAD_SIZE) + warp_hd_base + lane16
+                        )
+                        val = arith.trunc_f(T.bf16, vector.extract(pv_out, static_position=[elem], dynamic_position=[]))
+                        buffer_ops.buffer_store(val, out_rsrc, out_off)
+
+    return pa_decode_dot_kernel
+

--- a/tests/kernels/test_pa.py
+++ b/tests/kernels/test_pa.py
@@ -1,37 +1,61 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
-"""PA Decode FP8 — FlyDSL vs Gluon, with Gluon reduce + one-shot + PS modes."""
+"""PA Decode FP8 — unified test for CDNA (MFMA) and RDNA (WMMA).
+
+CDNA path: FlyDSL vs Gluon (requires aiter) — original run_single()
+RDNA path: FlyDSL vs torch reference (self-contained) — run_rdna()
+"""
 import sys, os, torch, math, logging, random, gc
 import pytest
-
-pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
 
 sys.path.insert(0, 'build-fly/python_packages'); sys.path.insert(1, '.')
 os.environ['FLYDSL_RUNTIME_ENABLE_CACHE'] = '1'
 logging.basicConfig(level=logging.INFO, format='%(message)s')
 
-aiter = pytest.importorskip("aiter", reason="aiter is not installed, skipping PA tests")
-
 from tests.test_common import run_perftest, verify_output, checkAllclose
-from kernels.pa_decode_fp8 import build_pa_decode_module, BLOCK_THREADS, QUERY_GROUP_SIZE, HEAD_SIZE, KV_COMPUTE_BLOCK
-import kernels.pa_decode_fp8 as _pa
 from flydsl.compiler.kernel_function import CompilationContext
 from flydsl._mlir import ir as _ir
 import flydsl.compiler as flyc, flydsl.expr as fx
 from flydsl.expr import arith
 from flydsl.expr.typing import T
-from aiter.ops.triton.gluon.pa_decode_gluon import (
-    pa_decode_gluon, get_recommended_splits,
-    _paged_attention_decode_v2_reduce_kernel_wrapper,
-)
-from aiter import per_tensor_quant, dtypes as aiter_dtypes
+from flydsl.runtime.device import get_rocm_arch, is_rdna_arch
+
+# ── Arch detection ──────────────────────────────────────────────
+ARCH = str(get_rocm_arch())
+IS_RDNA = is_rdna_arch(ARCH)
+
+# ── Conditional aiter ───────────────────────────────────────────
+try:
+    from aiter.ops.triton.gluon.pa_decode_gluon import (
+        pa_decode_gluon, get_recommended_splits,
+        _paged_attention_decode_v2_reduce_kernel_wrapper,
+    )
+    from aiter import per_tensor_quant, dtypes as aiter_dtypes
+    HAS_AITER = True
+except ImportError:
+    HAS_AITER = False
+
+# ── Arch-dependent kernel imports ───────────────────────────────
+if IS_RDNA:
+    from kernels.rdna_pa_decode_fp8 import build_pa_decode_module, BLOCK_THREADS
+    import kernels.rdna_pa_decode_fp8 as _pa
+    from kernels.pa_common import QUERY_GROUP_SIZE, HEAD_SIZE, KV_COMPUTE_BLOCK
+    fp8 = torch.float8_e4m3fn
+else:
+    from kernels.pa_decode_fp8 import build_pa_decode_module, BLOCK_THREADS, QUERY_GROUP_SIZE, HEAD_SIZE, KV_COMPUTE_BLOCK
+    import kernels.pa_decode_fp8 as _pa
+    fp8 = torch.float8_e4m3fnuz
 
 CPSZ = 256; QG = QUERY_GROUP_SIZE
-fp8 = torch.float8_e4m3fnuz; bf16 = torch.bfloat16; dev = 'cuda'
+bf16 = torch.bfloat16; dev = 'cuda'
 UNIFORM_RANGE = (-1, 1)
 SEED = 0
 
+
+# ============================================================================
+# Shared helpers
+# ============================================================================
 
 def setup_seed(seed):
     random.seed(seed)
@@ -43,28 +67,23 @@ def create_kv_caches(num_blocks, block_size, num_kv_heads, head_size):
     x = 16
     key_shape = (num_blocks, num_kv_heads, head_size // x, block_size, x)
     val_shape = (num_blocks, num_kv_heads, head_size, block_size)
-    kc = torch.empty(key_shape, dtype=bf16, device=dev)
-    vc = torch.empty(val_shape, dtype=bf16, device=dev)
-    kc.uniform_(*UNIFORM_RANGE)
-    vc.uniform_(*UNIFORM_RANGE)
+    kc = torch.empty(key_shape, dtype=bf16, device=dev).uniform_(*UNIFORM_RANGE)
+    vc = torch.empty(val_shape, dtype=bf16, device=dev).uniform_(*UNIFORM_RANGE)
     return kc, vc
 
 
-def quantize_kv_per_tensor(key_cache, value_cache):
-    num_blocks, num_heads, head_dim, block_size = value_cache.shape
-    x = 16
-    kc_reshaped = (key_cache.permute(0, 1, 3, 2, 4)
-                   .reshape(num_blocks, num_heads, block_size, -1).contiguous())
-    kc_reshaped = (kc_reshaped.view(num_blocks, num_heads, block_size,
-                                     head_dim // x, x)
-                   .permute(0, 1, 3, 2, 4).contiguous())
-    q_keys, key_scale = per_tensor_quant(kc_reshaped, quant_dtype=aiter_dtypes.fp8)
-    q_vals, val_scale = per_tensor_quant(value_cache, quant_dtype=aiter_dtypes.fp8)
-    return q_keys, key_scale, q_vals, val_scale
+def _per_tensor_quant_fp8_native(tensor, fp8_max=None):
+    """Torch-native FP8 per-tensor quantization (no aiter dependency)."""
+    if fp8_max is None:
+        fp8_max = 448.0 if fp8 == torch.float8_e4m3fn else 240.0
+    amax = tensor.float().abs().amax().clamp(min=1e-12)
+    scale = amax / fp8_max
+    return (tensor.float() / scale).clamp(-fp8_max, fp8_max).to(fp8), scale
 
 
 def torch_ref_attention(query, key_cache, value_cache, block_tables,
-                        context_lengths, key_scale, value_scale):
+                        context_lengths, key_scale, value_scale,
+                        query_scale=None):
     num_blocks, num_heads, head_dim, block_size = value_cache.shape
     softmax_scale = 1.0 / math.sqrt(head_dim)
     batch_size = query.shape[0]
@@ -83,6 +102,7 @@ def torch_ref_attention(query, key_cache, value_cache, block_tables,
         vals = vc_flat.view(torch.int8)[tok_idx].view(kv_dtype).float()
         if value_scale is not None: vals = vals * value_scale.item()
         q_b = query[b].float()
+        if query_scale is not None: q_b = q_b * query_scale.item()
         qg = num_query_heads // num_heads
         q_grouped = q_b.view(num_heads, qg, head_dim)
         scores = torch.einsum('gqd,tgd->gqt', q_grouped, keys) * softmax_scale
@@ -92,8 +112,24 @@ def torch_ref_attention(query, key_cache, value_cache, block_tables,
     return torch.stack(outputs).to(query.dtype)
 
 
+# ============================================================================
+# CDNA path: FlyDSL vs Gluon (UNCHANGED from original — requires aiter)
+# ============================================================================
+
+def quantize_kv_per_tensor(key_cache, value_cache):
+    num_blocks, num_heads, head_dim, block_size = value_cache.shape
+    x = 16
+    kc_reshaped = (key_cache.permute(0, 1, 3, 2, 4)
+                   .reshape(num_blocks, num_heads, block_size, -1).contiguous())
+    kc_reshaped = (kc_reshaped.view(num_blocks, num_heads, block_size,
+                                     head_dim // x, x)
+                   .permute(0, 1, 3, 2, 4).contiguous())
+    q_keys, key_scale = per_tensor_quant(kc_reshaped, quant_dtype=aiter_dtypes.fp8)
+    q_vals, val_scale = per_tensor_quant(value_cache, quant_dtype=aiter_dtypes.fp8)
+    return q_keys, key_scale, q_vals, val_scale
+
+
 def gluon_reduce(fd_out, fd_es, fd_ml, context_lengths, num_parts, ps_mode=False):
-    """Call Gluon's Triton reduce kernel on FlyDSL's partial outputs."""
     batch_size, num_kv_heads, _, qg, head_size = fd_out.shape
     output_5d = torch.empty(batch_size, 1, num_kv_heads, qg, head_size,
                             dtype=bf16, device=dev)
@@ -114,6 +150,7 @@ def gluon_reduce(fd_out, fd_es, fd_ml, context_lengths, num_parts, ps_mode=False
 def run_single(num_query_heads, num_kv_heads, batch_size, context_length,
                block_size=16, trans_v=False, ps=True, quant_q=True,
                num_iters=100, test_graph=False):
+    """CDNA path: full Gluon comparison. Unchanged from original."""
     setup_seed(SEED)
     head_size = HEAD_SIZE
     softmax_scale = 1.0 / math.sqrt(head_size)
@@ -211,7 +248,6 @@ def run_single(num_query_heads, num_kv_heads, batch_size, context_length,
             grid=(grid_x, grid_y, grid_z_val),
             block=(BLOCK_THREADS, 1, 1), stream=stream)
 
-    # Warmup (compilation happens here)
     fd_launch(fd_out, fd_es, fd_ml, fd_query, q_keys, q_vals,
               block_tables, context_length,
               batch_size, num_kv_heads, grid_z,
@@ -240,7 +276,7 @@ def run_single(num_query_heads, num_kv_heads, batch_size, context_length,
 
     mode_str = "one_shot" if _one_shot else (f"ps({fd_num_splits})" if fd_num_splits > 0 else "partitioned")
 
-    # ── Perf (GEMM-style: wrapper + run_perftest with tensor args) ──
+    # ── Perf ────────────────────────────────────────────────────
     if _one_shot:
         def launch_fd(out, es, ml, q, kc, vc, bt):
             fd_launch(out, es, ml, q, kc, vc, bt,
@@ -287,36 +323,178 @@ def run_single(num_query_heads, num_kv_heads, batch_size, context_length,
     return fd_ok, gl_ok, fd_us, gl_us, mode_str, err_fd
 
 
-# ── Test configs ─────────────────────────────────────────────────
+# ============================================================================
+# RDNA path: FlyDSL vs torch reference (no aiter dependency)
+# ============================================================================
+
+def _torch_reduce(fd_out, fd_es, fd_ml):
+    gmax = fd_ml.max(dim=2, keepdim=True).values
+    w = fd_es * torch.exp(fd_ml - gmax)
+    w = w / w.sum(dim=2, keepdim=True).clamp(min=1e-12)
+    return (fd_out.float() * w.unsqueeze(-1)).sum(dim=2).to(bf16)
+
+
+def run_rdna(num_query_heads, num_kv_heads, batch_size, context_length, block_size=16):
+    """RDNA path: self-contained, validates against torch reference."""
+    setup_seed(SEED)
+    head_size = HEAD_SIZE
+    softmax_scale = 1.0 / math.sqrt(head_size)
+    qg = num_query_heads // num_kv_heads
+
+    max_ctx = max(16384, context_length)
+    max_blocks_per_seq = (max_ctx + block_size - 1) // block_size
+    total_blocks = max_blocks_per_seq * batch_size
+    blocks_per_seq = (context_length + block_size - 1) // block_size
+    num_parts = (context_length + CPSZ - 1) // CPSZ
+    _one_shot = (num_parts <= 1)
+
+    query = torch.empty(batch_size, num_query_heads, head_size, dtype=bf16, device=dev).uniform_(*UNIFORM_RANGE)
+    kc_bf16, vc_bf16 = create_kv_caches(total_blocks, block_size, num_kv_heads, head_size)
+    q_keys, key_scale = _per_tensor_quant_fp8_native(kc_bf16.permute(0,1,3,2,4)
+        .reshape(-1, num_kv_heads, block_size, head_size // 16 * 16).contiguous()
+        .view(-1, num_kv_heads, block_size, head_size // 16, 16)
+        .permute(0,1,3,2,4).contiguous())
+    q_vals, val_scale = _per_tensor_quant_fp8_native(vc_bf16)
+
+    block_tables = torch.tensor(
+        [[random.randint(0, total_blocks - 1) for _ in range(blocks_per_seq)]
+         for _ in range(batch_size)], dtype=torch.int32, device=dev)
+    context_lengths_t = torch.full((batch_size,), context_length, dtype=torch.int32, device=dev)
+    fd_query, q_scale = _per_tensor_quant_fp8_native(query)
+
+    ref_out = torch_ref_attention(fd_query, q_keys, q_vals, block_tables,
+                                  context_lengths_t, key_scale, val_scale,
+                                  query_scale=q_scale)
+
+    grid_z = 1 if _one_shot else num_parts
+    fd_kfn = build_pa_decode_module(
+        batch_size, num_kv_heads, num_parts, blocks_per_seq,
+        kv_block_size=block_size, softmax_scale=softmax_scale,
+        query_scale=q_scale.item(), key_scale=key_scale.item(),
+        value_scale=val_scale.item(), one_shot=_one_shot)
+    fd_al = _pa.allocator
+
+    if _one_shot:
+        fd_out = torch.zeros(batch_size, num_kv_heads, 1, qg, head_size, dtype=bf16, device=dev)
+        fd_es = torch.zeros(1, dtype=torch.float32, device=dev)
+        fd_ml = torch.zeros(1, dtype=torch.float32, device=dev)
+    else:
+        fd_out = torch.zeros(batch_size, num_kv_heads, num_parts, qg, head_size, dtype=bf16, device=dev)
+        fd_es = torch.zeros(batch_size, num_kv_heads, num_parts, qg, dtype=torch.float32, device=dev)
+        fd_ml = torch.full((batch_size, num_kv_heads, num_parts, qg),
+                           float('-inf'), dtype=torch.float32, device=dev)
+
+    _cache_tag = (batch_size, num_kv_heads, grid_z, "rdna")
+
+    @flyc.jit
+    def fd_launch(out, es, ml, q, kc, vc, bt, cl: fx.Int32,
+                  gx: fx.Int32, gy: fx.Int32, gz: fx.Int32,
+                  stream: fx.Stream):
+        _ = _cache_tag
+        fd_al.finalized = False
+        ctx = CompilationContext.get_current()
+        with _ir.InsertionPoint(ctx.gpu_module_body):
+            fd_al.finalize()
+        fd_kfn(out, es, ml, q, kc, vc, bt, cl).launch(
+            grid=(arith.index_cast(T.index, gx.ir_value()),
+                  arith.index_cast(T.index, gy.ir_value()),
+                  arith.index_cast(T.index, gz.ir_value())),
+            block=(BLOCK_THREADS, 1, 1), stream=stream)
+
+    def run_kernel():
+        fd_launch(fd_out, fd_es, fd_ml, fd_query, q_keys, q_vals,
+                  block_tables, context_length, batch_size, num_kv_heads, grid_z,
+                  torch.cuda.current_stream())
+
+    run_kernel(); torch.cuda.synchronize()
+    fd_final = fd_out.squeeze(2) if _one_shot else _torch_reduce(fd_out, fd_es, fd_ml)
+
+    fd_flat = fd_final.reshape(batch_size, num_query_heads, head_size).float()
+    ref_flat = ref_out.float()
+    ok = verify_output(fd_flat, ref_flat, atol=0.1, rtol=0.1,
+                       msg=f"[RDNA b={batch_size} c={context_length}]")
+    _, avg_us = run_perftest(run_kernel, num_iters=50, num_warmup=5)
+    torch.cuda.empty_cache(); gc.collect()
+    return ok, avg_us
+
+
+# ============================================================================
+# Pytest tests
+# ============================================================================
+
+@pytest.mark.parametrize("batch,ctx", [
+    pytest.param(1, 128, id="1x128"),
+    pytest.param(1, 256, id="1x256"),
+    pytest.param(2, 256, id="2x256"),
+    pytest.param(1, 512, id="1x512"),
+])
+def test_pa_decode_rdna(batch, ctx):
+    if not IS_RDNA:
+        pytest.skip(f"Requires RDNA GPU, got {ARCH}")
+    ok, _ = run_rdna(16, 1, batch, ctx)
+    assert ok
+
+@pytest.mark.parametrize("batch,ctx", [
+    pytest.param(1, 1024, id="1x1024"),
+    pytest.param(4, 4096, id="4x4096", marks=pytest.mark.large_shape),
+])
+def test_pa_decode_rdna_bench(batch, ctx):
+    if not IS_RDNA:
+        pytest.skip(f"Requires RDNA GPU, got {ARCH}")
+    ok, us = run_rdna(16, 1, batch, ctx)
+    assert ok
+    logging.getLogger("flydsl").info(f"[rdna_pa] batch={batch} ctx={ctx}: {us:.1f} us")
+
+@pytest.mark.parametrize("batch,ctx,ps", [
+    pytest.param(128, 4096, False, id="128x4096"),
+    pytest.param(128, 8192, True, id="128x8192_ps"),
+])
+def test_pa_decode_cdna(batch, ctx, ps):
+    if IS_RDNA:
+        pytest.skip(f"Requires CDNA GPU, got {ARCH}")
+    if not HAS_AITER:
+        pytest.skip("Requires aiter")
+    fd_ok, _, _, _, _, err = run_single(
+        16, 1, batch, ctx, block_size=1024, trans_v=True, quant_q=False,
+        ps=ps, num_iters=20)
+    assert fd_ok, f"FlyDSL err={err:.4f}"
+
+
+# ============================================================================
+# Standalone runner
+# ============================================================================
+
 if __name__ == "__main__":
-    import argparse
-    parser = argparse.ArgumentParser(description="PA Decode FP8 benchmark")
-    parser.add_argument("--test_graph", "-tg", action="store_true", default=False)
-    parser.add_argument("--num_iters", type=int, default=100)
-    args = parser.parse_args()
-
-    NH, NKV, BS = 16, 1, 1024
-    tv, qq = True, False
-
-    print(f"{'mode':>14} |  NH  NKV |   BS | batch |   CTX | tv qq |   FlyDSL   |   Gluon    | ratio | status")
-    print("-" * 100)
-
-    configs = [
-        (128, 8192, False),
-        (128, 8192, True),
-        (128, 4096, False),
-    ]
-
-    for batch, CTX, use_ps in configs:
-        try:
-            fd_ok, gl_ok, fd_us, gl_us, mode_str, err_fd = run_single(
-                NH, NKV, batch, CTX, block_size=BS, trans_v=tv, quant_q=qq,
-                ps=use_ps, num_iters=args.num_iters, test_graph=args.test_graph)
-            sp = gl_us / fd_us
-            fd_s = "PASS" if fd_ok else "FAIL"
-            gl_s = "PASS" if gl_ok else "FAIL"
-            print(f"{mode_str:>14} | {NH:>3} {NKV:>4} | {BS:>4} | {batch:>5} | {CTX:>5} |  T  F | {fd_us:>8.1f}us | {gl_us:>8.1f}us | {sp:>5.2f}x | {fd_s:>4} {gl_s:>4} (err={err_fd:.4f})")
-        except Exception as ex:
-            import traceback; traceback.print_exc()
-            print(f"{'ERROR':>14} | {NH:>3} {NKV:>4} | {BS:>4} | {batch:>5} | {CTX:>5} | ps={'T' if use_ps else 'F'} | EXCEPTION")
-    print("-" * 100)
+    if IS_RDNA:
+        print(f"GPU: {ARCH} (RDNA)  HEAD={HEAD_SIZE}  QG={QG}")
+        print("%5s %5s | %10s | %s" % ("batch", "ctx", "kernel_us", "status"))
+        print("-" * 45)
+        for batch, ctx in [(1,128),(1,256),(2,256),(1,512),(4,256),(1,1024),(4,4096),(32,4096)]:
+            try:
+                ok, us = run_rdna(16, 1, batch, ctx)
+                print("%5d %5d | %8.1fus | %s" % (batch, ctx, us, "PASS" if ok else "FAIL"))
+            except Exception:
+                import traceback; traceback.print_exc()
+                print("%5d %5d | %10s | FAIL" % (batch, ctx, "ERROR"))
+        print("-" * 45)
+    elif HAS_AITER:
+        import argparse
+        parser = argparse.ArgumentParser(description="PA Decode FP8 benchmark")
+        parser.add_argument("--test_graph", "-tg", action="store_true", default=False)
+        parser.add_argument("--num_iters", type=int, default=100)
+        args = parser.parse_args()
+        NH, NKV, BS = 16, 1, 1024; tv, qq = True, False
+        print(f"{'mode':>14} |  NH  NKV |   BS | batch |   CTX | tv qq |   FlyDSL   |   Gluon    | ratio | status")
+        print("-" * 100)
+        for batch, CTX, use_ps in [(128,8192,False),(128,8192,True),(128,4096,False)]:
+            try:
+                fd_ok, gl_ok, fd_us, gl_us, mode_str, err_fd = run_single(
+                    NH, NKV, batch, CTX, block_size=BS, trans_v=tv, quant_q=qq,
+                    ps=use_ps, num_iters=args.num_iters, test_graph=args.test_graph)
+                sp = gl_us / fd_us
+                print(f"{mode_str:>14} | {NH:>3} {NKV:>4} | {BS:>4} | {batch:>5} | {CTX:>5} |  T  F | {fd_us:>8.1f}us | {gl_us:>8.1f}us | {sp:>5.2f}x | {'PASS' if fd_ok else 'FAIL':>4} {'PASS' if gl_ok else 'FAIL':>4} (err={err_fd:.4f})")
+            except Exception:
+                import traceback; traceback.print_exc()
+        print("-" * 100)
+    else:
+        print(f"GPU: {ARCH}, aiter not available, no CDNA tests to run")


### PR DESCRIPTION
## Motivation

Add RDNA4 (gfx120x) paged-attention FP8 decode kernel to FlyDSL, enabling LLM inference decode on consumer RDNA GPUs. The existing CDNA kernel uses MFMA wave64 instructions and cannot run on RDNA hardware.

## Technical Details

- **`kernels/pa_common.py` (new):** shared constants, stride computation, and reduce kernels extracted from `pa_decode_fp8.py` to eliminate duplication between CDNA and RDNA paths
- **`kernels/rdna_pa_decode_fp8.py` (new):** RDNA4 decode dot kernel using `wmma_f32_16x16x16_fp8_fp8` with wave32 (8 warps × 32 lanes), softmax P staged through LDS as f32
- **`kernels/pa_decode_fp8.py` (modified):** CDNA kernel now imports shared code from `pa_common`, removing ~360 duplicate lines
- **`tests/kernels/test_pa.py` (modified):** unified test for both CDNA and RDNA — arch-aware kernel selection, aiter made optional (RDNA validates against torch reference; CDNA validates against Gluon when aiter is available)
- **`tests/arch_compat.py` (modified):** `test_pa.py` removed from `CDNA_ONLY_TESTS` since it now self-manages arch dispatch

## Test Plan

- [x] RDNA correctness: `python tests/kernels/test_pa.py` on gfx1201 — all PASS (cos_sim > 0.999 vs torch reference)
- [x] RDNA performance: 2.5–146× faster than PyTorch SDPA (bf16) on gfx1201
- [ ] CDNA regression: existing `run_single()` path unchanged, needs gfx9xx CI validation

## Test Result

gfx1201 (RX 9070 XT, ROCm 7.1, PyTorch 2.9.1):

| batch | ctx  | kernel (us) | status |
|-------|------|-------------|--------|
| 1     | 128  | 6.7         | PASS   |
| 1     | 256  | 7.6         | PASS   |
| 4     | 4096 | 7.7         | PASS   |
| 32    | 4096 | 35.1        | PASS   |

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.