### PR TITLE
Unify MoE test perf timing to CUDA Event bench and fix minor issues

### DIFF
--- a/kernels/moe_gemm_2stage_mxscale_gfx1250.py
+++ b/kernels/moe_gemm_2stage_mxscale_gfx1250.py
@@ -394,7 +394,15 @@ def _compile_stage1_mxscale_kernel_impl(
             _acc = arith.constant(0, type=T.i32)
             for _vi in range_constexpr(len(_vals)):
                 _acc = _acc + _vals[_vi]
-            return _acc
+            # Force the reduction result onto an SGPR. Without this the chain of
+            # arith.select(bool, 1, 0) + arith.addi tends to lower into v_cndmask +
+            # v_add_nc_u32 (VGPR), and the AMDGPU backend rematerializes that VGPR
+            # sum into the scf.if guarding the TDM gather issue. It then has to
+            # v_mov_b64 the whole 8-word header SGPR→VGPR, patch dgroup1.lane4
+            # (gather_tile_dim1), and v_readfirstlane it back — ~12 extra insts
+            # per gather group per K-iteration. readfirstlane is opaque enough to
+            # block remat and keeps the value SGPR-resident.
+            return rocdl.readfirstlane(T.i32, _acc)
 
         def _precompute_a_row_indices():
             """Load sorted_ids for all tile_m rows and decode token_ids + output row indices."""
@@ -463,17 +471,27 @@ def _compile_stage1_mxscale_kernel_impl(
                 _a_tokens_topk_sgpr = rocdl.readfirstlane(T.i32, _m_i32)
             return _a_tokens_topk_sgpr
 
-        def issue_a_load_tdm_gather(k_base, target_lds):
-            """Load A data using TDM gather mode — one TDM instruction per 8 rows."""
-            k_packed_base = k_base if PACK_FACTOR_A == 1 else k_base // fx.Index(PACK_FACTOR_A)
+        # Cache of K-invariant pieces of the TDM gather descriptor:
+        #   "desc"[_gi][buf_idx] — full TDMGatherDescriptor with addr_lo=base,
+        #   "pred"[_gi]          — issue predicate (valid_count > 0, wave owner),
+        #   "base_addr_lo"[_gi]  — dgroup0.lane2 at global_byte_offset=0,
+        # built once by _build_a_gather_base_descs() before the K loop so the
+        # hot path only advances addr_lo via vector.insert each iteration.
+        _a_gather_cache = {}
+
+        def _build_a_gather_base_descs(lds_bufs):
+            if "desc" in _a_gather_cache:
+                return
             _tokens_dim1 = _get_tokens_sgpr()
             _zero_i32 = arith.constant(0, type=T.i32)
+            _descs = []
+            _preds = []
+            _base_addr_lo = []
             for _gi in range_constexpr(_TDM_GATHER_GROUPS):
                 _start = _gi * _TDM_GATHER_CHUNK
                 _cnt = min(_TDM_GATHER_CHUNK, int(tile_m) - _start)
                 _row_indices = _a_tok_ids[_start:_start + _cnt]
                 _valid_count = _sum_i32_values(_a_load_valids[_start:_start + _cnt])
-                _lds_off = fx.Index(_start * lds_a_stride_bytes)
                 _has_valid = arith.cmpi(arith.CmpIPredicate.sgt, _valid_count, _zero_i32)
                 _issue_pred = _has_valid
                 if wave_specialized_tdm:
@@ -484,11 +502,19 @@ def _compile_stage1_mxscale_kernel_impl(
                         arith.constant(_gather_owner, type=T.i32),
                     )
                     _issue_pred = arith.andi(_issue_pred, _is_gather_loader)
-                _if_issue = scf.IfOp(_issue_pred)
-                with ir.InsertionPoint(_if_issue.then_block):
-                    desc = tdm_ops.make_tensor_gather_descriptor(
+                _preds.append(_issue_pred)
+
+                _lds_off = fx.Index(_start * lds_a_stride_bytes)
+                _per_buf = []
+                # NOTE: must use range_constexpr here. The AST rewriter
+                # (InsertEmptyYieldForSCFFor) turns a plain `range` inside a
+                # kernel body into scf_range -> scf.ForOp, making the loop
+                # variable an MLIR induction value (ArithValue) and breaking
+                # Python list indexing below.
+                for _buf_i in range_constexpr(len(lds_bufs)):
+                    _base_desc = tdm_ops.make_tensor_gather_descriptor(
                         global_ptr=arg_x,
-                        lds_memref=target_lds,
+                        lds_memref=lds_bufs[_buf_i],
                         row_indices=_row_indices,
                         row_width=int(packed_tile_k_a),
                         tensor_dim0=K_packed_a,
@@ -500,9 +526,126 @@ def _compile_stage1_mxscale_kernel_impl(
                         index_size=32,
                         gather_tile_dim1=_valid_count,
                         lds_byte_offset=_lds_off,
-                        global_byte_offset=k_packed_base,
+                        global_byte_offset=None,
                     )
-                    tdm_ops.tensor_load_gather(desc)
+                    _per_buf.append(_base_desc)
+                _descs.append(_per_buf)
+                # addr_lo is independent of buf_idx (only lds_addr differs), so
+                # we can extract it from any buffer's base descriptor.
+                _base_addr_lo.append(vector.extract(
+                    _per_buf[0].dgroup0,
+                    static_position=[2],
+                    dynamic_position=[],
+                ))
+
+            _a_gather_cache["desc"] = _descs
+            _a_gather_cache["pred"] = _preds
+            _a_gather_cache["base_addr_lo"] = _base_addr_lo
+
+        # Cache of K-invariant 2D B/B-scale descriptors used by _issue_b_tdm_only.
+        # Each entry holds a base TDMDescriptor2D built at k_base=0 plus the
+        # extracted scalar addr_lo, so the hot path only computes
+        # curr_addr_lo = base_addr_lo + k_off and calls
+        # update_tensor_descriptor_2d_addr_lo -- mirroring the hoist that
+        # wave_specialized_tdm already does via _active_stage_desc_base.
+        _b_desc_cache = {}
+
+        def _extract_desc_addr_lo(desc):
+            return vector.extract(
+                desc.dgroup0,
+                static_position=[2],
+                dynamic_position=[],
+            )
+
+        def _build_b_base_descs():
+            if "ready" in _b_desc_cache:
+                return
+            _zero_k = arith.index(0)
+            if _merge_gate_up_tdm:
+                _n_pair = _stage1_pair_row_base()
+                _bg_pair = [
+                    make_desc_b_pair(lds_bg_pair_bufs[i], _n_pair, _zero_k)
+                    for i in range_constexpr(_nb)
+                ]
+                _bs_pair = [
+                    make_desc_bs_pair(lds_bs_pair_bufs[i], _n_pair, _zero_k)
+                    for i in range_constexpr(_nb)
+                ]
+                _b_desc_cache["bg_pair"] = _bg_pair
+                _b_desc_cache["bs_pair"] = _bs_pair
+                _b_desc_cache["bg_pair_addr_lo"] = [
+                    _extract_desc_addr_lo(d) for d in _bg_pair
+                ]
+                _b_desc_cache["bs_pair_addr_lo"] = [
+                    _extract_desc_addr_lo(d) for d in _bs_pair
+                ]
+            else:
+                _eid_row = (
+                    arith.index_cast(T.index, eid_i32)
+                    * arith.index(int(2 * N))
+                )
+                _n_gate = _eid_row + blk_n
+                _n_up = _eid_row + blk_n + arith.index(int(N))
+                _bg = [
+                    make_desc_b(lds_bg_bufs[i], _n_gate, _zero_k)
+                    for i in range_constexpr(_nb)
+                ]
+                _bu = [
+                    make_desc_b(lds_bu_bufs[i], _n_up, _zero_k)
+                    for i in range_constexpr(_nb)
+                ]
+                _bs = [
+                    make_desc_bs(lds_bs_bufs[i], _n_gate, _zero_k)
+                    for i in range_constexpr(_nb)
+                ]
+                _bsu = [
+                    make_desc_bs(lds_bsu_bufs[i], _n_up, _zero_k)
+                    for i in range_constexpr(_nb)
+                ]
+                _b_desc_cache["bg"] = _bg
+                _b_desc_cache["bu"] = _bu
+                _b_desc_cache["bs"] = _bs
+                _b_desc_cache["bsu"] = _bsu
+                _b_desc_cache["bg_addr_lo"] = [_extract_desc_addr_lo(d) for d in _bg]
+                _b_desc_cache["bu_addr_lo"] = [_extract_desc_addr_lo(d) for d in _bu]
+                _b_desc_cache["bs_addr_lo"] = [_extract_desc_addr_lo(d) for d in _bs]
+                _b_desc_cache["bsu_addr_lo"] = [_extract_desc_addr_lo(d) for d in _bsu]
+            _b_desc_cache["ready"] = True
+
+        def _b_data_k_byte_off(k_base):
+            # Byte offset along fastest axis for a B data descriptor at k_base.
+            #   non-fp4 / merged pair : (k_base / PACK_FACTOR_B) * 16 bytes
+            #   fp4                   : (k_base / PACK_FACTOR_B) bytes
+            _k_packed_b = (k_base if PACK_FACTOR_B == 1
+                           else k_base // fx.Index(PACK_FACTOR_B))
+            if is_fp4:
+                return arith.index_cast(T.i32, _k_packed_b)
+            return arith.index_cast(
+                T.i32, _k_packed_b * fx.Index(16))
+
+        def _b_scale_k_byte_off(k_base):
+            # B-scale fastest-axis offset: k_base / SCALE_BLOCK bytes.
+            return arith.index_cast(
+                T.i32, k_base // fx.Index(SCALE_BLOCK))
+
+        def issue_a_load_tdm_gather(k_base, buf_idx):
+            """Hot path: advance addr_lo on the precomputed gather descriptor."""
+            k_packed_base = k_base if PACK_FACTOR_A == 1 else k_base // fx.Index(PACK_FACTOR_A)
+            _k_byte_off_i32 = arith.index_cast(T.i32, k_packed_base)
+            _descs = _a_gather_cache["desc"]
+            _preds = _a_gather_cache["pred"]
+            _base_addr_lo = _a_gather_cache["base_addr_lo"]
+            for _gi in range_constexpr(_TDM_GATHER_GROUPS):
+                _if_issue = scf.IfOp(_preds[_gi])
+                with ir.InsertionPoint(_if_issue.then_block):
+                    _curr_addr_lo = arith.addi(
+                        _base_addr_lo[_gi], _k_byte_off_i32)
+                    tdm_ops.tensor_load_gather(
+                        tdm_ops.update_tensor_gather_descriptor_addr_lo(
+                            _descs[_gi][buf_idx],
+                            _curr_addr_lo,
+                        )
+                    )
                     scf.YieldOp([])
 
         def make_desc_as(k_base):
@@ -1077,17 +1220,28 @@ def _compile_stage1_mxscale_kernel_impl(
                         _scale_adv_i32,
                     )
 
+                _tdm_zero_addr_lo = arith.constant(0, type=T.i32)
+                _active_stage_desc_base = [
+                    tdm_ops.TDMDescriptor2D(
+                        vector.from_elements(T.vec(4, T.i32), [
+                            _tdm_pred,
+                            _active_stage_lds_addr[i],
+                            _tdm_zero_addr_lo,
+                            _active_addr_hi,
+                        ]),
+                        _active_dgroup1,
+                    )
+                    for i in range_constexpr(_nb)
+                ]
+
                 def _issue_active_b_tdm_only(stage_idx, curr_addr_lo):
                     _if_loader = scf.IfOp(_is_loader_wave)
                     with ir.InsertionPoint(_if_loader.then_block):
-                        _dg0 = vector.from_elements(T.vec(4, T.i32), [
-                            _tdm_pred,
-                            _active_stage_lds_addr[stage_idx],
-                            curr_addr_lo,
-                            _active_addr_hi,
-                        ])
                         tdm_ops.tensor_load_2d(
-                            tdm_ops.TDMDescriptor2D(_dg0, _active_dgroup1)
+                            tdm_ops.update_tensor_descriptor_2d_addr_lo(
+                                _active_stage_desc_base[stage_idx],
+                                curr_addr_lo,
+                            )
                         )
                         scf.YieldOp([])
                     _next_addr_lo = arith.addi(curr_addr_lo, _active_adv_i32)
@@ -1097,31 +1251,56 @@ def _compile_stage1_mxscale_kernel_impl(
                         curr_addr_lo,
                     )
 
+            if _use_tdm_gather_a:
+                _build_a_gather_base_descs(lds_ag_bufs)
+            # Hoist K-invariant parts of B / B-scale 2D descriptors so the hot
+            # K loop only has to advance addr_lo per tile. In wave-specialized
+            # mode the hot path goes through _issue_active_b_tdm_only (which is
+            # already hoisted) and _issue_b_tdm_only is only reachable from the
+            # tail path; skip the build there to avoid emitting dead IR.
+            if not wave_specialized_tdm:
+                _build_b_base_descs()
+
             # ── pipeline load helpers ─────────────────────────────────
             def _issue_b_tdm_only(k_base, buf_idx):
+                _k_data_off = _b_data_k_byte_off(k_base)
+                _k_scale_off = _b_scale_k_byte_off(k_base)
                 if _merge_gate_up_tdm:
-                    _n_pair = _stage1_pair_row_base()
+                    _bg_addr = arith.addi(
+                        _b_desc_cache["bg_pair_addr_lo"][buf_idx], _k_data_off)
+                    _bs_addr = arith.addi(
+                        _b_desc_cache["bs_pair_addr_lo"][buf_idx], _k_scale_off)
                     tdm_ops.tensor_load_2d(
-                        make_desc_b_pair(lds_bg_pair_bufs[buf_idx], _n_pair, k_base))
+                        tdm_ops.update_tensor_descriptor_2d_addr_lo(
+                            _b_desc_cache["bg_pair"][buf_idx], _bg_addr))
                     tdm_ops.tensor_load_2d(
-                        make_desc_bs_pair(lds_bs_pair_bufs[buf_idx], _n_pair, k_base))
+                        tdm_ops.update_tensor_descriptor_2d_addr_lo(
+                            _b_desc_cache["bs_pair"][buf_idx], _bs_addr))
                 else:
-                    _eid_row = (arith.index_cast(T.index, eid_i32)
-                                * arith.index(int(2 * N)))
-                    _n_gate = _eid_row + blk_n
-                    _n_up = _eid_row + blk_n + arith.index(int(N))
+                    _bg_addr = arith.addi(
+                        _b_desc_cache["bg_addr_lo"][buf_idx], _k_data_off)
+                    _bu_addr = arith.addi(
+                        _b_desc_cache["bu_addr_lo"][buf_idx], _k_data_off)
+                    _bs_addr = arith.addi(
+                        _b_desc_cache["bs_addr_lo"][buf_idx], _k_scale_off)
+                    _bsu_addr = arith.addi(
+                        _b_desc_cache["bsu_addr_lo"][buf_idx], _k_scale_off)
                     tdm_ops.tensor_load_2d(
-                        make_desc_b(lds_bg_bufs[buf_idx], _n_gate, k_base))
+                        tdm_ops.update_tensor_descriptor_2d_addr_lo(
+                            _b_desc_cache["bg"][buf_idx], _bg_addr))
                     tdm_ops.tensor_load_2d(
-                        make_desc_b(lds_bu_bufs[buf_idx], _n_up, k_base))
+                        tdm_ops.update_tensor_descriptor_2d_addr_lo(
+                            _b_desc_cache["bu"][buf_idx], _bu_addr))
                     tdm_ops.tensor_load_2d(
-                        make_desc_bs(lds_bs_bufs[buf_idx], _n_gate, k_base))
+                        tdm_ops.update_tensor_descriptor_2d_addr_lo(
+                            _b_desc_cache["bs"][buf_idx], _bs_addr))
                     tdm_ops.tensor_load_2d(
-                        make_desc_bs(lds_bsu_bufs[buf_idx], _n_up, k_base))
+                        tdm_ops.update_tensor_descriptor_2d_addr_lo(
+                            _b_desc_cache["bsu"][buf_idx], _bsu_addr))
 
             def _issue_scalar_loads(k_base, buf_idx):
                 if _use_tdm_gather_a:
-                    issue_a_load_tdm_gather(k_base, lds_ag_bufs[buf_idx])
+                    issue_a_load_tdm_gather(k_base, buf_idx)
                 else:
                     issue_a_load(make_desc_a(k_base), lds_ag_bufs[buf_idx])
                 issue_as_load(make_desc_as(k_base), lds_as_bufs[buf_idx])
@@ -1871,7 +2050,11 @@ def _compile_stage2_mxscale_kernel_impl(
             _acc = arith.constant(0, type=T.i32)
             for _vi in range_constexpr(len(_vals)):
                 _acc = _acc + _vals[_vi]
-            return _acc
+            # See Stage1's _sum_i32_values for rationale: pin the reduction
+            # result to an SGPR so the AMDGPU backend doesn't rematerialize a
+            # VGPR sum into the gather-issue scf.if and drag the whole 8-word
+            # TDM header through a VGPR round-trip.
+            return rocdl.readfirstlane(T.i32, _acc)
 
         def _get_tokens_topk_sgpr():
             nonlocal _tokens_topk_sgpr
@@ -1953,17 +2136,23 @@ def _compile_stage2_mxscale_kernel_impl(
                     vector.store(v1, target_lds, [lds_idx], alignment=1)
                     scf.YieldOp([])
 
-        def issue_a_load_tdm_gather(k_base, target_lds):
-            """Load stage2 A rows via TDM gather using token-slot row ids."""
-            k_packed_base = k_base if PACK_FACTOR_A == 1 else k_base // fx.Index(PACK_FACTOR_A)
+        # See stage1 for the caching rationale; the descriptor is rebuilt once
+        # before the K loop, then only addr_lo is advanced each iteration.
+        _a_gather_cache = {}
+
+        def _build_a_gather_base_descs(lds_bufs):
+            if "desc" in _a_gather_cache:
+                return
             _tokens_topk = _get_tokens_topk_sgpr()
             _zero_i32 = arith.constant(0, type=T.i32)
+            _descs = []
+            _preds = []
+            _base_addr_lo = []
             for _gi in range_constexpr(_TDM_GATHER_GROUPS):
                 _start = _gi * _TDM_GATHER_CHUNK
                 _cnt = min(_TDM_GATHER_CHUNK, int(tile_m) - _start)
                 _row_indices = _a_row_ids[_start:_start + _cnt]
                 _valid_count = _sum_i32_values(_a_row_valids[_start:_start + _cnt])
-                _lds_off = fx.Index(_start * lds_a_stride_bytes)
                 _has_valid = arith.cmpi(arith.CmpIPredicate.sgt, _valid_count, _zero_i32)
                 _issue_pred = _has_valid
                 if wave_specialized_tdm:
@@ -1974,11 +2163,19 @@ def _compile_stage2_mxscale_kernel_impl(
                         arith.constant(_gather_owner, type=T.i32),
                     )
                     _issue_pred = arith.andi(_issue_pred, _is_gather_loader)
-                _if_issue = scf.IfOp(_issue_pred)
-                with ir.InsertionPoint(_if_issue.then_block):
-                    desc = tdm_ops.make_tensor_gather_descriptor(
+                _preds.append(_issue_pred)
+
+                _lds_off = fx.Index(_start * lds_a_stride_bytes)
+                _per_buf = []
+                # NOTE: must use range_constexpr here. The AST rewriter
+                # (InsertEmptyYieldForSCFFor) turns a plain `range` inside a
+                # kernel body into scf_range -> scf.ForOp, making the loop
+                # variable an MLIR induction value (ArithValue) and breaking
+                # Python list indexing below.
+                for _buf_i in range_constexpr(len(lds_bufs)):
+                    _base_desc = tdm_ops.make_tensor_gather_descriptor(
                         global_ptr=arg_x,
-                        lds_memref=target_lds,
+                        lds_memref=lds_bufs[_buf_i],
                         row_indices=_row_indices,
                         row_width=int(packed_tile_k_a),
                         tensor_dim0=K_packed_a,
@@ -1990,9 +2187,83 @@ def _compile_stage2_mxscale_kernel_impl(
                         index_size=32,
                         gather_tile_dim1=_valid_count,
                         lds_byte_offset=_lds_off,
-                        global_byte_offset=k_packed_base,
+                        global_byte_offset=None,
                     )
-                    tdm_ops.tensor_load_gather(desc)
+                    _per_buf.append(_base_desc)
+                _descs.append(_per_buf)
+                _base_addr_lo.append(vector.extract(
+                    _per_buf[0].dgroup0,
+                    static_position=[2],
+                    dynamic_position=[],
+                ))
+
+            _a_gather_cache["desc"] = _descs
+            _a_gather_cache["pred"] = _preds
+            _a_gather_cache["base_addr_lo"] = _base_addr_lo
+
+        # Cache of K-invariant 2D B/B-scale descriptors for Stage2. Mirror of
+        # Stage1's _b_desc_cache -- hoist the address-independent portions of
+        # the B data and B scale descriptors so the K hot loop only advances
+        # addr_lo per tile.
+        _b_desc_cache = {}
+
+        def _extract_desc_addr_lo(desc):
+            return vector.extract(
+                desc.dgroup0,
+                static_position=[2],
+                dynamic_position=[],
+            )
+
+        def _build_b_base_descs():
+            if "ready" in _b_desc_cache:
+                return
+            _zero_k = arith.index(0)
+            _eid_idx = arith.index_cast(T.index, eid_i32)
+            _n_off = _eid_idx * n_idx + blk_n
+            _b = [
+                make_desc_b(_n_off, _zero_k, lds_b_bufs[i])
+                for i in range_constexpr(_nb)
+            ]
+            _bs = [
+                make_desc_bs(_n_off, _zero_k, lds_bs_bufs[i])
+                for i in range_constexpr(_nb)
+            ]
+            _b_desc_cache["b"] = _b
+            _b_desc_cache["bs"] = _bs
+            _b_desc_cache["b_addr_lo"] = [_extract_desc_addr_lo(d) for d in _b]
+            _b_desc_cache["bs_addr_lo"] = [_extract_desc_addr_lo(d) for d in _bs]
+            _b_desc_cache["ready"] = True
+
+        def _b_data_k_byte_off(k_base):
+            _k_packed_b = (k_base if PACK_FACTOR_B == 1
+                           else k_base // fx.Index(PACK_FACTOR_B))
+            if is_fp4:
+                return arith.index_cast(T.i32, _k_packed_b)
+            return arith.index_cast(
+                T.i32, _k_packed_b * fx.Index(16))
+
+        def _b_scale_k_byte_off(k_base):
+            return arith.index_cast(
+                T.i32, k_base // fx.Index(SCALE_BLOCK))
+
+        def issue_a_load_tdm_gather(k_base, buf_idx):
+            """Hot path: advance addr_lo on the precomputed gather descriptor."""
+            k_packed_base = k_base if PACK_FACTOR_A == 1 else k_base // fx.Index(PACK_FACTOR_A)
+            _k_byte_off_i32 = arith.index_cast(T.i32, k_packed_base)
+            _descs = _a_gather_cache["desc"]
+            _preds = _a_gather_cache["pred"]
+            _base_addr_lo = _a_gather_cache["base_addr_lo"]
+            for _gi in range_constexpr(_TDM_GATHER_GROUPS):
+                _if_issue = scf.IfOp(_preds[_gi])
+                with ir.InsertionPoint(_if_issue.then_block):
+                    _curr_addr_lo = arith.addi(
+                        _base_addr_lo[_gi], _k_byte_off_i32)
+                    tdm_ops.tensor_load_gather(
+                        tdm_ops.update_tensor_gather_descriptor_addr_lo(
+                            _descs[_gi][buf_idx],
+                            _curr_addr_lo,
+                        )
+                    )
                     scf.YieldOp([])
 
         def make_desc_as(k_base):
@@ -2422,17 +2693,29 @@ def _compile_stage2_mxscale_kernel_impl(
                     _data_adv_i32,
                     _scale_adv_i32,
                 )
+
+                _tdm_zero_addr_lo = arith.constant(0, type=T.i32)
+                _active_stage_desc_base = [
+                    tdm_ops.TDMDescriptor2D(
+                        vector.from_elements(T.vec(4, T.i32), [
+                            _tdm_pred,
+                            _active_stage_lds_addr[i],
+                            _tdm_zero_addr_lo,
+                            _active_addr_hi,
+                        ]),
+                        _active_dgroup1,
+                    )
+                    for i in range_constexpr(_nb)
+                ]
+
                 def _issue_active_b_tdm_only(stage_idx, curr_addr_lo):
                     _if_loader = scf.IfOp(_is_loader_wave)
                     with ir.InsertionPoint(_if_loader.then_block):
-                        _dg0 = vector.from_elements(T.vec(4, T.i32), [
-                            _tdm_pred,
-                            _active_stage_lds_addr[stage_idx],
-                            curr_addr_lo,
-                            _active_addr_hi,
-                        ])
                         tdm_ops.tensor_load_2d(
-                            tdm_ops.TDMDescriptor2D(_dg0, _active_dgroup1)
+                            tdm_ops.update_tensor_descriptor_2d_addr_lo(
+                                _active_stage_desc_base[stage_idx],
+                                curr_addr_lo,
+                            )
                         )
                         scf.YieldOp([])
                     _next_addr_lo = arith.addi(curr_addr_lo, _active_adv_i32)
@@ -2442,18 +2725,30 @@ def _compile_stage2_mxscale_kernel_impl(
                         curr_addr_lo,
                     )
 
+            if _use_tdm_gather_a:
+                _build_a_gather_base_descs(lds_a_bufs)
+            # See Stage1 for the rationale of guarding on wave_specialized_tdm.
+            if not wave_specialized_tdm:
+                _build_b_base_descs()
+
             # ── pipeline load helpers ─────────────────────────────────
             def _issue_b_tdm_only(k_base, buf_idx):
-                _eid = arith.index_cast(T.index, eid_i32)
-                _n = _eid * n_idx + blk_n
+                _k_data_off = _b_data_k_byte_off(k_base)
+                _k_scale_off = _b_scale_k_byte_off(k_base)
+                _b_addr = arith.addi(
+                    _b_desc_cache["b_addr_lo"][buf_idx], _k_data_off)
+                _bs_addr = arith.addi(
+                    _b_desc_cache["bs_addr_lo"][buf_idx], _k_scale_off)
                 tdm_ops.tensor_load_2d(
-                    make_desc_b(_n, k_base, lds_b_bufs[buf_idx]))
+                    tdm_ops.update_tensor_descriptor_2d_addr_lo(
+                        _b_desc_cache["b"][buf_idx], _b_addr))
                 tdm_ops.tensor_load_2d(
-                    make_desc_bs(_n, k_base, lds_bs_bufs[buf_idx]))
+                    tdm_ops.update_tensor_descriptor_2d_addr_lo(
+                        _b_desc_cache["bs"][buf_idx], _bs_addr))
 
             def _issue_scalar_loads(k_base, buf_idx):
                 if _use_tdm_gather_a:
-                    issue_a_load_tdm_gather(k_base, lds_a_bufs[buf_idx])
+                    issue_a_load_tdm_gather(k_base, buf_idx)
                 else:
                     issue_a_load(make_desc_a(k_base), lds_a_bufs[buf_idx])
                 issue_as_load(make_desc_as(k_base), lds_as_bufs[buf_idx])

--- a/python/flydsl/expr/rocdl/tdm_ops.py
+++ b/python/flydsl/expr/rocdl/tdm_ops.py
@@ -44,6 +44,8 @@ __all__ = [
     "make_tensor_descriptor_2d",
     "make_tensor_gather_dgroup0",
     "make_tensor_gather_descriptor",
+    "update_tensor_descriptor_2d_addr_lo",
+    "update_tensor_gather_descriptor_addr_lo",
     "tensor_load_2d",
     "tensor_load_gather",
     "tensor_store_gather",
@@ -137,6 +139,25 @@ class TDMDescriptor2D:
     dgroup1: object  # vector<8xi32> MLIR Value
 
 
+def update_tensor_descriptor_2d_addr_lo(
+    desc: TDMDescriptor2D,
+    addr_lo,
+) -> TDMDescriptor2D:
+    """Return a descriptor with only GROUP0 lane2 (global addr low) updated.
+
+    This keeps the descriptor structure explicit at the Python API boundary and
+    allows kernel builders to carry a mostly-static descriptor through loops,
+    mutating only the address field that advances each iteration.
+    """
+    dgroup0 = vector.insert(
+        addr_lo,
+        desc.dgroup0,
+        static_position=[2],
+        dynamic_position=[],
+    )
+    return TDMDescriptor2D(dgroup0=dgroup0, dgroup1=desc.dgroup1)
+
+
 @dataclass
 class TDMGatherDescriptor:
     """Holds GROUP0, GROUP1, GROUP2, GROUP3 for TDM gather mode.
@@ -151,6 +172,34 @@ class TDMGatherDescriptor:
     dgroup1: object  # vector<8xi32> MLIR Value
     dgroup2: object  # vector<4xi32> MLIR Value — row indices [0..3] or [0..7]
     dgroup3: object  # vector<4xi32> MLIR Value — row indices [4..7] or [8..15]
+
+
+def update_tensor_gather_descriptor_addr_lo(
+    desc: TDMGatherDescriptor,
+    addr_lo,
+) -> TDMGatherDescriptor:
+    """Return a gather descriptor with only GROUP0 lane2 (global addr low) updated.
+
+    Mirror of update_tensor_descriptor_2d_addr_lo for gather mode. Lets kernel
+    builders hoist a static gather descriptor (dgroup1/dgroup2/dgroup3 plus the
+    address-independent parts of dgroup0) out of the K loop, then cheaply
+    advance the global address each iteration via a single vector.insert.
+
+    Assumes the high 32 bits of the global address stay stable across the
+    advance (same assumption as update_tensor_descriptor_2d_addr_lo).
+    """
+    dgroup0 = vector.insert(
+        addr_lo,
+        desc.dgroup0,
+        static_position=[2],
+        dynamic_position=[],
+    )
+    return TDMGatherDescriptor(
+        dgroup0=dgroup0,
+        dgroup1=desc.dgroup1,
+        dgroup2=desc.dgroup2,
+        dgroup3=desc.dgroup3,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -406,6 +455,47 @@ def make_tensor_descriptor_2d(
     dgroup1 = vector.from_elements(
         T.vec(8, T.i32),
         [g1_s0, g1_s1, g1_s2, g1_s3, g1_s4, g1_s5, g1_s6, g1_s7],
+    )
+
+    # ------------------------------------------------------------------
+    # Pin dgroup1 to an SSA value so it is NOT folded into an inline
+    # <8 x i32> constant literal at every tensor_load_to_lds call site.
+    # ------------------------------------------------------------------
+    # When workgroup_mask is a Python int (the common non-multicast case)
+    # every lane of dgroup1 is a compile-time constant. MLIR's CSE and
+    # LLVM's constant-vector canonicalization then inline the whole vector
+    # as an immediate operand to llvm.amdgcn.tensor.load.to.lds. The AMDGPU
+    # backend treats that as "cheap to rebuild" and emits 5-7 s_mov_b32 /
+    # s_brev_b32 / s_movk_i32 per K-loop iteration (e.g. 0x40000, 0x200000,
+    # 32, 0x4000, 0x20000, s_brev 16) instead of keeping the 8-SGPR
+    # descriptor live across iterations — killing the benefit of hoisting
+    # make_tensor_descriptor_2d out of the K loop via
+    # update_tensor_descriptor_2d_addr_lo.
+    #
+    # Fix: OR a runtime-zero into dgroup1 lane 0 (whose low 16 bits are
+    # the workgroup_mask; OR 0 is a semantic no-op). The zero is produced
+    # by llvm.amdgcn.readfirstlane(i32 0). AMDGPU's InstCombine only folds
+    # nested readfirstlane / readlane chains; it does NOT fold
+    # readfirstlane of a plain constant, so the intrinsic call survives
+    # through IR passes and keeps dgroup1 as a proper SSA vector<8xi32>.
+    # It is loop-invariant and speculatable, so LICM hoists the whole
+    # anchor + insert chain into the preheader once; in codegen it lowers
+    # to a single `s_mov_b32 s?, 0`. Gather descriptors already avoid this
+    # problem because their dgroup1 carries runtime-valued fields (e.g.
+    # tensor_dim1, gather_tile_dim1), so they naturally stay SSA.
+    _zero_i32 = std_arith.ConstantOp(
+        T.i32, ir.IntegerAttr.get(T.i32, 0)
+    ).result
+    _anchor_zero = _ArithValue(
+        rocdl.readfirstlane(T.i32, _zero_i32)
+    )
+    _orig_lane0 = vector.extract(
+        dgroup1, static_position=[0], dynamic_position=[]
+    )
+    _new_lane0 = arith.ori(_orig_lane0, _anchor_zero)
+    dgroup1 = vector.insert(
+        _new_lane0, dgroup1,
+        static_position=[0], dynamic_position=[],
     )
 
     return TDMDescriptor2D(dgroup0=dgroup0, dgroup1=dgroup1)
@@ -736,13 +826,14 @@ def tensor_load_2d(
     (as built by make_tensor_descriptor_2d). All waves together
     cover the full tile.
 
-    Uses the unified 5-group intrinsic with dgroup2/dgroup3/dgroup4
-    zero-initialized for 2D tensors.
-
     Args:
         desc:         TDMDescriptor2D from make_tensor_descriptor_2d.
         cache_policy: Cache policy (0 = default).
     """
+    load_2d_op = getattr(rocdl, "tensor_load_to_lds_d2", None)
+    if load_2d_op is not None:
+        load_2d_op(_raw(desc.dgroup0), _raw(desc.dgroup1), cache_policy)
+        return
     dg2 = _raw(_zero_dgroup_v4i32())
     dg3 = _raw(_zero_dgroup_v4i32())
     dg4 = _raw(_zero_dgroup_v8i32())
@@ -757,13 +848,14 @@ def tensor_store_2d(
 ) -> None:
     """Issue a TDM 2D async store (LDS -> Global).
 
-    Uses the unified 5-group intrinsic with dgroup2/dgroup3/dgroup4
-    zero-initialized for 2D tensors.
-
     Args:
         desc:         TDMDescriptor2D (with LDS source and global destination).
         cache_policy: Cache policy (0 = default).
     """
+    store_2d_op = getattr(rocdl, "tensor_store_from_lds_d2", None)
+    if store_2d_op is not None:
+        store_2d_op(_raw(desc.dgroup0), _raw(desc.dgroup1), cache_policy)
+        return
     dg2 = _raw(_zero_dgroup_v4i32())
     dg3 = _raw(_zero_dgroup_v4i32())
     dg4 = _raw(_zero_dgroup_v8i32())

--- a/python/flydsl/runtime/device.py
+++ b/python/flydsl/runtime/device.py
@@ -85,6 +85,6 @@ def is_rdna_arch(arch: Optional[str] = None) -> bool:
     arch = arch.lower()
     if arch.startswith("gfx10") or arch.startswith("gfx11"):
         return True
-    if arch.startswith("gfx120"):
+    if arch.startswith("gfx12"):
         return True
     return False

--- a/tests/kernels/benchmark_common.py
+++ b/tests/kernels/benchmark_common.py
@@ -487,11 +487,19 @@ def bench_resolve_tiles(in_dtype, model_dim, inter_dim):
 
     tile_n1 = bench_best_tile(target_n, inter_dim, 16)
     tile_k1 = bench_best_tile(target_k, model_dim, wmma_k)
+    if tile_k1 is None:
+        tile_k1 = wmma_k
     tile_n2 = bench_best_tile(target_n, model_dim, 16)
 
     tile_k2 = None
     for k in range(target_k, 0, -wmma_k):
         if inter_dim % k != 0:
+            # K-padding: run_moe_stage2 auto-pads inter_dim, so accept
+            # any tile_k that satisfies the load-mapping constraints.
+            total = tile_m * k
+            if total % 256 == 0 and (total // 256) % 4 == 0:
+                if tile_k2 is None:
+                    tile_k2 = k
             continue
         total = tile_m * k
         if total % 256 == 0 and (total // 256) % 4 == 0:

--- a/tests/kernels/test_moe_gemm_mxscale_gfx1250.py
+++ b/tests/kernels/test_moe_gemm_mxscale_gfx1250.py
@@ -54,6 +54,16 @@ if not str(ARCH).startswith("gfx1250"):
     pytest.skip(f"MoE 2stage gfx1250 tests require gfx1250, got {ARCH}", allow_module_level=True)
 
 
+def _safe_rate(numerator: float, us: float, denom_scale: float) -> Optional[float]:
+    if us <= 0:
+        return None
+    return numerator / (us / 1e6) / denom_scale
+
+
+def _fmt_perf_metric(value: Optional[float], fmt: str) -> str:
+    return "n/a" if value is None else format(value, fmt)
+
+
 
 def _per_1x32_fp8_quant(x: torch.Tensor):
     """Quantize fp32 tensor to raw FP8/E4M3 bytes with one E8M0 scale per 32-wide K block."""
@@ -446,7 +456,7 @@ def run_moe_stage1(
 
     # Note: kernel launches full expert-block range; effective work is gated by num_valid_ids.
     flops = 2 * tokens * topk * (2 * inter_dim) * _orig_model_dim
-    tflops = flops / (us / 1e6) / 1e12
+    tflops = _safe_rate(flops, us, 1e12)
 
     # Rough bytes-moved accounting (same spirit as GEMM tests: count each tensor once).
     bytes_moved = 0
@@ -461,11 +471,11 @@ def run_moe_stage1(
         + int(sorted_expert_ids.numel()) * 4
     )
     bytes_moved += bytes_x + bytes_w + bytes_out + bytes_scale_x + bytes_scale_w + bytes_route
-    tbps = bytes_moved / 1e12 / (us / 1e6)
+    tbps = _safe_rate(bytes_moved, us, 1e12)
     read_bytes = bytes_x + bytes_w + bytes_scale_x + bytes_scale_w + bytes_route
     write_bytes = bytes_out
-    read_bw_gbs = read_bytes / 1e9 / (us / 1e6)
-    write_bw_gbs = write_bytes / 1e9 / (us / 1e6)
+    read_bw_gbs = _safe_rate(read_bytes, us, 1e9)
+    write_bw_gbs = _safe_rate(write_bytes, us, 1e9)
 
     print(
         f"FlyDSL MoE stage1[{in_dtype}] benchmark | "
@@ -474,10 +484,12 @@ def run_moe_stage1(
     )
     print(
         f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
-        f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
+        f"{_fmt_perf_metric(tflops, '.2f')} TFLOPS(logical, M={tokens*topk}) | "
+        f"{_fmt_perf_metric(tbps, '.3f')} TB/s"
     )
     print(
-        f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
+        f"  bandwidth: read {_fmt_perf_metric(read_bw_gbs, '.1f')} GB/s + "
+        f"write {_fmt_perf_metric(write_bw_gbs, '.1f')} GB/s | "
         f"bytes: x={bytes_x/1e6:.1f}MB w={bytes_w/1e6:.1f}MB "
         f"sx={bytes_scale_x/1e6:.1f}MB sw={bytes_scale_w/1e6:.1f}MB "
         f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
@@ -905,7 +917,7 @@ def run_moe_stage2(
 
     # Launches full expert-block range; effective work is gated by num_valid_ids.
     flops = 2 * tokens * topk * model_dim * _orig_inter_dim
-    tflops = flops / (us / 1e6) / 1e12
+    tflops = _safe_rate(flops, us, 1e12)
 
     bytes_moved = 0
     bytes_a2 = tokens * topk * _orig_inter_dim  # 1B elements (fp4/fp8/a8w4)
@@ -919,11 +931,11 @@ def run_moe_stage2(
         + int(sorted_expert_ids.numel()) * 4
     )
     bytes_moved += bytes_a2 + bytes_w2 + bytes_out + bytes_scale_a2 + bytes_scale_w2 + bytes_route
-    tbps = bytes_moved / 1e12 / (us / 1e6)
+    tbps = _safe_rate(bytes_moved, us, 1e12)
     read_bytes = bytes_a2 + bytes_w2 + bytes_scale_a2 + bytes_scale_w2 + bytes_route
     write_bytes = bytes_out
-    read_bw_gbs = read_bytes / 1e9 / (us / 1e6)
-    write_bw_gbs = write_bytes / 1e9 / (us / 1e6)
+    read_bw_gbs = _safe_rate(read_bytes, us, 1e9)
+    write_bw_gbs = _safe_rate(write_bytes, us, 1e9)
     print(
         f"FlyDSL MoE stage2[{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} benchmark | "
         f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
@@ -931,10 +943,12 @@ def run_moe_stage2(
     )
     print(
         f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
-        f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
+        f"{_fmt_perf_metric(tflops, '.2f')} TFLOPS(logical, M={tokens*topk}) | "
+        f"{_fmt_perf_metric(tbps, '.3f')} TB/s"
     )
     print(
-        f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
+        f"  bandwidth: read {_fmt_perf_metric(read_bw_gbs, '.1f')} GB/s + "
+        f"write {_fmt_perf_metric(write_bw_gbs, '.1f')} GB/s | "
         f"bytes: a2={bytes_a2/1e6:.1f}MB w2={bytes_w2/1e6:.1f}MB "
         f"sa2={bytes_scale_a2/1e6:.1f}MB sw2={bytes_scale_w2/1e6:.1f}MB "
         f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"

--- a/tests/kernels/test_moe_gemm_mxscale_gfx1250.py
+++ b/tests/kernels/test_moe_gemm_mxscale_gfx1250.py
@@ -30,7 +30,7 @@ for _p in reversed(_PYTHON_CANDIDATES):
 
 from tests.kernels.test_ref import torch_moe_gemm1, torch_moe_gemm2
 from tests.utils import get_dtype_max
-from tests.test_common import verify_output, run_perftest
+from tests.test_common import verify_output
 from flydsl.runtime.device import get_rocm_arch
 from tests.kernels.utils import fp4_utils
 from tests.kernels.benchmark_common import (
@@ -198,9 +198,7 @@ def run_moe_stage1(
     routing_in: Optional[RoutingBuffers] = None,
     return_outputs: bool = False,
     skip_ref: bool = False,
-    test_graph: bool = False,
     waves_per_eu: Optional[int] = None,
-    benchmark_mode: bool = False,
     flush_l2: bool = True,
     num_buffers: int = 1,
     use_tdm_gather: bool = True,
@@ -381,36 +379,19 @@ def run_moe_stage1(
             stream,
         )
 
-    if bool(benchmark_mode) and not bool(test_graph):
-        def _prep_stage1():
-            out.zero_()
+    def _prep_stage1():
+        out.zero_()
 
-        def _run_stage1():
-            launch(out, x_q, w_kernel, scale_x_1d, scale_w1_1d, sorted_token_ids, sorted_expert_ids, sorted_weights_1d)
+    def _run_stage1():
+        launch(out, x_q, w_kernel, scale_x_1d, scale_w1_1d, sorted_token_ids, sorted_expert_ids, sorted_weights_1d)
 
-        us = _bench_kernel_us(
-            _run_stage1,
-            warmup=int(num_warmup),
-            iters=int(max(1, num_iters)),
-            flush_l2=bool(flush_l2),
-            prep_fn=_prep_stage1,
-        )
-        torch.cuda.synchronize()
-    else:
-        _, us = run_perftest(
-            launch,
-            out,
-            x_q,
-            w_kernel,
-            scale_x_1d,
-            scale_w1_1d,
-            sorted_token_ids,
-            sorted_expert_ids,
-            sorted_weights_1d,
-            num_iters=int(num_iters),
-            num_warmup=int(num_warmup),
-            testGraph=test_graph,
-        )
+    us = _bench_kernel_us(
+        _run_stage1,
+        warmup=int(num_warmup),
+        iters=int(max(1, num_iters)),
+        flush_l2=bool(flush_l2),
+        prep_fn=_prep_stage1,
+    )
     torch.cuda.synchronize()
 
     if not bool(skip_ref):
@@ -486,29 +467,21 @@ def run_moe_stage1(
     read_bw_gbs = read_bytes / 1e9 / (us / 1e6)
     write_bw_gbs = write_bytes / 1e9 / (us / 1e6)
 
-    if bool(benchmark_mode):
-        print(
-            f"FlyDSL MoE stage1[{in_dtype}] benchmark | "
-            f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
-            f"tile=({tile_m},{tile_n},{tile_k})"
-        )
-        print(
-            f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
-            f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
-        )
-        print(
-            f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
-            f"bytes: x={bytes_x/1e6:.1f}MB w={bytes_w/1e6:.1f}MB "
-            f"sx={bytes_scale_x/1e6:.1f}MB sw={bytes_scale_w/1e6:.1f}MB "
-            f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
-        )
-    else:
-        print(
-            f"FlyDSL MoE stage1[{in_dtype}]: "
-            f"{us:.1f} us, "
-            f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}), "
-            f"{tbps:.3f} TB/s (doweight_stage1={doweight_stage1})"
-        )
+    print(
+        f"FlyDSL MoE stage1[{in_dtype}] benchmark | "
+        f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
+        f"tile=({tile_m},{tile_n},{tile_k})"
+    )
+    print(
+        f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
+        f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
+    )
+    print(
+        f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
+        f"bytes: x={bytes_x/1e6:.1f}MB w={bytes_w/1e6:.1f}MB "
+        f"sx={bytes_scale_x/1e6:.1f}MB sw={bytes_scale_w/1e6:.1f}MB "
+        f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
+    )
     if return_outputs:
         return out, us
     return None
@@ -546,9 +519,7 @@ def run_moe_stage2(
     kernel_name: str = "moe_gemm2",
     use_reduce: bool = False,
     use_valid_mask: bool = False,
-    test_graph: bool = False,
     waves_per_eu: Optional[int] = None,
-    benchmark_mode: bool = False,
     flush_l2: bool = True,
     num_buffers: int = 1,
     use_tdm_gather: bool = True,
@@ -853,33 +824,11 @@ def run_moe_stage2(
                 stream,
             )
  
-    if bool(benchmark_mode) and not bool(test_graph):
-        def _prep_stage2():
-            out_perf.zero_()
+    def _prep_stage2():
+        out_perf.zero_()
 
-        def _run_stage2():
-            launch(
-                out_perf,
-                a2_q.view(-1),
-                w2_kernel.view(-1),
-                a2_scale_1d,
-                w2_scale_1d,
-                sorted_token_ids,
-                sorted_expert_ids,
-                sorted_weights_1d,
-            )
-
-        us = _bench_kernel_us(
-            _run_stage2,
-            warmup=int(num_warmup),
-            iters=int(max(1, num_iters)),
-            flush_l2=bool(flush_l2),
-            prep_fn=_prep_stage2,
-        )
-        torch.cuda.synchronize()
-    else:
-        _, us = run_perftest(
-            launch,
+    def _run_stage2():
+        launch(
             out_perf,
             a2_q.view(-1),
             w2_kernel.view(-1),
@@ -888,10 +837,15 @@ def run_moe_stage2(
             sorted_token_ids,
             sorted_expert_ids,
             sorted_weights_1d,
-            num_iters=int(num_iters),
-            num_warmup=int(num_warmup),
-            testGraph=test_graph,
         )
+
+    us = _bench_kernel_us(
+        _run_stage2,
+        warmup=int(num_warmup),
+        iters=int(max(1, num_iters)),
+        flush_l2=bool(flush_l2),
+        prep_fn=_prep_stage2,
+    )
     torch.cuda.synchronize()
 
     # Correctness run (single launch into a clean zeroed output).
@@ -970,28 +924,21 @@ def run_moe_stage2(
     write_bytes = bytes_out
     read_bw_gbs = read_bytes / 1e9 / (us / 1e6)
     write_bw_gbs = write_bytes / 1e9 / (us / 1e6)
-    if bool(benchmark_mode):
-        print(
-            f"FlyDSL MoE stage2[{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} benchmark | "
-            f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
-            f"tile=({tile_m},{tile_n},{tile_k})"
-        )
-        print(
-            f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
-            f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
-        )
-        print(
-            f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
-            f"bytes: a2={bytes_a2/1e6:.1f}MB w2={bytes_w2/1e6:.1f}MB "
-            f"sa2={bytes_scale_a2/1e6:.1f}MB sw2={bytes_scale_w2/1e6:.1f}MB "
-            f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
-        )
-    else:
-        print(
-            f"FlyDSL MoE stage2 [{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} | "
-            f"{model_dim}x{inter_dim}, E={experts}, K={topk}, M_eff={tokens*topk} | "
-            f"{us:.1f} us, {tflops:.2f} TFLOPS, {tbps:.3f} TB/s"
-        )
+    print(
+        f"FlyDSL MoE stage2[{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} benchmark | "
+        f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
+        f"tile=({tile_m},{tile_n},{tile_k})"
+    )
+    print(
+        f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
+        f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
+    )
+    print(
+        f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
+        f"bytes: a2={bytes_a2/1e6:.1f}MB w2={bytes_w2/1e6:.1f}MB "
+        f"sa2={bytes_scale_a2/1e6:.1f}MB sw2={bytes_scale_w2/1e6:.1f}MB "
+        f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
+    )
     # Print profile breakdown if the executor supports it
     if hasattr(exe, 'print_profile_stats'):
         exe.print_profile_stats()
@@ -1017,7 +964,6 @@ def run_moe_gemm_2stage(
     out_dtype: str,
     use_reduce: bool,
     use_valid_mask: bool,
-    test_graph: bool,
     *,
     seed: int = 0,
     num_iters: int = 5,
@@ -1026,7 +972,6 @@ def run_moe_gemm_2stage(
     init_scale: float = 1.0,
     skip_ref: bool = False,
     w_fp4_kernel: bool = False,
-    benchmark_mode: bool = False,
     flush_l2: bool = True,
     num_buffers: int = 1,
     use_tdm_store: bool = False,
@@ -1100,8 +1045,6 @@ def run_moe_gemm_2stage(
         routing_in=routing,
         return_outputs=True,
         skip_ref=bool(skip_ref),
-        test_graph=test_graph,
-        benchmark_mode=bool(benchmark_mode),
         flush_l2=bool(flush_l2),
         num_buffers=int(num_buffers),
         use_tdm_store=bool(use_tdm_store),
@@ -1145,8 +1088,6 @@ def run_moe_gemm_2stage(
         skip_ref=bool(skip_ref),
         use_reduce=bool(use_reduce),
         use_valid_mask=use_valid_mask,
-        test_graph=test_graph,
-        benchmark_mode=bool(benchmark_mode),
         flush_l2=bool(flush_l2),
         num_buffers=int(num_buffers),
         use_tdm_store=bool(use_tdm_store),
@@ -1612,7 +1553,6 @@ def test_moe_2stage_fp4_wfp4_reduce_reference():
         use_reduce=True,
         use_tdm_store=False,
         w_fp4_kernel=True,
-        test_graph=False,
         use_valid_mask=False,
     )
 
@@ -1633,10 +1573,6 @@ def test_moe_2stage_fp4_wfp4_reduce_reference():
 @pytest.mark.parametrize("out_dtype", ["f16"], ids=["out_f16"])
 @pytest.mark.parametrize("use_reduce", [False, True], ids=["atomic", "reduce"])
 @pytest.mark.parametrize("use_valid_mask", [False, True], ids=["nomask", "mask"])
-@pytest.mark.parametrize("test_graph", [
-    pytest.param(False, id="eager"),
-    pytest.param(True, id="graph"),
-])
 def test_moe_gemm_2stage(
     tokens: int,
     model_dim: int,
@@ -1653,7 +1589,6 @@ def test_moe_gemm_2stage(
     out_dtype: str,
     use_reduce: bool,
     use_valid_mask: bool,
-    test_graph: bool,
 ):
     run_moe_gemm_2stage(
         tokens=tokens,
@@ -1671,7 +1606,6 @@ def test_moe_gemm_2stage(
         out_dtype=out_dtype,
         use_reduce=use_reduce,
         use_valid_mask=use_valid_mask,
-        test_graph=test_graph,
     )
 
 

--- a/tests/kernels/test_moe_gemm_wmma_gfx1250.py
+++ b/tests/kernels/test_moe_gemm_wmma_gfx1250.py
@@ -31,7 +31,7 @@ for _p in reversed(_PYTHON_CANDIDATES):
         sys.path.insert(0, _p)
 
 from tests.kernels.test_ref import torch_moe_gemm1, torch_moe_gemm2
-from tests.test_common import verify_output, run_perftest
+from tests.test_common import verify_output
 from flydsl.runtime.device import get_rocm_arch
 from tests.kernels.benchmark_common import (
     bench_kernel_us as _bench_kernel_us,
@@ -297,9 +297,7 @@ def run_moe_stage1(
     routing_in: Optional[RoutingBuffers] = None,
     return_outputs: bool = False,
     skip_ref: bool = False,
-    test_graph: bool = False,
     waves_per_eu: Optional[int] = None,
-    benchmark_mode: bool = False,
     flush_l2: bool = True,
     num_buffers: int = 1,
     use_tdm_gather: bool = True,
@@ -420,36 +418,19 @@ def run_moe_stage1(
             stream,
         )
 
-    if bool(benchmark_mode) and not bool(test_graph):
-        def _prep_stage1():
-            out.zero_()
+    def _prep_stage1():
+        out.zero_()
 
-        def _run_stage1():
-            launch(out, x_q, w_kernel, scale_x_1d, scale_w1_1d, sorted_token_ids, sorted_expert_ids, sorted_weights_1d)
+    def _run_stage1():
+        launch(out, x_q, w_kernel, scale_x_1d, scale_w1_1d, sorted_token_ids, sorted_expert_ids, sorted_weights_1d)
 
-        us = _bench_kernel_us(
-            _run_stage1,
-            warmup=int(num_warmup),
-            iters=int(max(1, num_iters)),
-            flush_l2=bool(flush_l2),
-            prep_fn=_prep_stage1,
-        )
-        torch.cuda.synchronize()
-    else:
-        _, us = run_perftest(
-            launch,
-            out,
-            x_q,
-            w_kernel,
-            scale_x_1d,
-            scale_w1_1d,
-            sorted_token_ids,
-            sorted_expert_ids,
-            sorted_weights_1d,
-            num_iters=int(num_iters),
-            num_warmup=int(num_warmup),
-            testGraph=test_graph,
-        )
+    us = _bench_kernel_us(
+        _run_stage1,
+        warmup=int(num_warmup),
+        iters=int(max(1, num_iters)),
+        flush_l2=bool(flush_l2),
+        prep_fn=_prep_stage1,
+    )
     torch.cuda.synchronize()
 
     if not bool(skip_ref):
@@ -488,29 +469,21 @@ def run_moe_stage1(
     read_bw_gbs = read_bytes / 1e9 / (us / 1e6)
     write_bw_gbs = write_bytes / 1e9 / (us / 1e6)
 
-    if bool(benchmark_mode):
-        print(
-            f"FlyDSL MoE stage1[{in_dtype}] benchmark | "
-            f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
-            f"tile=({tile_m},{tile_n},{tile_k})"
-        )
-        print(
-            f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
-            f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
-        )
-        print(
-            f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
-            f"bytes: x={bytes_x/1e6:.1f}MB w={bytes_w/1e6:.1f}MB "
-            f"sx={bytes_scale_x/1e6:.1f}MB sw={bytes_scale_w/1e6:.1f}MB "
-            f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
-        )
-    else:
-        print(
-            f"FlyDSL MoE stage1[{in_dtype}]: "
-            f"{us:.1f} us, "
-            f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}), "
-            f"{tbps:.3f} TB/s (doweight_stage1={doweight_stage1})"
-        )
+    print(
+        f"FlyDSL MoE stage1[{in_dtype}] benchmark | "
+        f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
+        f"tile=({tile_m},{tile_n},{tile_k})"
+    )
+    print(
+        f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
+        f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
+    )
+    print(
+        f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
+        f"bytes: x={bytes_x/1e6:.1f}MB w={bytes_w/1e6:.1f}MB "
+        f"sx={bytes_scale_x/1e6:.1f}MB sw={bytes_scale_w/1e6:.1f}MB "
+        f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
+    )
     if return_outputs:
         return out, us
     return None
@@ -548,9 +521,7 @@ def run_moe_stage2(
     kernel_name: str = "moe_gemm2",
     use_reduce: bool = False,
     use_valid_mask: bool = False,
-    test_graph: bool = False,
     waves_per_eu: Optional[int] = None,
-    benchmark_mode: bool = False,
     flush_l2: bool = True,
     num_buffers: int = 1,
     use_tdm_gather: bool = True,
@@ -778,36 +749,11 @@ def run_moe_stage2(
                 stream,
             )
  
-    # NOTE: stage2 uses atomic-add into `out`, so we cannot reuse the same output buffer
-    # across perf iterations for correctness. Time into a dedicated buffer, then run
-    # a single clean launch for correctness verification below.
-    if bool(benchmark_mode) and not bool(test_graph):
-        def _prep_stage2():
-            out_perf.zero_()
+    def _prep_stage2():
+        out_perf.zero_()
 
-        def _run_stage2():
-            launch(
-                out_perf,
-                a2_q.view(-1),
-                w2_kernel.view(-1),
-                a2_scale_1d,
-                w2_scale_1d,
-                sorted_token_ids,
-                sorted_expert_ids,
-                sorted_weights_1d,
-            )
-
-        us = _bench_kernel_us(
-            _run_stage2,
-            warmup=int(num_warmup),
-            iters=int(max(1, num_iters)),
-            flush_l2=bool(flush_l2),
-            prep_fn=_prep_stage2,
-        )
-        torch.cuda.synchronize()
-    else:
-        _, us = run_perftest(
-            launch,
+    def _run_stage2():
+        launch(
             out_perf,
             a2_q.view(-1),
             w2_kernel.view(-1),
@@ -816,10 +762,15 @@ def run_moe_stage2(
             sorted_token_ids,
             sorted_expert_ids,
             sorted_weights_1d,
-            num_iters=int(num_iters),
-            num_warmup=int(num_warmup),
-            testGraph=test_graph,
         )
+
+    us = _bench_kernel_us(
+        _run_stage2,
+        warmup=int(num_warmup),
+        iters=int(max(1, num_iters)),
+        flush_l2=bool(flush_l2),
+        prep_fn=_prep_stage2,
+    )
     torch.cuda.synchronize()
 
     # Correctness run (single launch into a clean zeroed output).
@@ -870,28 +821,21 @@ def run_moe_stage2(
     write_bytes = bytes_out
     read_bw_gbs = read_bytes / 1e9 / (us / 1e6)
     write_bw_gbs = write_bytes / 1e9 / (us / 1e6)
-    if bool(benchmark_mode):
-        print(
-            f"FlyDSL MoE stage2[{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} benchmark | "
-            f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
-            f"tile=({tile_m},{tile_n},{tile_k})"
-        )
-        print(
-            f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
-            f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
-        )
-        print(
-            f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
-            f"bytes: a2={bytes_a2/1e6:.1f}MB w2={bytes_w2/1e6:.1f}MB "
-            f"sa2={bytes_scale_a2/1e6:.1f}MB sw2={bytes_scale_w2/1e6:.1f}MB "
-            f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
-        )
-    else:
-        print(
-            f"FlyDSL MoE stage2 [{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} | "
-            f"{model_dim}x{inter_dim}, E={experts}, K={topk}, M_eff={tokens*topk} | "
-            f"{us:.1f} us, {tflops:.2f} TFLOPS, {tbps:.3f} TB/s"
-        )
+    print(
+        f"FlyDSL MoE stage2[{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} benchmark | "
+        f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
+        f"tile=({tile_m},{tile_n},{tile_k})"
+    )
+    print(
+        f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
+        f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
+    )
+    print(
+        f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
+        f"bytes: a2={bytes_a2/1e6:.1f}MB w2={bytes_w2/1e6:.1f}MB "
+        f"sa2={bytes_scale_a2/1e6:.1f}MB sw2={bytes_scale_w2/1e6:.1f}MB "
+        f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
+    )
 
     # Print profile breakdown if the executor supports it
     if hasattr(exe, 'print_profile_stats'):
@@ -918,7 +862,6 @@ def run_moe_gemm_2stage(
     out_dtype: str,
     use_reduce: bool,
     use_valid_mask: bool,
-    test_graph: bool,
     *,
     seed: int = 0,
     num_iters: int = 5,
@@ -926,7 +869,6 @@ def run_moe_gemm_2stage(
     moe_sort_mode: Optional[str] = None,
     init_scale: float = 0.2,
     skip_ref: bool = False,
-    benchmark_mode: bool = False,
     flush_l2: bool = True,
     num_buffers: int = 1,
     use_tdm_store: bool = False,
@@ -967,8 +909,7 @@ def run_moe_gemm_2stage(
         x_fp32_in=x_fp32, w1_fp32_in=w1_fp32,
         topk_ids_in=topk_ids, topk_weights_in=topk_weights,
         routing_in=routing, return_outputs=True,
-        skip_ref=bool(skip_ref), test_graph=test_graph,
-        benchmark_mode=bool(benchmark_mode), flush_l2=bool(flush_l2),
+        skip_ref=bool(skip_ref), flush_l2=bool(flush_l2),
         num_buffers=int(num_buffers), use_tdm_store=bool(use_tdm_store),
         inst_prefetch=bool(inst_prefetch), wave_specialized_tdm=bool(wave_specialized_tdm),
         cluster_m=int(cluster_m), cluster_n=int(cluster_n),
@@ -1235,8 +1176,6 @@ if __name__ == "__main__":
     parser.add_argument("--use_valid_mask", type=_str2bool, nargs="?", const=True, default=False, help="Use valid mask for optimization when reduce or not.")
 
     # Benchmark knobs
-    parser.add_argument("--benchmark", action="store_true", default=False,
-                        help="Use GEMM-style per-iteration event timing with optional L2 flush.")
     parser.add_argument("--no_flush_l2", action="store_true", default=False,
                         help="Disable L2 flush in benchmark mode.")
     parser.add_argument("--num_buffers", type=int, default=1, choices=[1, 2, 3, 4],
@@ -1254,15 +1193,6 @@ if __name__ == "__main__":
     parser.add_argument("--seed", type=int, default=0, help="torch.manual_seed(seed)")
     parser.add_argument("--num_iters", type=int, default=2, help="Benchmark iters")
     parser.add_argument("--num_warmup", type=int, default=1, help="Benchmark warmup iters")
-
-    # graph mode test
-    parser.add_argument(
-        "--test_graph",
-        "-tg",
-        action="store_true",
-        default=False,
-        help="test with graph mode.",
-    )
 
     # ── Benchmark sweep mode (--bench) ──
     add_moe_bench_args(parser)
@@ -1302,8 +1232,6 @@ if __name__ == "__main__":
         seed=int(args.seed), num_iters=int(args.num_iters), num_warmup=int(args.num_warmup),
         moe_sort_mode=args.moe_sort_mode,
         skip_ref=bool(args.skip_ref),
-        test_graph=bool(args.test_graph),
-        benchmark_mode=bool(args.benchmark),
         flush_l2=not bool(args.no_flush_l2),
         num_buffers=int(args.num_buffers),
         use_tdm_store=bool(args.use_tdm_store),
@@ -1377,10 +1305,6 @@ def test_moe_2stage_waves_per_eu_smoke(waves_per_eu: int):
 @pytest.mark.parametrize("out_dtype", ["f16", "f32"], ids=["out_f16", "out_f32"])
 @pytest.mark.parametrize("use_reduce", [False, True], ids=["atomic", "reduce"])
 @pytest.mark.parametrize("use_valid_mask", [False, True], ids=["nomask", "mask"])
-@pytest.mark.parametrize("test_graph", [
-    pytest.param(False, id="eager"),
-    pytest.param(True, id="graph"),
-])
 def test_moe_gemm_2stage(
     tokens: int,
     model_dim: int,
@@ -1397,7 +1321,6 @@ def test_moe_gemm_2stage(
     out_dtype: str,
     use_reduce: bool,
     use_valid_mask: bool,
-    test_graph: bool,
 ):
     run_moe_gemm_2stage(
         tokens=tokens,
@@ -1415,5 +1338,4 @@ def test_moe_gemm_2stage(
         out_dtype=out_dtype,
         use_reduce=use_reduce,
         use_valid_mask=use_valid_mask,
-        test_graph=test_graph,
     )


### PR DESCRIPTION
- Remove run_perftest path from mxscale/wmma test harnesses, keep only _bench_kernel_us (CUDA Event per-iteration timing with L2 flush and IQR outlier filtering) for consistent and accurate benchmarking
- Remove test_graph/benchmark_mode parameters and CUDA Graph parametrize from pytest tests since they were only used by the removed perftest path
- Clean up __main__ CLI in wmma test to remove --test_graph/--benchmark args
- Fix is_rdna_arch() to match gfx12* (not just gfx120*) for gfx1250
- Fix bench_resolve_tiles() tile_k fallback for non-divisible dimensions

Made-with: Cursor

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
