### PR TITLE
Adjust allreduce CI benchmark thresholds

### DIFF
--- a/tests/kernels/compare_allreduce_benchmark.py
+++ b/tests/kernels/compare_allreduce_benchmark.py
@@ -5,14 +5,14 @@ Usage:
     python3 compare_benchmark.py <main.csv> <pr.csv>
 
 Exit code 1 if any case regresses more than BOTH thresholds:
-    - relative increase > MAX_REGRESSION_PCT  (default 10%)
-    - absolute increase > MIN_ABS_REGRESSION_US (default 5 us)
+    - relative increase > MAX_REGRESSION_PCT  (default 15%)
+    - absolute increase > MIN_ABS_REGRESSION_US (default 10 us)
 """
 import sys
 import pandas as pd
 
-MAX_REGRESSION_PCT = 10.0
-MIN_ABS_REGRESSION_US = 5.0
+MAX_REGRESSION_PCT = 15.0
+MIN_ABS_REGRESSION_US = 10.0
 
 
 def main():
@@ -76,8 +76,8 @@ def main():
         print("\n=== Cases BROKEN in PR (work on main but fail on PR) ===")
         for shape, dtype in newly_broken:
             fail_count += 1
-            err = pr_agg_indexed.loc[(shape, dtype)].get("error", "unknown")
-            print(f"  {shape:>20s} {dtype:>4s}  [BROKEN]  error: {err}")
+            acc = pr_agg_indexed.loc[(shape, dtype)].get("acc_res", "unknown")
+            print(f"  {shape:>20s} {dtype:>4s}  [BROKEN]  acc_res: {acc}")
 
     if fail_count > 0:
         print(f"\nFAILED: {fail_count} issue(s) detected.")

--- a/tests/kernels/test_allreduce.py
+++ b/tests/kernels/test_allreduce.py
@@ -637,6 +637,10 @@ def run_all_tests(
                 
                 # Add aggregate row
                 rank0 = rank_results[0] if rank_results else {}
+                has_failure = any(
+                    r.get("error") or r.get("kernel_name") in ("skip", "error")
+                    for r in rank_results
+                )
                 aggregate_result = {
                     "rank": "aggregate",
                     "shape": str(shape),
@@ -651,7 +655,7 @@ def run_all_tests(
                     "kernel_name": rank0.get("kernel_name", "unknown"),
                     "num_iters": num_iters,
                     "num_warmup": num_warmup,
-                    "error": rank0.get("error"),
+                    "acc_res": "failed" if has_failure else "pass",
                 }
                 all_results.append(aggregate_result)
                 
@@ -681,14 +685,12 @@ def run_all_tests(
 
         failed = [
             r for r in all_results
-            if r.get("rank") == "aggregate"
-            and (r.get("kernel_name") in ("skip", "error") or r.get("error"))
+            if r.get("rank") == "aggregate" and r.get("acc_res") == "failed"
         ]
         if failed:
             print("\n✗ FAILED cases:")
             for r in failed:
-                reason = r.get("error") or r.get("kernel_name", "unknown")
-                print(f"  {r['shape']}  {r['dtype']}  {r['mode']}  → {reason}")
+                print(f"  {r['shape']}  {r['dtype']}  {r['mode']}  → {r.get('kernel_name', 'unknown')}")
             sys.exit(1)
 
         return df


### PR DESCRIPTION
## Motivation

Adjust allreduce CI benchmark thresholds

## Technical Details

- Raise regression thresholds to 10us absolute / 15% relative
- Replace aggregate 'error' field (always NaN) with 'acc_res' showing pass/failed

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
