### PR TITLE
Detach requires_grad tensors before FlyDSL DLPack export

### DIFF
--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -147,11 +147,12 @@ class TensorAdaptor:
         assumed_align: Optional[int] = None,
         use_32bit_stride: bool = False,
     ):
-        self._tensor_keepalive = tensor
-        dlpack_tensor = tensor
-        if _FLOAT8_DTYPES and tensor.dtype in _FLOAT8_DTYPES:
-            dlpack_tensor = tensor.view(torch.uint8)
-            self._tensor_keepalive = dlpack_tensor
+        # Forward-only interop: DLPack export from torch rejects tensors that
+        # still participate in autograd, so detach before crossing into FlyDSL.
+        dlpack_tensor = tensor.detach() if tensor.requires_grad else tensor
+        if _FLOAT8_DTYPES and dlpack_tensor.dtype in _FLOAT8_DTYPES:
+            dlpack_tensor = dlpack_tensor.view(torch.uint8)
+        self._tensor_keepalive = dlpack_tensor
 
         self.tensor_adaptor = DLTensorAdaptor(dlpack_tensor.__dlpack__(stream=-1), assumed_align, use_32bit_stride)
         self.assumed_align = assumed_align

--- a/tests/unit/test_jit_stream_param.py
+++ b/tests/unit/test_jit_stream_param.py
@@ -188,3 +188,15 @@ class TestKernelParameter:
         _vecadd(a, b, c, SIZE, BLOCK_DIM, VEC_WIDTH)
         torch.cuda.synchronize()
         assert torch.allclose(c, a.data + b.data, atol=1e-5)
+
+    def test_parameter_requires_grad_forward_only(self):
+        """requires_grad=True Parameter should be accepted for forward-only use."""
+        w = torch.nn.Parameter(
+            torch.randn(SIZE, device="cuda", dtype=torch.float32),
+            requires_grad=True,
+        )
+        b = torch.randn(SIZE, device="cuda", dtype=torch.float32)
+        c = torch.empty_like(b)
+        _vecadd(w, b, c, SIZE, BLOCK_DIM, VEC_WIDTH)
+        torch.cuda.synchronize()
+        assert torch.allclose(c, w.detach() + b, atol=1e-5)


### PR DESCRIPTION
Allow forward-only use of requires_grad torch tensors in the FlyDSL wrapper path and cover the behavior with a unit test.


Made-with: Cursor

