### PR TITLE
[OPT] Optimize swizzle in layoutCrd2Idx when outer is period-divisible

### DIFF
--- a/include/flydsl/Dialect/Fly/IR/FlyAttrDefs.td
+++ b/include/flydsl/Dialect/Fly/IR/FlyAttrDefs.td
@@ -156,6 +156,8 @@ def Fly_SwizzleAttr : Fly_Attr<"Swizzle", "swizzle", []> {
   let extraClassDeclaration = [{
     bool isTrivialSwizzle() const;
     static SwizzleAttr getTrivialSwizzle(MLIRContext *context);
+    
+    int32_t getPeriod() const;
   }];
 }
 

--- a/include/flydsl/Dialect/Fly/Utils/IntUtils.h
+++ b/include/flydsl/Dialect/Fly/Utils/IntUtils.h
@@ -56,6 +56,8 @@ IntAttr intCeilDiv(IntAttr lhs, IntAttr rhs);
 IntAttr intShapeDiv(IntAttr lhs, IntAttr rhs);
 IntAttr intApplySwizzle(IntAttr v, SwizzleAttr swizzle);
 
+bool isDivisible(IntAttr attr, int32_t divisor);
+
 //===----------------------------------------------------------------------===//
 // BasisAttr operations
 //===----------------------------------------------------------------------===//

--- a/include/flydsl/Dialect/Fly/Utils/LayoutUtils.h
+++ b/include/flydsl/Dialect/Fly/Utils/LayoutUtils.h
@@ -237,7 +237,14 @@ auto layoutCrd2Idx(LayoutBuilder<Layout> &builder, typename LayoutBuilder<Layout
 
     auto inner = builder.getInner(layout);
     if (builder.isSwizzle(inner)) {
-      return builder.applySwizzle(intermediate, builder.getSwizzleAttr(inner));
+      auto swizzle = builder.getSwizzleAttr(inner);
+      auto outerResultAttr = builder.getAttr(outerResult);
+      if (outerResultAttr.isLeafInt() &&
+          isDivisible(outerResultAttr.getLeafAsInt(), swizzle.getPeriod())) {
+        auto swizzledOffset = builder.applySwizzle(builder.getOffset(layout), swizzle);
+        return builder.add(swizzledOffset, outerResult);
+      }
+      return builder.applySwizzle(intermediate, swizzle);
     } else {
       return layoutCrd2Idx(builder, intermediate, inner);
     }

--- a/lib/Dialect/Fly/IR/FlyAttrDefs.cpp
+++ b/lib/Dialect/Fly/IR/FlyAttrDefs.cpp
@@ -51,6 +51,9 @@ int32_t BasisAttr::depth() { return static_cast<int32_t>(getModes().size()); }
 
 bool SwizzleAttr::isTrivialSwizzle() const { return getMask() == 0; }
 SwizzleAttr SwizzleAttr::getTrivialSwizzle(MLIRContext *context) { return get(context, 0, 0, 0); }
+int32_t SwizzleAttr::getPeriod() const {
+  return int32_t{1} << (getBase() + getShift() + getMask());
+}
 
 //===----------------------------------------------------------------------===//
 // IntTupleAttr

--- a/lib/Dialect/Fly/Utils/IntUtils.cpp
+++ b/lib/Dialect/Fly/Utils/IntUtils.cpp
@@ -250,6 +250,12 @@ IntAttr intApplySwizzle(IntAttr v, SwizzleAttr swizzle) {
                              utils::divisibilityApplySwizzle(v.getDivisibility(), swizzle));
 }
 
+bool isDivisible(IntAttr attr, int32_t divisor) {
+  if (attr.isStatic())
+    return attr.getValue() % divisor == 0;
+  return attr.getDivisibility() % divisor == 0;
+}
+
 BasisAttr operator*(BasisAttr lhs, IntAttr rhs) {
   return BasisAttr::get(lhs.getValue() * rhs, lhs.getModes());
 }


### PR DESCRIPTION
Add SwizzleAttr::getPeriod(), isDivisible(IntAttr, int32_t), and when the outer layout result is divisible by the swizzle period, apply swizzle to offset+outer instead of the full intermediate expression.

Made-with: Cursor

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
