### PR TITLE
[Fix] Support IntAttr tiled MMA permutation modes

### DIFF
--- a/lib/Bindings/Python/TiledOpTraits.cpp
+++ b/lib/Bindings/Python/TiledOpTraits.cpp
@@ -96,9 +96,15 @@ LayoutAttr tiledMmaGetTiledThrValLayout(MmaAtomType mmaAtom, LayoutAttr atomLayo
       auto thrSizeI = intTupleProduct(attrBuilder, atomLayoutMNK.getShape().at(i)).getLeafAsInt();
       tileSizeElems.push_back(IntTupleAttr::get(atomShapeI * thrSizeI));
     } else {
-      auto permLayout = cast<LayoutAttr>(permutationMNK.at(i));
-      auto sizeI = intTupleProduct(attrBuilder, permLayout.getShape()).getLeafAsInt();
-      tileSizeElems.push_back(IntTupleAttr::get(sizeI));
+      auto permMode = permutationMNK.at(i);
+      if (auto permLayout = dyn_cast<LayoutAttr>(permMode)) {
+        tileSizeElems.push_back(
+            IntTupleAttr::get(intTupleProduct(attrBuilder, permLayout.getShape()).getLeafAsInt()));
+      } else if (auto permInt = dyn_cast<IntAttr>(permMode)) {
+        tileSizeElems.push_back(IntTupleAttr::get(permInt));
+      } else {
+        llvm_unreachable("unsupported tiled MMA permutation element");
+      }
     }
   }
   IntTupleAttr refShape = IntTupleAttr::get(ArrayAttr::get(ctx, tileSizeElems));
@@ -179,9 +185,15 @@ IntTupleAttr tiledMmaGetTileSizeMNK(MmaAtomType mmaAtom, LayoutAttr atomLayoutMN
       auto thrSizeI = intTupleProduct(attrBuilder, atomLayoutMNK.getShape().at(i)).getLeafAsInt();
       tileSizeElems.push_back(IntTupleAttr::get(atomShapeI * thrSizeI));
     } else {
-      auto permLayout = cast<LayoutAttr>(permutationMNK.at(i));
-      auto sizeI = intTupleProduct(attrBuilder, permLayout.getShape()).getLeafAsInt();
-      tileSizeElems.push_back(IntTupleAttr::get(sizeI));
+      auto permMode = permutationMNK.at(i);
+      if (auto permLayout = dyn_cast<LayoutAttr>(permMode)) {
+        tileSizeElems.push_back(
+            IntTupleAttr::get(intTupleProduct(attrBuilder, permLayout.getShape()).getLeafAsInt()));
+      } else if (auto permInt = dyn_cast<IntAttr>(permMode)) {
+        tileSizeElems.push_back(IntTupleAttr::get(permInt));
+      } else {
+        llvm_unreachable("unsupported tiled MMA permutation element");
+      }
     }
   }
   return IntTupleAttr::get(ArrayAttr::get(ctx, tileSizeElems));


### PR DESCRIPTION
Allow the tiled MMA Python helpers to accept scalar permutation modes instead of assuming every non-None mode is a layout. This avoids crashes when mixed int/layout permutations are inspected from Python.

Made-with: Cursor

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
