### PR TITLE
optimized fast path by reducing register use and vectorize on normal …

### DIFF
--- a/kernels/rmsnorm_kernel.py
+++ b/kernels/rmsnorm_kernel.py
@@ -14,23 +14,18 @@ Optimised paths:
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl.compiler.kernel_function import CompilationContext
-
 from flydsl.expr import arith, vector, gpu, range_constexpr
 from flydsl.expr.typing import T, Int32
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
-
+import math
+from kernels.kernels_common import dtype_to_elem_type, get_warp_size
 from flydsl._mlir import ir
 from flydsl.expr import buffer_ops
-
 
 KERNEL_NAME = "rmsnorm"
 
 EPS = 1e-5
-
-import math
-from kernels.kernels_common import dtype_to_elem_type, get_warp_size
-
 WARP_SIZE = get_warp_size()
 BLOCK_THREADS = 256
 DEFAULT_VEC_WIDTH = 8
@@ -50,10 +45,8 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
     # f32 vec8 lowers to a 32-byte/v8i32 buffer_load, which may fail AMDGPU
     # instruction selection. Keep f32 on vec4 while preserving vec8 for f16/bf16.
     VEC_WIDTH = F32_VEC_WIDTH if dtype_str == "f32" else DEFAULT_VEC_WIDTH
-
-    BLOCK_THREADS = _select_block_threads(N, dtype_str)
     UNROLL = 2 if (dtype_str != "f32" and N <= 4096) else 1
-    USE_GENERIC_X_CACHE = (dtype_str != "f32" and N <= 4096)
+    USE_GENERIC_X_CACHE = dtype_str != "f32" and N <= 4096
 
     tile_cols = BLOCK_THREADS * VEC_WIDTH
     RED_SLOTS = max(1, (BLOCK_THREADS + WARP_SIZE - 1) // WARP_SIZE)
@@ -167,7 +160,9 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
                     upper = u.shrui(c16_v)
                     c1_v = vector.broadcast(vec_i32_ty, arith.constant(1, type=T.i32))
                     lsb = upper & c1_v
-                    c7fff_v = vector.broadcast(vec_i32_ty, arith.constant(0x7FFF, type=T.i32))
+                    c7fff_v = vector.broadcast(
+                        vec_i32_ty, arith.constant(0x7FFF, type=T.i32)
+                    )
                     bias = ArithValue(c7fff_v) + ArithValue(lsb)
                     u_round = ArithValue(u) + bias
                     bf16_bits = u_round.shrui(c16_v)
@@ -196,12 +191,16 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
 
             # Pass 1: sumsq only
             for tile_i in range_constexpr(num_tiles):
-                col_bytes = ArithValue(thr_col_bytes) + (tile_i * tile_cols * elem_bytes)
+                col_bytes = ArithValue(thr_col_bytes) + (
+                    tile_i * tile_cols * elem_bytes
+                )
                 vec_e = _load_vec(in_rsrc, col_bytes, soff=row_soffset)
                 x = vec_e if dtype_str == "f32" else vec_e.extf(vec_type_c)
                 x_av = ArithValue(x)
                 x2 = x_av * x_av
-                red2 = vector.reduction(compute_type, vector.CombiningKind.ADD, x2, fastmath=fm_fast)
+                red2 = vector.reduction(
+                    compute_type, vector.CombiningKind.ADD, x2, fastmath=fm_fast
+                )
                 thread_sumsq = ArithValue(thread_sumsq) + red2
 
             sum_sq = block_reduce_add(thread_sumsq)
@@ -213,7 +212,9 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
 
             # Pass 2: reload x + gamma + store
             for tile_i in range_constexpr(num_tiles):
-                col_bytes = ArithValue(thr_col_bytes) + (tile_i * tile_cols * elem_bytes)
+                col_bytes = ArithValue(thr_col_bytes) + (
+                    tile_i * tile_cols * elem_bytes
+                )
 
                 x_e = _load_vec(in_rsrc, col_bytes, soff=row_soffset)
                 g_e = _load_vec(gamma_rsrc, col_bytes)
@@ -270,7 +271,9 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
                 c_total_vecs_i32 = Int32(total_vecs)
                 for u in range_constexpr(UNROLL):
                     vec_idx = tid + vec_base_int + (u * BLOCK_THREADS)
-                    in_range = arith.cmpi(arith.CmpIPredicate.ult, vec_idx, c_total_vecs_i32)
+                    in_range = arith.cmpi(
+                        arith.CmpIPredicate.ult, vec_idx, c_total_vecs_i32
+                    )
                     safe_vec_idx = in_range.select(vec_idx, Int32(0))
                     col_bytes = ArithValue(safe_vec_idx) * (VEC_WIDTH * elem_bytes)
                     x_e = _load_vec(in_rsrc, col_bytes, soff=row_soffset)
@@ -311,11 +314,15 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
                     if in_range:
                         _store_vec(out_vec, out_rsrc, col_bytes, soff=row_soffset)
             else:
-                for vec_base_int in range_constexpr(0, total_vecs, BLOCK_THREADS * UNROLL):
+                for vec_base_int in range_constexpr(
+                    0, total_vecs, BLOCK_THREADS * UNROLL
+                ):
                     c_total_vecs_i32 = Int32(total_vecs)
                     for u in range_constexpr(UNROLL):
                         vec_idx = tid + vec_base_int + (u * BLOCK_THREADS)
-                        in_range = arith.cmpi(arith.CmpIPredicate.ult, vec_idx, c_total_vecs_i32)
+                        in_range = arith.cmpi(
+                            arith.CmpIPredicate.ult, vec_idx, c_total_vecs_i32
+                        )
                         safe_vec_idx = in_range.select(vec_idx, Int32(0))
                         col_bytes = ArithValue(safe_vec_idx) * (VEC_WIDTH * elem_bytes)
                         x_e = _load_vec(in_rsrc, col_bytes, soff=row_soffset)
@@ -366,4 +373,3 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
         )
 
     return launch_rmsnorm
-

--- a/kernels/rmsnorm_kernel.py
+++ b/kernels/rmsnorm_kernel.py
@@ -5,24 +5,23 @@
 
 RMSNorm(x) = x / sqrt(mean(x^2) + eps) * gamma
 
-Two paths:
-  - Fast path (N % tile_cols == 0): buffer_load/store vectorised access.
-  - Generic path (arbitrary N): scalar copy_atom_call.
+Optimised paths:
+  - Tile-fast path for N % (BLOCK_THREADS * VEC_WIDTH) == 0 using buffer_load/store.
+  - Vector-generic path for arbitrary N using vectorised buffer_load/store for the bulk
+    and a scalar tail only for the final leftover elements.
 """
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl.compiler.kernel_function import CompilationContext
 
-from flydsl.expr import arith, gpu, range_constexpr
-from flydsl.expr.arith import ArithValue
+from flydsl.expr import arith, vector, gpu, range_constexpr
 from flydsl.expr.typing import T, Int32
-from flydsl.expr.vector import ReductionOp, full
-from flydsl.expr.numeric import Numeric, Float32, Uint32
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 
 from flydsl._mlir import ir
+from flydsl.expr import buffer_ops
 
 
 KERNEL_NAME = "rmsnorm"
@@ -32,14 +31,28 @@ EPS = 1e-5
 import math
 from kernels.kernels_common import dtype_to_elem_type, get_warp_size
 
-BLOCK_THREADS = 256
 WARP_SIZE = get_warp_size()
-VEC_WIDTH = 8
+DEFAULT_VEC_WIDTH = 8
+F32_VEC_WIDTH = 4
+
+
+def _select_block_threads(N: int, dtype_str: str) -> int:
+    # Prefer 256 threads for faster block reduction; medium-width bf16 paths use
+    # bounded vector caching instead of smaller blocks.
+    return 256
 
 
 def build_rmsnorm_module(M: int, N: int, dtype_str: str):
     arch = get_hip_arch()
     USE_HW_CVT_PK_BF16_F32 = (arch == "gfx950") or str(arch).startswith("gfx95")
+
+    # f32 vec8 lowers to a 32-byte/v8i32 buffer_load, which may fail AMDGPU
+    # instruction selection. Keep f32 on vec4 while preserving vec8 for f16/bf16.
+    VEC_WIDTH = F32_VEC_WIDTH if dtype_str == "f32" else DEFAULT_VEC_WIDTH
+
+    BLOCK_THREADS = _select_block_threads(N, dtype_str)
+    UNROLL = 2 if (dtype_str != "f32" and N <= 4096) else 1
+    USE_GENERIC_X_CACHE = (dtype_str != "f32" and N <= 4096)
 
     tile_cols = BLOCK_THREADS * VEC_WIDTH
     RED_SLOTS = max(1, (BLOCK_THREADS + WARP_SIZE - 1) // WARP_SIZE)
@@ -49,8 +62,6 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
     f32_bytes = 4
     red_offset = allocator._align(allocator.ptr, 16)
     allocator.ptr = red_offset + RED_SLOTS * f32_bytes
-    red2_offset = allocator._align(allocator.ptr, 16)
-    allocator.ptr = red2_offset + RED_SLOTS * f32_bytes
 
     @flyc.kernel
     def rmsnorm_kernel(
@@ -71,9 +82,7 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
 
         base_ptr = allocator.get_base()
         s_red = SmemPtr(base_ptr, red_offset, T.f32, shape=(RED_SLOTS,))
-        s_red2 = SmemPtr(base_ptr, red2_offset, T.f32, shape=(RED_SLOTS,))
         s_red.get()
-        s_red2.get()
 
         def wave_reduce_add(x):
             width_i32 = fx.Int32(WARP_SIZE)
@@ -85,207 +94,251 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
             return w
 
         def block_reduce_add(val):
-            dummy = fx.Float32(0.0)
-            r0, _ = block_reduce_add2(val, dummy)
-            return r0
-
-        def block_reduce_add2(val0, val1):
             if RED_SLOTS == 1:
-                return wave_reduce_add(val0), wave_reduce_add(val1)
+                return wave_reduce_add(val)
 
             lane = tid % WARP_SIZE
             wave = tid // WARP_SIZE
 
-            w0 = wave_reduce_add(val0)
-            w1 = wave_reduce_add(val1)
+            w0 = wave_reduce_add(val)
 
             if lane == fx.Int32(0):
-                wave_idx = ArithValue(wave).index_cast(T.index)
+                wave_idx = arith.index_cast(T.index, wave)
                 s_red.store(w0, [wave_idx])
-                s_red2.store(w1, [wave_idx])
             gpu.barrier()
 
             if wave == fx.Int32(0):
                 in_range = lane < RED_SLOTS
                 lane_safe = in_range.select(lane, fx.Int32(0))
-                lane_safe_idx = ArithValue(lane_safe).index_cast(T.index)
+                lane_safe_idx = arith.index_cast(T.index, lane_safe)
                 v0 = s_red.load([lane_safe_idx])
-                v1 = s_red2.load([lane_safe_idx])
                 z = fx.Float32(0.0)
                 ww0 = in_range.select(v0, z)
-                ww1 = in_range.select(v1, z)
                 ww0 = wave_reduce_add(ww0)
-                ww1 = wave_reduce_add(ww1)
 
                 if lane == fx.Int32(0):
                     c0_idx = fx.Index(0)
                     s_red.store(ww0, [c0_idx])
-                    s_red2.store(ww1, [c0_idx])
             gpu.barrier()
 
             c0_idx = fx.Index(0)
-            return s_red.load([c0_idx]), s_red2.load([c0_idx])
+            return s_red.load([c0_idx])
 
-        # ==================================================================
-        # Fast path: N is a multiple of tile_cols
-        # ==================================================================
-        if N >= tile_cols and N % tile_cols == 0 and elem_bits <= 16:
-            num_tiles = N // tile_cols
-            elem_dtype = Numeric.from_ir_type(elem_type)
+        from flydsl.expr.arith import ArithValue
 
-            # ── Layout API: buffer-backed tensors + tiled access ─────
-            Input_buf = fx.rocdl.make_buffer_tensor(Input)
-            Output_buf = fx.rocdl.make_buffer_tensor(Output)
-            Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
+        elem_bytes = 4 if dtype_str == "f32" else 2
+        vec_dwords = (VEC_WIDTH * elem_bytes) // 4
 
-            row_in = fx.slice(Input_buf, (bid, None))
-            row_out = fx.slice(Output_buf, (bid, None))
+        vec_type_c = T.vec(VEC_WIDTH, compute_type)
+        vec_type_e = T.vec(VEC_WIDTH, elem_type)
 
-            in_div = fx.logical_divide(row_in, fx.make_layout(VEC_WIDTH, 1))
-            out_div = fx.logical_divide(row_out, fx.make_layout(VEC_WIDTH, 1))
-            gamma_div = fx.logical_divide(Gamma_buf, fx.make_layout(VEC_WIDTH, 1))
+        in_rsrc = buffer_ops.create_buffer_resource(Input, max_size=True)
+        out_rsrc = buffer_ops.create_buffer_resource(Output, max_size=True)
+        gamma_rsrc = buffer_ops.create_buffer_resource(Gamma, max_size=True)
 
-            copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_bits)
-            vec_reg_ty = fx.MemRefType.get(
-                elem_type, fx.LayoutType.get(VEC_WIDTH, 1), fx.AddressSpace.Register
+        row_soffset = ArithValue(bid) * (N * elem_bytes)
+
+        def _load_vec(rsrc, col_byte_off, soff=None):
+            dw = col_byte_off >> fx.Int32(2)
+            raw = buffer_ops.buffer_load(
+                rsrc, dw, vec_width=vec_dwords, dtype=T.i32, soffset_bytes=soff
             )
-            vec_reg_lay = fx.make_layout(VEC_WIDTH, 1)
+            # Always use vector.bitcast when the destination is a vector type.
+            # raw.bitcast(vec_type_e) fails for f32 because vec_type_e is an MLIR
+            # VectorType and does not expose dtype.width.
+            return vector.bitcast(vec_type_e, raw)
 
-            def _load_vec(div_tensor, idx):
-                r = fx.memref_alloca(vec_reg_ty, vec_reg_lay)
-                fx.copy_atom_call(copy_atom, fx.slice(div_tensor, (None, idx)), r)
-                return fx.memref_load_vec(r)
+        def _store_vec(data, rsrc, col_byte_off, soff=None):
+            dw = col_byte_off >> fx.Int32(2)
+            buffer_ops.buffer_store(data, rsrc, dw, soffset_bytes=soff)
 
-            def _store_vec(val, div_tensor, idx):
-                r = fx.memref_alloca(vec_reg_ty, vec_reg_lay)
-                fx.memref_store_vec(val, r)
-                fx.copy_atom_call(copy_atom, r, fx.slice(div_tensor, (None, idx)))
+        def _pack_output_vec(y_val):
+            if dtype_str == "bf16":
+                if USE_HW_CVT_PK_BF16_F32:
+                    out_e = y_val.truncf(vec_type_e)
+                else:
+                    vec_i32_ty = T.vec(VEC_WIDTH, T.i32)
+                    vec4_i32_ty = T.vec(VEC_WIDTH // 2, T.i32)
+                    vec_bf16_ty = T.vec(VEC_WIDTH, elem_type)
+                    c16_i32 = arith.constant(16, type=T.i32)
+                    c16_v = vector.broadcast(vec_i32_ty, c16_i32)
+                    u = y_val.bitcast(vec_i32_ty)
+                    upper = u.shrui(c16_v)
+                    c1_v = vector.broadcast(vec_i32_ty, arith.constant(1, type=T.i32))
+                    lsb = upper & c1_v
+                    c7fff_v = vector.broadcast(vec_i32_ty, arith.constant(0x7FFF, type=T.i32))
+                    bias = ArithValue(c7fff_v) + ArithValue(lsb)
+                    u_round = ArithValue(u) + bias
+                    bf16_bits = u_round.shrui(c16_v)
+                    even = vector.shuffle(bf16_bits, bf16_bits, [0, 2, 4, 6])
+                    odd = vector.shuffle(bf16_bits, bf16_bits, [1, 3, 5, 7])
+                    odd_sh = odd << vector.broadcast(vec4_i32_ty, c16_i32)
+                    out_e = vector.bitcast(vec_bf16_ty, even | odd_sh)
+            elif dtype_str == "f32":
+                out_e = y_val
+            else:
+                out_e = y_val.truncf(vec_type_e)
+
+            i32_vec_ty = T.vec(vec_dwords, T.i32)
+            # Always use vector.bitcast when the destination is a vector type.
+            return vector.bitcast(i32_vec_ty, out_e)
+
+        # ==================================================================
+        # Tile-fast path: full tiles only. No x caching to reduce register use.
+        # ==================================================================
+        if N >= tile_cols and N % tile_cols == 0:
+            num_tiles = N // tile_cols
+            thr_col_bytes = ArithValue(tid) * (VEC_WIDTH * elem_bytes)
 
             c_zero_f = arith.constant(0.0, type=compute_type)
             thread_sumsq = c_zero_f
-            thread_dummy = c_zero_f
-            in_local = []
 
-            # Pass 1: load + cache + sumsq
+            # Pass 1: sumsq only
             for tile_i in range_constexpr(num_tiles):
-                idx = tid + tile_i * BLOCK_THREADS
-                vec = _load_vec(in_div, idx)
-                in_local.append(vec)
-                x = vec.to(Float32)
-
-                x2 = x * x
-                red2 = x2.reduce(ReductionOp.ADD, fastmath=fm_fast)
+                col_bytes = ArithValue(thr_col_bytes) + (tile_i * tile_cols * elem_bytes)
+                vec_e = _load_vec(in_rsrc, col_bytes, soff=row_soffset)
+                x = vec_e if dtype_str == "f32" else vec_e.extf(vec_type_c)
+                x_av = ArithValue(x)
+                x2 = x_av * x_av
+                red2 = vector.reduction(compute_type, vector.CombiningKind.ADD, x2, fastmath=fm_fast)
                 thread_sumsq = ArithValue(thread_sumsq) + red2
 
-            _, sum_sq = block_reduce_add2(thread_dummy, thread_sumsq)
+            sum_sq = block_reduce_add(thread_sumsq)
             mean_sq = ArithValue(sum_sq) / n_float
-            ms_eps = mean_sq + eps_c
+            ms_eps = ArithValue(mean_sq) + eps_c
             rrms = ms_eps.rsqrt(fastmath=fm_fast)
+            rrms_splat = vector.broadcast(vec_type_c, rrms)
+            rrms_splat_av = ArithValue(rrms_splat)
 
-            # Pass 2: normalize + gamma + store (reuse cached input)
+            # Pass 2: reload x + gamma + store
             for tile_i in range_constexpr(num_tiles):
-                idx = tid + tile_i * BLOCK_THREADS
+                col_bytes = ArithValue(thr_col_bytes) + (tile_i * tile_cols * elem_bytes)
 
-                g = _load_vec(gamma_div, idx).to(Float32)
-                x = in_local[tile_i].to(Float32)
+                x_e = _load_vec(in_rsrc, col_bytes, soff=row_soffset)
+                g_e = _load_vec(gamma_rsrc, col_bytes)
 
-                y = (x * rrms) * g
+                x = x_e if dtype_str == "f32" else x_e.extf(vec_type_c)
+                g = g_e if dtype_str == "f32" else g_e.extf(vec_type_c)
 
-                if dtype_str == "bf16":
-                    if USE_HW_CVT_PK_BF16_F32:
-                        out_e = y.to(elem_dtype)
-                    else:
-                        u = y.bitcast(Uint32)
-                        upper = u >> 16
-                        lsb = upper & 1
-                        bias = lsb + 0x7FFF
-                        u_round = y.bitcast(Uint32) + bias
-                        bf16_bits = u_round >> 16
-                        even = bf16_bits.shuffle(bf16_bits, [0, 2, 4, 6])
-                        odd = bf16_bits.shuffle(bf16_bits, [1, 3, 5, 7])
-                        odd_sh = odd << 16
-                        packed = even | odd_sh
-                        out_e = packed.bitcast(elem_dtype)
-                elif dtype_str == "f32":
-                    out_e = y
-                else:
-                    out_e = y.to(elem_dtype)
-
-                out_idx = tid + tile_i * BLOCK_THREADS
-                _store_vec(out_e, out_div, out_idx)
+                y_val = (ArithValue(x) * rrms_splat_av) * ArithValue(g)
+                out_vec = _pack_output_vec(y_val)
+                _store_vec(out_vec, out_rsrc, col_bytes, soff=row_soffset)
 
         else:
             # ==============================================================
-            # Generic path: scalar 2-pass for arbitrary N
+            # Vector-generic path: vectorised bulk + scalar tail only.
             # ==============================================================
-            elem_dtype = Numeric.from_ir_type(elem_type)
+            row_in = fx.slice(Input, (bid, None))
+            row_out = fx.slice(Output, (bid, None))
 
-            Input_buf = fx.rocdl.make_buffer_tensor(Input)
-            Output_buf = fx.rocdl.make_buffer_tensor(Output)
-            Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
-
-            row_in = fx.slice(Input_buf, (bid, None))
-            row_out = fx.slice(Output_buf, (bid, None))
-
-            copy_atom_s = fx.make_copy_atom(
-                fx.rocdl.BufferCopy16b() if elem_bits <= 16 else fx.rocdl.BufferCopy32b(),
-                elem_bits,
+            copy_atom_s = fx.make_copy_atom(fx.UniversalCopy(elem_bits), elem_bits)
+            scalar_reg_ty = fx.MemRefType.get(
+                elem_type, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
             )
-            scalar_reg_ty = fx.MemRefType.get(elem_type, fx.LayoutType.get(1, 1), fx.AddressSpace.Register)
             scalar_reg_lay = fx.make_layout(1, 1)
 
             row_div = fx.logical_divide(row_in, fx.make_layout(1, 1))
-            gamma_div = fx.logical_divide(Gamma_buf, fx.make_layout(1, 1))
+            gamma_div = fx.logical_divide(Gamma, fx.make_layout(1, 1))
             out_div = fx.logical_divide(row_out, fx.make_layout(1, 1))
 
             def _load_scalar(divided_tensor, index):
                 view = fx.slice(divided_tensor, (None, index))
                 r = fx.memref_alloca(scalar_reg_ty, scalar_reg_lay)
                 fx.copy_atom_call(copy_atom_s, view, r)
-                return fx.memref_load_vec(r)[0].ir_value()
+                v = fx.memref_load_vec(r)
+                return vector.extract(v, static_position=[0])
 
             def _store_scalar(divided_tensor, index, val):
                 r = fx.memref_alloca(scalar_reg_ty, scalar_reg_lay)
-                ts = full(1, elem_dtype(val), elem_dtype)
-                fx.memref_store_vec(ts, r)
+                vec_ty = T.vec(1, elem_type)
+                v = vector.from_elements(vec_ty, [val])
+                fx.memref_store_vec(v, r)
                 view = fx.slice(divided_tensor, (None, index))
                 fx.copy_atom_call(copy_atom_s, r, view)
 
             c_zero_f = arith.constant(0.0, type=compute_type)
             thread_sumsq = c_zero_f
 
-            for base_idx_int in range_constexpr(0, N, BLOCK_THREADS):
-                idx = tid + base_idx_int
-                c_N_i32 = Int32(N)
-                is_valid = idx < c_N_i32
-                c0_i = Int32(0)
-                idx_safe = is_valid.select(idx, c0_i)
-                x_e = _load_scalar(row_div, idx_safe)
-                x = x_e if dtype_str == "f32" else x_e.extf(compute_type)
-                x_av = ArithValue(x)
-                x2 = x_av * x_av
-                x2_safe = is_valid.select(x2, c_zero_f)
-                thread_sumsq = ArithValue(thread_sumsq) + x2_safe
+            total_vecs = N // VEC_WIDTH
+            tail_start = total_vecs * VEC_WIDTH
+
+            x_cache = []
+
+            # Pass 1a: vectorised bulk
+            for vec_base_int in range_constexpr(0, total_vecs, BLOCK_THREADS * UNROLL):
+                c_total_vecs_i32 = Int32(total_vecs)
+                for u in range_constexpr(UNROLL):
+                    vec_idx = tid + vec_base_int + (u * BLOCK_THREADS)
+                    in_range = arith.cmpi(arith.CmpIPredicate.ult, vec_idx, c_total_vecs_i32)
+                    safe_vec_idx = in_range.select(vec_idx, Int32(0))
+                    col_bytes = ArithValue(safe_vec_idx) * (VEC_WIDTH * elem_bytes)
+                    x_e = _load_vec(in_rsrc, col_bytes, soff=row_soffset)
+                    x = x_e if dtype_str == "f32" else x_e.extf(vec_type_c)
+                    if USE_GENERIC_X_CACHE:
+                        x_cache.append((in_range, col_bytes, x))
+                    x_av = ArithValue(x)
+                    x2 = x_av * x_av
+                    red2 = vector.reduction(
+                        compute_type, vector.CombiningKind.ADD, x2, fastmath=fm_fast
+                    )
+                    red2_safe = in_range.select(red2, c_zero_f)
+                    thread_sumsq = ArithValue(thread_sumsq) + red2_safe
+
+            # Pass 1b: scalar tail
+            for idx_int in range_constexpr(tail_start, N):
+                idx = Int32(idx_int)
+                if arith.cmpi(arith.CmpIPredicate.eq, tid, fx.Int32(0)):
+                    x_e = _load_scalar(row_div, idx)
+                    x = x_e if dtype_str == "f32" else x_e.extf(compute_type)
+                    x2 = ArithValue(x) * ArithValue(x)
+                    thread_sumsq = ArithValue(thread_sumsq) + x2
 
             sum_sq = block_reduce_add(thread_sumsq)
             mean_sq = ArithValue(sum_sq) / n_float
-            ms_eps = mean_sq + eps_c
+            ms_eps = ArithValue(mean_sq) + eps_c
             rrms = ms_eps.rsqrt(fastmath=fm_fast)
+            rrms_splat = vector.broadcast(vec_type_c, rrms)
+            rrms_splat_av = ArithValue(rrms_splat)
 
-            for base_idx_int in range_constexpr(0, N, BLOCK_THREADS):
-                idx = tid + base_idx_int
-                c_N_i32 = Int32(N)
-                if arith.cmpi(arith.CmpIPredicate.ult, idx, c_N_i32):
+            # Pass 2a: vectorised bulk
+            if USE_GENERIC_X_CACHE:
+                for in_range, col_bytes, x in x_cache:
+                    g_e = _load_vec(gamma_rsrc, col_bytes)
+                    g = g_e if dtype_str == "f32" else g_e.extf(vec_type_c)
+                    y_val = (ArithValue(x) * rrms_splat_av) * ArithValue(g)
+                    out_vec = _pack_output_vec(y_val)
+                    if in_range:
+                        _store_vec(out_vec, out_rsrc, col_bytes, soff=row_soffset)
+            else:
+                for vec_base_int in range_constexpr(0, total_vecs, BLOCK_THREADS * UNROLL):
+                    c_total_vecs_i32 = Int32(total_vecs)
+                    for u in range_constexpr(UNROLL):
+                        vec_idx = tid + vec_base_int + (u * BLOCK_THREADS)
+                        in_range = arith.cmpi(arith.CmpIPredicate.ult, vec_idx, c_total_vecs_i32)
+                        safe_vec_idx = in_range.select(vec_idx, Int32(0))
+                        col_bytes = ArithValue(safe_vec_idx) * (VEC_WIDTH * elem_bytes)
+                        x_e = _load_vec(in_rsrc, col_bytes, soff=row_soffset)
+                        g_e = _load_vec(gamma_rsrc, col_bytes)
+
+                        x = x_e if dtype_str == "f32" else x_e.extf(vec_type_c)
+                        g = g_e if dtype_str == "f32" else g_e.extf(vec_type_c)
+
+                        y_val = (ArithValue(x) * rrms_splat_av) * ArithValue(g)
+                        out_vec = _pack_output_vec(y_val)
+                        if in_range:
+                            _store_vec(out_vec, out_rsrc, col_bytes, soff=row_soffset)
+
+            # Pass 2b: scalar tail
+            for idx_int in range_constexpr(tail_start, N):
+                idx = Int32(idx_int)
+                if arith.cmpi(arith.CmpIPredicate.eq, tid, fx.Int32(0)):
                     x_e = _load_scalar(row_div, idx)
                     g_e = _load_scalar(gamma_div, idx)
                     x = x_e if dtype_str == "f32" else x_e.extf(compute_type)
                     g = g_e if dtype_str == "f32" else g_e.extf(compute_type)
-                    norm = ArithValue(x) * rrms
-                    y = norm * g
+                    y = (ArithValue(x) * ArithValue(rrms)) * ArithValue(g)
                     if dtype_str == "f32":
                         y_e = y
-                    elif dtype_str == "bf16":
-                        y_e = y.truncf(elem_type)
                     else:
                         y_e = y.truncf(elem_type)
                     _store_scalar(out_div, idx, y_e)
@@ -303,7 +356,7 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
         with ir.InsertionPoint(ctx.gpu_module_body):
             allocator.finalize()
 
-        idx_m = ArithValue(m_in).index_cast(T.index)
+        idx_m = arith.index_cast(T.index, m_in)
         launcher = rmsnorm_kernel(Input, Gamma, Gamma, Output)
         launcher.launch(
             grid=(idx_m, 1, 1),
@@ -312,3 +365,4 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
         )
 
     return launch_rmsnorm
+

--- a/kernels/rmsnorm_kernel.py
+++ b/kernels/rmsnorm_kernel.py
@@ -32,6 +32,7 @@ import math
 from kernels.kernels_common import dtype_to_elem_type, get_warp_size
 
 WARP_SIZE = get_warp_size()
+BLOCK_THREADS = 256
 DEFAULT_VEC_WIDTH = 8
 F32_VEC_WIDTH = 4
 


### PR DESCRIPTION
## Motivation

This PR improves the performance of the FlyDSL RMSNorm kernel by addressing inefficiencies observed in production-like workloads (e.g., GPT-style shapes such as N=2880).

The previous implementation suffered from:

- heavy reliance on scalar operations in non-aligned cases
- high per-row overhead in generic paths
- inconsistent performance across different shapes

The goal of this PR is to:
- eliminate scalar bottlenecks
- maximize vectorized execution
- improve performance consistency across both aligned and non-aligned workloads

## Technical Details

This PR introduces several optimizations to the RMSNorm kernel:

1. Dual execution paths

- Tile-fast path (aligned shapes): fully vectorized using buffer_load/store
- Vector-generic path (arbitrary shapes): vectorized bulk + minimal scalar tail. This ensures most workloads avoid expensive scalar execution.

2. Vectorized memory access

- Standardized on VEC_WIDTH = 8
- Improved memory coalescing and throughput using vectorized buffer ops

3. Reduced scalar overhead

- Scalar operations are now restricted to the final tail only
- Eliminates full-row scalar fallback in generic cases

4. Block reduction simplification

- Replaced multi-buffer reduction with a single shared-memory reduction
- Reduced synchronization and shared memory traffic

5. Loop unrolling

- Added UNROLL = 2 for medium-width bf16/f16 workloads (N <= 4096)
- Improves instruction-level parallelism and reduces loop overhead

6. Bounded input caching (generic path)

- Cached x values during reduction pass to avoid reloading in normalization pass
- Enabled only for medium-width cases to control register pressure

7. Register pressure optimization

- Removed input caching from fast tiled path
- Avoids excessive register usage and potential spills

## Test Plan

The unit-test on test_rmsnorm.py within FlyDSL repo. Run python -m tests.kernels.test_rmsnorm

## Test Result
================
Running RMSNorm Tests
================================================================================

Testing RMSNorm (M=32768, N=8192, dtype=bf16)
Launching kernel...
[W424 19:43:23.196708004 collection.cpp:1133] Warning: ROCTracer produced duplicate flow start: 1 (function operator())
Kernel avg time: 0.2125 ms via run_perftest (warmup=10, iters=100)
Bandwidth: 5052.71 GB/s
Max absolute error: 1.56e-02 (atol=0.02)
PASSED

================================================================================
ALL TESTS PASSED
================================================================================