### PR TITLE
[FIX] Fix atom_set_value signature mismatch and ROCDL compat

### DIFF
--- a/python/flydsl/__init__.py
+++ b/python/flydsl/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
-_BASE_VERSION = "0.1.2"
+_BASE_VERSION = "0.1.3"
 
 # FFM simulator compatibility shim (no-op outside simulator sessions).
 from ._compat import _maybe_preload_system_comgr  # noqa: E402

--- a/python/flydsl/expr/primitive.py
+++ b/python/flydsl/expr/primitive.py
@@ -696,7 +696,7 @@ def atom_set_value(atom, field, value, loc=None, ip=None):
         field = str(field)
     if isinstance(field, str):
         field = ir.StringAttr.get(field)
-    return fly.atom_set_value(atom.type, atom, field, value, loc=loc, ip=ip)
+    return fly.atom_set_value(atom, field, value, loc=loc, ip=ip)
 
 
 @traced_op

--- a/python/flydsl/expr/primitive.py
+++ b/python/flydsl/expr/primitive.py
@@ -694,7 +694,9 @@ def make_copy_atom(copy_op_type, elem_type, loc=None, ip=None):
 def atom_set_value(atom, field, value, loc=None, ip=None):
     if isinstance(field, IntEnum):
         field = str(field)
-    return fly.atom_set_value(atom, field, value, loc=loc, ip=ip)
+    if isinstance(field, str):
+        field = ir.StringAttr.get(field)
+    return fly.atom_set_value(atom.type, atom, field, value, loc=loc, ip=ip)
 
 
 @traced_op

--- a/python/flydsl/expr/rocdl/__init__.py
+++ b/python/flydsl/expr/rocdl/__init__.py
@@ -22,9 +22,9 @@ from . import cdna4
 _ods_wmma_scale_f32_16x16x128_f8f6f4 = globals().get("wmma_scale_f32_16x16x128_f8f6f4", None)
 _ods_wmma_scale_f32_32x16x128_f4 = globals().get("wmma_scale_f32_32x16x128_f4", None)
 _ods_wave_id = wave_id  # ODS: wave_id(res, ...) -> i32
-_ods_cluster_workgroup_id_x = cluster_workgroup_id_x
-_ods_cluster_workgroup_id_y = cluster_workgroup_id_y
-_ods_cluster_workgroup_id_z = cluster_workgroup_id_z
+_ods_cluster_workgroup_id_x = globals().get("cluster_workgroup_id_x", None)
+_ods_cluster_workgroup_id_y = globals().get("cluster_workgroup_id_y", None)
+_ods_cluster_workgroup_id_z = globals().get("cluster_workgroup_id_z", None)
 _ods_cluster_load_async_to_lds_b8 = cluster_load_async_to_lds_b8
 _ods_cluster_load_async_to_lds_b32 = cluster_load_async_to_lds_b32
 _ods_cluster_load_async_to_lds_b64 = cluster_load_async_to_lds_b64


### PR DESCRIPTION
## Summary

Two fixes for issues discovered while integrating FlyDSL fused RoPE kernel into AITER:

**1. `atom_set_value` signature mismatch** (`primitive.py`)

Commit #377 changed `atom_set_value` to call `fly.atom_set_value(atom, field, value)`, but the ODS-generated binding still expects `(result, atom, field, value)`. Additionally, the `field` string must be wrapped in `ir.StringAttr` for the MLIR op to accept it.

This breaks any kernel using `copy_atom.set_value("soffset", ...)`, including the fused RoPE+KV cache kernel.

**2. Missing ROCDL ops** (`rocdl/__init__.py`)

`cluster_workgroup_id_{x,y,z}` are referenced at module level but not present in the current LLVM ROCDL dialect, causing `NameError` on import. Changed to `globals().get()` to make them optional, matching the pattern used for `wmma_scale_f32_*`.

## Test

```bash
PYTHONPATH=./ pytest tests/kernels/test_fused_rope_cache.py -v -s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)