### PR TITLE
[OPT] Add fly-int-swizzle-simplify pass

### DIFF
--- a/include/flydsl/Dialect/Fly/IR/FlyAttrDefs.td
+++ b/include/flydsl/Dialect/Fly/IR/FlyAttrDefs.td
@@ -156,6 +156,8 @@ def Fly_SwizzleAttr : Fly_Attr<"Swizzle", "swizzle", []> {
   let extraClassDeclaration = [{
     bool isTrivialSwizzle() const;
     static SwizzleAttr getTrivialSwizzle(MLIRContext *context);
+
+    int32_t period() const { return 1 << (getMask() + getBase() + getShift()); }
   }];
 }
 

--- a/include/flydsl/Dialect/Fly/Transforms/Passes.td
+++ b/include/flydsl/Dialect/Fly/Transforms/Passes.td
@@ -65,22 +65,25 @@ def FlyConvertAtomCallToSSAFormPass : Pass<"fly-convert-atom-call-to-ssa-form"> 
 def FlyIntSwizzleSimplifyPass : Pass<"fly-int-swizzle-simplify"> {
   let summary = "Algebraically simplify swizzle-shaped arith sequences";
   let description = [{
-      Recognize the canonical three-instruction swizzle sequence emitted by `applySwizzle`,
+      Recognize the canonical swizzle sequence emitted by `applySwizzle`,
 
         %m  = arith.constant ((1<<M)-1) << (base+shift) : iN     // ring of 1s
         %s  = arith.constant shift                       : iN
-        %r  = arith.xori %x, arith.shrui(arith.andi %x, %m), %s
+        %a  = arith.andi %x, %m : iN
+        %h  = arith.shrui %a, %s : iN
+        %r  = arith.xori %x, %h : iN
 
       and apply the algebraic identity
 
         swizzle(a + d) = swizzle(a) + d   when d % period == 0,
 
-      The peeled-off addends survive as plain `arith.addi/subi`, exposing them to CSE and constant
+      The peeled-off addends survive as plain `arith.addi`, exposing them to CSE and constant
       folding that the bit-level form would hide.
     }];
-    
+
   let dependentDialects = [
-    "arith::ArithDialect"
+    "arith::ArithDialect",
+    "gpu::GPUDialect"
   ];
 }
 

--- a/include/flydsl/Dialect/Fly/Transforms/Passes.td
+++ b/include/flydsl/Dialect/Fly/Transforms/Passes.td
@@ -62,6 +62,28 @@ def FlyConvertAtomCallToSSAFormPass : Pass<"fly-convert-atom-call-to-ssa-form"> 
   ];
 }
 
+def FlyIntSwizzleSimplifyPass : Pass<"fly-int-swizzle-simplify"> {
+  let summary = "Algebraically simplify swizzle-shaped arith sequences";
+  let description = [{
+      Recognize the canonical three-instruction swizzle sequence emitted by `applySwizzle`,
+
+        %m  = arith.constant ((1<<M)-1) << (base+shift) : iN     // ring of 1s
+        %s  = arith.constant shift                       : iN
+        %r  = arith.xori %x, arith.shrui(arith.andi %x, %m), %s
+
+      and apply the algebraic identity
+
+        swizzle(a + d) = swizzle(a) + d   when d % period == 0,
+
+      The peeled-off addends survive as plain `arith.addi/subi`, exposing them to CSE and constant
+      folding that the bit-level form would hide.
+    }];
+    
+  let dependentDialects = [
+    "arith::ArithDialect"
+  ];
+}
+
 def FlyPromoteRegMemToVectorSSAPass : Pass<"fly-promote-regmem-to-vectorssa"> {
   let summary = "Promote register memory to vector SSA values";
   let description = [{

--- a/include/flydsl/Dialect/Fly/Utils/IntUtils.h
+++ b/include/flydsl/Dialect/Fly/Utils/IntUtils.h
@@ -56,6 +56,8 @@ IntAttr intCeilDiv(IntAttr lhs, IntAttr rhs);
 IntAttr intShapeDiv(IntAttr lhs, IntAttr rhs);
 IntAttr intApplySwizzle(IntAttr v, SwizzleAttr swizzle);
 
+bool isDivisibleBy(IntAttr attr, int32_t divisor);
+
 //===----------------------------------------------------------------------===//
 // BasisAttr operations
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Fly/CMakeLists.txt
+++ b/lib/Dialect/Fly/CMakeLists.txt
@@ -13,7 +13,8 @@ add_mlir_dialect_library(MLIRFlyDialect
   Transforms/RewriteFuncSignature.cpp
   Transforms/ConvertAtomCallToSSAForm.cpp
   Transforms/PromoteRegMemToVectorSSA.cpp
-  
+  Transforms/IntSwizzleSimplify.cpp
+
   DEPENDS
   MLIRFlyIncGen
   FlyTransformPassIncGen

--- a/lib/Dialect/Fly/Transforms/IntSwizzleSimplify.cpp
+++ b/lib/Dialect/Fly/Transforms/IntSwizzleSimplify.cpp
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 FlyDSL Project Contributors
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+#include "flydsl/Dialect/Fly/IR/FlyDialect.h"
+
+#include <functional>
+#include <numeric>
+
+using namespace mlir;
+using namespace mlir::fly;
+
+namespace mlir {
+namespace fly {
+#define GEN_PASS_DEF_FLYINTSWIZZLESIMPLIFYPASS
+#include "flydsl/Dialect/Fly/Transforms/Passes.h.inc"
+} // namespace fly
+} // namespace mlir
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Divisibility lattice over SSA values.
+//
+// For each value we take max() of two evidences:
+//   * forward, from the defining arith op (gcd / sat-mul / shl);
+//   * backward, from any Make*Op user that carries a static
+//     IntAttr.divisibility annotation on its result IntTupleAttr.
+//===----------------------------------------------------------------------===//
+
+class Divisibility {
+public:
+  int get(Value v);
+
+private:
+  static int satMul(int a, int b) {
+    if (a == 0 || b == 0)
+      return 0;
+    return (a > INT32_MAX / b) ? INT32_MAX : a * b;
+  }
+
+  int fromDef(Value v);
+  int fromUses(Value v);
+  static int fromMakeOpUser(Operation *user, unsigned operandIdx);
+
+  DenseMap<Value, int> cache;
+  llvm::SmallPtrSet<Value, 16> visiting;
+};
+
+int Divisibility::get(Value v) {
+  if (auto c = getConstantIntValue(v))
+    return *c == 0 ? INT32_MAX : (int)std::abs(*c);
+  if (auto it = cache.find(v); it != cache.end())
+    return it->second;
+  if (!visiting.insert(v).second)
+    return 1; // conservative on cycles
+  int d = std::max(fromDef(v), fromUses(v));
+  visiting.erase(v);
+  return cache[v] = d;
+}
+
+int Divisibility::fromDef(Value v) {
+  Operation *def = v.getDefiningOp();
+  if (!def)
+    return 1;
+  return llvm::TypeSwitch<Operation *, int>(def)
+      .Case<arith::AddIOp>([&](auto op) { return std::gcd(get(op.getLhs()), get(op.getRhs())); })
+      .Case<arith::MulIOp>([&](auto op) { return satMul(get(op.getLhs()), get(op.getRhs())); })
+      .Case<arith::ShLIOp>([&](auto op) {
+        int lhs = get(op.getLhs());
+        auto k = getConstantIntValue(op.getRhs());
+        return (k && *k >= 0 && *k < 31) ? satMul(lhs, 1 << *k) : lhs;
+      })
+      .Case<arith::SelectOp>(
+          [&](auto op) { return std::gcd(get(op.getTrueValue()), get(op.getFalseValue())); })
+      .Default(1);
+}
+
+int Divisibility::fromUses(Value v) {
+  int best = 1;
+  for (OpOperand &use : v.getUses())
+    best = std::max(best, fromMakeOpUser(use.getOwner(), use.getOperandNumber()));
+  return best;
+}
+
+int Divisibility::fromMakeOpUser(Operation *user, unsigned operandIdx) {
+  auto resTy = llvm::TypeSwitch<Operation *, IntTupleType>(user)
+                   .Case<MakeIntTupleOp, MakeShapeOp, MakeStrideOp, MakeCoordOp>(
+                       [](auto op) { return cast<IntTupleType>(op.getType()); })
+                   .Default(IntTupleType());
+  if (!resTy)
+    return 1;
+
+  // DFS the IntTupleAttr to find the operandIdx-th dynamic leaf.
+  unsigned cursor = 0;
+  int result = 1;
+  std::function<bool(IntTupleAttr)> visit = [&](IntTupleAttr a) -> bool {
+    if (a.isLeaf()) {
+      auto leaf = a.extractIntFromLeaf();
+      if (!leaf || leaf.getStaticFlag())
+        return false;
+      if (cursor++ == operandIdx) {
+        int32_t d = leaf.getDivisibility();
+        result = d > 0 ? (int)d : 1;
+        return true;
+      }
+      return false;
+    }
+    auto arr = dyn_cast<ArrayAttr>(a.getValue());
+    if (!arr)
+      return false;
+    for (int i = 0, e = arr.size(); i < e; ++i)
+      if (visit(a.at(i)))
+        return true;
+    return false;
+  };
+  visit(resTy.getAttr());
+  return result;
+}
+
+//===------------------------------------------------------------------------------------------===//
+// Peel period-aligned summands out of the swizzle's input:
+//
+//   swizzle(base + Σ aᵢ)  →  swizzle(base) + Σ aᵢ
+//
+// when each aᵢ ≡ 0 (mod period).  When `base` drops out entirely the swizzle of 0 folds to 0.
+//===------------------------------------------------------------------------------------------===//
+
+struct PeelResult {
+  Value base;
+  SmallVector<Value> offsets;
+};
+
+PeelResult peelByPeriod(Value v, int period, Divisibility &div) {
+  auto period_multiple = [&](Value x) { return div.get(x) % period == 0; };
+
+  if (auto add = v.getDefiningOp<arith::AddIOp>()) {
+    if (period_multiple(add.getRhs())) {
+      auto rec = peelByPeriod(add.getLhs(), period, div);
+      rec.offsets.push_back(add.getRhs());
+      return rec;
+    }
+    if (period_multiple(add.getLhs())) {
+      auto rec = peelByPeriod(add.getRhs(), period, div);
+      rec.offsets.push_back(add.getLhs());
+      return rec;
+    }
+    return {v, {}};
+  }
+  if (period_multiple(v))
+    return {/*base=*/Value(), {v}};
+  return {v, {}};
+}
+
+//===----------------------------------------------------------------------===//
+// Pass.
+//===----------------------------------------------------------------------===//
+
+class FlyIntSwizzleSimplifyPass
+    : public mlir::fly::impl::FlyIntSwizzleSimplifyPassBase<FlyIntSwizzleSimplifyPass> {
+public:
+  using mlir::fly::impl::FlyIntSwizzleSimplifyPassBase<
+      FlyIntSwizzleSimplifyPass>::FlyIntSwizzleSimplifyPassBase;
+
+  void runOnOperation() override {
+    auto module = getOperation();
+    module->walk([&](gpu::GPUFuncOp fn) { simplifyInFunc(fn); });
+  }
+
+  void simplifyInFunc(gpu::GPUFuncOp fn) {
+    Divisibility div;
+
+    // Collect candidate xori ops (with their period) up-front so we can rewrite
+    // without invalidating the walk.
+    SmallVector<std::pair<arith::XOrIOp, int>> candidates;
+
+    fn.walk([&](arith::XOrIOp xori) {
+      auto shrui = xori.getRhs().getDefiningOp<arith::ShRUIOp>();
+      if (!shrui)
+        return;
+      auto andi = shrui.getLhs().getDefiningOp<arith::AndIOp>();
+      if (!andi)
+        return;
+      Value x = xori.getLhs();
+      if (andi.getLhs() != x)
+        return;
+      auto maskC = getConstantIntValue(andi.getRhs());
+      auto shiftC = getConstantIntValue(shrui.getRhs());
+      if (!maskC || !shiftC)
+        return;
+      unsigned mask = (unsigned)*maskC;
+      if (mask == 0)
+        return;
+      int low = mask & -mask;
+      int plus = mask + low;
+      if ((mask & plus) != 0)
+        return;
+      int K = llvm::countr_zero(mask);
+      int M = llvm::popcount(mask);
+      if ((int)*shiftC > K)
+        return;
+      candidates.push_back({xori, 1 << (M + K)});
+    });
+
+    for (auto [xori, period] : candidates) {
+      Value input = xori.getLhs();
+      auto peeled = peelByPeriod(input, period, div);
+      if (peeled.offsets.empty())
+        continue;
+
+      OpBuilder b(xori);
+      Location loc = xori.getLoc();
+      Type ty = xori.getType();
+
+      auto shrui = cast<arith::ShRUIOp>(xori.getRhs().getDefiningOp());
+      auto andi = cast<arith::AndIOp>(shrui.getLhs().getDefiningOp());
+      Value mask = andi.getRhs();
+      Value shiftC = shrui.getRhs();
+
+      Value cur;
+      if (peeled.base) {
+        Value masked = arith::AndIOp::create(b, loc, peeled.base, mask);
+        Value shifted = arith::ShRUIOp::create(b, loc, masked, shiftC);
+        cur = arith::XOrIOp::create(b, loc, peeled.base, shifted);
+      } else {
+        cur = arith::ConstantIntOp::create(b, loc, ty, 0);
+      }
+      for (Value v : peeled.offsets)
+        cur = arith::AddIOp::create(b, loc, cur, v);
+
+      xori.replaceAllUsesWith(cur);
+      xori.erase();
+    }
+  }
+};
+
+} // namespace

--- a/lib/Dialect/Fly/Transforms/IntSwizzleSimplify.cpp
+++ b/lib/Dialect/Fly/Transforms/IntSwizzleSimplify.cpp
@@ -54,8 +54,10 @@ private:
 };
 
 int Divisibility::get(Value v) {
-  if (auto c = getConstantIntValue(v))
-    return *c == 0 ? INT32_MAX : (int)std::abs(*c);
+  if (auto c = getConstantIntValue(v)) {
+    int64_t abs_c = *c == INT64_MIN ? INT64_MAX : std::abs(*c);
+    return abs_c == 0 ? INT32_MAX : (int)std::min(abs_c, (int64_t)INT32_MAX);
+  }
   if (auto it = cache.find(v); it != cache.end())
     return it->second;
   if (!visiting.insert(v).second)
@@ -138,6 +140,8 @@ struct PeelResult {
 };
 
 PeelResult peelByPeriod(Value v, int period, Divisibility &div) {
+  if (period <= 0)
+    return {v, {}};
   auto period_multiple = [&](Value x) { return div.get(x) % period == 0; };
 
   if (auto add = v.getDefiningOp<arith::AddIOp>()) {
@@ -194,11 +198,11 @@ public:
       auto shiftC = getConstantIntValue(shrui.getRhs());
       if (!maskC || !shiftC)
         return;
-      unsigned mask = (unsigned)*maskC;
+      uint64_t mask = (uint64_t)*maskC;
       if (mask == 0)
         return;
-      int low = mask & -mask;
-      int plus = mask + low;
+      uint64_t low = mask & -mask;
+      uint64_t plus = mask + low;
       if ((mask & plus) != 0)
         return;
       int K = llvm::countr_zero(mask);

--- a/lib/Dialect/Fly/Utils/IntUtils.cpp
+++ b/lib/Dialect/Fly/Utils/IntUtils.cpp
@@ -250,6 +250,12 @@ IntAttr intApplySwizzle(IntAttr v, SwizzleAttr swizzle) {
                              utils::divisibilityApplySwizzle(v.getDivisibility(), swizzle));
 }
 
+bool isDivisibleBy(IntAttr attr, int32_t divisor) {
+  if (attr.isStatic())
+    return attr.getValue() % divisor == 0;
+  return attr.getDivisibility() % divisor == 0;
+}
+
 BasisAttr operator*(BasisAttr lhs, IntAttr rhs) {
   return BasisAttr::get(lhs.getValue() * rhs, lhs.getModes());
 }

--- a/python/flydsl/compiler/backends/rocm.py
+++ b/python/flydsl/compiler/backends/rocm.py
@@ -66,6 +66,7 @@ class RocmBackend(BaseBackend):
             "fly-canonicalize",
             "fly-layout-lowering",
             "fly-int-swizzle-simplify",
+            "canonicalize",
             "fly-convert-atom-call-to-ssa-form",
             "fly-promote-regmem-to-vectorssa",
             "convert-fly-to-rocdl",

--- a/python/flydsl/compiler/backends/rocm.py
+++ b/python/flydsl/compiler/backends/rocm.py
@@ -65,6 +65,7 @@ class RocmBackend(BaseBackend):
             "fly-rewrite-func-signature",
             "fly-canonicalize",
             "fly-layout-lowering",
+            "fly-int-swizzle-simplify",
             "fly-convert-atom-call-to-ssa-form",
             "fly-promote-regmem-to-vectorssa",
             "convert-fly-to-rocdl",

--- a/tests/mlir/Transforms/int_swizzle_simplify.mlir
+++ b/tests/mlir/Transforms/int_swizzle_simplify.mlir
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 FlyDSL Project Contributors
+// RUN: %fly-opt %s --fly-int-swizzle-simplify | FileCheck %s
+
+// SwizzleType(M=3, B=3, S=3): mask = 0b111000000 = 448, shift = 3,
+// period P = 2^(3+3+3) = 512.
+
+// -----------------------------------------------------------------------------
+// (1) Plain swizzle sequence whose input has no peelable structure: untouched.
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: gpu.func @no_peel
+// CHECK:       %[[M:.+]] = arith.constant 448 : i32
+// CHECK:       %[[S:.+]] = arith.constant 3   : i32
+// CHECK:       %[[A:.+]] = arith.andi %arg0, %[[M]]
+// CHECK:       %[[H:.+]] = arith.shrui %[[A]], %[[S]]
+// CHECK:       arith.xori %arg0, %[[H]]
+// CHECK-NOT:   arith.addi
+gpu.module @t1 {
+  gpu.func @no_peel(%x: i32) {
+    %m = arith.constant 448 : i32
+    %s = arith.constant 3   : i32
+    %a = arith.andi %x, %m : i32
+    %h = arith.shrui %a, %s : i32
+    %r = arith.xori %x, %h : i32
+    %t = fly.make_int_tuple(%r) : (i32) -> !fly.int_tuple<?>
+    gpu.return
+  }
+}
+
+// -----------------------------------------------------------------------------
+// (2) Period-aligned constant addend is peeled out:
+//     swizzle(x + 512)  →  swizzle(x) + 512.
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: gpu.func @peel_const_addend
+// CHECK:       %[[D:.+]]   = arith.constant 512 : i32
+// CHECK:       %[[M:.+]]   = arith.constant 448 : i32
+// CHECK:       %[[S:.+]]   = arith.constant 3   : i32
+// CHECK:       %[[AND:.+]] = arith.andi %arg0, %[[M]]
+// CHECK:       %[[SHR:.+]] = arith.shrui %[[AND]], %[[S]]
+// CHECK:       %[[SW:.+]]  = arith.xori %arg0, %[[SHR]]
+// CHECK:       arith.addi %[[SW]], %[[D]]
+gpu.module @t2 {
+  gpu.func @peel_const_addend(%x: i32) {
+    %d = arith.constant 512 : i32
+    %y = arith.addi %x, %d : i32
+    %m = arith.constant 448 : i32
+    %s = arith.constant 3   : i32
+    %a = arith.andi %y, %m : i32
+    %h = arith.shrui %a, %s : i32
+    %r = arith.xori %y, %h : i32
+    %t = fly.make_int_tuple(%r) : (i32) -> !fly.int_tuple<?>
+    gpu.return
+  }
+}
+
+// -----------------------------------------------------------------------------
+// (3) Whole input divisible by period: swizzle(d) → 0; result is 0 + d = d.
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: gpu.func @peel_to_zero
+// CHECK:       %[[D:.+]]    = arith.constant 1024 : i32
+// CHECK:       %[[ZERO:.+]] = arith.constant 0    : i32
+// CHECK:       arith.addi %[[ZERO]], %[[D]]
+// CHECK-NOT:   arith.xori
+gpu.module @t3 {
+  gpu.func @peel_to_zero(%x: i32) {
+    %d = arith.constant 1024 : i32
+    %m = arith.constant 448  : i32
+    %s = arith.constant 3    : i32
+    %a = arith.andi %d, %m : i32
+    %h = arith.shrui %a, %s : i32
+    %r = arith.xori %d, %h : i32
+    %t = fly.make_int_tuple(%r) : (i32) -> !fly.int_tuple<?>
+    gpu.return
+  }
+}
+
+// -----------------------------------------------------------------------------
+// (4) Non-period-aligned addend stays in place (no rewrite).
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: gpu.func @no_peel_misaligned
+// CHECK:       %[[D:.+]] = arith.constant 7 : i32
+// CHECK:       arith.addi %arg0, %[[D]]
+// CHECK:       arith.xori
+// CHECK-NOT:   arith.addi
+gpu.module @t4 {
+  gpu.func @no_peel_misaligned(%x: i32) {
+    %d = arith.constant 7   : i32
+    %y = arith.addi %x, %d  : i32
+    %m = arith.constant 448 : i32
+    %s = arith.constant 3   : i32
+    %a = arith.andi %y, %m : i32
+    %h = arith.shrui %a, %s : i32
+    %r = arith.xori %y, %h : i32
+    %t = fly.make_int_tuple(%r) : (i32) -> !fly.int_tuple<?>
+    gpu.return
+  }
+}
+
+// -----------------------------------------------------------------------------
+// (5) i64 type works the same.
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: gpu.func @peel_i64
+// CHECK:       %[[D:.+]]   = arith.constant 512 : i64
+// CHECK:       %[[M:.+]]   = arith.constant 448 : i64
+// CHECK:       %[[S:.+]]   = arith.constant 3   : i64
+// CHECK:       %[[AND:.+]] = arith.andi %arg0, %[[M]]
+// CHECK:       %[[SHR:.+]] = arith.shrui %[[AND]], %[[S]]
+// CHECK:       %[[SW:.+]]  = arith.xori %arg0, %[[SHR]]
+// CHECK:       arith.addi %[[SW]], %[[D]]
+gpu.module @t5 {
+  gpu.func @peel_i64(%x: i64) {
+    %d = arith.constant 512 : i64
+    %y = arith.addi %x, %d : i64
+    %m = arith.constant 448 : i64
+    %s = arith.constant 3   : i64
+    %a = arith.andi %y, %m : i64
+    %h = arith.shrui %a, %s : i64
+    %r = arith.xori %y, %h : i64
+    %t = fly.make_int_tuple(%r) : (i64) -> !fly.int_tuple<?>
+    gpu.return
+  }
+}


### PR DESCRIPTION
Add an algebraic simplification pass that recognizes the canonical three-instruction swizzle sequence (andi/shrui/xori) emitted by `applySwizzle` and peels period-aligned addends out of the swizzle:

    swizzle(base + d)  →  swizzle(base) + d   when d % period == 0

In example04 (preshuffle_gemm) with SwizzleType S<3,3,3> (period=512), the LDS address for each pipeline stage is `swizzle(thread_offset + stage * lds_stride)`.  Since lds_stride (BLOCK_M × BLOCK_K × sizeof(f16) = 16384) is a multiple of 512, the pass peels the stage offset out:

  Before: each stage recomputes the full swizzle (andi+shrui+xori) on
          (thread_offset + stage_offset), duplicating 3 ALU ops per stage.
  After:  swizzle is computed once on thread_offset; stage offsets become
          plain arith.addi with an immediate, which then fold/CSE across
          stages.

Concrete effects on the ds_read/ds_write address computation in the GEMM hot loop:
  - Instruction count: eliminates redundant andi+shrui+xori triplets per pipeline stage (−6 SALU/VALU ops for 2-stage, −9 for 3-stage).
  - Immediate offsets: the peeled constant addends enable ds_read_b128 with immediate byte offsets instead of a full v_add + swizzle, which the ISA can encode directly in the ds instruction offset field.
  - Register pressure: fewer live intermediates (%masked, %shifted) per stage reduces VGPR demand in the address-computation section.

The pass also includes a divisibility lattice that propagates alignment info both forward (through arith add/mul/shl) and backward (from IntAttr.divisibility annotations on Make*Op results), enabling the optimization even for dynamic strides with known alignment.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
