### PR TITLE
[CI] Build cp311 + cp313 wheels alongside cp310 + cp312

### DIFF
--- a/.github/workflows/build-whl.yaml
+++ b/.github/workflows/build-whl.yaml
@@ -47,7 +47,14 @@ jobs:
       - name: Install build dependencies
         run: |
           docker exec flydsl_build bash -c "apt-get update && apt-get install -y cmake build-essential patchelf software-properties-common"
-          docker exec flydsl_build bash -c "add-apt-repository -y ppa:deadsnakes/ppa && apt-get update && apt-get install -y python3.12 python3.12-dev python3.12-venv"
+          # Install all CPython versions we ship wheels for (deadsnakes covers 3.10-3.13 on jammy/noble).
+          # Keep this list aligned with DEFAULT_PYTHON_VERSIONS in scripts/build_wheels.sh
+          # and with TheRock's supported set (3.10, 3.11, 3.12, 3.13).
+          docker exec flydsl_build bash -c "add-apt-repository -y ppa:deadsnakes/ppa && apt-get update && apt-get install -y \
+            python3.10 python3.10-dev python3.10-venv \
+            python3.11 python3.11-dev python3.11-venv \
+            python3.12 python3.12-dev python3.12-venv \
+            python3.13 python3.13-dev python3.13-venv"
           docker exec flydsl_build bash -c "python3 -m pip install -U pip setuptools wheel"
           docker exec flydsl_build bash -c "python3 -m pip install ninja>=1.11.1"
           docker exec flydsl_build bash -c "git config --global --add safe.directory '*'"
@@ -76,7 +83,15 @@ jobs:
         run: |
           docker exec flydsl_build bash -c "export MLIR_PATH=/llvm-project/mlir_install && export EXPECTED_GLIBC=2.35 && export FLYDSL_RELEASE_TYPE=${{ inputs.release_type }} && cd /flydsl && bash scripts/build_wheels.sh"
           docker cp flydsl_build:/flydsl/dist ./dist
-          docker cp flydsl_build:/flydsl/build-fly/build_py312/bin/fly-opt ./dist/fly-opt
+          # fly-opt is a Python-independent C++ binary; pick whichever per-version
+          # build dir produced it (path is build-fly/build_py<MAJ><MIN>/bin/fly-opt).
+          FLY_OPT_SRC=$(docker exec flydsl_build bash -c 'ls -1 /flydsl/build-fly/build_py*/bin/fly-opt 2>/dev/null | head -n1')
+          if [ -z "${FLY_OPT_SRC}" ]; then
+            echo "Error: fly-opt not found in any build-fly/build_py*/bin directory" >&2
+            exit 1
+          fi
+          echo "Copying fly-opt from ${FLY_OPT_SRC}"
+          docker cp "flydsl_build:${FLY_OPT_SRC}" ./dist/fly-opt
 
       - name: Collect wheel names
         id: collect-wheels

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -6,12 +6,23 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
+# Python versions to build wheels for. Aligned with TheRock's supported set
+# (https://github.com/ROCm/TheRock RELEASES.md): 3.10, 3.11, 3.12, 3.13.
+# Override via env: PYTHON_VERSIONS="3.10 3.13" bash scripts/build_wheels.sh
+DEFAULT_PYTHON_VERSIONS="3.10 3.11 3.12 3.13"
+IFS=' ' read -r -a PYTHON_VERSIONS <<< "${PYTHON_VERSIONS:-${DEFAULT_PYTHON_VERSIONS}}"
+
 usage() {
-  cat <<'EOF'
-Build FlyDSL wheels for Python 3.10 and 3.12.
+  cat <<EOF
+Build FlyDSL wheels for one or more CPython versions.
+
+Default versions: ${DEFAULT_PYTHON_VERSIONS}
 
 Usage:
   bash scripts/build_wheels.sh [--skip-build] [--install-deps]
+
+Override versions:
+  PYTHON_VERSIONS="3.10 3.13" bash scripts/build_wheels.sh
 
 Required env:
   MLIR_PATH    path to llvm-project build (defaults to ./llvm-project/mlir_install)
@@ -19,6 +30,8 @@ Required env:
 Other knobs:
   FLY_REBUILD=1|auto|0   (default: 1)
   EXPECTED_GLIBC=2.35    (default: 2.35, set ALLOW_ANY_GLIBC=1 to skip check)
+  PYTHON_VERSIONS="..."  whitespace-separated list, default "${DEFAULT_PYTHON_VERSIONS}"
+  PY<MAJ><MIN>_BIN       per-version python binary override (e.g. PY313_BIN=/opt/py313/bin/python3.13)
 EOF
 }
 
@@ -38,15 +51,23 @@ FLY_REBUILD="${FLY_REBUILD:-1}"
 EXPECTED_GLIBC="${EXPECTED_GLIBC:-2.35}"
 ALLOW_ANY_GLIBC="${ALLOW_ANY_GLIBC:-0}"
 
-PY310_BIN="${PY310_BIN:-python3.10}"
-PY312_BIN="${PY312_BIN:-python3.12}"
-
 VENV_ROOT="${VENV_ROOT:-${REPO_ROOT}/.venvs/release}"
-VENV_310="${VENV_ROOT}/cp310"
-VENV_312="${VENV_ROOT}/cp312"
 
-FLY_BUILD_DIR_310="${FLY_BUILD_DIR_310:-build-fly/build_py310}"
-FLY_BUILD_DIR_312="${FLY_BUILD_DIR_312:-build-fly/build_py312}"
+# Resolve the python binary for a version like "3.13".
+# Honors PY<MAJ><MIN>_BIN env override (e.g. PY313_BIN), else falls back to
+# `python<ver>` on PATH.
+py_bin_for_version() {
+  local ver="$1"
+  local env_var_name="PY${ver//./}_BIN"
+  local val="${!env_var_name:-python${ver}}"
+  echo "${val}"
+}
+
+# Convert "3.13" -> "cp313".
+py_tag_for_version() {
+  local ver="$1"
+  echo "cp${ver//./}"
+}
 
 if [[ -z "${MLIR_PATH:-}" ]]; then
   MLIR_PATH="${REPO_ROOT}/llvm-project/mlir_install"
@@ -115,24 +136,30 @@ ensure_glibc() {
 }
 
 ensure_python_bins() {
-  local missing=0
-  for py in "${PY310_BIN}" "${PY312_BIN}"; do
-    if ! command -v "${py}" >/dev/null 2>&1; then
-      echo "Missing: ${py}" >&2
+  local ver py_bin missing=0
+  for ver in "${PYTHON_VERSIONS[@]}"; do
+    py_bin="$(py_bin_for_version "${ver}")"
+    if ! command -v "${py_bin}" >/dev/null 2>&1; then
+      echo "Missing: ${py_bin}" >&2
       missing=1
     fi
   done
 
   if [[ "${missing}" == "1" ]]; then
     local pkgs=()
-    command -v "${PY310_BIN}" >/dev/null 2>&1 || pkgs+=( python3.10 python3.10-dev python3.10-venv )
-    command -v "${PY312_BIN}" >/dev/null 2>&1 || pkgs+=( python3.12 python3.12-dev python3.12-venv )
+    for ver in "${PYTHON_VERSIONS[@]}"; do
+      py_bin="$(py_bin_for_version "${ver}")"
+      if ! command -v "${py_bin}" >/dev/null 2>&1; then
+        pkgs+=( "python${ver}" "python${ver}-dev" "python${ver}-venv" )
+      fi
+    done
     [[ "${#pkgs[@]}" -eq 0 ]] || apt_install_if_possible "${pkgs[@]}" || true
   fi
 
-  for py in "${PY310_BIN}" "${PY312_BIN}"; do
-    if ! command -v "${py}" >/dev/null 2>&1; then
-      echo "Error: Python not found: ${py}" >&2
+  for ver in "${PYTHON_VERSIONS[@]}"; do
+    py_bin="$(py_bin_for_version "${ver}")"
+    if ! command -v "${py_bin}" >/dev/null 2>&1; then
+      echo "Error: Python not found: ${py_bin}" >&2
       exit 1
     fi
   done
@@ -182,6 +209,8 @@ build_one() {
 
 
 main() {
+  echo "Building wheels for Python versions: ${PYTHON_VERSIONS[*]}"
+
   ensure_host_deps
   ensure_glibc
   ensure_python_bins
@@ -192,8 +221,14 @@ main() {
     rm -rf dist
     mkdir -p dist
 
-    build_one "${PY310_BIN}" "${VENV_310}" "${FLY_BUILD_DIR_310}" "cp310"
-    build_one "${PY312_BIN}" "${VENV_312}" "${FLY_BUILD_DIR_312}" "cp312"
+    local ver py_bin py_tag venv build_dir
+    for ver in "${PYTHON_VERSIONS[@]}"; do
+      py_bin="$(py_bin_for_version "${ver}")"
+      py_tag="$(py_tag_for_version "${ver}")"
+      venv="${VENV_ROOT}/${py_tag}"
+      build_dir="build-fly/build_py${ver//./}"
+      build_one "${py_bin}" "${venv}" "${build_dir}" "${py_tag}"
+    done
   fi
 
   echo ""


### PR DESCRIPTION
## Summary

Refactor the wheel build matrix to a configurable list of CPython versions, defaulting to **3.10 / 3.11 / 3.12 / 3.13** — the set TheRock currently publishes PyTorch nightlies for (per [`ROCm/TheRock` `RELEASES.md`](https://github.com/ROCm/TheRock/blob/main/RELEASES.md)).

- `scripts/build_wheels.sh`: replace hardcoded `PY310_BIN` / `PY312_BIN` / `VENV_310` / `VENV_312` / `FLY_BUILD_DIR_310` / `FLY_BUILD_DIR_312` with a single `PYTHON_VERSIONS` list. Add `py_bin_for_version` (honors `PY<MAJ><MIN>_BIN` overrides such as `PY313_BIN`) and `py_tag_for_version` helpers, plus a single loop in `main()` that derives venv path, build dir, and wheel tag uniformly. Updated `--help` to document the new knobs.
- `.github/workflows/build-whl.yaml`: install `python3.10/3.11/3.12/3.13` (and `-dev` / `-venv`) from the deadsnakes PPA in the build container. Replace the hardcoded `docker cp .../build_py312/bin/fly-opt` with a glob-and-pick (`fly-opt` is Python-version-independent), so the workflow tolerates whichever versions are listed in `PYTHON_VERSIONS`.

## Why

Closes #432. Tracks [ROCM-23479](https://amd-hub.atlassian.net/browse/ROCM-23479): aiter and downstream packages (e.g. flash-attention used by vLLM Docker images on Strix Halo `gfx1151`) install via TheRock's Python 3.13 nightly index. flydsl was only shipping cp310 + cp312, so `pip install flydsl` on a cp313 environment fails with `No matching distribution found`, blocking model build and fine-tune flows on the affected images (e.g. `rocm/utd-private:vllm-0.19.0-py3.13-nightlies-gfx1151-rocm7.13.0a*`).

TheRock's S3 mirror (`update_dependencies.py --package rocm`) already pulls flydsl from PyPI and `_ALLOWED_CPYTHON_TAGS` already permits cp311 + cp313, so once the next tagged FlyDSL release ships these wheels via `publish-pypi.yaml`, TheRock auto-picks them up — no follow-up change required there.

## Distribution paths covered (no further changes needed)

| Path | How wheels reach the user |
|---|---|
| Tagged release | `tag (v*) -> publish-pypi.yaml -> pypi.org -> TheRock update_dependencies.py mirror -> S3 (dev/nightly) -> pip install` |
| Nightly cron | `ci.yaml -> promote.yaml -> s3://framework-whls-{nightlies,devreleases}/whl/gfx942-gfx950/` |

`publish-pypi.yaml` and `promote.yaml` consume `dist/*.whl` / the `wheel_names` output without filtering by tag, so the 4 wheels flow through unchanged.

## Test plan

- [x] `bash -n scripts/build_wheels.sh` — clean.
- [x] Smoke-tested helpers locally: default expands to `cp310`/`cp311`/`cp312`/`cp313`; `PY313_BIN` override resolves correctly; `PYTHON_VERSIONS="3.10 3.13"` override produces only those two; `--help` renders the new knobs.
- [ ] CI on this PR exercises the full 4-wheel build via `build-whl.yaml` (called from `ci.yaml` for `devreleases`).
- [ ] Verify all 4 wheels land in `dist/` with `cp310`, `cp311`, `cp312`, `cp313` ABI tags and a `manylinux_*` platform tag.
- [ ] Verify `dist/fly-opt` is copied out (regardless of which per-version build dir produced it).
- [ ] After this lands on `main` and the next tag is pushed, confirm 4 wheels are uploaded to PyPI.

## Notes / future work

- `PYTHON_VERSIONS` is intentionally left at 3.10–3.13 (TheRock's currently-supported set). Adding `cp314` later is a one-character change to `DEFAULT_PYTHON_VERSIONS` once TheRock formally supports it.
- This PR does not republish older versions (e.g. `flydsl==0.1.1.dev409` referenced by an old aiter snapshot in the bug report). aiter will need to bump its `flydsl==` pin to a release built after this lands; aiter's current `requirements.txt` already pins `flydsl==0.1.4.2`.
- Wheel-size optimizations (strip + duplicate `libFlyPythonCAPI.so` removal) and parallel builds present in the unmerged `ci/multi-python-versions` branch are intentionally not included here — kept as a separate concern to keep this PR small and focused on the cp313 unblock.