### PR TITLE
Refactor MLA decode kernel: unify types and simplify MLIR calls

### DIFF
--- a/kernels/fused_rope_cache_kernel.py
+++ b/kernels/fused_rope_cache_kernel.py
@@ -181,7 +181,7 @@ def build_fused_rope_cache_module(
                 peer_v_i32 = vector.from_elements(T.vec(n_i32, T.i32), peer_chunks)
                 return vector.bitcast(T.vec(VEC_WIDTH, elem_type), peer_v_i32)
 
-        if tid < fx.Int32(vecs_per_head):
+        if tid < vecs_per_head:
             # --- Load position (scalar i32) ---
             pos_rsrc = buffer_ops.create_buffer_resource(Positions, max_size=True)
             if const_expr(pos_dtype == "i64"):
@@ -190,13 +190,13 @@ def build_fused_rope_cache_module(
                 pos_elem_off = pid_t
             pos_val = buffer_ops.buffer_load(pos_rsrc, pos_elem_off, vec_width=1, dtype=T.i32)
 
-            is_first_half = tid < fx.Int32(vecs_per_half)
+            is_first_half = tid < vecs_per_half
             cos_vec_idx = tid % vecs_per_half if reuse_freqs_front_part else tid
 
             # Pair lane for ds_bpermute: tid XOR vecs_per_half (symmetric, works for both halves).
             # pair_byte_addr = pair_lane * 4 (ds_bpermute address unit is bytes, VGPR = 4 bytes).
-            pair_lane = tid ^ fx.Int32(vecs_per_half)
-            pair_byte_addr = pair_lane * fx.Int32(4)
+            pair_lane = tid ^ vecs_per_half
+            pair_byte_addr = pair_lane * 4
 
             # --- Shared cos/sin (loaded once, used by both Q and K) ---
             Cos_buf = fx.rocdl.make_buffer_tensor(CosCache)
@@ -209,7 +209,7 @@ def build_fused_rope_cache_module(
             sin_e = load_vec(sin_div, cos_vec_idx)
 
             # --- Q RoPE (head_idx < num_q_heads) ---
-            if head_idx < fx.Int32(num_q_heads_val):
+            if head_idx < num_q_heads_val:
                 Q_buf = fx.rocdl.make_buffer_tensor(Q)
                 Q_out_buf = fx.rocdl.make_buffer_tensor(Q_out)
 
@@ -231,7 +231,7 @@ def build_fused_rope_cache_module(
                 store_vec(q_rot_e.ir_value(), qo_div, tid)
 
             # --- K RoPE + KV cache (head_idx < num_kv_heads) ---
-            if head_idx < fx.Int32(num_kv_heads_val):
+            if head_idx < num_kv_heads_val:
                 K_buf = fx.rocdl.make_buffer_tensor(K)
                 K_out_buf = fx.rocdl.make_buffer_tensor(K_out)
 
@@ -261,7 +261,7 @@ def build_fused_rope_cache_module(
                     slot_elem_off = pid_t
                 slot_val = buffer_ops.buffer_load(slot_rsrc, slot_elem_off, vec_width=1, dtype=T.i32)
 
-                if slot_val >= fx.Int32(0):
+                if slot_val >= 0:
                     pid_t_slot = slot_val // block_size
                     pid_b = slot_val % block_size
 
@@ -279,8 +279,8 @@ def build_fused_rope_cache_module(
                         vs_div = fx.logical_divide(vs_buf, f32_reg_lay)
                         r_ks = fx.memref_alloca(f32_reg_ty, f32_reg_lay)
                         r_vs = fx.memref_alloca(f32_reg_ty, f32_reg_lay)
-                        fx.copy_atom_call(f32_copy_atom, fx.slice(ks_div, (None, fx.Int32(0))), r_ks)
-                        fx.copy_atom_call(f32_copy_atom, fx.slice(vs_div, (None, fx.Int32(0))), r_vs)
+                        fx.copy_atom_call(f32_copy_atom, fx.slice(ks_div, (None, 0)), r_ks)
+                        fx.copy_atom_call(f32_copy_atom, fx.slice(vs_div, (None, 0)), r_vs)
                         k_scale_val = fx.memref_load_vec(r_ks)[0]
                         v_scale_val = fx.memref_load_vec(r_vs)[0]
                         k_rcp = fx.rocdl.rcp(T.f32, k_scale_val)
@@ -304,9 +304,7 @@ def build_fused_rope_cache_module(
                             def pack_fp8(vals):
                                 i32s = []
                                 for i in range_constexpr(VEC_WIDTH // 4):
-                                    lo = fx.rocdl.cvt_pk_fp8_f32(
-                                        T.i32, vals[i * 4], vals[i * 4 + 1], fx.Int32(0), False
-                                    )
+                                    lo = fx.rocdl.cvt_pk_fp8_f32(T.i32, vals[i * 4], vals[i * 4 + 1], 0, False)
                                     wd = fx.rocdl.cvt_pk_fp8_f32(
                                         T.i32, vals[i * 4 + 2], vals[i * 4 + 3], lo, True
                                     )
@@ -320,59 +318,55 @@ def build_fused_rope_cache_module(
                                 kc_byte_off = (
                                     pid_t_slot * (block_size * num_kv_heads * head_dim)
                                     + pid_b * (num_kv_heads * head_dim)
-                                    + ArithValue(head_idx) * head_dim
-                                    + ArithValue(tid) * VEC_WIDTH
+                                    + head_idx * head_dim
+                                    + tid * VEC_WIDTH
                                 )
-                                kc_dw = kc_byte_off // fx.Int32(4)
+                                kc_dw = kc_byte_off // 4
                                 for wi in range_constexpr(VEC_WIDTH // 4):
-                                    buffer_ops.buffer_store(k_fp8[wi], kc_fp8_rsrc, kc_dw + fx.Int32(wi))
-                                    buffer_ops.buffer_store(v_fp8[wi], vc_fp8_rsrc, kc_dw + fx.Int32(wi))
+                                    buffer_ops.buffer_store(k_fp8[wi], kc_fp8_rsrc, kc_dw + wi)
+                                    buffer_ops.buffer_store(v_fp8[wi], vc_fp8_rsrc, kc_dw + wi)
                             else:
-                                dim_group = ArithValue(tid) * VEC_WIDTH // x_size
-                                sub_off = ArithValue(tid) * VEC_WIDTH % x_size
+                                dim_group = tid * VEC_WIDTH // x_size
+                                sub_off = tid * VEC_WIDTH % x_size
                                 kc_byte_off = (
                                     pid_t_slot * (num_kv_heads * (head_dim // x_size) * block_size * x_size)
-                                    + ArithValue(head_idx) * ((head_dim // x_size) * block_size * x_size)
+                                    + head_idx * ((head_dim // x_size) * block_size * x_size)
                                     + dim_group * (block_size * x_size)
                                     + pid_b * x_size
                                     + sub_off
                                 )
-                                kc_dw = kc_byte_off // fx.Int32(4)
+                                kc_dw = kc_byte_off // 4
                                 for wi in range_constexpr(VEC_WIDTH // 4):
-                                    buffer_ops.buffer_store(k_fp8[wi], kc_fp8_rsrc, kc_dw + fx.Int32(wi))
+                                    buffer_ops.buffer_store(k_fp8[wi], kc_fp8_rsrc, kc_dw + wi)
 
                                 for vi in range_constexpr(VEC_WIDTH):
-                                    d_idx = ArithValue(tid) * VEC_WIDTH + vi
+                                    d_idx = tid * VEC_WIDTH + vi
                                     vc_byte_off = (
                                         pid_t_slot * (num_kv_heads * head_dim * block_size)
-                                        + ArithValue(head_idx) * (head_dim * block_size)
+                                        + head_idx * (head_dim * block_size)
                                         + d_idx * block_size
                                         + pid_b
                                     )
                                     i32_idx = vi // 4
                                     byte_in_i32 = vi % 4
-                                    shifted = ArithValue(v_fp8[i32_idx]) >> (byte_in_i32 * 8)
+                                    shifted = v_fp8[i32_idx] >> (byte_in_i32 * 8)
                                     fp8_byte = arith.trunci(T.i8, shifted)
                                     buffer_ops.buffer_store(fp8_byte, vc_fp8_rsrc, vc_byte_off)
                         else:
                             # VEC_WIDTH < 4: store individual fp8 bytes
                             for vi in range_constexpr(VEC_WIDTH):
-                                k_pk = fx.rocdl.cvt_pk_fp8_f32(
-                                    T.i32, k_scaled[vi], fx.Float32(0.0), fx.Int32(0), False
-                                )
-                                v_pk = fx.rocdl.cvt_pk_fp8_f32(
-                                    T.i32, v_scaled[vi], fx.Float32(0.0), fx.Int32(0), False
-                                )
+                                k_pk = fx.rocdl.cvt_pk_fp8_f32(T.i32, k_scaled[vi], 0.0, 0, False)
+                                v_pk = fx.rocdl.cvt_pk_fp8_f32(T.i32, v_scaled[vi], 0.0, 0, False)
                                 k_byte = arith.trunci(T.i8, k_pk)
                                 v_byte = arith.trunci(T.i8, v_pk)
 
-                                d_idx = ArithValue(tid) * VEC_WIDTH + vi
+                                d_idx = tid * VEC_WIDTH + vi
 
                                 if const_expr(flash_layout):
                                     byte_off = (
                                         pid_t_slot * (block_size * num_kv_heads * head_dim)
                                         + pid_b * (num_kv_heads * head_dim)
-                                        + ArithValue(head_idx) * head_dim
+                                        + head_idx * head_dim
                                         + d_idx
                                     )
                                     buffer_ops.buffer_store(k_byte, kc_fp8_rsrc, byte_off)
@@ -382,7 +376,7 @@ def build_fused_rope_cache_module(
                                     sub_o = d_idx % x_size
                                     kc_byte_off = (
                                         pid_t_slot * (num_kv_heads * (head_dim // x_size) * block_size * x_size)
-                                        + ArithValue(head_idx) * ((head_dim // x_size) * block_size * x_size)
+                                        + head_idx * ((head_dim // x_size) * block_size * x_size)
                                         + dim_grp * (block_size * x_size)
                                         + pid_b * x_size
                                         + sub_o
@@ -391,7 +385,7 @@ def build_fused_rope_cache_module(
 
                                     vc_byte_off = (
                                         pid_t_slot * (num_kv_heads * head_dim * block_size)
-                                        + ArithValue(head_idx) * (head_dim * block_size)
+                                        + head_idx * (head_dim * block_size)
                                         + d_idx * block_size
                                         + pid_b
                                     )
@@ -413,12 +407,12 @@ def build_fused_rope_cache_module(
                             kc_rsrc = buffer_ops.create_buffer_resource(KeyCache, max_size=True)
                             vc_rsrc = buffer_ops.create_buffer_resource(ValueCache, max_size=True)
                             for vi in range_constexpr(VEC_WIDTH):
-                                d_idx = ArithValue(tid) * VEC_WIDTH + vi
+                                d_idx = tid * VEC_WIDTH + vi
                                 dim_grp = d_idx // x_size
                                 sub_o = d_idx % x_size
                                 kc_nf_off = (
                                     pid_t_slot * (num_kv_heads * (head_dim // x_size) * block_size * x_size)
-                                    + ArithValue(head_idx) * ((head_dim // x_size) * block_size * x_size)
+                                    + head_idx * ((head_dim // x_size) * block_size * x_size)
                                     + dim_grp * (block_size * x_size)
                                     + pid_b * x_size
                                     + sub_o
@@ -427,10 +421,10 @@ def build_fused_rope_cache_module(
                                 buffer_ops.buffer_store(k_elem, kc_rsrc, kc_nf_off)
 
                             for vi in range_constexpr(VEC_WIDTH):
-                                d_idx = ArithValue(tid) * VEC_WIDTH + vi
+                                d_idx = tid * VEC_WIDTH + vi
                                 vc_nf_off = (
                                     pid_t_slot * (num_kv_heads * head_dim * block_size)
-                                    + ArithValue(head_idx) * (head_dim * block_size)
+                                    + head_idx * (head_dim * block_size)
                                     + d_idx * block_size
                                     + pid_b
                                 )

--- a/kernels/layernorm_kernel.py
+++ b/kernels/layernorm_kernel.py
@@ -65,7 +65,7 @@ def build_layernorm_module(M: int, N: int, dtype_str: str):
         elem_dtype = dtype_to_elem_type(dtype_str)
         elem_type = elem_dtype.ir_type
         fm_fast = arith.FastMathFlags.fast
-        eps_c = fx.Float32(EPS)
+        eps_c = EPS
 
         base_ptr = allocator.get_base()
         s_sum = SmemPtr(base_ptr, sum_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
@@ -75,11 +75,10 @@ def build_layernorm_module(M: int, N: int, dtype_str: str):
 
         # ── helpers: wave / block reduction ───────────────────────────────
         def wave_reduce_add(x):
-            width_i32 = fx.Int32(WARP_SIZE)
             w = x
             for _sh_exp in range_constexpr(int(math.log2(WARP_SIZE))):
-                off = fx.Int32(WARP_SIZE // (2 << _sh_exp))
-                peer = w.shuffle_xor(off, width_i32)
+                off = WARP_SIZE // (2 << _sh_exp)
+                peer = w.shuffle_xor(off, WARP_SIZE)
                 w = w.addf(peer, fastmath=fm_fast)
             return w
 
@@ -93,44 +92,36 @@ def build_layernorm_module(M: int, N: int, dtype_str: str):
             w0 = wave_reduce_add(val0)
             w1 = wave_reduce_add(val1)
 
-            if lane == fx.Int32(0):
-                wave_idx = fx.Index(wave)
-                SmemPtr.store(s_sum, w0, [wave_idx])
-                SmemPtr.store(s_sumsq, w1, [wave_idx])
+            if lane == 0:
+                SmemPtr.store(s_sum, w0, [wave])
+                SmemPtr.store(s_sumsq, w1, [wave])
             gpu.barrier()
 
-            if wave == fx.Int32(0):
+            if wave == 0:
                 in_range = lane < RED_SLOTS
-                lane_safe = in_range.select(lane, fx.Int32(0))
-                lane_safe_idx = fx.Index(lane_safe)
-                v0 = SmemPtr.load(s_sum, [lane_safe_idx])
-                v1 = SmemPtr.load(s_sumsq, [lane_safe_idx])
-                z = fx.Float32(0.0)
-                ww0 = in_range.select(v0, z)
-                ww1 = in_range.select(v1, z)
+                lane_safe = in_range.select(lane, 0)
+                v0 = SmemPtr.load(s_sum, [lane_safe])
+                v1 = SmemPtr.load(s_sumsq, [lane_safe])
+                ww0 = in_range.select(v0, 0.0)
+                ww1 = in_range.select(v1, 0.0)
                 ww0 = wave_reduce_add(ww0)
                 ww1 = wave_reduce_add(ww1)
 
-                if lane == fx.Int32(0):
-                    c0_idx = fx.Index(0)
-                    SmemPtr.store(s_sum, ww0, [c0_idx])
-                    SmemPtr.store(s_sumsq, ww1, [c0_idx])
+                if lane == 0:
+                    SmemPtr.store(s_sum, ww0, [0])
+                    SmemPtr.store(s_sumsq, ww1, [0])
             gpu.barrier()
 
-            c0_idx = fx.Index(0)
-            return SmemPtr.load(s_sum, [c0_idx]), SmemPtr.load(s_sumsq, [c0_idx])
+            return SmemPtr.load(s_sum, [0]), SmemPtr.load(s_sumsq, [0])
 
         def compute_mean_rstd(sum_val, sumsq_val):
-            inv_n = fx.Float32(1.0 / float(N))
-            s = fx.Float32(sum_val)
-            ss = fx.Float32(sumsq_val)
-            mean = s * inv_n
-            mean_sq = ss * inv_n
+            inv_n = 1.0 / float(N)
+            mean = sum_val * inv_n
+            mean_sq = sumsq_val * inv_n
             mean2 = mean * mean
             var = mean_sq - mean2
-            c0_f = fx.Float32(0.0)
-            is_neg = var < c0_f
-            var = is_neg.select(c0_f, var)
+            is_neg = var < 0.0
+            var = is_neg.select(0.0, var)
             var_eps = var + eps_c
             rstd = fmath.rsqrt(var_eps, fastmath=fm_fast)
             return mean, rstd
@@ -285,10 +276,8 @@ def build_layernorm_module(M: int, N: int, dtype_str: str):
             # ── Pass 1: sum + sumsq ──────────────────────────────────────
             for base_idx_int in range_constexpr(0, N, BLOCK_THREADS):
                 idx = tid + base_idx_int
-                c_N_i32 = fx.Int32(N)
-                is_valid = idx < c_N_i32
-                c0_i = fx.Int32(0)
-                idx_safe = is_valid.select(idx, c0_i)
+                is_valid = idx < N
+                idx_safe = is_valid.select(idx, 0)
                 x_e = _load_scalar(row_div, idx_safe)
                 x = (
                     x_e
@@ -307,8 +296,7 @@ def build_layernorm_module(M: int, N: int, dtype_str: str):
             # ── Pass 2: normalize + affine + store ───────────────────────
             for base_idx_int in range_constexpr(0, N, BLOCK_THREADS):
                 idx = tid + base_idx_int
-                c_N_i32 = fx.Int32(N)
-                if idx < c_N_i32:
+                if idx < N:
                     x_e = _load_scalar(row_div, idx)
                     g_e = _load_scalar(gamma_div, idx)
                     b_e = _load_scalar(beta_div, idx)

--- a/kernels/mla_fwd_decode_m16x8_fp8_fp8.py
+++ b/kernels/mla_fwd_decode_m16x8_fp8_fp8.py
@@ -211,6 +211,14 @@ def _lds_load_volatile(base_i32, vec_type, byte_offset=0):
     return llvm.LoadOp(vec_type, lds_ptr, alignment=8, volatile_=True).result
 
 
+def _lds_ptr_from_i32(addr_i32, byte_offset=0):
+    """Build an LDS pointer (ptr<3>) from an i32 byte address + optional static offset."""
+    ptr = _inttoptr_lds(_raw(ArithValue(addr_i32).extui(T.i64)))
+    if byte_offset != 0:
+        ptr = _gep(ptr, static_byte_offset=byte_offset)
+    return ptr
+
+
 def _i32(value):
     """Cast index/ArithValue to i32.  No-op if already i32."""
     raw = _raw(value) if not isinstance(value, ir.Value) else value
@@ -293,10 +301,10 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     lds_base_idx = _memref.ExtractAlignedPointerAsIndexOp(lds_buffer).result
 
     # ---- V^T transpose perm constants ----
-    c_perm0 = arith.constant(0x05010400, type=T.i32)
-    c_perm1 = arith.constant(0x07030602, type=T.i32)
-    c_perm2 = arith.constant(0x05040100, type=T.i32)
-    c_perm3 = arith.constant(0x07060302, type=T.i32)
+    c_perm0 = fx.Int32(0x05010400)
+    c_perm1 = fx.Int32(0x07030602)
+    c_perm2 = fx.Int32(0x05040100)
+    c_perm3 = fx.Int32(0x07060302)
 
     def _vt_perm(src_hi, src_lo, sel):
         return llvm.call_intrinsic(
@@ -308,14 +316,14 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         )
 
     # ---- Constants ----
-    c_neg_inf = arith.constant(float("-inf"), type=T.f32)
-    c_zero_f32 = arith.constant(0.0, type=T.f32)
-    c_one_f32 = arith.constant(1.0, type=T.f32)
-    c_zero_i32 = arith.constant(0, type=T.i32)
+    c_neg_inf = fx.Float32(float("-inf"))
+    c_zero_f32 = fx.Float32(0.0)
+    c_one_f32 = fx.Float32(1.0)
+    c_zero_i32 = fx.Int32(0)
     c_zero_v4f32 = Vec.filled(4, 0.0, fx.Float32)
-    c_log2e = arith.constant(LOG2E, type=T.f32)
-    c_inv_log2e = arith.constant(1.0 / LOG2E, type=T.f32)
-    c_dword_sz = arith.constant(4, type=T.i32)
+    c_log2e = fx.Float32(LOG2E)
+    c_inv_log2e = fx.Float32(1.0 / LOG2E)
+    c_dword_sz = fx.Int32(4)
     c_aux_zero = c_zero_i32
 
     # ---- Buffer resources ----
@@ -363,7 +371,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         """
         row_idx_i32 = _raw(ArithValue(kv_ld_row_base_i32) + kv_tile_start_i32)
         if const_expr(check_boundary):
-            phys_row = arith.constant(-1, type=T.i32)
+            phys_row = fx.Int32(-1)
             if ArithValue(row_idx_i32) < ArithValue(kv_tile_end_i32):
                 phys_row = buffer_ops.buffer_load(
                     kv_page_indices_rsrc, row_idx_i32, vec_width=1, dtype=T.i32
@@ -386,27 +394,27 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # p_lds_kv_warp points to warp's sub-block start.
         # Actual LDS target: p_lds_kv_warp + block*KV_BLOCK_BYTES - block*64
         lds_adjust = lds_warp_offset - block_idx_const * KV_NUM_COLS
-        lds_base_i32 = _raw(ArithValue(p_lds_kv_warp_i32) + arith.constant(lds_adjust, type=T.i32))
+        lds_base_i32 = _raw(ArithValue(p_lds_kv_warp_i32) + lds_adjust)
 
         def _emit_vram_to_lds():
-            voff = _raw(ArithValue(row_i32) * arith.constant(QK_HEAD_DIM, type=T.i32) + col_base_i32)
-            col_off = arith.constant(block_idx_const * KV_NUM_COLS, type=T.i32)
-            lds_ptr = _inttoptr_lds(_raw(ArithValue(lds_base_i32).extui(T.i64)))
+            voff = _raw(ArithValue(row_i32) * QK_HEAD_DIM + col_base_i32)
+            col_off = fx.Int32(block_idx_const * KV_NUM_COLS)
+            lds_ptr = _lds_ptr_from_i32(lds_base_i32)
             rocdl.raw_ptr_buffer_load_lds(
                 kv_rsrc, lds_ptr, _raw(c_dword_sz), voff,
                 _raw(c_aux_zero), _raw(col_off), _raw(c_aux_zero),
             )
 
         if const_expr(check_boundary):
-            is_oob = ArithValue(row_i32) == arith.constant(-1, type=T.i32)
+            is_oob = ArithValue(row_i32) == -1
             if is_oob:
                 # Write zero via ds_write_b32 at lane's position
                 lds_addr = _raw(
                     ArithValue(lds_base_i32)
-                    + arith.constant(block_idx_const * KV_NUM_COLS, type=T.i32)
-                    + ArithValue(lane_idx_i32) * arith.constant(4, type=T.i32)
+                    + block_idx_const * KV_NUM_COLS
+                    + ArithValue(lane_idx_i32) * 4
                 )
-                lds_ptr = _inttoptr_lds(_raw(ArithValue(lds_addr).extui(T.i64)))
+                lds_ptr = _lds_ptr_from_i32(lds_addr)
                 llvm.StoreOp(_raw(c_zero_i32), lds_ptr, alignment=4)
             else:
                 _emit_vram_to_lds()
@@ -447,10 +455,10 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             allowing runtime bypass.
         """
         lds_adjust = block_idx_const * KV_BLOCK_BYTES - block_idx_const * KV_NUM_COLS
-        lds_base_i32 = _raw(ArithValue(p_lds_kv_warp_i32) + arith.constant(lds_adjust, type=T.i32))
+        lds_base_i32 = _raw(ArithValue(p_lds_kv_warp_i32) + lds_adjust)
 
         def _emit_normal_load():
-            voff = _raw(ArithValue(row_i32) * arith.constant(QK_HEAD_DIM, type=T.i32) + col_base_i32)
+            voff = _raw(ArithValue(row_i32) * QK_HEAD_DIM + col_base_i32)
             col_off_imm = block_idx_const * KV_NUM_COLS
             asm_str = (
                 "s_mov_b32 m0, $0\n"
@@ -470,7 +478,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             _emit_normal_load()
         else:
             # Build OOB condition: row == -1
-            is_oob = ArithValue(row_i32) == arith.constant(-1, type=T.i32)
+            is_oob = ArithValue(row_i32) == -1
             # If check_boundary is a runtime i1, AND it in
             if const_expr(check_boundary is not True):
                 is_oob = _raw(ArithValue(check_boundary) & ArithValue(is_oob))
@@ -479,8 +487,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                 # OOB: write zero to LDS via inline asm ds_write_b32
                 lds_zero_addr = _raw(
                     ArithValue(lds_base_i32)
-                    + arith.constant(block_idx_const * KV_NUM_COLS, type=T.i32)
-                    + ArithValue(lane_idx_i32) * arith.constant(4, type=T.i32)
+                    + block_idx_const * KV_NUM_COLS
+                    + ArithValue(lane_idx_i32) * 4
                 )
                 llvm.InlineAsmOp(
                     res=None,
@@ -680,7 +688,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         peer_i32 = ArithValue(val_i32).shuffle_xor(offset_i32, width_i32)
         return _raw(ArithValue(peer_i32).bitcast(T.f32))
 
-    c_warp_size_i32 = arith.constant(WARP_SIZE, type=T.i32)
+    c_warp_size_i32 = fx.Int32(WARP_SIZE)
 
     def _warp_reduce_max_16(val):
         """Butterfly max reduce across MFMA column groups.
@@ -689,7 +697,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         """
         w = _to_mlir(val)
         for sh in [32, 16]:
-            peer = _shfl_xor_f32(w, arith.constant(sh, type=T.i32), c_warp_size_i32)
+            peer = _shfl_xor_f32(w, fx.Int32(sh), c_warp_size_i32)
             w = arith.MaximumFOp(w, peer, fastmath=fm_no_inf).result
         return w
 
@@ -697,7 +705,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         """Butterfly sum reduce across MFMA column groups."""
         w = _to_mlir(val)
         for sh in [32, 16]:
-            peer = _shfl_xor_f32(w, arith.constant(sh, type=T.i32), c_warp_size_i32)
+            peer = _shfl_xor_f32(w, fx.Int32(sh), c_warp_size_i32)
             w = ArithValue(w).addf(peer, fastmath=fm_fast)
         return w
 
@@ -722,8 +730,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # v_offset = (row * QK_HEAD_DIM + col) * sizeof(fp8)
         # s_offset = warp * 16 * QK_HEAD_DIM + qo_start * NUM_QO_HEADS * QK_HEAD_DIM
         s_offset_i32 = _raw(
-            ArithValue(warp_idx_i32) * arith.constant(16 * QK_HEAD_DIM, type=T.i32)
-            + ArithValue(qo_start_i32) * arith.constant(NUM_QO_HEADS * QK_HEAD_DIM, type=T.i32)
+            ArithValue(warp_idx_i32) * (16 * QK_HEAD_DIM)
+            + ArithValue(qo_start_i32) * (NUM_QO_HEADS * QK_HEAD_DIM)
         )
 
         row = lane_idx / 4
@@ -759,8 +767,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # v_offset_i32 is in bytes; buffer_load auto-scales by element_bytes
         # (i32 = 4), so divide by 4.  s_offset_i32 is also in bytes.
         voff_dw = _raw(
-            (ArithValue(v_offset_i32) + ArithValue(s_offset_i32))
-            // arith.constant(4, type=T.i32)
+            (ArithValue(v_offset_i32) + ArithValue(s_offset_i32)) // 4
         )
 
         # Pre-compute LDS pointers (constant across passes)
@@ -771,7 +778,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
         def _q_buf_load(pass_idx):
             voff_pass = _raw(
-                ArithValue(voff_dw) + arith.constant(pass_idx * Q_ELEM_PER_ROW // 4, type=T.i32)
+                ArithValue(voff_dw) + pass_idx * Q_ELEM_PER_ROW // 4
             )
             return buffer_ops.buffer_load(
                 query_rsrc,
@@ -832,7 +839,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         if const_expr(check_boundary is not False):
             for i in range_constexpr(8):
                 sub_offset = (i // 4) * 16 + (i % 4)
-                pos_i32 = _raw(ArithValue(col_0_start_i32) + arith.constant(sub_offset, type=T.i32))
+                pos_i32 = _raw(ArithValue(col_0_start_i32) + sub_offset)
                 is_oob = ArithValue(pos_i32) >= ArithValue(kv_end_i32)
                 if const_expr(check_boundary is not True):
                     is_oob = _raw(ArithValue(check_boundary) & ArithValue(is_oob))
@@ -906,7 +913,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         return p_exp_vals, new_row_max, row_sum_e_new, rescale
 
     # ---- Helper: pack P from f32 to fp8 ----
-    c_32_i64 = arith.constant(32, type=T.i64)
+    c_32_i64 = fx.Int64(32)
 
     def _pack_p_to_fp8(p_exp_vals):
         """Pack 8 f32 -> 2 i32 (4x cvt_pk_fp8_f32) -> 1 i64 for MFMA."""
@@ -1053,11 +1060,11 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # ---- Resolve row for tile+2 (2-ahead, matches HK line 407-426) ----
         # The buffer_load has softmax+V-transpose+GEMM2+barrier to complete.
         if const_expr(do_resolve_nn is not None):
-            row_kv_ld_nn = arith.constant(-1, type=T.i32)
+            row_kv_ld_nn = fx.Int32(-1)
             if do_resolve_nn:
                 row_kv_ld_nn = _get_kv_ld_row(nn_resolve_start, nn_resolve_end, True)
         else:
-            row_kv_ld_nn = arith.constant(-1, type=T.i32)
+            row_kv_ld_nn = fx.Int32(-1)
 
         # ---- Softmax ----
         p_exp_vals, row_max_new, row_sum_e_new, rescale = _softmax(
@@ -1151,60 +1158,50 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         rocdl.sched_barrier(0)
         return _gemm2_core(p_pack, oaccu, vt_base_i32)
 
-    c_16_i32 = arith.constant(16, type=T.i32)
-
     def _pack_f32x4_to_bf16_2dw(acc_val):
         """Convert f32x4 accumulator to 2 packed bf16 dwords."""
         i16s = Vec(arith.trunc_f(T.bf16x4, acc_val)).bitcast(fx.Int16)
         i16_0, i16_1, i16_2, i16_3 = (_raw(i16s[j]) for j in range(4))
-        dw0 = _raw(ArithValue(i16_0).extui(T.i32) | (ArithValue(i16_1).extui(T.i32) << c_16_i32))
-        dw1 = _raw(ArithValue(i16_2).extui(T.i32) | (ArithValue(i16_3).extui(T.i32) << c_16_i32))
+        dw0 = _raw(ArithValue(i16_0).extui(T.i32) | (ArithValue(i16_1).extui(T.i32) << 16))
+        dw1 = _raw(ArithValue(i16_2).extui(T.i32) | (ArithValue(i16_3).extui(T.i32) << 16))
         return dw0, dw1
 
     # ---- Pre-compute LDS reshape addresses (computed once, reused per store) ----
-    # Use unsigned div/rem via ArithValue (signedness inherited from type).
     # Need explicit DivUI/RemUI since ArithValue `/` `%` are signed.
+    def _udiv(a, b):
+        return arith.DivUIOp(_raw(a), _raw(fx.Int32(b))).result
+
+    def _urem(a, b):
+        return arith.RemUIOp(_raw(a), _raw(fx.Int32(b))).result
+
     lane_u = ArithValue(lane_idx_i32)
 
     # bf16 LDS write address (MFMA layout): row_st = lane%16, col_st = (lane/16)*4
-    o16_row_st = arith.RemUIOp(_raw(lane_u), _raw(c_16_i32)).result
-    o16_col_st = _raw(ArithValue(arith.DivUIOp(_raw(lane_u), _raw(c_16_i32)).result) * 4)
+    o16_row_st = _urem(lane_u, 16)
+    o16_col_st = _raw(ArithValue(_udiv(lane_u, 16)) * 4)
     # get_v_offset_lds(r,c) = ((r/2)*68 + (r%2)*32 + c) * 2  [bytes]
     o16_st_offset = _raw(
-        (
-            ArithValue(arith.DivUIOp(o16_row_st, _raw(arith.constant(2, type=T.i32))).result)
-            * arith.constant(O16_ELEM_PER_PAD_2ROWS, type=T.i32)
-            + ArithValue(arith.RemUIOp(o16_row_st, _raw(arith.constant(2, type=T.i32))).result)
-            * arith.constant(O16_NUM_COLS, type=T.i32)
-            + ArithValue(o16_col_st)
-        ) * 2  # sizeof(bf16)
+        (ArithValue(_udiv(o16_row_st, 2)) * O16_ELEM_PER_PAD_2ROWS
+         + ArithValue(_urem(o16_row_st, 2)) * O16_NUM_COLS
+         + ArithValue(o16_col_st)) * 2
     )
 
     # bf16 LDS read address (coalesced layout): row_ld = lane/4, col_ld = (lane%4)*8
-    o16_row_ld = arith.DivUIOp(_raw(lane_u), _raw(arith.constant(4, type=T.i32))).result
-    o16_col_ld = _raw(ArithValue(arith.RemUIOp(_raw(lane_u), _raw(arith.constant(4, type=T.i32))).result) * 8)
+    o16_row_ld = _udiv(lane_u, 4)
+    o16_col_ld = _raw(ArithValue(_urem(lane_u, 4)) * 8)
     o16_rd_offset = _raw(
-        (
-            ArithValue(arith.DivUIOp(o16_row_ld, _raw(arith.constant(2, type=T.i32))).result)
-            * arith.constant(O16_ELEM_PER_PAD_2ROWS, type=T.i32)
-            + ArithValue(arith.RemUIOp(o16_row_ld, _raw(arith.constant(2, type=T.i32))).result)
-            * arith.constant(O16_NUM_COLS, type=T.i32)
-            + ArithValue(o16_col_ld)
-        ) * 2  # sizeof(bf16)
+        (ArithValue(_udiv(o16_row_ld, 2)) * O16_ELEM_PER_PAD_2ROWS
+         + ArithValue(_urem(o16_row_ld, 2)) * O16_NUM_COLS
+         + ArithValue(o16_col_ld)) * 2
     )
 
     # f32 LDS write address: row_st/col_st reused, different padding
-    # get_v_offset_lds(r,c) = (r * 36 + c) * 4  [bytes]
-    o32_st_offset = _raw(
-        (ArithValue(o16_row_st) * arith.constant(O32_ELEM_PER_PAD_ROW, type=T.i32) + ArithValue(o16_col_st)) * 4
-    )
+    o32_st_offset = _raw((ArithValue(o16_row_st) * O32_ELEM_PER_PAD_ROW + ArithValue(o16_col_st)) * 4)
 
     # f32 LDS read address: row_ld = lane/8, col_ld = (lane%8)*4
-    o32_row_ld = arith.DivUIOp(_raw(lane_u), _raw(arith.constant(8, type=T.i32))).result
-    o32_col_ld = _raw(ArithValue(arith.RemUIOp(_raw(lane_u), _raw(arith.constant(8, type=T.i32))).result) * 4)
-    o32_rd_offset = _raw(
-        (ArithValue(o32_row_ld) * arith.constant(O32_ELEM_PER_PAD_ROW, type=T.i32) + ArithValue(o32_col_ld)) * 4
-    )
+    o32_row_ld = _udiv(lane_u, 8)
+    o32_col_ld = _raw(ArithValue(_urem(lane_u, 8)) * 4)
+    o32_rd_offset = _raw((ArithValue(o32_row_ld) * O32_ELEM_PER_PAD_ROW + ArithValue(o32_col_ld)) * 4)
 
     def _store_oaccu_pair_bf16(oaccu_a, oaccu_b, tile_idx, p_lds_o_i32, row_base_i32):
         """Store 2 oaccu groups (1 PV iter) as bf16 via LDS reshape.
@@ -1213,7 +1210,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         reads back in row-major coalesced layout, then buffer_store_dwordx4.
         """
         # Per-warp LDS base
-        lds_warp = _raw(ArithValue(p_lds_o_i32) + ArithValue(warp_idx_i32) * arith.constant(O16_LDS_PER_WARP, type=T.i32))
+        lds_warp = _raw(ArithValue(p_lds_o_i32) + ArithValue(warp_idx_i32) * O16_LDS_PER_WARP)
         lds_st_addr = _raw(ArithValue(lds_warp) + ArithValue(o16_st_offset))
 
         # LDS write: 2 sub-blocks -> 2x ds_write_b64
@@ -1221,23 +1218,23 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             dw0, dw1 = _pack_f32x4_to_bf16_2dw(acc_val)
             vec_2dw = Vec.from_elements([dw0, dw1], fx.Int32)
             sub_offset = sub * O16_NUM_COLS
-            st_addr_sub = _raw(ArithValue(lds_st_addr) + arith.constant(sub_offset, type=T.i32))
-            st_ptr = _inttoptr_lds(_raw(ArithValue(st_addr_sub).extui(T.i64)))
+            st_addr_sub = _raw(ArithValue(lds_st_addr) + sub_offset)
+            st_ptr = _lds_ptr_from_i32(st_addr_sub)
             llvm.StoreOp(vec_2dw, st_ptr, alignment=8, volatile_=True)
 
         rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
         # LDS read: ds_read_b128 (4 dwords = 8 bf16 in coalesced layout)
         lds_rd_addr = _raw(ArithValue(lds_warp) + ArithValue(o16_rd_offset))
-        rd_ptr = _inttoptr_lds(_raw(ArithValue(lds_rd_addr).extui(T.i64)))
+        rd_ptr = _lds_ptr_from_i32(lds_rd_addr)
         data = llvm.LoadOp(T.i32x4, rd_ptr, alignment=16).result
 
         rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
         # Coalesced VRAM store: buffer_store_dwordx4
         row_vram = ArithValue(row_base_i32) + ArithValue(o16_row_ld)
-        col_vram = ArithValue(o16_col_ld) + arith.constant(tile_idx * MFMA_N * 2, type=T.i32)
-        vram_offset = _raw((row_vram * arith.constant(V_HEAD_DIM, type=T.i32) + col_vram) * 2)
+        col_vram = ArithValue(o16_col_ld) + tile_idx * MFMA_N * 2
+        vram_offset = _raw((row_vram * V_HEAD_DIM + col_vram) * 2)
         buffer_ops.buffer_store(data, final_output_rsrc, vram_offset, offset_is_bytes=True)
 
     def _store_oaccu_pair_split(oaccu_a, oaccu_b, tile_idx, p_lds_o_i32, row_base_i32):
@@ -1248,25 +1245,25 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         16 rows need 2 rounds (8 rows each) because 64 lanes / 8 lanes-per-row = 8.
         """
         # Per-warp LDS base
-        lds_warp = _raw(ArithValue(p_lds_o_i32) + ArithValue(warp_idx_i32) * arith.constant(O32_LDS_PER_WARP, type=T.i32))
+        lds_warp = _raw(ArithValue(p_lds_o_i32) + ArithValue(warp_idx_i32) * O32_LDS_PER_WARP)
         lds_st_addr = _raw(ArithValue(lds_warp) + ArithValue(o32_st_offset))
 
-        col_offset_i32 = arith.constant(tile_idx * MFMA_N * 2, type=T.i32)
+        col_offset_i32 = tile_idx * MFMA_N * 2
         O32_LD_DELTA = 8 * O32_ELEM_PER_PAD_ROW * 4  # 1152 bytes between round 0/1
 
         # LDS write: 2 sub-blocks -> 2x ds_write_b128
         rocdl.s_waitcnt(_encode_waitcnt(vmcnt=0))
         for sub, acc_val in enumerate([oaccu_a, oaccu_b]):
             sub_offset = sub * O32_NUM_COLS // 2 * 4
-            st_addr_sub = _raw(ArithValue(lds_st_addr) + arith.constant(sub_offset, type=T.i32))
-            st_ptr = _inttoptr_lds(_raw(ArithValue(st_addr_sub).extui(T.i64)))
+            st_addr_sub = _raw(ArithValue(lds_st_addr) + sub_offset)
+            st_ptr = _lds_ptr_from_i32(st_addr_sub)
             llvm.StoreOp(acc_val, st_ptr, alignment=16)
 
         rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
         # LDS read: 2x ds_read_b128 (round 0 = rows 0-7, round 1 = rows 8-15)
         lds_rd_addr = _raw(ArithValue(lds_warp) + ArithValue(o32_rd_offset))
-        rd_ptr = _inttoptr_lds(_raw(ArithValue(lds_rd_addr).extui(T.i64)))
+        rd_ptr = _lds_ptr_from_i32(lds_rd_addr)
         data_0 = llvm.LoadOp(T.f32x4, rd_ptr, alignment=16).result
         data_1 = llvm.LoadOp(T.f32x4, _gep(rd_ptr, static_byte_offset=O32_LD_DELTA), alignment=16).result
 
@@ -1275,11 +1272,11 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # 2x coalesced VRAM store
         row_vram_0 = ArithValue(row_base_i32) + ArithValue(o32_row_ld)
         col_vram = ArithValue(o32_col_ld) + col_offset_i32
-        vram_off_0 = _raw((row_vram_0 * arith.constant(V_HEAD_DIM, type=T.i32) + col_vram) * 4)
+        vram_off_0 = _raw((row_vram_0 * V_HEAD_DIM + col_vram) * 4)
         buffer_ops.buffer_store(_raw(Vec(data_0).bitcast(fx.Int32)), split_output_rsrc, vram_off_0, offset_is_bytes=True)
 
-        row_vram_1 = row_vram_0 + arith.constant(8, type=T.i32)
-        vram_off_1 = _raw((row_vram_1 * arith.constant(V_HEAD_DIM, type=T.i32) + col_vram) * 4)
+        row_vram_1 = row_vram_0 + 8
+        vram_off_1 = _raw((row_vram_1 * V_HEAD_DIM + col_vram) * 4)
         buffer_ops.buffer_store(_raw(Vec(data_1).bitcast(fx.Int32)), split_output_rsrc, vram_off_1, offset_is_bytes=True)
 
     def _gemm2_last_with_store(
@@ -1393,7 +1390,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     p_lds_kv_0_base = lds_base_idx + arith.index(P_LDS_KV_0)
     p_lds_kv_1_base = lds_base_idx + arith.index(P_LDS_KV_1)
 
-    kv_warp_offset_i32 = _raw(ArithValue(warp_idx_i32) * arith.constant(KV_SUB_BYTES, type=T.i32))
+    kv_warp_offset_i32 = _raw(ArithValue(warp_idx_i32) * KV_SUB_BYTES)
 
     p_lds_kv_0_warp_i32 = _raw(ArithValue(_i32(p_lds_kv_0_base)) + ArithValue(kv_warp_offset_i32))
     p_lds_kv_1_warp_i32 = _raw(ArithValue(_i32(p_lds_kv_1_base)) + ArithValue(kv_warp_offset_i32))
@@ -1431,20 +1428,20 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         row_sum_e = _raw(c_zero_f32)
 
         # Compute number of tiles
-        c_block_n = arith.constant(BLOCK_N, type=T.i32)
+        c_block_n = fx.Int32(BLOCK_N)
         kv_len_v = ArithValue(kv_len)
         c_block_n_v = ArithValue(c_block_n)
         num_tiles = arith.DivUIOp(
-            _raw(kv_len_v + arith.constant(BLOCK_N - 1, type=T.i32)), _raw(c_block_n)
+            _raw(kv_len_v + BLOCK_N - 1), _raw(c_block_n)
         ).result
 
         # --- Pre-compute boundary flags ---
         first_tile_needs_boundary = kv_len_v < c_block_n_v
         has_multi_tiles = kv_len_v > c_block_n_v
-        last_tile_partial = (kv_len_v & arith.constant(BLOCK_N - 1, type=T.i32)) != arith.constant(0, type=T.i32)
+        last_tile_partial = (kv_len_v & BLOCK_N - 1) != 0
 
         # --- First tile: resolve KV row (branched on boundary) ---
-        row_kv_ld_first = arith.constant(-1, type=T.i32)
+        row_kv_ld_first = fx.Int32(-1)
         if first_tile_needs_boundary:
             row_kv_ld_first = _get_kv_ld_row(kv_start, kv_end, True)
         else:
@@ -1471,9 +1468,9 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
         # --- Tile-1 row resolution (only meaningful for multi-tile) ---
         kv_start_plus_bn = _raw(ArithValue(kv_start) + c_block_n_v)
-        kv_start_plus_2bn = _raw(ArithValue(kv_start) + arith.constant(2 * BLOCK_N, type=T.i32))
+        kv_start_plus_2bn = _raw(ArithValue(kv_start) + 2 * BLOCK_N)
         tile1_is_full = ArithValue(kv_start_plus_2bn) <= ArithValue(kv_end)
-        row_kv_ld_tile1 = arith.constant(-1, type=T.i32)
+        row_kv_ld_tile1 = fx.Int32(-1)
         if tile1_is_full:
             row_kv_ld_tile1 = _get_kv_ld_row(kv_start_plus_bn, kv_start_plus_2bn, False)
         else:
@@ -1495,9 +1492,9 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         do_resolve_nn_first = ArithValue(kv_start_plus_2bn) < ArithValue(kv_end)
 
         # Branch on has_multi_tiles: multi-tile gets prefetch, single doesn't
-        p_pack_first = arith.constant(0, type=T.i64)
+        p_pack_first = fx.Int64(0)
         rescale_first = c_one_f32
-        row_kv_ld_nn_first = arith.constant(-1, type=T.i32)
+        row_kv_ld_nn_first = fx.Int32(-1)
         if _raw(has_multi_tiles):
             # Multi-tile: first tile is always full, prefetch tile 1.
             # Sub-branch on first_tile_cbn for compile-time check_boundary_next.
@@ -1563,12 +1560,12 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
         def _write_lse(pqo_loc_i32, rm, rse):
             """Write LSE for split output (first 16 lanes per warp)."""
-            if ArithValue(lane_idx_i32) < arith.constant(16, type=T.i32):
+            if ArithValue(lane_idx_i32) < 16:
                 log2_sum = fmath.log2(rse, fastmath=fm_fast)
                 lse = fmath.fma(log2_sum, c_inv_log2e, rm, fastmath=fm_fast)
                 row_idx_i32 = _raw(
                     ArithValue(lane_idx_i32) + ArithValue(warp_idx_i32) * 16
-                    + ArithValue(pqo_loc_i32) * arith.constant(NUM_QO_HEADS, type=T.i32)
+                    + ArithValue(pqo_loc_i32) * NUM_QO_HEADS
                 )
                 buffer_ops.buffer_store(lse, split_lse_rsrc, row_idx_i32)
 
@@ -1588,10 +1585,10 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             Branches on partial_qo_loc to select bf16 vs f32 split output.
             """
             reci = arith.DivFOp(_raw(c_one_f32), _raw(rse), fastmath=fm_fast).result
-            is_not_split = ArithValue(partial_qo_loc) < arith.constant(0, type=T.i32)
+            is_not_split = ArithValue(partial_qo_loc) < 0
             if is_not_split:
                 # bf16 final output: row_base = qo_start * NUM_QO_HEADS + warp*16
-                rb_bf16 = _raw(ArithValue(qo_start) * arith.constant(NUM_QO_HEADS, type=T.i32) + ArithValue(warp_idx_i32) * 16)
+                rb_bf16 = _raw(ArithValue(qo_start) * NUM_QO_HEADS + ArithValue(warp_idx_i32) * 16)
                 _gemm2_last_with_store(
                     pp,
                     rs,
@@ -1605,7 +1602,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                 )
             else:
                 # f32 split output: row_base = pqo_loc * NUM_QO_HEADS + warp*16
-                rb_split = _raw(ArithValue(partial_qo_loc) * arith.constant(NUM_QO_HEADS, type=T.i32) + ArithValue(warp_idx_i32) * 16)
+                rb_split = _raw(ArithValue(partial_qo_loc) * NUM_QO_HEADS + ArithValue(warp_idx_i32) * 16)
                 _gemm2_last_with_store(
                     pp,
                     rs,
@@ -1629,9 +1626,9 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
             # --- Middle tiles [1, num_tiles-1) via scf.ForOp ---
             c_one_idx = arith.index(1)
-            num_tiles_m1 = _raw(ArithValue(num_tiles) - arith.constant(1, type=T.i32))
+            num_tiles_m1 = _raw(ArithValue(num_tiles) - 1)
             num_tiles_m1_idx = arith.index_cast(T.index, num_tiles_m1)
-            num_tiles_m2 = _raw(ArithValue(num_tiles) - arith.constant(2, type=T.i32))
+            num_tiles_m2 = _raw(ArithValue(num_tiles) - 2)
 
             init_args = [row_max, row_sum_e] + oaccu_mt + [row_kv_ld_nn_first]
 
@@ -1650,7 +1647,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
                 # Buffer parity
                 tile_iv_av = ArithValue(tile_iv_i32)
-                is_odd = (tile_iv_av & arith.constant(1, type=T.i32)) != arith.constant(0, type=T.i32)
+                is_odd = (tile_iv_av & 1) != 0
                 curr_base_idx = ArithValue(is_odd).select(p_lds_kv_1_base, p_lds_kv_0_base)
                 next_warp = ArithValue(is_odd).select(p_lds_kv_0_warp_i32, p_lds_kv_1_warp_i32)
 
@@ -1659,14 +1656,14 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                 mid_cbn = _raw(ArithValue(is_second_to_last) & ArithValue(last_tile_partial))
 
                 # 2-ahead resolve params
-                nn_start_mid = _raw(ArithValue(kv_tile_start_i32) + arith.constant(2 * BLOCK_N, type=T.i32))
+                nn_start_mid = _raw(ArithValue(kv_tile_start_i32) + 2 * BLOCK_N)
                 do_resolve_nn_mid = ArithValue(nn_start_mid) < ArithValue(kv_end)
 
                 rm_m = c_neg_inf
                 rse_m = c_zero_f32
-                pp_m = arith.constant(0, type=T.i64)
+                pp_m = fx.Int64(0)
                 rs_m = c_one_f32
-                nn_m = arith.constant(-1, type=T.i32)
+                nn_m = fx.Int32(-1)
                 if mid_cbn:
                     # cbn=True: next tile needs boundary check
                     _barrier(vmcnt=0, lgkmcnt=0)
@@ -1723,7 +1720,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             # --- Last tile: GEMM1 + interleaved GEMM2 store ---
             last_tile_iv = ArithValue(num_tiles_m1)
             kv_last_start = _raw(ArithValue(kv_start) + last_tile_iv * c_block_n_v)
-            last_is_odd = (last_tile_iv & arith.constant(1, type=T.i32)) != arith.constant(0, type=T.i32)
+            last_is_odd = (last_tile_iv & 1) != 0
             last_curr_base = ArithValue(last_is_odd).select(p_lds_kv_1_base, p_lds_kv_0_base)
 
             _barrier(vmcnt=0, lgkmcnt=0)

--- a/kernels/mla_fwd_decode_m16x8_fp8_fp8.py
+++ b/kernels/mla_fwd_decode_m16x8_fp8_fp8.py
@@ -239,9 +239,9 @@ def _to_mlir(val):
     return _raw(val) if not isinstance(val, ir.Value) else val
 
 
-def _pack_i32x2(lo, hi, c32):
+def _pack_i32x2(lo, hi):
     """Pack two i32 values into a single i64: lo | (hi << 32)."""
-    return _raw(ArithValue(lo).extui(T.i64) | (ArithValue(hi).extui(T.i64) << c32))
+    return _raw(ArithValue(lo).extui(T.i64) | (ArithValue(hi).extui(T.i64) << 32))
 
 
 # ---------------------------------------------------------------------------
@@ -678,31 +678,24 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         return v0, v1
 
     # ---- Helper: warp reduce (butterfly XOR) ----
-    def _shfl_xor_f32(val_f32, offset_i32, width_i32):
+    def _shfl_xor_f32(val_f32, offset, width=WARP_SIZE):
         """XOR shuffle for f32 via bitcast to i32 and back."""
         val_i32 = _raw(ArithValue(val_f32).bitcast(T.i32))
-        peer_i32 = ArithValue(val_i32).shuffle_xor(offset_i32, width_i32)
+        peer_i32 = ArithValue(val_i32).shuffle_xor(offset, width)
         return _raw(ArithValue(peer_i32).bitcast(T.f32))
 
-    c_warp_size_i32 = fx.Int32(WARP_SIZE)
-
     def _warp_reduce_max_16(val):
-        """Butterfly max reduce across MFMA column groups.
-
-        HK: reduce_range=64, stop_stride=15 -> strides [32, 16].
-        """
+        """Butterfly max reduce across MFMA column groups (strides 32, 16)."""
         w = _to_mlir(val)
         for sh in [32, 16]:
-            peer = _shfl_xor_f32(w, fx.Int32(sh), c_warp_size_i32)
-            w = arith.MaximumFOp(w, peer, fastmath=fm_no_inf).result
+            w = arith.MaximumFOp(w, _shfl_xor_f32(w, sh), fastmath=fm_no_inf).result
         return w
 
     def _warp_reduce_add_16(val):
-        """Butterfly sum reduce across MFMA column groups."""
+        """Butterfly sum reduce across MFMA column groups (strides 32, 16)."""
         w = _to_mlir(val)
         for sh in [32, 16]:
-            peer = _shfl_xor_f32(w, fx.Int32(sh), c_warp_size_i32)
-            w = ArithValue(w).addf(peer, fastmath=fm_fast)
+            w = ArithValue(w).addf(_shfl_xor_f32(w, sh), fastmath=fm_fast)
         return w
 
     # ---- Helper: Q loading (QManagerV3) ----
@@ -909,15 +902,13 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         return p_exp_vals, new_row_max, row_sum_e_new, rescale
 
     # ---- Helper: pack P from f32 to fp8 ----
-    c_32_i64 = fx.Int64(32)
-
     def _pack_p_to_fp8(p_exp_vals):
         """Pack 8 f32 -> 2 i32 (4x cvt_pk_fp8_f32) -> 1 i64 for MFMA."""
         w0 = rocdl.cvt_pk_fp8_f32(T.i32, _raw(p_exp_vals[0]), _raw(p_exp_vals[1]), c_zero_i32, 0)
         w0 = rocdl.cvt_pk_fp8_f32(T.i32, _raw(p_exp_vals[2]), _raw(p_exp_vals[3]), w0, 1)
         w1 = rocdl.cvt_pk_fp8_f32(T.i32, _raw(p_exp_vals[4]), _raw(p_exp_vals[5]), c_zero_i32, 0)
         w1 = rocdl.cvt_pk_fp8_f32(T.i32, _raw(p_exp_vals[6]), _raw(p_exp_vals[7]), w1, 1)
-        return _raw(ArithValue(w0).extui(T.i64) | (ArithValue(w1).extui(T.i64) << c_32_i64))
+        return _pack_i32x2(w0, w1)
 
     # ---- Helper: rescale oaccu ----
     def _rescale_oaccu(oaccu, rescale):
@@ -1110,20 +1101,20 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
             # MFMA pair A
             oaccu[iter_a * 2] = _mfma_fp8(
-                T.f32x4, [_pack_i32x2(vta0_lo, vta0_hi, c_32_i64), p_pack, oaccu[iter_a * 2], 0, 0, 0]
+                T.f32x4, [_pack_i32x2(vta0_lo, vta0_hi), p_pack, oaccu[iter_a * 2], 0, 0, 0]
             )
             oaccu[iter_a * 2 + 1] = _mfma_fp8(
-                T.f32x4, [_pack_i32x2(vta1_lo, vta1_hi, c_32_i64), p_pack, oaccu[iter_a * 2 + 1], 0, 0, 0]
+                T.f32x4, [_pack_i32x2(vta1_lo, vta1_hi), p_pack, oaccu[iter_a * 2 + 1], 0, 0, 0]
             )
             rocdl.sched_barrier(0)
             rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
             # MFMA pair B
             oaccu[iter_b * 2] = _mfma_fp8(
-                T.f32x4, [_pack_i32x2(vtb0_lo, vtb0_hi, c_32_i64), p_pack, oaccu[iter_b * 2], 0, 0, 0]
+                T.f32x4, [_pack_i32x2(vtb0_lo, vtb0_hi), p_pack, oaccu[iter_b * 2], 0, 0, 0]
             )
             oaccu[iter_b * 2 + 1] = _mfma_fp8(
-                T.f32x4, [_pack_i32x2(vtb1_lo, vtb1_hi, c_32_i64), p_pack, oaccu[iter_b * 2 + 1], 0, 0, 0]
+                T.f32x4, [_pack_i32x2(vtb1_lo, vtb1_hi), p_pack, oaccu[iter_b * 2 + 1], 0, 0, 0]
             )
             rocdl.sched_barrier(0)
 
@@ -1295,8 +1286,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         4. Multiply by reci_sum
         5. Store immediately (bf16 or f32 split)
         """
-        rescale_vec = _raw(Vec.filled(4, rescale, fx.Float32))
-        reci_vec = _raw(Vec.filled(4, reci_sum, fx.Float32))
+        rescale_vec = _raw(Vec.filled(4, fx.Float32(rescale), fx.Float32))
+        reci_vec = _raw(Vec.filled(4, fx.Float32(reci_sum), fx.Float32))
 
         _barrier(lgkmcnt=0)
         rocdl.sched_barrier(0)
@@ -1325,20 +1316,20 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
             # MFMA pair A
             oaccu_in[iter_a * 2] = _mfma_fp8(
-                T.f32x4, [_pack_i32x2(vta0_lo, vta0_hi, c_32_i64), p_pack, oaccu_in[iter_a * 2], 0, 0, 0]
+                T.f32x4, [_pack_i32x2(vta0_lo, vta0_hi), p_pack, oaccu_in[iter_a * 2], 0, 0, 0]
             )
             oaccu_in[iter_a * 2 + 1] = _mfma_fp8(
-                T.f32x4, [_pack_i32x2(vta1_lo, vta1_hi, c_32_i64), p_pack, oaccu_in[iter_a * 2 + 1], 0, 0, 0]
+                T.f32x4, [_pack_i32x2(vta1_lo, vta1_hi), p_pack, oaccu_in[iter_a * 2 + 1], 0, 0, 0]
             )
             rocdl.sched_barrier(0)
             rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
             # MFMA pair B
             oaccu_in[iter_b * 2] = _mfma_fp8(
-                T.f32x4, [_pack_i32x2(vtb0_lo, vtb0_hi, c_32_i64), p_pack, oaccu_in[iter_b * 2], 0, 0, 0]
+                T.f32x4, [_pack_i32x2(vtb0_lo, vtb0_hi), p_pack, oaccu_in[iter_b * 2], 0, 0, 0]
             )
             oaccu_in[iter_b * 2 + 1] = _mfma_fp8(
-                T.f32x4, [_pack_i32x2(vtb1_lo, vtb1_hi, c_32_i64), p_pack, oaccu_in[iter_b * 2 + 1], 0, 0, 0]
+                T.f32x4, [_pack_i32x2(vtb1_lo, vtb1_hi), p_pack, oaccu_in[iter_b * 2 + 1], 0, 0, 0]
             )
             rocdl.sched_barrier(0)
 
@@ -1424,24 +1415,20 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         row_sum_e = _raw(c_zero_f32)
 
         # Compute number of tiles
-        c_block_n = fx.Int32(BLOCK_N)
         kv_len_v = ArithValue(kv_len)
-        c_block_n_v = ArithValue(c_block_n)
-        num_tiles = arith.DivUIOp(
-            _raw(kv_len_v + BLOCK_N - 1), _raw(c_block_n)
-        ).result
+        num_tiles = _udiv(kv_len_v + BLOCK_N - 1, BLOCK_N)
 
         # --- Pre-compute boundary flags ---
-        first_tile_needs_boundary = kv_len_v < c_block_n_v
-        has_multi_tiles = kv_len_v > c_block_n_v
-        last_tile_partial = (kv_len_v & BLOCK_N - 1) != 0
+        first_tile_needs_boundary = kv_len_v < BLOCK_N
+        has_multi_tiles = kv_len_v > BLOCK_N
+        last_tile_partial = (kv_len_v & (BLOCK_N - 1)) != 0
 
         # --- First tile: resolve KV row (branched on boundary) ---
         row_kv_ld_first = fx.Int32(-1)
         if first_tile_needs_boundary:
             row_kv_ld_first = _get_kv_ld_row(kv_start, kv_end, True)
         else:
-            row_kv_ld_first = _get_kv_ld_row(kv_start, _raw(ArithValue(kv_start) + c_block_n_v), False)
+            row_kv_ld_first = _get_kv_ld_row(kv_start, _raw(ArithValue(kv_start) + BLOCK_N), False)
 
         # Load Q to GPR (independent of boundary check)
         q_nope_packs, q_rope_packs = _load_q_to_regs(qo_start)
@@ -1463,8 +1450,9 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             )
 
         # --- Tile-1 row resolution (only meaningful for multi-tile) ---
-        kv_start_plus_bn = _raw(ArithValue(kv_start) + c_block_n_v)
-        kv_start_plus_2bn = _raw(ArithValue(kv_start) + 2 * BLOCK_N)
+        kv_start_v = ArithValue(kv_start)
+        kv_start_plus_bn = _raw(kv_start_v + BLOCK_N)
+        kv_start_plus_2bn = _raw(kv_start_v + 2 * BLOCK_N)
         tile1_is_full = ArithValue(kv_start_plus_2bn) <= ArithValue(kv_end)
         row_kv_ld_tile1 = fx.Int32(-1)
         if tile1_is_full:
@@ -1621,34 +1609,29 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             oaccu_mt = _gemm2_first_iter(p_pack_first, vt_base_i32)
 
             # --- Middle tiles [1, num_tiles-1) via scf.ForOp ---
-            c_one_idx = arith.index(1)
-            num_tiles_m1 = _raw(ArithValue(num_tiles) - 1)
-            num_tiles_m1_idx = arith.index_cast(T.index, num_tiles_m1)
-            num_tiles_m2 = _raw(ArithValue(num_tiles) - 2)
+            num_tiles_v = ArithValue(num_tiles)
+            num_tiles_m1 = _raw(num_tiles_v - 1)
+            num_tiles_m2 = _raw(num_tiles_v - 2)
 
             init_args = [row_max, row_sum_e] + oaccu_mt + [row_kv_ld_nn_first]
 
-            for tile_iv, state in range(c_one_idx, num_tiles_m1_idx, c_one_idx, init=init_args):
-                tile_iv_i32 = arith.index_cast(T.i32, tile_iv)
-                kv_tile_start_i32 = _raw(ArithValue(kv_start) + ArithValue(tile_iv_i32) * c_block_n_v)
+            for tile_iv, state in range(arith.index(1), arith.index_cast(T.index, num_tiles_m1), arith.index(1), init=init_args):
+                tile_iv_i32 = ArithValue(arith.index_cast(T.i32, tile_iv))
+                kv_tile_start_i32 = _raw(kv_start_v + tile_iv_i32 * BLOCK_N)
 
                 # Unpack carried state
                 rm_carried = state[0]
                 rse_carried = state[1]
-                oaccu_carried = [
-                    state[2 + i] for i in range(NUM_PV_ITERS * 2)
-                ]
-                # 2-ahead: row resolved by previous iteration's _process_tile_gemm1
+                oaccu_carried = [state[2 + i] for i in range(NUM_PV_ITERS * 2)]
                 row_kv_ld_next = state[2 + NUM_PV_ITERS * 2]
 
                 # Buffer parity
-                tile_iv_av = ArithValue(tile_iv_i32)
-                is_odd = (tile_iv_av & 1) != 0
+                is_odd = (tile_iv_i32 & 1) != 0
                 curr_base_idx = ArithValue(is_odd).select(p_lds_kv_1_base, p_lds_kv_0_base)
                 next_warp = ArithValue(is_odd).select(p_lds_kv_0_warp_i32, p_lds_kv_1_warp_i32)
 
                 # check_boundary_next: True when tile_idx == num_tiles-2 AND last_tile_partial
-                is_second_to_last = tile_iv_av == ArithValue(num_tiles_m2)
+                is_second_to_last = tile_iv_i32 == ArithValue(num_tiles_m2)
                 mid_cbn = _raw(ArithValue(is_second_to_last) & ArithValue(last_tile_partial))
 
                 # 2-ahead resolve params
@@ -1715,7 +1698,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
             # --- Last tile: GEMM1 + interleaved GEMM2 store ---
             last_tile_iv = ArithValue(num_tiles_m1)
-            kv_last_start = _raw(ArithValue(kv_start) + last_tile_iv * c_block_n_v)
+            kv_last_start = _raw(kv_start_v + last_tile_iv * BLOCK_N)
             last_is_odd = (last_tile_iv & 1) != 0
             last_curr_base = ArithValue(last_is_odd).select(p_lds_kv_1_base, p_lds_kv_0_base)
 

--- a/kernels/mla_fwd_decode_m16x8_fp8_fp8.py
+++ b/kernels/mla_fwd_decode_m16x8_fp8_fp8.py
@@ -18,11 +18,10 @@ import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import gpu as _mlir_gpu
 from flydsl._mlir.dialects import llvm, scf
-from flydsl._mlir.dialects import math as _math
 from flydsl._mlir.dialects import memref as _memref
-from flydsl._mlir.dialects._arith_enum_gen import CmpIPredicate
 from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl, vector
+from flydsl.expr import math as fmath
 from flydsl.expr.arith import _to_raw as _raw
 from flydsl.expr.typing import T
 from flydsl.expr.typing import Vector as Vec
@@ -378,9 +377,9 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     # ---- Thread indices ----
     worker_idx = gpu.block_idx.x
     tid = gpu.thread_id("x")
-    warp_idx = tid / arith.index(WARP_SIZE)
-    lane_idx = tid % arith.index(WARP_SIZE)
-    warp_idx_i32 = rocdl.readfirstlane(T.i32, _raw(_index_cast_to_i32(warp_idx)))
+    warp_idx = tid / WARP_SIZE
+    lane_idx = tid % WARP_SIZE
+    warp_idx_i32 = rocdl.readfirstlane(T.i32, _index_cast_to_i32(warp_idx))
     lane_idx_i32 = _index_cast_to_i32(lane_idx)
 
     # ---- Work range ----
@@ -391,21 +390,19 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     work_range_vec = Vec(work_range)
     work_start_i32 = rocdl.readfirstlane(T.i32, work_range_vec[0])
     work_end_i32 = rocdl.readfirstlane(T.i32, work_range_vec[1])
-    work_start_idx = arith.index_cast(T.index, work_start_i32)
-    work_end_idx = arith.index_cast(T.index, work_end_i32)
+    work_start_idx = fx.Index(work_start_i32)
+    work_end_idx = fx.Index(work_end_i32)
 
     # ---- KvManagerV2 thread-to-data mapping ----
     # Each warp takes 4 rows: warp w -> rows {w*2, w*2+1, w*2+16, w*2+17}
     # lane mapping: (lane/32)*16 + (lane/16)%2 + warp*2
     kv_ld_row_base = (
-        lane_idx / arith.index(32) * arith.index(16)
-        + (lane_idx / arith.index(16)) % arith.index(2)
-        + warp_idx * arith.index(2)
+        lane_idx / 32 * 16
+        + (lane_idx / 16) % 2
+        + warp_idx * 2
     )
     kv_ld_row_base_i32 = _index_cast_to_i32(kv_ld_row_base)
-    kv_ld_col_base_i32 = _index_cast_to_i32(
-        (lane_idx % arith.index(16)) * arith.index(4)
-    )
+    kv_ld_col_base_i32 = _index_cast_to_i32((lane_idx % 16) * 4)
 
     # ---- Helper: resolve KV page index -> physical row ----
     def _get_kv_ld_row(kv_tile_start_i32, kv_tile_end_i32, check_boundary):
@@ -417,7 +414,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         row_idx_i32 = _raw(kv_ld_row_base_i32 + kv_tile_start_i32)
         if const_expr(check_boundary):
             phys_row = fx.Int32(-1)
-            if arith.cmpi(CmpIPredicate.slt, row_idx_i32, _raw(kv_tile_end_i32)):
+            if fx.Int32(row_idx_i32) < fx.Int32(kv_tile_end_i32):
                 phys_row = buffer_ops.buffer_load(
                     kv_page_indices_rsrc, row_idx_i32, vec_width=1, dtype=fx.Int32
                 )
@@ -439,14 +436,14 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         lds_warp_offset = block_idx_const * KV_BLOCK_BYTES
         # p_lds_kv_warp points to warp's sub-block start.
         # Actual LDS target: p_lds_kv_warp + block*KV_BLOCK_BYTES - block*64
-        _lds_adj = arith.constant(
+        lds_adjust = arith.constant(
             lds_warp_offset - block_idx_const * KV_NUM_COLS, type=T.i32
         )
-        lds_base_i32 = _raw(arith.ArithValue(p_lds_kv_warp_i32) + _lds_adj)
+        lds_base_i32 = _raw(arith.ArithValue(p_lds_kv_warp_i32) + lds_adjust)
 
         if const_expr(check_boundary):
             neg_one = _raw(arith.constant(-1, type=T.i32))
-            is_oob = arith.cmpi(CmpIPredicate.eq, _raw(row_i32), neg_one)
+            is_oob = fx.Int32(row_i32) == fx.Int32(neg_one)
             if is_oob:
                 # Write zero via ds_write_b32 at lane's position
                 zero_u32 = _raw(arith.constant(0, type=T.i32))
@@ -533,10 +530,10 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             allowing runtime bypass.
         """
         lds_warp_offset = block_idx_const * KV_BLOCK_BYTES
-        _lds_adj2 = arith.constant(
+        lds_adjust = arith.constant(
             lds_warp_offset - block_idx_const * KV_NUM_COLS, type=T.i32
         )
-        lds_base_i32 = _raw(arith.ArithValue(p_lds_kv_warp_i32) + _lds_adj2)
+        lds_base_i32 = _raw(arith.ArithValue(p_lds_kv_warp_i32) + lds_adjust)
 
         def _emit_normal_load():
             voff = _raw(
@@ -564,7 +561,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         else:
             # Build OOB condition: row == -1
             neg_one = _raw(arith.constant(-1, type=T.i32))
-            is_oob = arith.cmpi(CmpIPredicate.eq, _raw(row_i32), neg_one)
+            is_oob = fx.Int32(row_i32) == fx.Int32(neg_one)
             # If check_boundary is a runtime i1, AND it in
             if const_expr(check_boundary is not True):
                 is_oob = _raw(arith.ArithValue(check_boundary) & arith.ArithValue(is_oob))
@@ -592,29 +589,23 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     # Per-lane dynamic part of the K LDS address, stored as an LDS pointer.
     # All K loads use this as base + GEP(fixed_offset), so LLVM can fold
     # the fixed_offset into ds_read's 16-bit immediate offset field.
-    _k_row_in_mfma = lane_idx % arith.index(MFMA_M)
-    _k_row_phy = (_k_row_in_mfma / arith.index(2)) * arith.index(
-        4
-    ) + _k_row_in_mfma % arith.index(2)
-    _k_col_in_lane = (lane_idx / arith.index(MFMA_M)) * arith.index(MFMA_ELEM_PER_THR)
-    _k_lds_lane_offset = (
-        (_k_row_phy / arith.index(4)) * arith.index(KV_SUB_BYTES)
-        + (_k_row_phy % arith.index(4)) * arith.index(KV_BYTES_PER_ROW)
-        + (_k_col_in_lane % arith.index(KV_NUM_COLS))
+    k_row_in_mfma = lane_idx % MFMA_M
+    k_row_phy = (k_row_in_mfma / 2) * 4 + k_row_in_mfma % 2
+    k_col_in_lane = (lane_idx / MFMA_M) * MFMA_ELEM_PER_THR
+    k_lds_lane_offset = (
+        (k_row_phy / 4) * KV_SUB_BYTES
+        + (k_row_phy % 4) * KV_BYTES_PER_ROW
+        + (k_col_in_lane % KV_NUM_COLS)
     )
 
     # ---- Vt LDS lane base offset (computed once, shared across all Vt loads) ----
-    _vt_row_blk = lane_idx / arith.index(16)
-    _vt_col_blk = (lane_idx % arith.index(16)) / arith.index(VT_COLS_PER_THR)
-    _vt_row_inblk = lane_idx % arith.index(VT_ROWS_PER_THR)
-    _vt_col_inblk = (
-        (lane_idx % arith.index(8)) / arith.index(VT_ROWS_PER_THR)
-    ) * arith.index(VT_ROWS_PER_THR)
-    _vt_block_offset = (
-        _vt_row_blk * arith.index(VT_BLKS_PER_ROW_PAD) + _vt_col_blk
-    ) * arith.index(VT_ELEMS_PER_BLK)
-    _vt_inblock_offset = _vt_row_inblk * arith.index(VT_COLS_PER_THR) + _vt_col_inblk
-    _vt_lds_lane_offset = _vt_block_offset + _vt_inblock_offset
+    vt_row_blk = lane_idx / 16
+    vt_col_blk = (lane_idx % 16) / VT_COLS_PER_THR
+    vt_row_inblk = lane_idx % VT_ROWS_PER_THR
+    vt_col_inblk = ((lane_idx % 8) / VT_ROWS_PER_THR) * VT_ROWS_PER_THR
+    vt_block_offset = (vt_row_blk * VT_BLKS_PER_ROW_PAD + vt_col_blk) * VT_ELEMS_PER_BLK
+    vt_inblock_offset = vt_row_inblk * VT_COLS_PER_THR + vt_col_inblk
+    vt_lds_lane_offset = vt_block_offset + vt_inblock_offset
 
     # ---- Helper: load K sub-tile from LDS (16x32 for MFMA) ----
     def _load_k_from_lds(k_base_i32, row_offset, col_offset):
@@ -657,24 +648,20 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
           col = (lane%16)*8 + (warp/2)*128
         Returns 8 i32 values.
         """
-        row = (warp_idx_val % arith.index(2)) * arith.index(16) + (
-            lane_idx_val / arith.index(16)
-        ) * arith.index(4)
-        row_mod16 = row % arith.index(16)
+        row = (warp_idx_val % 2) * 16 + (lane_idx_val / 16) * 4
+        row_mod16 = row % 16
         row_phy = (
-            (row_mod16 / arith.index(2)) * arith.index(4)
-            + arith.index(2) * (row / arith.index(16))
-            + row % arith.index(2)
+            (row_mod16 / 2) * 4
+            + 2 * (row / 16)
+            + row % 2
         )
-        col = (lane_idx_val % arith.index(16)) * arith.index(8) + (
-            warp_idx_val / arith.index(2)
-        ) * arith.index(128)
+        col = (lane_idx_val % 16) * 8 + (warp_idx_val / 2) * 128
 
         lds_v_offset = (
-            (row_phy / arith.index(4)) * arith.index(KV_SUB_BYTES)
-            + (row_phy % arith.index(4)) * arith.index(KV_BYTES_PER_ROW)
-            + (col / arith.index(KV_NUM_COLS)) * arith.index(KV_BLOCK_BYTES)
-            + (col % arith.index(KV_NUM_COLS))
+            (row_phy / 4) * KV_SUB_BYTES
+            + (row_phy % 4) * KV_BYTES_PER_ROW
+            + (col / KV_NUM_COLS) * KV_BLOCK_BYTES
+            + (col % KV_NUM_COLS)
         )
 
         lds_addr = p_lds_kv_base_idx + lds_v_offset
@@ -696,8 +683,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                 static_byte_offset=off,
             )
             data_vec = Vec(data)
-            v_vals.append(_raw(data_vec[0]))
-            v_vals.append(_raw(data_vec[1]))
+            v_vals.append(data_vec[0])
+            v_vals.append(data_vec[1])
         return v_vals  # 8 i32 values
 
     # ---- Helper: transpose V in-register ----
@@ -741,25 +728,19 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         col_blk = (lane%16) + (warp/2)*16
         block_offset = (row_blk * VT_BLKS_PER_ROW_PAD + col_blk) * VT_ELEMS_PER_BLK
         """
-        row_blk = (warp_idx_val % arith.index(2)) * arith.index(
-            4
-        ) + lane_idx_val / arith.index(16)
-        col_blk = (lane_idx_val % arith.index(16)) + (
-            warp_idx_val / arith.index(2)
-        ) * arith.index(16)
-        block_offset = (
-            row_blk * arith.index(VT_BLKS_PER_ROW_PAD) + col_blk
-        ) * arith.index(VT_ELEMS_PER_BLK)
+        row_blk = (warp_idx_val % 2) * 4 + lane_idx_val / 16
+        col_blk = (lane_idx_val % 16) + (warp_idx_val / 2) * 16
+        block_offset = (row_blk * VT_BLKS_PER_ROW_PAD + col_blk) * VT_ELEMS_PER_BLK
         lds_vt_addr = vt_lds_base_idx + block_offset
 
         # ds_write_b128 x 2 (4 dwords each = 32 fp8)
-        lo_packed = vector.from_elements(T.i32x4, vt8[0:4])
+        lo_packed = Vec.from_elements(vt8[0:4], fx.Int32)
         lo_i8 = Vec(lo_packed).bitcast(fx.Int8)
         vector.store(lo_i8, lds_buffer, [_raw(lds_vt_addr)])
 
-        hi_packed = vector.from_elements(T.i32x4, vt8[4:8])
+        hi_packed = Vec.from_elements(vt8[4:8], fx.Int32)
         hi_i8 = Vec(hi_packed).bitcast(fx.Int8)
-        vector.store(hi_i8, lds_buffer, [_raw(lds_vt_addr + arith.index(16))])
+        vector.store(hi_i8, lds_buffer, [_raw(lds_vt_addr + 16)])
 
     # ---- Helper: load transposed V from Vt LDS ----
     def _load_vt_from_lds(vt_base_i32, col_offset):
@@ -769,7 +750,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         vt_base_i32: i32 LDS byte address with lane offset pre-baked.
         col_offset: Python int, multiple of 16, in [0, 512).
 
-        Lane offset pre-computed in _vt_lds_lane_offset (top level).
+        Lane offset pre-computed in vt_lds_lane_offset (top level).
         Only col_offset contributes a fixed immediate offset here.
         offset_tl_bl = 4 * VT_BLKS_PER_ROW_PAD * VT_ELEMS_PER_BLK = 8448
         """
@@ -833,8 +814,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         """
         p_lds_q_warp = (
             lds_base_idx
-            + arith.index(P_LDS_Q)
-            + warp_idx * arith.index(SZ_LDS_Q_PER_WARP)
+            + P_LDS_Q
+            + warp_idx * SZ_LDS_Q_PER_WARP
         )
 
         # VRAM addressing: row = lane/4, col = (lane%4)*16
@@ -850,29 +831,29 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         )
         s_offset_i32 = _raw(arith.ArithValue(s_offset_i32) + arith.ArithValue(q_base_offset))
 
-        row = lane_idx / arith.index(4)
-        col = (lane_idx % arith.index(4)) * arith.index(16)
-        v_offset_i32 = _index_cast_to_i32(row * arith.index(QK_HEAD_DIM) + col)
+        row = lane_idx / 4
+        col = (lane_idx % 4) * 16
+        v_offset_i32 = _index_cast_to_i32(row * QK_HEAD_DIM + col)
 
         # LDS store layout (QManagerV3):
         # row_st = lane/4, col_st = (lane%4)*16
         # v_offset_st = (row_st/2)*Q_BYTES_PER_2ROWS + ((row_st%2)*64 + col_st)
-        row_st = lane_idx / arith.index(4)
-        col_st = (lane_idx % arith.index(4)) * arith.index(16)
+        row_st = lane_idx / 4
+        col_st = (lane_idx % 4) * 16
         lds_st_offset = (
-            (row_st / arith.index(2)) * arith.index(Q_BYTES_PER_2ROWS)
-            + (row_st % arith.index(2)) * arith.index(Q_ELEM_PER_ROW)
+            (row_st / 2) * Q_BYTES_PER_2ROWS
+            + (row_st % 2) * Q_ELEM_PER_ROW
             + col_st
         )
 
         # LDS read layout (MFMA-compatible):
         # row_ld = lane%16, col_ld = (lane/16)*8
         # v_offset_ld = (row_ld/2)*Q_BYTES_PER_2ROWS + ((row_ld%2)*64 + col_ld)
-        row_ld = lane_idx % arith.index(16)
-        col_ld = (lane_idx / arith.index(16)) * arith.index(8)
+        row_ld = lane_idx % 16
+        col_ld = (lane_idx / 16) * 8
         lds_ld_offset = (
-            (row_ld / arith.index(2)) * arith.index(Q_BYTES_PER_2ROWS)
-            + (row_ld % arith.index(2)) * arith.index(Q_ELEM_PER_ROW)
+            (row_ld / 2) * Q_BYTES_PER_2ROWS
+            + (row_ld % 2) * Q_ELEM_PER_ROW
             + col_ld
         )
 
@@ -964,9 +945,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                     arith.ArithValue(_raw(col_0_start_i32))
                     + arith.constant(sub_offset, type=T.i32)
                 )
-                is_oob = arith.cmpi(
-                    CmpIPredicate.sge, pos_i32, _raw(kv_end_i32)
-                )
+                is_oob = fx.Int32(pos_i32) >= fx.Int32(kv_end_i32)
                 # If check_boundary is a runtime i1, AND it in
                 if const_expr(check_boundary is not True):
                     is_oob = _raw(arith.ArithValue(check_boundary) & arith.ArithValue(is_oob))
@@ -989,9 +968,9 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         Returns: (p_exp_vals, row_max_new, row_sum_e_new, rescale)
         """
         # Column index for this thread's first element
-        col_0_idx = lane_idx / arith.index(16)
+        col_0_idx = lane_idx / 16
         col_0_start_i32 = _raw(
-            arith.ArithValue(_index_cast_to_i32(col_0_idx * arith.index(4)))
+            arith.ArithValue(_index_cast_to_i32(col_0_idx * 4))
             + kv_tile_start_i32
         )
 
@@ -1082,7 +1061,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     def _rescale_oaccu(oaccu, rescale):
         """Multiply all oaccu accumulators by rescale factor.
         Descending s_setprio 3->0 across 4 groups of 8 muls."""
-        rescale_vec = vector.broadcast(T.f32x4, _raw(rescale))
+        rescale_vec = Vec.filled(4, fx.Float32(rescale), fx.Float32)
         result = [None] * len(oaccu)
         for group in range_constexpr(4):
             rocdl.s_setprio(3 - group)
@@ -1125,7 +1104,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # ---- K base VGPR (baked-in lane offset) ----
         k_base_i32 = _raw(
             arith.ArithValue(_index_cast_to_i32(p_lds_kv_base))
-            + arith.ArithValue(_index_cast_to_i32(_k_lds_lane_offset))
+            + arith.ArithValue(_index_cast_to_i32(k_lds_lane_offset))
         )
 
         do_prefetch = p_lds_kv_next_warp_i32 is not None
@@ -1239,7 +1218,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
         # ---- Transpose V and store to Vt LDS ----
         vt8 = _transpose_v(v8_raw)
-        vt_lds_base = lds_base_idx + arith.index(P_LDS_VT)
+        vt_lds_base = lds_base_idx + P_LDS_VT
         _store_vt_to_lds(vt_lds_base, warp_idx, lane_idx, vt8)
 
         # ---- Pack P to fp8 ----
@@ -1356,68 +1335,67 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
     # ---- Pre-compute LDS reshape addresses (computed once, reused per store) ----
     # bf16 LDS write address (MFMA layout): row_st = lane%16, col_st = (lane/16)*4
-    _li = arith.ArithValue(_raw(lane_idx_i32))
-    _c2 = arith.constant(2, type=T.i32)
-    _c4 = arith.constant(4, type=T.i32)
-    _c8 = arith.constant(8, type=T.i32)
-    _c16_i = arith.constant(16, type=T.i32)
+    lane_i32 = arith.ArithValue(_raw(lane_idx_i32))
+    c2_i32 = arith.constant(2, type=T.i32)
+    c4_i32 = arith.constant(4, type=T.i32)
+    c8_i32 = arith.constant(8, type=T.i32)
+    c16_i32 = arith.constant(16, type=T.i32)
 
-    _o16_row_st = arith.RemUIOp(_raw(_li), _raw(_c16_i)).result
-    _o16_col_st = _raw(
-        arith.ArithValue(arith.DivUIOp(_raw(_li), _raw(_c16_i)).result) * _c4
+    o16_row_st = arith.RemUIOp(_raw(lane_i32), _raw(c16_i32)).result
+    o16_col_st = _raw(
+        arith.ArithValue(arith.DivUIOp(_raw(lane_i32), _raw(c16_i32)).result) * c4_i32
     )
     # get_v_offset_lds(r,c) = ((r/2)*68 + (r%2)*32 + c) * 2  [bytes]
-    _o16_st_r = arith.ArithValue(_o16_row_st)
-    _o16_st_offset = _raw(
+    o16_st_offset = _raw(
         (
-            arith.ArithValue(arith.DivUIOp(_o16_row_st, _raw(_c2)).result)
+            arith.ArithValue(arith.DivUIOp(o16_row_st, _raw(c2_i32)).result)
             * arith.constant(O16_ELEM_PER_PAD_2ROWS, type=T.i32)
-            + arith.ArithValue(arith.RemUIOp(_o16_row_st, _raw(_c2)).result)
+            + arith.ArithValue(arith.RemUIOp(o16_row_st, _raw(c2_i32)).result)
             * arith.constant(O16_NUM_COLS, type=T.i32)
-            + arith.ArithValue(_o16_col_st)
+            + arith.ArithValue(o16_col_st)
         )
-        * _c2  # sizeof(bf16)
+        * c2_i32  # sizeof(bf16)
     )
 
     # bf16 LDS read address (coalesced layout): row_ld = lane/4, col_ld = (lane%4)*8
-    _o16_row_ld = arith.DivUIOp(_raw(_li), _raw(_c4)).result
-    _o16_col_ld = _raw(
-        arith.ArithValue(arith.RemUIOp(_raw(_li), _raw(_c4)).result) * _c8
+    o16_row_ld = arith.DivUIOp(_raw(lane_i32), _raw(c4_i32)).result
+    o16_col_ld = _raw(
+        arith.ArithValue(arith.RemUIOp(_raw(lane_i32), _raw(c4_i32)).result) * c8_i32
     )
-    _o16_rd_offset = _raw(
+    o16_rd_offset = _raw(
         (
-            arith.ArithValue(arith.DivUIOp(_o16_row_ld, _raw(_c2)).result)
+            arith.ArithValue(arith.DivUIOp(o16_row_ld, _raw(c2_i32)).result)
             * arith.constant(O16_ELEM_PER_PAD_2ROWS, type=T.i32)
-            + arith.ArithValue(arith.RemUIOp(_o16_row_ld, _raw(_c2)).result)
+            + arith.ArithValue(arith.RemUIOp(o16_row_ld, _raw(c2_i32)).result)
             * arith.constant(O16_NUM_COLS, type=T.i32)
-            + arith.ArithValue(_o16_col_ld)
+            + arith.ArithValue(o16_col_ld)
         )
-        * _c2  # sizeof(bf16)
+        * c2_i32  # sizeof(bf16)
     )
 
     # f32 LDS write address: same row_st/col_st but different padding
     # get_v_offset_lds(r,c) = (r * 36 + c) * 4  [bytes]
-    _o32_st_offset = _raw(
+    o32_st_offset = _raw(
         (
-            arith.ArithValue(_o16_row_st)  # reuse: lane%16
+            arith.ArithValue(o16_row_st)  # reuse: lane%16
             * arith.constant(O32_ELEM_PER_PAD_ROW, type=T.i32)
-            + arith.ArithValue(_o16_col_st)  # reuse: (lane/16)*4
+            + arith.ArithValue(o16_col_st)  # reuse: (lane/16)*4
         )
-        * _c4  # sizeof(f32)
+        * c4_i32  # sizeof(f32)
     )
 
     # f32 LDS read address: row_ld = lane/8, col_ld = (lane%8)*4
-    _o32_row_ld = arith.DivUIOp(_raw(_li), _raw(_c8)).result
-    _o32_col_ld = _raw(
-        arith.ArithValue(arith.RemUIOp(_raw(_li), _raw(_c8)).result) * _c4
+    o32_row_ld = arith.DivUIOp(_raw(lane_i32), _raw(c8_i32)).result
+    o32_col_ld = _raw(
+        arith.ArithValue(arith.RemUIOp(_raw(lane_i32), _raw(c8_i32)).result) * c4_i32
     )
-    _o32_rd_offset = _raw(
+    o32_rd_offset = _raw(
         (
-            arith.ArithValue(_o32_row_ld)
+            arith.ArithValue(o32_row_ld)
             * arith.constant(O32_ELEM_PER_PAD_ROW, type=T.i32)
-            + arith.ArithValue(_o32_col_ld)
+            + arith.ArithValue(o32_col_ld)
         )
-        * _c4  # sizeof(f32)
+        * c4_i32  # sizeof(f32)
     )
 
     def _store_oaccu_pair_bf16(oaccu_a, oaccu_b, tile_idx, p_lds_o_i32, row_base_i32):
@@ -1431,12 +1409,12 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             arith.ArithValue(p_lds_o_i32)
             + warp_idx_i32 * arith.constant(O16_LDS_PER_WARP, type=T.i32)
         )
-        lds_st_addr = _raw(arith.ArithValue(lds_warp) + arith.ArithValue(_o16_st_offset))
+        lds_st_addr = _raw(arith.ArithValue(lds_warp) + arith.ArithValue(o16_st_offset))
 
         # LDS write: 2 sub-blocks -> 2x ds_write_b64
         for sub, acc_val in enumerate([oaccu_a, oaccu_b]):
             dw0, dw1 = _pack_f32x4_to_bf16_2dw(acc_val)
-            vec_2dw = vector.from_elements(T.i32x2, [dw0, dw1])
+            vec_2dw = Vec.from_elements([dw0, dw1], fx.Int32)
             sub_offset = sub * O16_NUM_COLS  # 0 or 32 bytes (16 bf16 cols x 2 bytes)
             st_addr_sub = _raw(
                 arith.ArithValue(lds_st_addr) + arith.constant(sub_offset, type=T.i32)
@@ -1453,7 +1431,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
         # LDS read: ds_read_b128 (4 dwords = 8 bf16 in coalesced layout)
-        lds_rd_addr = _raw(arith.ArithValue(lds_warp) + arith.ArithValue(_o16_rd_offset))
+        lds_rd_addr = _raw(arith.ArithValue(lds_warp) + arith.ArithValue(o16_rd_offset))
         rd_i64 = _raw(arith.ArithValue(lds_rd_addr).extui(T.i64))
         rd_ptr = _inttoptr_lds(rd_i64)
         data = llvm.LoadOp(T.i32x4, rd_ptr, alignment=16).result  # ds_read_b128
@@ -1463,8 +1441,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # Coalesced VRAM store: buffer_store_dwordx4
         # row = row_ld + row_base, col = col_ld + tile_idx * MFMA_N * 2
         col_offset_i32 = arith.constant(tile_idx * MFMA_N * 2, type=T.i32)
-        row_vram = arith.ArithValue(row_base_i32) + arith.ArithValue(_o16_row_ld)
-        col_vram = arith.ArithValue(_o16_col_ld) + col_offset_i32
+        row_vram = arith.ArithValue(row_base_i32) + arith.ArithValue(o16_row_ld)
+        col_vram = arith.ArithValue(o16_col_ld) + col_offset_i32
         vram_offset = _raw(
             (row_vram * arith.constant(V_HEAD_DIM, type=T.i32) + col_vram)
             * arith.constant(2, type=T.i32)  # sizeof(bf16)
@@ -1488,7 +1466,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             arith.ArithValue(p_lds_o_i32)
             + warp_idx_i32 * arith.constant(O32_LDS_PER_WARP, type=T.i32)
         )
-        lds_st_addr = _raw(arith.ArithValue(lds_warp) + arith.ArithValue(_o32_st_offset))
+        lds_st_addr = _raw(arith.ArithValue(lds_warp) + arith.ArithValue(o32_st_offset))
 
         col_offset_i32 = _raw(arith.constant(tile_idx * MFMA_N * 2, type=T.i32))
         O32_LD_DELTA = 8 * O32_ELEM_PER_PAD_ROW * 4  # 1152 bytes between round 0/1
@@ -1507,7 +1485,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
         # LDS read: 2x ds_read_b128 (round 0 = rows 0-7, round 1 = rows 8-15)
-        lds_rd_addr = _raw(arith.ArithValue(lds_warp) + arith.ArithValue(_o32_rd_offset))
+        lds_rd_addr = _raw(arith.ArithValue(lds_warp) + arith.ArithValue(o32_rd_offset))
         rd_i64 = _raw(arith.ArithValue(lds_rd_addr).extui(T.i64))
         rd_ptr = _inttoptr_lds(rd_i64)
         data_0 = llvm.LoadOp(T.f32x4, rd_ptr, alignment=16).result  # rows 0-7
@@ -1518,8 +1496,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
         # 2x coalesced VRAM store
         # Round 0: row = row_ld_base(0..7) + row_base
-        row_vram_0 = arith.ArithValue(row_base_i32) + arith.ArithValue(_o32_row_ld)
-        col_vram = arith.ArithValue(_o32_col_ld) + arith.ArithValue(col_offset_i32)
+        row_vram_0 = arith.ArithValue(row_base_i32) + arith.ArithValue(o32_row_ld)
+        col_vram = arith.ArithValue(o32_col_ld) + arith.ArithValue(col_offset_i32)
         vram_off_0 = _raw(
             (row_vram_0 * arith.constant(V_HEAD_DIM, type=T.i32) + col_vram)
             * arith.constant(4, type=T.i32)  # sizeof(f32)
@@ -1567,8 +1545,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         4. Multiply by reci_sum
         5. Store immediately (bf16 or f32 split)
         """
-        rescale_vec = vector.broadcast(T.f32x4, _raw(rescale))
-        reci_vec = vector.broadcast(T.f32x4, reci_sum)
+        rescale_vec = Vec.filled(4, fx.Float32(rescale), fx.Float32)
+        reci_vec = Vec.filled(4, fx.Float32(reci_sum), fx.Float32)
         c32_i64_pv = _raw(arith.constant(32, type=T.i64))
 
         _barrier(lgkmcnt=0)
@@ -1722,8 +1700,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     # lds_base_idx + P_LDS_VT + lane offset).  Computed once here so
     # _gemm2_with_rescale can use it outside branches.
     vt_base_i32 = _raw(
-        arith.ArithValue(_index_cast_to_i32(lds_base_idx + arith.index(P_LDS_VT)))
-        + arith.ArithValue(_index_cast_to_i32(_vt_lds_lane_offset))
+        arith.ArithValue(_index_cast_to_i32(lds_base_idx + P_LDS_VT))
+        + arith.ArithValue(_index_cast_to_i32(vt_lds_lane_offset))
     )
 
     # ==================================================================
@@ -1734,49 +1712,37 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         wi_base_i32 = _index_cast_to_i32(work_idx * SIZE_MLA_WORK_INFO_IN_DW)
         wi_dw1_4 = buffer_ops.buffer_load(
             work_info_set_rsrc,
-            arith.addi(wi_base_i32, arith.constant(1, type=T.i32)),
+            wi_base_i32 + 1,
             vec_width=4,
             dtype=T.i32,
         )
         wi_dw5 = buffer_ops.buffer_load(
             work_info_set_rsrc,
-            arith.addi(wi_base_i32, arith.constant(5, type=T.i32)),
+            wi_base_i32 + 5,
             vec_width=1,
             dtype=T.i32,
         )
         wi_dw1_4_vec = Vec(wi_dw1_4)
         partial_qo_loc = rocdl.readfirstlane(T.i32, wi_dw1_4_vec[0])
         qo_start = rocdl.readfirstlane(T.i32, wi_dw1_4_vec[1])
-        qo_end = rocdl.readfirstlane(T.i32, wi_dw1_4_vec[2])
         kv_start = rocdl.readfirstlane(T.i32, wi_dw1_4_vec[3])
         kv_end = rocdl.readfirstlane(T.i32, _raw(wi_dw5))
-        kv_len = arith.subi(kv_end, kv_start)
+        kv_len = kv_end - kv_start
 
         # ---- KV tile iteration ----
         # Initialize softmax state
         row_max = _raw(c_neg_inf_f32)
         row_sum_e = _raw(c_zero_f32)
-        oaccu = [_raw(c_zero_v4f32)] * (NUM_PV_ITERS * 2)
 
         # Compute number of tiles
-        c_block_n = arith.constant(BLOCK_N, type=T.i32)
-        c_block_n_m1 = arith.constant(BLOCK_N - 1, type=T.i32)
-        num_tiles = arith.divui(arith.addi(kv_len, c_block_n_m1), c_block_n)
-        num_tiles_idx = arith.index_cast(T.index, num_tiles)
+        c_block_n = fx.Int32(BLOCK_N)
+        num_tiles = (fx.Uint32(kv_len) + (BLOCK_N - 1)) // BLOCK_N
 
         # --- Pre-compute boundary flags ---
-        first_tile_needs_boundary = arith.cmpi(
-            CmpIPredicate.slt, _raw(kv_len), _raw(c_block_n),
-        )
-        has_multi_tiles = arith.cmpi(
-            CmpIPredicate.sgt, _raw(kv_len), _raw(c_block_n),
-        )
+        first_tile_needs_boundary = fx.Int32(kv_len) < fx.Int32(c_block_n)
+        has_multi_tiles = fx.Int32(kv_len) > fx.Int32(c_block_n)
         # last_tile_partial: (kv_len & (BLOCK_N-1)) != 0
-        last_tile_partial = arith.cmpi(
-            CmpIPredicate.ne,
-            _raw(arith.ArithValue(_raw(kv_len)) & c_block_n_m1),
-            _raw(arith.constant(0, type=T.i32)),
-        )
+        last_tile_partial = (fx.Int32(kv_len) & (BLOCK_N - 1)) != 0
 
         # --- First tile: resolve KV row (branched on boundary) ---
         row_kv_ld_first = fx.Int32(-1)
@@ -1807,12 +1773,10 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
         # --- Tile-1 row resolution (only meaningful for multi-tile) ---
         # tile1_is_full: kv_start + 2*BN <= kv_end (equiv to num_tiles >= 3)
-        c_2bn = arith.constant(2 * BLOCK_N, type=T.i32)
         kv_start_plus_bn = _raw(kv_start + c_block_n)
+        c_2bn = arith.constant(2 * BLOCK_N, type=T.i32)
         kv_start_plus_2bn = _raw(kv_start + c_2bn)
-        tile1_is_full = arith.cmpi(
-            CmpIPredicate.sle, kv_start_plus_2bn, _raw(kv_end),
-        )
+        tile1_is_full = fx.Int32(kv_start_plus_2bn) <= fx.Int32(kv_end)
         row_kv_ld_tile1 = fx.Int32(-1)
         if tile1_is_full:
             # Tile 1 is full -> no boundary check, tile_end = start+2*BN
@@ -1833,26 +1797,18 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # cbn=True when !tile1_is_full. This is correct regardless of last_tile_partial because
         # when num_tiles==2 and !tile1_is_full, the next tile IS the last and IS partial.
         # !tile1_is_full: kv_start + 2*BN > kv_end (num_tiles == 2, next tile partial)
-        first_tile_cbn = arith.cmpi(
-            CmpIPredicate.sgt, kv_start_plus_2bn, _raw(kv_end),
-        )
-
-        # --- Process first tile ---
-        # 5 values through phi: rm, rse, p_pack, rescale, row_kv_ld_nn
-        first_result_types = [T.f32, T.f32, T.i64, T.f32, T.i32]
+        first_tile_cbn = fx.Int32(kv_start_plus_2bn) > fx.Int32(kv_end)
 
         # 2-ahead resolve params for first tile (tile 0 -> resolve tile 2)
         # nn_start = kv_start + 2*BN, nn_end = kv_end (always boundary check)
         # do_resolve: tile 2 exists iff kv_start + 2*BN < kv_end
-        do_resolve_nn_first = arith.cmpi(
-            CmpIPredicate.slt, kv_start_plus_2bn, _raw(kv_end),
-        )
+        do_resolve_nn_first = fx.Int32(kv_start_plus_2bn) < fx.Int32(kv_end)
 
         # Branch on has_multi_tiles: multi-tile gets prefetch, single doesn't
         p_pack_first = fx.Int64(0)
         rescale_first = c_one_f32
         row_kv_ld_nn_first = fx.Int32(-1)
-        if has_multi_tiles:
+        if _raw(has_multi_tiles):
             # Multi-tile: first tile is always full, prefetch tile 1.
             # Sub-branch on first_tile_cbn for compile-time check_boundary_next.
             if first_tile_cbn:
@@ -1874,7 +1830,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                     kv_ld_col_base_i32_arg=kv_ld_col_base_i32,
                     check_boundary_next=True,
                     nn_resolve_start=kv_start_plus_2bn,
-                    nn_resolve_end=_raw(kv_end),
+                    nn_resolve_end=kv_end,
                     do_resolve_nn=do_resolve_nn_first,
                 )
             else:
@@ -1896,7 +1852,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                     kv_ld_col_base_i32_arg=kv_ld_col_base_i32,
                     check_boundary_next=False,
                     nn_resolve_start=kv_start_plus_2bn,
-                    nn_resolve_end=_raw(kv_end),
+                    nn_resolve_end=kv_end,
                     do_resolve_nn=do_resolve_nn_first,
                 )
         else:
@@ -1917,19 +1873,10 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
         def _write_lse(pqo_loc_i32, rm, rse):
             """Write LSE for split output (first 16 lanes per warp)."""
-            if arith.cmpi(
-                CmpIPredicate.ult, lane_idx_i32, arith.constant(16, type=T.i32)
-            ):
-                log2_sum = _math.log2(_raw(rse))
-                ln_sum = arith.MulFOp(
-                    log2_sum, _raw(c_inv_log2e), fastmath=fm_fast
-                ).result
-                lse = arith.AddFOp(_raw(rm), ln_sum, fastmath=fm_fast).result
-                row_idx_i32 = _raw(
-                    lane_idx_i32
-                    + warp_idx_i32 * arith.constant(16, type=T.i32)
-                    + arith.ArithValue(pqo_loc_i32) * arith.constant(NUM_QO_HEADS, type=T.i32)
-                )
+            if fx.Int32(lane_idx_i32) < 16:
+                log2_sum = fmath.log2(rse, fastmath=fm_fast)
+                lse = fmath.fma(log2_sum, c_inv_log2e, rm, fastmath=fm_fast)
+                row_idx_i32 = lane_idx_i32 + warp_idx_i32 * 16 + fx.Int32(pqo_loc_i32) * NUM_QO_HEADS
                 buffer_ops.buffer_store(lse, split_lse_rsrc, row_idx_i32)
 
         # LDS base for output reshape (reuse KV buffer 0 region)
@@ -1948,18 +1895,10 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             Branches on partial_qo_loc to select bf16 vs f32 split output.
             """
             reci = arith.DivFOp(_raw(c_one_f32), _raw(rse), fastmath=fm_fast).result
-            is_not_split = arith.cmpi(
-                CmpIPredicate.slt,
-                _raw(partial_qo_loc),
-                _raw(arith.constant(0, type=T.i32)),
-            )
-            if_out = scf.IfOp(is_not_split, [], has_else=True)
-            with ir.InsertionPoint(if_out.regions[0].blocks[0]):
+            is_not_split = fx.Int32(partial_qo_loc) < 0
+            if is_not_split:
                 # bf16 final output: row_base = qo_start * NUM_QO_HEADS + warp*16
-                rb_bf16 = _raw(
-                    arith.ArithValue(_raw(qo_start)) * arith.constant(NUM_QO_HEADS, type=T.i32)
-                    + warp_idx_i32 * arith.constant(16, type=T.i32)
-                )
+                rb_bf16 = fx.Int32(qo_start) * NUM_QO_HEADS + warp_idx_i32 * 16
                 _gemm2_last_with_store(
                     pp,
                     rs,
@@ -1971,13 +1910,9 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                     rb_bf16,
                     is_first_iter_flag,
                 )
-                scf.YieldOp([])
-            with ir.InsertionPoint(if_out.regions[1].blocks[0]):
+            else:
                 # f32 split output: row_base = pqo_loc * NUM_QO_HEADS + warp*16
-                rb_split = _raw(
-                    arith.ArithValue(_raw(partial_qo_loc)) * arith.constant(NUM_QO_HEADS, type=T.i32)
-                    + warp_idx_i32 * arith.constant(16, type=T.i32)
-                )
+                rb_split = fx.Int32(partial_qo_loc) * NUM_QO_HEADS + warp_idx_i32 * 16
                 _gemm2_last_with_store(
                     pp,
                     rs,
@@ -1990,7 +1925,6 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                     is_first_iter_flag,
                 )
                 _write_lse(_raw(partial_qo_loc), rm, rse)
-                scf.YieldOp([])
 
         # ---- Multi-tile vs single-tile dispatch ----
         if_multi = scf.IfOp(has_multi_tiles, [], has_else=True)
@@ -2001,21 +1935,16 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             oaccu_mt = _gemm2_first_iter(p_pack_first, vt_base_i32)
 
             # --- Middle tiles [1, num_tiles-1) via scf.ForOp ---
-            c_one_idx = arith.index(1)
-            num_tiles_m1 = arith.subi(num_tiles, arith.constant(1, type=T.i32))
-            num_tiles_m1_idx = arith.index_cast(T.index, num_tiles_m1)
-            num_tiles_m2 = arith.subi(num_tiles, arith.constant(2, type=T.i32))
+            c_one_idx = fx.Index(1)
+            num_tiles_m1 = num_tiles - 1
+            num_tiles_m1_idx = fx.Index(num_tiles_m1)
+            num_tiles_m2 = num_tiles - 2
 
             init_args = [row_max, row_sum_e] + oaccu_mt + [row_kv_ld_nn_first]
-            init_args = [
-                _raw(v) if not isinstance(v, ir.Value) else v for v in init_args
-            ]
 
             for tile_iv, state in range(c_one_idx, num_tiles_m1_idx, c_one_idx, init=init_args):
-                tile_iv_i32 = _index_cast_to_i32(tile_iv)
-                kv_tile_start_i32 = _raw(
-                    kv_start + arith.ArithValue(tile_iv_i32) * c_block_n
-                )
+                tile_iv_i32 = fx.Int32(tile_iv)
+                kv_tile_start_i32 = kv_start + tile_iv_i32 * c_block_n
 
                 # Unpack carried state
                 rm_carried = state[0]
@@ -2052,7 +1981,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                     rm_m, rse_m, pp_m, rs_m, nn_m = _process_tile_gemm1(
                         curr_base_idx,
                         kv_tile_start_i32,
-                        _raw(kv_end),
+                        kv_end,
                         q_nope_packs,
                         q_rope_packs,
                         rm_carried,
@@ -2064,7 +1993,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                         kv_ld_col_base_i32_arg=kv_ld_col_base_i32,
                         check_boundary_next=True,
                         nn_resolve_start=nn_start_mid,
-                        nn_resolve_end=_raw(kv_end),
+                        nn_resolve_end=kv_end,
                         do_resolve_nn=do_resolve_nn_mid,
                     )
                 else:
@@ -2074,7 +2003,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                     rm_m, rse_m, pp_m, rs_m, nn_m = _process_tile_gemm1(
                         curr_base_idx,
                         kv_tile_start_i32,
-                        _raw(kv_end),
+                        kv_end,
                         q_nope_packs,
                         q_rope_packs,
                         rm_carried,
@@ -2086,14 +2015,11 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                         kv_ld_col_base_i32_arg=kv_ld_col_base_i32,
                         check_boundary_next=False,
                         nn_resolve_start=nn_start_mid,
-                        nn_resolve_end=_raw(kv_end),
+                        nn_resolve_end=kv_end,
                         do_resolve_nn=do_resolve_nn_mid,
                     )
                 oa_m = _gemm2_with_rescale(pp_m, rs_m, oaccu_carried, vt_base_i32)
                 yield_vals = [rm_m, rse_m] + oa_m + [nn_m]
-                yield_vals = [
-                    _raw(v) if not isinstance(v, ir.Value) else v for v in yield_vals
-                ]
                 results = yield yield_vals
 
             # Unpack results from middle tiles loop
@@ -2102,26 +2028,18 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             oaccu_mt = [results[2 + i] for i in range(NUM_PV_ITERS * 2)]
 
             # --- Last tile: GEMM1 + interleaved GEMM2 store ---
-            last_tile_iv_i32 = _raw(num_tiles_m1)
-            kv_last_start = _raw(
-                kv_start + arith.ArithValue(last_tile_iv_i32) * c_block_n
-            )
-            last_parity = _raw(
-                arith.ArithValue(last_tile_iv_i32) & arith.constant(1, type=T.i32)
-            )
-            last_is_odd = arith.cmpi(
-                CmpIPredicate.ne, last_parity, _raw(arith.constant(0, type=T.i32)),
-            )
-            last_curr_base = _raw(arith.select(
-                last_is_odd, _raw(p_lds_kv_1_base), _raw(p_lds_kv_0_base),
-            ))
+            last_tile_iv_i32 = fx.Int32(num_tiles_m1)
+            kv_last_start = kv_start + last_tile_iv_i32 * c_block_n
+            last_parity = last_tile_iv_i32 & 1
+            last_is_odd = fx.Int32(last_parity) != 0
+            last_curr_base = last_is_odd.select(p_lds_kv_1_base, p_lds_kv_0_base)
 
             _barrier(vmcnt=0, lgkmcnt=0)
             rocdl.sched_barrier(0)
             rm_l, rse_l, pp_l, rs_l, _nn_l = _process_tile_gemm1(
                 last_curr_base,
                 kv_last_start,
-                _raw(kv_end),
+                kv_end,
                 q_nope_packs,
                 q_rope_packs,
                 row_max_mt,

--- a/kernels/mla_fwd_decode_m16x8_fp8_fp8.py
+++ b/kernels/mla_fwd_decode_m16x8_fp8_fp8.py
@@ -16,7 +16,6 @@ NOTE: Do NOT use ``from __future__ import annotations`` here -- it breaks
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
-from flydsl._mlir.dialects import gpu as _mlir_gpu
 from flydsl._mlir.dialects import llvm, scf
 from flydsl._mlir.dialects import memref as _memref
 from flydsl.compiler.kernel_function import CompilationContext
@@ -25,6 +24,7 @@ from flydsl.expr import math as fmath
 from flydsl.expr.arith import _to_raw as _raw
 from flydsl.expr.typing import T
 from flydsl.expr.typing import Vector as Vec
+from flydsl.expr.utils.arith import ArithValue
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import SmemAllocator
 
@@ -184,62 +184,15 @@ def _inttoptr_lds(i64_val):
     return llvm.inttoptr(_LDS_PTR_TYPE, i64_val)
 
 
-def _get_element_ptr(base_ptr, byte_offset=None, static_byte_offset=0, elem_type=None):
-    """GEP-based pointer arithmetic."""
-    _GEP_DYN = -(2**31)
-    raw_ptr = _raw(base_ptr) if not isinstance(base_ptr, ir.Value) else base_ptr
-    if elem_type is None:
-        elem_type = T.i8
-
-    if byte_offset is None:
-        return llvm.GEPOp(
-            raw_ptr.type,
-            raw_ptr,
-            [],
-            [int(static_byte_offset)],
-            elem_type,
-            None,
-        ).result
-    elif isinstance(byte_offset, int):
-        return llvm.GEPOp(
-            raw_ptr.type,
-            raw_ptr,
-            [],
-            [int(byte_offset) + int(static_byte_offset)],
-            elem_type,
-            None,
-        ).result
-    else:
-        offset_val = (
-            _raw(byte_offset) if not isinstance(byte_offset, ir.Value) else byte_offset
-        )
-        if isinstance(offset_val.type, ir.IndexType):
-            offset_val = arith.index_cast(T.i64, offset_val)
-        if static_byte_offset != 0:
-            static_attr = ir.IntegerAttr.get(offset_val.type, int(static_byte_offset))
-            static_const = arith.ConstantOp(offset_val.type, static_attr).result
-            offset_val = _raw(arith.ArithValue(offset_val) + arith.ArithValue(static_const))
-        return llvm.GEPOp(
-            raw_ptr.type,
-            raw_ptr,
-            [offset_val],
-            [_GEP_DYN],
-            elem_type,
-            None,
-        ).result
+_gep = buffer_ops.get_element_ptr
 
 
 def _lds_load(byte_addr_index, vec_type, static_byte_offset=0):
     """LDS load via raw llvm.LoadOp on an LDS pointer (addr space 3)."""
-    raw_addr = (
-        _raw(byte_addr_index)
-        if not isinstance(byte_addr_index, ir.Value)
-        else byte_addr_index
-    )
-    addr_i64 = arith.index_cast(T.i64, raw_addr)
+    addr_i64 = arith.index_cast(T.i64, byte_addr_index)
     lds_ptr = _inttoptr_lds(addr_i64)
     if static_byte_offset != 0:
-        lds_ptr = _get_element_ptr(lds_ptr, static_byte_offset=static_byte_offset)
+        lds_ptr = _gep(lds_ptr, static_byte_offset=static_byte_offset)
     return llvm.LoadOp(vec_type, lds_ptr, alignment=16, nontemporal=True).result
 
 
@@ -251,14 +204,14 @@ def _lds_load_volatile(base_i32, vec_type, byte_offset=0):
     LLVM still tracks these as LDS loads for lgkmcnt.
     Input: base_i32 must be an i32 ir.Value (LDS byte address).
     """
-    addr_i64 = _raw(arith.ArithValue(base_i32).extui(T.i64))
+    addr_i64 = _raw(ArithValue(base_i32).extui(T.i64))
     lds_ptr = _inttoptr_lds(addr_i64)
     if byte_offset != 0:
-        lds_ptr = _get_element_ptr(lds_ptr, static_byte_offset=byte_offset)
+        lds_ptr = _gep(lds_ptr, static_byte_offset=byte_offset)
     return llvm.LoadOp(vec_type, lds_ptr, alignment=8, volatile_=True).result
 
 
-def _index_cast_to_i32(value):
+def _i32(value):
     """Cast index/ArithValue to i32.  No-op if already i32."""
     raw = _raw(value) if not isinstance(value, ir.Value) else value
     if raw.type == T.i32:
@@ -271,15 +224,16 @@ def _fast_exp2(val):
     return rocdl.exp2(T.f32, _raw(val))
 
 
-def _to_mlir(val, index=False):
+def _to_mlir(val):
     """Convert Python int/float, ArithValue, or ir.Value to raw MLIR Value."""
-    if isinstance(val, int):
-        return _raw(arith.constant(val, index=index))
-    if isinstance(val, float):
+    if isinstance(val, (int, float)):
         return _raw(arith.constant(val))
-    if isinstance(val, ir.Value):
-        return val
-    return _raw(val)
+    return _raw(val) if not isinstance(val, ir.Value) else val
+
+
+def _pack_i32x2(lo, hi, c32):
+    """Pack two i32 values into a single i64: lo | (hi << 32)."""
+    return _raw(ArithValue(lo).extui(T.i64) | (ArithValue(hi).extui(T.i64) << c32))
 
 
 # ---------------------------------------------------------------------------
@@ -339,10 +293,10 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     lds_base_idx = _memref.ExtractAlignedPointerAsIndexOp(lds_buffer).result
 
     # ---- V^T transpose perm constants ----
-    c_perm0 = fx.Int32(0x05010400)
-    c_perm1 = fx.Int32(0x07030602)
-    c_perm2 = fx.Int32(0x05040100)
-    c_perm3 = fx.Int32(0x07060302)
+    c_perm0 = arith.constant(0x05010400, type=T.i32)
+    c_perm1 = arith.constant(0x07030602, type=T.i32)
+    c_perm2 = arith.constant(0x05040100, type=T.i32)
+    c_perm3 = arith.constant(0x07060302, type=T.i32)
 
     def _vt_perm(src_hi, src_lo, sel):
         return llvm.call_intrinsic(
@@ -354,15 +308,15 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         )
 
     # ---- Constants ----
-    c_neg_inf_f32 = fx.Float32(float("-inf"))
-    c_zero_f32 = fx.Float32(0.0)
-    c_one_f32 = fx.Float32(1.0)
-    c_zero_i32 = fx.Int32(0)
+    c_neg_inf = arith.constant(float("-inf"), type=T.f32)
+    c_zero_f32 = arith.constant(0.0, type=T.f32)
+    c_one_f32 = arith.constant(1.0, type=T.f32)
+    c_zero_i32 = arith.constant(0, type=T.i32)
     c_zero_v4f32 = Vec.filled(4, 0.0, fx.Float32)
-    c_log2e = fx.Float32(LOG2E)
-    c_inv_log2e = fx.Float32(1.0 / LOG2E)
-    c_dword_sz = fx.Int32(4)
-    c_aux_zero = fx.Int32(0)
+    c_log2e = arith.constant(LOG2E, type=T.f32)
+    c_inv_log2e = arith.constant(1.0 / LOG2E, type=T.f32)
+    c_dword_sz = arith.constant(4, type=T.i32)
+    c_aux_zero = c_zero_i32
 
     # ---- Buffer resources ----
     query_rsrc = buffer_ops.create_buffer_resource(query)
@@ -379,30 +333,26 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     tid = gpu.thread_id("x")
     warp_idx = tid / WARP_SIZE
     lane_idx = tid % WARP_SIZE
-    warp_idx_i32 = rocdl.readfirstlane(T.i32, _index_cast_to_i32(warp_idx))
-    lane_idx_i32 = _index_cast_to_i32(lane_idx)
+    warp_idx_i32 = rocdl.readfirstlane(T.i32, _i32(warp_idx))
+    lane_idx_i32 = _i32(lane_idx)
 
     # ---- Work range ----
-    worker_idx_i32 = _index_cast_to_i32(worker_idx)
     work_range = buffer_ops.buffer_load(
-        work_indptr_rsrc, worker_idx_i32, vec_width=2, dtype=fx.Int32
+        work_indptr_rsrc, _i32(worker_idx), vec_width=2, dtype=T.i32
     )
     work_range_vec = Vec(work_range)
     work_start_i32 = rocdl.readfirstlane(T.i32, work_range_vec[0])
     work_end_i32 = rocdl.readfirstlane(T.i32, work_range_vec[1])
-    work_start_idx = fx.Index(work_start_i32)
-    work_end_idx = fx.Index(work_end_i32)
+    work_start_idx = arith.index_cast(T.index, work_start_i32)
+    work_end_idx = arith.index_cast(T.index, work_end_i32)
 
     # ---- KvManagerV2 thread-to-data mapping ----
     # Each warp takes 4 rows: warp w -> rows {w*2, w*2+1, w*2+16, w*2+17}
     # lane mapping: (lane/32)*16 + (lane/16)%2 + warp*2
-    kv_ld_row_base = (
-        lane_idx / 32 * 16
-        + (lane_idx / 16) % 2
-        + warp_idx * 2
+    kv_ld_row_base_i32 = _i32(
+        lane_idx / 32 * 16 + (lane_idx / 16) % 2 + warp_idx * 2
     )
-    kv_ld_row_base_i32 = _index_cast_to_i32(kv_ld_row_base)
-    kv_ld_col_base_i32 = _index_cast_to_i32((lane_idx % 16) * 4)
+    kv_ld_col_base_i32 = _i32((lane_idx % 16) * 4)
 
     # ---- Helper: resolve KV page index -> physical row ----
     def _get_kv_ld_row(kv_tile_start_i32, kv_tile_end_i32, check_boundary):
@@ -411,19 +361,18 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         For OOB rows (row >= kv_end), returns -1 WITHOUT issuing a
         buffer_load -- avoids reading garbage from kv_page_indices.
         """
-        row_idx_i32 = _raw(kv_ld_row_base_i32 + kv_tile_start_i32)
+        row_idx_i32 = _raw(ArithValue(kv_ld_row_base_i32) + kv_tile_start_i32)
         if const_expr(check_boundary):
-            phys_row = fx.Int32(-1)
-            if fx.Int32(row_idx_i32) < fx.Int32(kv_tile_end_i32):
+            phys_row = arith.constant(-1, type=T.i32)
+            if ArithValue(row_idx_i32) < ArithValue(kv_tile_end_i32):
                 phys_row = buffer_ops.buffer_load(
-                    kv_page_indices_rsrc, row_idx_i32, vec_width=1, dtype=fx.Int32
+                    kv_page_indices_rsrc, row_idx_i32, vec_width=1, dtype=T.i32
                 )
             return _raw(phys_row)
         else:
-            phys_row = buffer_ops.buffer_load(
-                kv_page_indices_rsrc, row_idx_i32, vec_width=1, dtype=fx.Int32
+            return buffer_ops.buffer_load(
+                kv_page_indices_rsrc, row_idx_i32, vec_width=1, dtype=T.i32
             )
-            return _raw(phys_row)
 
     # ---- Helper: async_load_k_tile (VRAM->LDS via buffer_load_dword_lds) ----
     def _async_load_k_tile(
@@ -436,65 +385,33 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         lds_warp_offset = block_idx_const * KV_BLOCK_BYTES
         # p_lds_kv_warp points to warp's sub-block start.
         # Actual LDS target: p_lds_kv_warp + block*KV_BLOCK_BYTES - block*64
-        lds_adjust = arith.constant(
-            lds_warp_offset - block_idx_const * KV_NUM_COLS, type=T.i32
-        )
-        lds_base_i32 = _raw(arith.ArithValue(p_lds_kv_warp_i32) + lds_adjust)
+        lds_adjust = lds_warp_offset - block_idx_const * KV_NUM_COLS
+        lds_base_i32 = _raw(ArithValue(p_lds_kv_warp_i32) + arith.constant(lds_adjust, type=T.i32))
+
+        def _emit_vram_to_lds():
+            voff = _raw(ArithValue(row_i32) * arith.constant(QK_HEAD_DIM, type=T.i32) + col_base_i32)
+            col_off = arith.constant(block_idx_const * KV_NUM_COLS, type=T.i32)
+            lds_ptr = _inttoptr_lds(_raw(ArithValue(lds_base_i32).extui(T.i64)))
+            rocdl.raw_ptr_buffer_load_lds(
+                kv_rsrc, lds_ptr, _raw(c_dword_sz), voff,
+                _raw(c_aux_zero), _raw(col_off), _raw(c_aux_zero),
+            )
 
         if const_expr(check_boundary):
-            neg_one = _raw(arith.constant(-1, type=T.i32))
-            is_oob = fx.Int32(row_i32) == fx.Int32(neg_one)
+            is_oob = ArithValue(row_i32) == arith.constant(-1, type=T.i32)
             if is_oob:
                 # Write zero via ds_write_b32 at lane's position
-                zero_u32 = _raw(arith.constant(0, type=T.i32))
-                lane_offset = _raw(lane_idx_i32 * arith.constant(4, type=T.i32))
-                lds_addr_zero = _raw(
-                    arith.ArithValue(lds_base_i32)
-                    + arith.ArithValue(
-                        _raw(arith.constant(block_idx_const * KV_NUM_COLS, type=T.i32))
-                        + arith.ArithValue(lane_offset)
-                    )
+                lds_addr = _raw(
+                    ArithValue(lds_base_i32)
+                    + arith.constant(block_idx_const * KV_NUM_COLS, type=T.i32)
+                    + ArithValue(lane_idx_i32) * arith.constant(4, type=T.i32)
                 )
-                lds_addr_i64 = _raw(arith.ArithValue(lds_addr_zero).extui(T.i64))
-                lds_ptr = _inttoptr_lds(lds_addr_i64)
-                llvm.StoreOp(zero_u32, lds_ptr, alignment=4)
+                lds_ptr = _inttoptr_lds(_raw(ArithValue(lds_addr).extui(T.i64)))
+                llvm.StoreOp(_raw(c_zero_i32), lds_ptr, alignment=4)
             else:
-                # Normal load
-                voff = _raw(
-                    arith.ArithValue(_raw(row_i32))
-                    * arith.constant(QK_HEAD_DIM, type=T.i32)
-                    + col_base_i32
-                )
-                col_off = arith.constant(block_idx_const * KV_NUM_COLS, type=T.i32)
-                lds_ptr_i64 = _raw(arith.ArithValue(lds_base_i32).extui(T.i64))
-                lds_ptr = _inttoptr_lds(lds_ptr_i64)
-                rocdl.raw_ptr_buffer_load_lds(
-                    kv_rsrc,
-                    lds_ptr,
-                    _raw(c_dword_sz),
-                    voff,
-                    _raw(c_aux_zero),
-                    _raw(col_off),
-                    _raw(c_aux_zero),
-                )
+                _emit_vram_to_lds()
         else:
-            voff = _raw(
-                arith.ArithValue(_raw(row_i32))
-                * arith.constant(QK_HEAD_DIM, type=T.i32)
-                + col_base_i32
-            )
-            col_off = arith.constant(block_idx_const * KV_NUM_COLS, type=T.i32)
-            lds_ptr_i64 = _raw(arith.ArithValue(lds_base_i32).extui(T.i64))
-            lds_ptr = _inttoptr_lds(lds_ptr_i64)
-            rocdl.raw_ptr_buffer_load_lds(
-                kv_rsrc,
-                lds_ptr,
-                _raw(c_dword_sz),
-                voff,
-                _raw(c_aux_zero),
-                _raw(col_off),
-                _raw(c_aux_zero),
-            )
+            _emit_vram_to_lds()
 
     def _async_load_kv_all(
         p_lds_kv_warp_i32, row_i32, col_base_i32, check_boundary=False
@@ -529,18 +446,11 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
           - ir.Value (i1): emits scf.IfOp(check_boundary AND row==-1),
             allowing runtime bypass.
         """
-        lds_warp_offset = block_idx_const * KV_BLOCK_BYTES
-        lds_adjust = arith.constant(
-            lds_warp_offset - block_idx_const * KV_NUM_COLS, type=T.i32
-        )
-        lds_base_i32 = _raw(arith.ArithValue(p_lds_kv_warp_i32) + lds_adjust)
+        lds_adjust = block_idx_const * KV_BLOCK_BYTES - block_idx_const * KV_NUM_COLS
+        lds_base_i32 = _raw(ArithValue(p_lds_kv_warp_i32) + arith.constant(lds_adjust, type=T.i32))
 
         def _emit_normal_load():
-            voff = _raw(
-                arith.ArithValue(_raw(row_i32))
-                * arith.constant(QK_HEAD_DIM, type=T.i32)
-                + col_base_i32
-            )
+            voff = _raw(ArithValue(row_i32) * arith.constant(QK_HEAD_DIM, type=T.i32) + col_base_i32)
             col_off_imm = block_idx_const * KV_NUM_COLS
             asm_str = (
                 "s_mov_b32 m0, $0\n"
@@ -560,23 +470,21 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             _emit_normal_load()
         else:
             # Build OOB condition: row == -1
-            neg_one = _raw(arith.constant(-1, type=T.i32))
-            is_oob = fx.Int32(row_i32) == fx.Int32(neg_one)
+            is_oob = ArithValue(row_i32) == arith.constant(-1, type=T.i32)
             # If check_boundary is a runtime i1, AND it in
             if const_expr(check_boundary is not True):
-                is_oob = _raw(arith.ArithValue(check_boundary) & arith.ArithValue(is_oob))
+                is_oob = _raw(ArithValue(check_boundary) & ArithValue(is_oob))
 
             if is_oob:
                 # OOB: write zero to LDS via inline asm ds_write_b32
-                lane_offset = _raw(lane_idx_i32 * arith.constant(4, type=T.i32))
                 lds_zero_addr = _raw(
-                    arith.ArithValue(lds_base_i32)
+                    ArithValue(lds_base_i32)
                     + arith.constant(block_idx_const * KV_NUM_COLS, type=T.i32)
-                    + arith.ArithValue(lane_offset)
+                    + ArithValue(lane_idx_i32) * arith.constant(4, type=T.i32)
                 )
                 llvm.InlineAsmOp(
                     res=None,
-                    operands_=[lds_zero_addr, _raw(arith.constant(0, type=T.i32))],
+                    operands_=[lds_zero_addr, _raw(c_zero_i32)],
                     asm_string="ds_write_b32 $0, $1",
                     constraints="v,v",
                     has_side_effects=True,
@@ -768,38 +676,29 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     # ---- Helper: warp reduce (butterfly XOR) ----
     def _shfl_xor_f32(val_f32, offset_i32, width_i32):
         """XOR shuffle for f32 via bitcast to i32 and back."""
-        # Bitcast f32 -> i32
-        val_i32 = _raw(arith.ArithValue(val_f32).bitcast(T.i32))
-        # Shuffle as i32
-        peer_i32 = _mlir_gpu.ShuffleOp(
-            val_i32, offset_i32, width_i32, _mlir_gpu.ShuffleMode.XOR
-        ).shuffleResult
-        # Bitcast i32 -> f32
-        return _raw(arith.ArithValue(peer_i32).bitcast(T.f32))
+        val_i32 = _raw(ArithValue(val_f32).bitcast(T.i32))
+        peer_i32 = ArithValue(val_i32).shuffle_xor(offset_i32, width_i32)
+        return _raw(ArithValue(peer_i32).bitcast(T.f32))
+
+    c_warp_size_i32 = arith.constant(WARP_SIZE, type=T.i32)
 
     def _warp_reduce_max_16(val):
         """Butterfly max reduce across MFMA column groups.
 
         HK: reduce_range=64, stop_stride=15 -> strides [32, 16].
-        This reduces across the 4 column groups (each owning 4 K positions)
-        while keeping each row (Q head) independent.
         """
         w = _to_mlir(val)
-        width = _raw(arith.constant(WARP_SIZE, type=T.i32))
         for sh in [32, 16]:
-            offset = _raw(arith.constant(sh, type=T.i32))
-            peer = _shfl_xor_f32(w, offset, width)
+            peer = _shfl_xor_f32(w, arith.constant(sh, type=T.i32), c_warp_size_i32)
             w = arith.MaximumFOp(w, peer, fastmath=fm_no_inf).result
         return w
 
     def _warp_reduce_add_16(val):
         """Butterfly sum reduce across MFMA column groups."""
         w = _to_mlir(val)
-        width = _raw(arith.constant(WARP_SIZE, type=T.i32))
         for sh in [32, 16]:
-            offset = _raw(arith.constant(sh, type=T.i32))
-            peer = _shfl_xor_f32(w, offset, width)
-            w = arith.ArithValue(w).addf(peer, fastmath=fm_fast)
+            peer = _shfl_xor_f32(w, arith.constant(sh, type=T.i32), c_warp_size_i32)
+            w = ArithValue(w).addf(peer, fastmath=fm_fast)
         return w
 
     # ---- Helper: Q loading (QManagerV3) ----
@@ -821,19 +720,15 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # VRAM addressing: row = lane/4, col = (lane%4)*16
         # s_offset = warp * 16 * QK_HEAD_DIM * sizeof(fp8)
         # v_offset = (row * QK_HEAD_DIM + col) * sizeof(fp8)
+        # s_offset = warp * 16 * QK_HEAD_DIM + qo_start * NUM_QO_HEADS * QK_HEAD_DIM
         s_offset_i32 = _raw(
-            warp_idx_i32 * arith.constant(16 * QK_HEAD_DIM, type=T.i32)
+            ArithValue(warp_idx_i32) * arith.constant(16 * QK_HEAD_DIM, type=T.i32)
+            + ArithValue(qo_start_i32) * arith.constant(NUM_QO_HEADS * QK_HEAD_DIM, type=T.i32)
         )
-        # Add qo_start offset: qo_start * NUM_QO_HEADS * QK_HEAD_DIM
-        q_base_offset = _raw(
-            arith.ArithValue(_raw(qo_start_i32))
-            * arith.constant(NUM_QO_HEADS * QK_HEAD_DIM, type=T.i32)
-        )
-        s_offset_i32 = _raw(arith.ArithValue(s_offset_i32) + arith.ArithValue(q_base_offset))
 
         row = lane_idx / 4
         col = (lane_idx % 4) * 16
-        v_offset_i32 = _index_cast_to_i32(row * QK_HEAD_DIM + col)
+        v_offset_i32 = _i32(row * QK_HEAD_DIM + col)
 
         # LDS store layout (QManagerV3):
         # row_st = lane/4, col_st = (lane%4)*16
@@ -864,7 +759,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # v_offset_i32 is in bytes; buffer_load auto-scales by element_bytes
         # (i32 = 4), so divide by 4.  s_offset_i32 is also in bytes.
         voff_dw = _raw(
-            (arith.ArithValue(_raw(v_offset_i32)) + arith.ArithValue(s_offset_i32))
+            (ArithValue(v_offset_i32) + ArithValue(s_offset_i32))
             // arith.constant(4, type=T.i32)
         )
 
@@ -876,8 +771,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
         def _q_buf_load(pass_idx):
             voff_pass = _raw(
-                arith.ArithValue(voff_dw)
-                + arith.constant(pass_idx * Q_ELEM_PER_ROW // 4, type=T.i32)
+                ArithValue(voff_dw) + arith.constant(pass_idx * Q_ELEM_PER_ROW // 4, type=T.i32)
             )
             return buffer_ops.buffer_load(
                 query_rsrc,
@@ -933,23 +827,16 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         """
         result = [None] * 8
         for i in range_constexpr(8):
-            result[i] = arith.MulFOp(
-                _raw(p_vals[i]), _raw(softmax_scale), fastmath=fm_fast
-            ).result
+            result[i] = arith.MulFOp(_raw(p_vals[i]), _raw(softmax_scale), fastmath=fm_fast).result
 
         if const_expr(check_boundary is not False):
             for i in range_constexpr(8):
-                # Position of this element: col_0_start + (i//4)*16 + (i%4)
                 sub_offset = (i // 4) * 16 + (i % 4)
-                pos_i32 = _raw(
-                    arith.ArithValue(_raw(col_0_start_i32))
-                    + arith.constant(sub_offset, type=T.i32)
-                )
-                is_oob = fx.Int32(pos_i32) >= fx.Int32(kv_end_i32)
-                # If check_boundary is a runtime i1, AND it in
+                pos_i32 = _raw(ArithValue(col_0_start_i32) + arith.constant(sub_offset, type=T.i32))
+                is_oob = ArithValue(pos_i32) >= ArithValue(kv_end_i32)
                 if const_expr(check_boundary is not True):
-                    is_oob = _raw(arith.ArithValue(check_boundary) & arith.ArithValue(is_oob))
-                result[i] = _raw(arith.select(is_oob, _raw(c_neg_inf_f32), result[i]))
+                    is_oob = _raw(ArithValue(check_boundary) & ArithValue(is_oob))
+                result[i] = _raw(arith.select(is_oob, _raw(c_neg_inf), result[i]))
         return result
 
     # ---- Helper: online softmax ----
@@ -968,11 +855,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         Returns: (p_exp_vals, row_max_new, row_sum_e_new, rescale)
         """
         # Column index for this thread's first element
-        col_0_idx = lane_idx / 16
-        col_0_start_i32 = _raw(
-            arith.ArithValue(_index_cast_to_i32(col_0_idx * 4))
-            + kv_tile_start_i32
-        )
+        col_0_start_i32 = _raw(ArithValue(_i32(lane_idx / 16 * 4)) + kv_tile_start_i32)
 
         # Scale and mask
         scaled = _softmax_scale_p(p_vals, col_0_start_i32, kv_end_i32, check_boundary)
@@ -992,31 +875,21 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             new_row_max = local_max
             rescale = _raw(c_one_f32)
         else:
-            new_row_max = arith.MaximumFOp(
-                local_max, _raw(row_max_old), fastmath=fm_no_inf
-            ).result
+            new_row_max = arith.MaximumFOp(local_max, _raw(row_max_old), fastmath=fm_no_inf).result
             # rescale = exp2((old_max - new_max) * log2e)
-            diff = arith.SubFOp(
-                _raw(row_max_old), new_row_max, fastmath=fm_no_inf
-            ).result
-            rescale_arg = arith.MulFOp(
-                diff, _raw(c_log2e), fastmath=fm_no_inf
-            ).result
-            rescale = _fast_exp2(rescale_arg)
+            diff = arith.SubFOp(_raw(row_max_old), new_row_max, fastmath=fm_no_inf).result
+            rescale = _fast_exp2(arith.MulFOp(diff, _raw(c_log2e), fastmath=fm_no_inf).result)
 
         # exp(p - max) for each value, and sum
         p_exp_vals = [None] * 8
         local_sum = _raw(c_zero_f32)
         for i in range_constexpr(8):
-            # exp2((p[i] - new_max) * log2e)
-            diff = arith.SubFOp(
-                _raw(scaled[i]), new_row_max, fastmath=fm_no_inf
+            exp_arg = arith.MulFOp(
+                arith.SubFOp(_raw(scaled[i]), new_row_max, fastmath=fm_no_inf).result,
+                _raw(c_log2e), fastmath=fm_no_inf,
             ).result
-            exp_arg = arith.MulFOp(diff, _raw(c_log2e), fastmath=fm_no_inf).result
             p_exp_vals[i] = _fast_exp2(exp_arg)
-            local_sum = arith.AddFOp(
-                local_sum, p_exp_vals[i], fastmath=fm_fast
-            ).result
+            local_sum = arith.AddFOp(local_sum, p_exp_vals[i], fastmath=fm_fast).result
 
         # Warp reduce sum
         local_sum = _warp_reduce_add_16(local_sum)
@@ -1026,50 +899,34 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             row_sum_e_new = local_sum
         else:
             row_sum_e_new = arith.AddFOp(
-                arith.MulFOp(
-                    rescale, _raw(row_sum_e_old), fastmath=fm_fast
-                ).result,
-                local_sum,
-                fastmath=fm_fast,
+                arith.MulFOp(rescale, _raw(row_sum_e_old), fastmath=fm_fast).result,
+                local_sum, fastmath=fm_fast,
             ).result
 
         return p_exp_vals, new_row_max, row_sum_e_new, rescale
 
     # ---- Helper: pack P from f32 to fp8 ----
+    c_32_i64 = arith.constant(32, type=T.i64)
+
     def _pack_p_to_fp8(p_exp_vals):
         """Pack 8 f32 -> 2 i32 (4x cvt_pk_fp8_f32) -> 1 i64 for MFMA."""
-        w0 = rocdl.cvt_pk_fp8_f32(
-            T.i32, _raw(p_exp_vals[0]), _raw(p_exp_vals[1]), c_zero_i32, 0
-        )
-        w0 = rocdl.cvt_pk_fp8_f32(
-            T.i32, _raw(p_exp_vals[2]), _raw(p_exp_vals[3]), w0, 1
-        )
-        w1 = rocdl.cvt_pk_fp8_f32(
-            T.i32, _raw(p_exp_vals[4]), _raw(p_exp_vals[5]), c_zero_i32, 0
-        )
-        w1 = rocdl.cvt_pk_fp8_f32(
-            T.i32, _raw(p_exp_vals[6]), _raw(p_exp_vals[7]), w1, 1
-        )
-        w0_i64 = arith.ArithValue(w0).extui(T.i64)
-        w1_i64 = arith.ArithValue(w1).extui(T.i64)
-        c32_i64 = arith.constant(32, type=T.i64)
-        w1_shifted = w1_i64 << c32_i64
-        p_pack = _raw(w0_i64 | w1_shifted)
-        return p_pack
+        w0 = rocdl.cvt_pk_fp8_f32(T.i32, _raw(p_exp_vals[0]), _raw(p_exp_vals[1]), c_zero_i32, 0)
+        w0 = rocdl.cvt_pk_fp8_f32(T.i32, _raw(p_exp_vals[2]), _raw(p_exp_vals[3]), w0, 1)
+        w1 = rocdl.cvt_pk_fp8_f32(T.i32, _raw(p_exp_vals[4]), _raw(p_exp_vals[5]), c_zero_i32, 0)
+        w1 = rocdl.cvt_pk_fp8_f32(T.i32, _raw(p_exp_vals[6]), _raw(p_exp_vals[7]), w1, 1)
+        return _raw(ArithValue(w0).extui(T.i64) | (ArithValue(w1).extui(T.i64) << c_32_i64))
 
     # ---- Helper: rescale oaccu ----
     def _rescale_oaccu(oaccu, rescale):
         """Multiply all oaccu accumulators by rescale factor.
         Descending s_setprio 3->0 across 4 groups of 8 muls."""
-        rescale_vec = Vec.filled(4, fx.Float32(rescale), fx.Float32)
+        rv = _raw(Vec.filled(4, rescale, fx.Float32))
         result = [None] * len(oaccu)
         for group in range_constexpr(4):
             rocdl.s_setprio(3 - group)
             for j in range_constexpr(8):
                 i = group * 8 + j
-                result[i] = arith.MulFOp(
-                    _raw(oaccu[i]), _raw(rescale_vec), fastmath=fm_fast
-                ).result
+                result[i] = arith.MulFOp(_raw(oaccu[i]), rv, fastmath=fm_fast).result
         return result
 
     # ---- Helper: process one KV tile (GEMM1 + softmax + V + GEMM2) ----
@@ -1102,10 +959,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         Returns (row_max, row_sum_e, p_pack, rescale).
         """
         # ---- K base VGPR (baked-in lane offset) ----
-        k_base_i32 = _raw(
-            arith.ArithValue(_index_cast_to_i32(p_lds_kv_base))
-            + arith.ArithValue(_index_cast_to_i32(k_lds_lane_offset))
-        )
+        k_base_i32 = _raw(ArithValue(_i32(p_lds_kv_base)) + ArithValue(_i32(k_lds_lane_offset)))
 
         do_prefetch = p_lds_kv_next_warp_i32 is not None
 
@@ -1199,11 +1053,11 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # ---- Resolve row for tile+2 (2-ahead, matches HK line 407-426) ----
         # The buffer_load has softmax+V-transpose+GEMM2+barrier to complete.
         if const_expr(do_resolve_nn is not None):
-            row_kv_ld_nn = fx.Int32(-1)
+            row_kv_ld_nn = arith.constant(-1, type=T.i32)
             if do_resolve_nn:
                 row_kv_ld_nn = _get_kv_ld_row(nn_resolve_start, nn_resolve_end, True)
         else:
-            row_kv_ld_nn = fx.Int32(-1)
+            row_kv_ld_nn = arith.constant(-1, type=T.i32)
 
         # ---- Softmax ----
         p_exp_vals, row_max_new, row_sum_e_new, rescale = _softmax(
@@ -1232,7 +1086,6 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         Matches HK interleaving: 8x ds_read_b32 burst (2 PV iters),
         lgkmcnt(4) -> 2 MFMA, lgkmcnt(0) -> 2 MFMA.
         """
-        c32_i64_pv = _raw(arith.constant(32, type=T.i64))
         rocdl.s_setprio(15)
         for pv_pair in range_constexpr(NUM_PV_ITERS // 2):
             # Load 8 values: vt for 2 consecutive PV iterations
@@ -1252,40 +1105,22 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             rocdl.sched_barrier(0)
             rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=4))
 
-            # MFMA pair A (first PV iter)
-            kv_mfma_a0 = _raw(
-                arith.ArithValue(vta0_lo).extui(T.i64)
-                | (arith.ArithValue(vta0_hi).extui(T.i64) << c32_i64_pv)
-            )
+            # MFMA pair A
             oaccu[iter_a * 2] = _mfma_fp8(
-                T.f32x4, [kv_mfma_a0, p_pack, oaccu[iter_a * 2], 0, 0, 0]
-            )
-
-            kv_mfma_a1 = _raw(
-                arith.ArithValue(vta1_lo).extui(T.i64)
-                | (arith.ArithValue(vta1_hi).extui(T.i64) << c32_i64_pv)
+                T.f32x4, [_pack_i32x2(vta0_lo, vta0_hi, c_32_i64), p_pack, oaccu[iter_a * 2], 0, 0, 0]
             )
             oaccu[iter_a * 2 + 1] = _mfma_fp8(
-                T.f32x4, [kv_mfma_a1, p_pack, oaccu[iter_a * 2 + 1], 0, 0, 0]
+                T.f32x4, [_pack_i32x2(vta1_lo, vta1_hi, c_32_i64), p_pack, oaccu[iter_a * 2 + 1], 0, 0, 0]
             )
             rocdl.sched_barrier(0)
             rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
-            # MFMA pair B (second PV iter)
-            kv_mfma_b0 = _raw(
-                arith.ArithValue(vtb0_lo).extui(T.i64)
-                | (arith.ArithValue(vtb0_hi).extui(T.i64) << c32_i64_pv)
-            )
+            # MFMA pair B
             oaccu[iter_b * 2] = _mfma_fp8(
-                T.f32x4, [kv_mfma_b0, p_pack, oaccu[iter_b * 2], 0, 0, 0]
-            )
-
-            kv_mfma_b1 = _raw(
-                arith.ArithValue(vtb1_lo).extui(T.i64)
-                | (arith.ArithValue(vtb1_hi).extui(T.i64) << c32_i64_pv)
+                T.f32x4, [_pack_i32x2(vtb0_lo, vtb0_hi, c_32_i64), p_pack, oaccu[iter_b * 2], 0, 0, 0]
             )
             oaccu[iter_b * 2 + 1] = _mfma_fp8(
-                T.f32x4, [kv_mfma_b1, p_pack, oaccu[iter_b * 2 + 1], 0, 0, 0]
+                T.f32x4, [_pack_i32x2(vtb1_lo, vtb1_hi, c_32_i64), p_pack, oaccu[iter_b * 2 + 1], 0, 0, 0]
             )
             rocdl.sched_barrier(0)
 
@@ -1316,86 +1151,59 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         rocdl.sched_barrier(0)
         return _gemm2_core(p_pack, oaccu, vt_base_i32)
 
+    c_16_i32 = arith.constant(16, type=T.i32)
+
     def _pack_f32x4_to_bf16_2dw(acc_val):
         """Convert f32x4 accumulator to 2 packed bf16 dwords."""
-        bf16_vals = arith.trunc_f(T.bf16x4, acc_val)
-        i16_vals = Vec(bf16_vals).bitcast(fx.Int16)
-        i16_0 = _raw(i16_vals[0])
-        i16_1 = _raw(i16_vals[1])
-        i16_2 = _raw(i16_vals[2])
-        i16_3 = _raw(i16_vals[3])
-        c16 = arith.constant(16, type=T.i32)
-        lo_0 = arith.ArithValue(i16_0).extui(T.i32)
-        hi_0 = arith.ArithValue(i16_1).extui(T.i32)
-        dw0 = _raw(lo_0 | (hi_0 << c16))
-        lo_1 = arith.ArithValue(i16_2).extui(T.i32)
-        hi_1 = arith.ArithValue(i16_3).extui(T.i32)
-        dw1 = _raw(lo_1 | (hi_1 << c16))
+        i16s = Vec(arith.trunc_f(T.bf16x4, acc_val)).bitcast(fx.Int16)
+        i16_0, i16_1, i16_2, i16_3 = (_raw(i16s[j]) for j in range(4))
+        dw0 = _raw(ArithValue(i16_0).extui(T.i32) | (ArithValue(i16_1).extui(T.i32) << c_16_i32))
+        dw1 = _raw(ArithValue(i16_2).extui(T.i32) | (ArithValue(i16_3).extui(T.i32) << c_16_i32))
         return dw0, dw1
 
     # ---- Pre-compute LDS reshape addresses (computed once, reused per store) ----
-    # bf16 LDS write address (MFMA layout): row_st = lane%16, col_st = (lane/16)*4
-    lane_i32 = arith.ArithValue(_raw(lane_idx_i32))
-    c2_i32 = arith.constant(2, type=T.i32)
-    c4_i32 = arith.constant(4, type=T.i32)
-    c8_i32 = arith.constant(8, type=T.i32)
-    c16_i32 = arith.constant(16, type=T.i32)
+    # Use unsigned div/rem via ArithValue (signedness inherited from type).
+    # Need explicit DivUI/RemUI since ArithValue `/` `%` are signed.
+    lane_u = ArithValue(lane_idx_i32)
 
-    o16_row_st = arith.RemUIOp(_raw(lane_i32), _raw(c16_i32)).result
-    o16_col_st = _raw(
-        arith.ArithValue(arith.DivUIOp(_raw(lane_i32), _raw(c16_i32)).result) * c4_i32
-    )
+    # bf16 LDS write address (MFMA layout): row_st = lane%16, col_st = (lane/16)*4
+    o16_row_st = arith.RemUIOp(_raw(lane_u), _raw(c_16_i32)).result
+    o16_col_st = _raw(ArithValue(arith.DivUIOp(_raw(lane_u), _raw(c_16_i32)).result) * 4)
     # get_v_offset_lds(r,c) = ((r/2)*68 + (r%2)*32 + c) * 2  [bytes]
     o16_st_offset = _raw(
         (
-            arith.ArithValue(arith.DivUIOp(o16_row_st, _raw(c2_i32)).result)
+            ArithValue(arith.DivUIOp(o16_row_st, _raw(arith.constant(2, type=T.i32))).result)
             * arith.constant(O16_ELEM_PER_PAD_2ROWS, type=T.i32)
-            + arith.ArithValue(arith.RemUIOp(o16_row_st, _raw(c2_i32)).result)
+            + ArithValue(arith.RemUIOp(o16_row_st, _raw(arith.constant(2, type=T.i32))).result)
             * arith.constant(O16_NUM_COLS, type=T.i32)
-            + arith.ArithValue(o16_col_st)
-        )
-        * c2_i32  # sizeof(bf16)
+            + ArithValue(o16_col_st)
+        ) * 2  # sizeof(bf16)
     )
 
     # bf16 LDS read address (coalesced layout): row_ld = lane/4, col_ld = (lane%4)*8
-    o16_row_ld = arith.DivUIOp(_raw(lane_i32), _raw(c4_i32)).result
-    o16_col_ld = _raw(
-        arith.ArithValue(arith.RemUIOp(_raw(lane_i32), _raw(c4_i32)).result) * c8_i32
-    )
+    o16_row_ld = arith.DivUIOp(_raw(lane_u), _raw(arith.constant(4, type=T.i32))).result
+    o16_col_ld = _raw(ArithValue(arith.RemUIOp(_raw(lane_u), _raw(arith.constant(4, type=T.i32))).result) * 8)
     o16_rd_offset = _raw(
         (
-            arith.ArithValue(arith.DivUIOp(o16_row_ld, _raw(c2_i32)).result)
+            ArithValue(arith.DivUIOp(o16_row_ld, _raw(arith.constant(2, type=T.i32))).result)
             * arith.constant(O16_ELEM_PER_PAD_2ROWS, type=T.i32)
-            + arith.ArithValue(arith.RemUIOp(o16_row_ld, _raw(c2_i32)).result)
+            + ArithValue(arith.RemUIOp(o16_row_ld, _raw(arith.constant(2, type=T.i32))).result)
             * arith.constant(O16_NUM_COLS, type=T.i32)
-            + arith.ArithValue(o16_col_ld)
-        )
-        * c2_i32  # sizeof(bf16)
+            + ArithValue(o16_col_ld)
+        ) * 2  # sizeof(bf16)
     )
 
-    # f32 LDS write address: same row_st/col_st but different padding
+    # f32 LDS write address: row_st/col_st reused, different padding
     # get_v_offset_lds(r,c) = (r * 36 + c) * 4  [bytes]
     o32_st_offset = _raw(
-        (
-            arith.ArithValue(o16_row_st)  # reuse: lane%16
-            * arith.constant(O32_ELEM_PER_PAD_ROW, type=T.i32)
-            + arith.ArithValue(o16_col_st)  # reuse: (lane/16)*4
-        )
-        * c4_i32  # sizeof(f32)
+        (ArithValue(o16_row_st) * arith.constant(O32_ELEM_PER_PAD_ROW, type=T.i32) + ArithValue(o16_col_st)) * 4
     )
 
     # f32 LDS read address: row_ld = lane/8, col_ld = (lane%8)*4
-    o32_row_ld = arith.DivUIOp(_raw(lane_i32), _raw(c8_i32)).result
-    o32_col_ld = _raw(
-        arith.ArithValue(arith.RemUIOp(_raw(lane_i32), _raw(c8_i32)).result) * c4_i32
-    )
+    o32_row_ld = arith.DivUIOp(_raw(lane_u), _raw(arith.constant(8, type=T.i32))).result
+    o32_col_ld = _raw(ArithValue(arith.RemUIOp(_raw(lane_u), _raw(arith.constant(8, type=T.i32))).result) * 4)
     o32_rd_offset = _raw(
-        (
-            arith.ArithValue(o32_row_ld)
-            * arith.constant(O32_ELEM_PER_PAD_ROW, type=T.i32)
-            + arith.ArithValue(o32_col_ld)
-        )
-        * c4_i32  # sizeof(f32)
+        (ArithValue(o32_row_ld) * arith.constant(O32_ELEM_PER_PAD_ROW, type=T.i32) + ArithValue(o32_col_ld)) * 4
     )
 
     def _store_oaccu_pair_bf16(oaccu_a, oaccu_b, tile_idx, p_lds_o_i32, row_base_i32):
@@ -1405,54 +1213,32 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         reads back in row-major coalesced layout, then buffer_store_dwordx4.
         """
         # Per-warp LDS base
-        lds_warp = _raw(
-            arith.ArithValue(p_lds_o_i32)
-            + warp_idx_i32 * arith.constant(O16_LDS_PER_WARP, type=T.i32)
-        )
-        lds_st_addr = _raw(arith.ArithValue(lds_warp) + arith.ArithValue(o16_st_offset))
+        lds_warp = _raw(ArithValue(p_lds_o_i32) + ArithValue(warp_idx_i32) * arith.constant(O16_LDS_PER_WARP, type=T.i32))
+        lds_st_addr = _raw(ArithValue(lds_warp) + ArithValue(o16_st_offset))
 
         # LDS write: 2 sub-blocks -> 2x ds_write_b64
         for sub, acc_val in enumerate([oaccu_a, oaccu_b]):
             dw0, dw1 = _pack_f32x4_to_bf16_2dw(acc_val)
             vec_2dw = Vec.from_elements([dw0, dw1], fx.Int32)
-            sub_offset = sub * O16_NUM_COLS  # 0 or 32 bytes (16 bf16 cols x 2 bytes)
-            st_addr_sub = _raw(
-                arith.ArithValue(lds_st_addr) + arith.constant(sub_offset, type=T.i32)
-            )
-            st_i64 = _raw(arith.ArithValue(st_addr_sub).extui(T.i64))
-            st_ptr = _inttoptr_lds(st_i64)
-            llvm.StoreOp(
-                vec_2dw,
-                st_ptr,
-                alignment=8,
-                volatile_=True,
-            )  # ds_write_b64
+            sub_offset = sub * O16_NUM_COLS
+            st_addr_sub = _raw(ArithValue(lds_st_addr) + arith.constant(sub_offset, type=T.i32))
+            st_ptr = _inttoptr_lds(_raw(ArithValue(st_addr_sub).extui(T.i64)))
+            llvm.StoreOp(vec_2dw, st_ptr, alignment=8, volatile_=True)
 
         rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
         # LDS read: ds_read_b128 (4 dwords = 8 bf16 in coalesced layout)
-        lds_rd_addr = _raw(arith.ArithValue(lds_warp) + arith.ArithValue(o16_rd_offset))
-        rd_i64 = _raw(arith.ArithValue(lds_rd_addr).extui(T.i64))
-        rd_ptr = _inttoptr_lds(rd_i64)
-        data = llvm.LoadOp(T.i32x4, rd_ptr, alignment=16).result  # ds_read_b128
+        lds_rd_addr = _raw(ArithValue(lds_warp) + ArithValue(o16_rd_offset))
+        rd_ptr = _inttoptr_lds(_raw(ArithValue(lds_rd_addr).extui(T.i64)))
+        data = llvm.LoadOp(T.i32x4, rd_ptr, alignment=16).result
 
         rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
         # Coalesced VRAM store: buffer_store_dwordx4
-        # row = row_ld + row_base, col = col_ld + tile_idx * MFMA_N * 2
-        col_offset_i32 = arith.constant(tile_idx * MFMA_N * 2, type=T.i32)
-        row_vram = arith.ArithValue(row_base_i32) + arith.ArithValue(o16_row_ld)
-        col_vram = arith.ArithValue(o16_col_ld) + col_offset_i32
-        vram_offset = _raw(
-            (row_vram * arith.constant(V_HEAD_DIM, type=T.i32) + col_vram)
-            * arith.constant(2, type=T.i32)  # sizeof(bf16)
-        )
-        buffer_ops.buffer_store(
-            data,
-            final_output_rsrc,
-            vram_offset,
-            offset_is_bytes=True,
-        )
+        row_vram = ArithValue(row_base_i32) + ArithValue(o16_row_ld)
+        col_vram = ArithValue(o16_col_ld) + arith.constant(tile_idx * MFMA_N * 2, type=T.i32)
+        vram_offset = _raw((row_vram * arith.constant(V_HEAD_DIM, type=T.i32) + col_vram) * 2)
+        buffer_ops.buffer_store(data, final_output_rsrc, vram_offset, offset_is_bytes=True)
 
     def _store_oaccu_pair_split(oaccu_a, oaccu_b, tile_idx, p_lds_o_i32, row_base_i32):
         """Store 2 oaccu groups (1 PV iter) as f32 via LDS reshape.
@@ -1462,68 +1248,39 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         16 rows need 2 rounds (8 rows each) because 64 lanes / 8 lanes-per-row = 8.
         """
         # Per-warp LDS base
-        lds_warp = _raw(
-            arith.ArithValue(p_lds_o_i32)
-            + warp_idx_i32 * arith.constant(O32_LDS_PER_WARP, type=T.i32)
-        )
-        lds_st_addr = _raw(arith.ArithValue(lds_warp) + arith.ArithValue(o32_st_offset))
+        lds_warp = _raw(ArithValue(p_lds_o_i32) + ArithValue(warp_idx_i32) * arith.constant(O32_LDS_PER_WARP, type=T.i32))
+        lds_st_addr = _raw(ArithValue(lds_warp) + ArithValue(o32_st_offset))
 
-        col_offset_i32 = _raw(arith.constant(tile_idx * MFMA_N * 2, type=T.i32))
+        col_offset_i32 = arith.constant(tile_idx * MFMA_N * 2, type=T.i32)
         O32_LD_DELTA = 8 * O32_ELEM_PER_PAD_ROW * 4  # 1152 bytes between round 0/1
 
         # LDS write: 2 sub-blocks -> 2x ds_write_b128
-        rocdl.s_waitcnt(_encode_waitcnt(vmcnt=0))  # HK pattern: drain prior stores
+        rocdl.s_waitcnt(_encode_waitcnt(vmcnt=0))
         for sub, acc_val in enumerate([oaccu_a, oaccu_b]):
-            sub_offset = sub * O32_NUM_COLS // 2 * 4  # 0 or 64 bytes
-            st_addr_sub = _raw(
-                arith.ArithValue(lds_st_addr) + arith.constant(sub_offset, type=T.i32)
-            )
-            st_i64 = _raw(arith.ArithValue(st_addr_sub).extui(T.i64))
-            st_ptr = _inttoptr_lds(st_i64)
-            llvm.StoreOp(acc_val, st_ptr, alignment=16)  # ds_write_b128
+            sub_offset = sub * O32_NUM_COLS // 2 * 4
+            st_addr_sub = _raw(ArithValue(lds_st_addr) + arith.constant(sub_offset, type=T.i32))
+            st_ptr = _inttoptr_lds(_raw(ArithValue(st_addr_sub).extui(T.i64)))
+            llvm.StoreOp(acc_val, st_ptr, alignment=16)
 
         rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
         # LDS read: 2x ds_read_b128 (round 0 = rows 0-7, round 1 = rows 8-15)
-        lds_rd_addr = _raw(arith.ArithValue(lds_warp) + arith.ArithValue(o32_rd_offset))
-        rd_i64 = _raw(arith.ArithValue(lds_rd_addr).extui(T.i64))
-        rd_ptr = _inttoptr_lds(rd_i64)
-        data_0 = llvm.LoadOp(T.f32x4, rd_ptr, alignment=16).result  # rows 0-7
-        rd_ptr_1 = _get_element_ptr(rd_ptr, static_byte_offset=O32_LD_DELTA)
-        data_1 = llvm.LoadOp(T.f32x4, rd_ptr_1, alignment=16).result  # rows 8-15
+        lds_rd_addr = _raw(ArithValue(lds_warp) + ArithValue(o32_rd_offset))
+        rd_ptr = _inttoptr_lds(_raw(ArithValue(lds_rd_addr).extui(T.i64)))
+        data_0 = llvm.LoadOp(T.f32x4, rd_ptr, alignment=16).result
+        data_1 = llvm.LoadOp(T.f32x4, _gep(rd_ptr, static_byte_offset=O32_LD_DELTA), alignment=16).result
 
         rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
         # 2x coalesced VRAM store
-        # Round 0: row = row_ld_base(0..7) + row_base
-        row_vram_0 = arith.ArithValue(row_base_i32) + arith.ArithValue(o32_row_ld)
-        col_vram = arith.ArithValue(o32_col_ld) + arith.ArithValue(col_offset_i32)
-        vram_off_0 = _raw(
-            (row_vram_0 * arith.constant(V_HEAD_DIM, type=T.i32) + col_vram)
-            * arith.constant(4, type=T.i32)  # sizeof(f32)
-        )
-        # Bitcast f32x4 -> i32x4 for buffer_store
-        data_0_i32 = _raw(Vec(data_0).bitcast(fx.Int32))
-        buffer_ops.buffer_store(
-            data_0_i32,
-            split_output_rsrc,
-            vram_off_0,
-            offset_is_bytes=True,
-        )
+        row_vram_0 = ArithValue(row_base_i32) + ArithValue(o32_row_ld)
+        col_vram = ArithValue(o32_col_ld) + col_offset_i32
+        vram_off_0 = _raw((row_vram_0 * arith.constant(V_HEAD_DIM, type=T.i32) + col_vram) * 4)
+        buffer_ops.buffer_store(_raw(Vec(data_0).bitcast(fx.Int32)), split_output_rsrc, vram_off_0, offset_is_bytes=True)
 
-        # Round 1: row = row_ld_base + 8 + row_base
         row_vram_1 = row_vram_0 + arith.constant(8, type=T.i32)
-        vram_off_1 = _raw(
-            (row_vram_1 * arith.constant(V_HEAD_DIM, type=T.i32) + col_vram)
-            * arith.constant(4, type=T.i32)
-        )
-        data_1_i32 = _raw(Vec(data_1).bitcast(fx.Int32))
-        buffer_ops.buffer_store(
-            data_1_i32,
-            split_output_rsrc,
-            vram_off_1,
-            offset_is_bytes=True,
-        )
+        vram_off_1 = _raw((row_vram_1 * arith.constant(V_HEAD_DIM, type=T.i32) + col_vram) * 4)
+        buffer_ops.buffer_store(_raw(Vec(data_1).bitcast(fx.Int32)), split_output_rsrc, vram_off_1, offset_is_bytes=True)
 
     def _gemm2_last_with_store(
         p_pack,
@@ -1545,9 +1302,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         4. Multiply by reci_sum
         5. Store immediately (bf16 or f32 split)
         """
-        rescale_vec = Vec.filled(4, fx.Float32(rescale), fx.Float32)
-        reci_vec = Vec.filled(4, fx.Float32(reci_sum), fx.Float32)
-        c32_i64_pv = _raw(arith.constant(32, type=T.i64))
+        rescale_vec = _raw(Vec.filled(4, rescale, fx.Float32))
+        reci_vec = _raw(Vec.filled(4, reci_sum, fx.Float32))
 
         _barrier(lgkmcnt=0)
         rocdl.sched_barrier(0)
@@ -1562,26 +1318,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
             # Rescale 4 oaccu groups for this pair (skip if first iter)
             if const_expr(not is_first_iter_flag):
-                oaccu_in[iter_a * 2] = arith.MulFOp(
-                    _raw(oaccu_in[iter_a * 2]),
-                    _raw(rescale_vec),
-                    fastmath=fm_fast,
-                ).result
-                oaccu_in[iter_a * 2 + 1] = arith.MulFOp(
-                    _raw(oaccu_in[iter_a * 2 + 1]),
-                    _raw(rescale_vec),
-                    fastmath=fm_fast,
-                ).result
-                oaccu_in[iter_b * 2] = arith.MulFOp(
-                    _raw(oaccu_in[iter_b * 2]),
-                    _raw(rescale_vec),
-                    fastmath=fm_fast,
-                ).result
-                oaccu_in[iter_b * 2 + 1] = arith.MulFOp(
-                    _raw(oaccu_in[iter_b * 2 + 1]),
-                    _raw(rescale_vec),
-                    fastmath=fm_fast,
-                ).result
+                for idx in [iter_a * 2, iter_a * 2 + 1, iter_b * 2, iter_b * 2 + 1]:
+                    oaccu_in[idx] = arith.MulFOp(_raw(oaccu_in[idx]), rescale_vec, fastmath=fm_fast).result
 
             # 8x ds_read_b32 burst
             vta0_lo, vta0_hi = _load_vt_from_lds(vt_base_i32, col_a0)
@@ -1593,55 +1331,27 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=4))
 
             # MFMA pair A
-            kv_mfma_a0 = _raw(
-                arith.ArithValue(vta0_lo).extui(T.i64)
-                | (arith.ArithValue(vta0_hi).extui(T.i64) << c32_i64_pv)
-            )
             oaccu_in[iter_a * 2] = _mfma_fp8(
-                T.f32x4, [kv_mfma_a0, p_pack, oaccu_in[iter_a * 2], 0, 0, 0]
-            )
-
-            kv_mfma_a1 = _raw(
-                arith.ArithValue(vta1_lo).extui(T.i64)
-                | (arith.ArithValue(vta1_hi).extui(T.i64) << c32_i64_pv)
+                T.f32x4, [_pack_i32x2(vta0_lo, vta0_hi, c_32_i64), p_pack, oaccu_in[iter_a * 2], 0, 0, 0]
             )
             oaccu_in[iter_a * 2 + 1] = _mfma_fp8(
-                T.f32x4, [kv_mfma_a1, p_pack, oaccu_in[iter_a * 2 + 1], 0, 0, 0]
+                T.f32x4, [_pack_i32x2(vta1_lo, vta1_hi, c_32_i64), p_pack, oaccu_in[iter_a * 2 + 1], 0, 0, 0]
             )
             rocdl.sched_barrier(0)
             rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
             # MFMA pair B
-            kv_mfma_b0 = _raw(
-                arith.ArithValue(vtb0_lo).extui(T.i64)
-                | (arith.ArithValue(vtb0_hi).extui(T.i64) << c32_i64_pv)
-            )
             oaccu_in[iter_b * 2] = _mfma_fp8(
-                T.f32x4, [kv_mfma_b0, p_pack, oaccu_in[iter_b * 2], 0, 0, 0]
-            )
-
-            kv_mfma_b1 = _raw(
-                arith.ArithValue(vtb1_lo).extui(T.i64)
-                | (arith.ArithValue(vtb1_hi).extui(T.i64) << c32_i64_pv)
+                T.f32x4, [_pack_i32x2(vtb0_lo, vtb0_hi, c_32_i64), p_pack, oaccu_in[iter_b * 2], 0, 0, 0]
             )
             oaccu_in[iter_b * 2 + 1] = _mfma_fp8(
-                T.f32x4, [kv_mfma_b1, p_pack, oaccu_in[iter_b * 2 + 1], 0, 0, 0]
+                T.f32x4, [_pack_i32x2(vtb1_lo, vtb1_hi, c_32_i64), p_pack, oaccu_in[iter_b * 2 + 1], 0, 0, 0]
             )
             rocdl.sched_barrier(0)
 
             # Normalize by reci_sum
-            oaccu_in[iter_a * 2] = arith.MulFOp(
-                oaccu_in[iter_a * 2], _raw(reci_vec), fastmath=fm_fast
-            ).result
-            oaccu_in[iter_a * 2 + 1] = arith.MulFOp(
-                oaccu_in[iter_a * 2 + 1], _raw(reci_vec), fastmath=fm_fast
-            ).result
-            oaccu_in[iter_b * 2] = arith.MulFOp(
-                oaccu_in[iter_b * 2], _raw(reci_vec), fastmath=fm_fast
-            ).result
-            oaccu_in[iter_b * 2 + 1] = arith.MulFOp(
-                oaccu_in[iter_b * 2 + 1], _raw(reci_vec), fastmath=fm_fast
-            ).result
+            for idx in [iter_a * 2, iter_a * 2 + 1, iter_b * 2, iter_b * 2 + 1]:
+                oaccu_in[idx] = arith.MulFOp(oaccu_in[idx], reci_vec, fastmath=fm_fast).result
 
             # Store immediately via LDS reshape (coalesced)
             if const_expr(is_split):
@@ -1683,33 +1393,19 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     p_lds_kv_0_base = lds_base_idx + arith.index(P_LDS_KV_0)
     p_lds_kv_1_base = lds_base_idx + arith.index(P_LDS_KV_1)
 
-    kv_warp_offset_i32 = _raw(
-        warp_idx_i32 * arith.constant(KV_SUB_BYTES, type=T.i32)
-    )
+    kv_warp_offset_i32 = _raw(ArithValue(warp_idx_i32) * arith.constant(KV_SUB_BYTES, type=T.i32))
 
-    p_lds_kv_0_warp_i32 = _raw(
-        arith.ArithValue(_index_cast_to_i32(p_lds_kv_0_base))
-        + arith.ArithValue(kv_warp_offset_i32)
-    )
-    p_lds_kv_1_warp_i32 = _raw(
-        arith.ArithValue(_index_cast_to_i32(p_lds_kv_1_base))
-        + arith.ArithValue(kv_warp_offset_i32)
-    )
+    p_lds_kv_0_warp_i32 = _raw(ArithValue(_i32(p_lds_kv_0_base)) + ArithValue(kv_warp_offset_i32))
+    p_lds_kv_1_warp_i32 = _raw(ArithValue(_i32(p_lds_kv_1_base)) + ArithValue(kv_warp_offset_i32))
 
-    # Vt base pointer (invariant across all tiles -- only depends on
-    # lds_base_idx + P_LDS_VT + lane offset).  Computed once here so
-    # _gemm2_with_rescale can use it outside branches.
-    vt_base_i32 = _raw(
-        arith.ArithValue(_index_cast_to_i32(lds_base_idx + P_LDS_VT))
-        + arith.ArithValue(_index_cast_to_i32(vt_lds_lane_offset))
-    )
+    vt_base_i32 = _raw(ArithValue(_i32(lds_base_idx + P_LDS_VT)) + ArithValue(_i32(vt_lds_lane_offset)))
 
     # ==================================================================
     # Main kernel body: persistent-thread work loop
     # ==================================================================
     for work_idx in range(work_start_idx, work_end_idx):
         # Load MlaWorkInfo
-        wi_base_i32 = _index_cast_to_i32(work_idx * SIZE_MLA_WORK_INFO_IN_DW)
+        wi_base_i32 = _i32(work_idx * SIZE_MLA_WORK_INFO_IN_DW)
         wi_dw1_4 = buffer_ops.buffer_load(
             work_info_set_rsrc,
             wi_base_i32 + 1,
@@ -1731,26 +1427,28 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
         # ---- KV tile iteration ----
         # Initialize softmax state
-        row_max = _raw(c_neg_inf_f32)
+        row_max = _raw(c_neg_inf)
         row_sum_e = _raw(c_zero_f32)
 
         # Compute number of tiles
-        c_block_n = fx.Int32(BLOCK_N)
-        num_tiles = (fx.Uint32(kv_len) + (BLOCK_N - 1)) // BLOCK_N
+        c_block_n = arith.constant(BLOCK_N, type=T.i32)
+        kv_len_v = ArithValue(kv_len)
+        c_block_n_v = ArithValue(c_block_n)
+        num_tiles = arith.DivUIOp(
+            _raw(kv_len_v + arith.constant(BLOCK_N - 1, type=T.i32)), _raw(c_block_n)
+        ).result
 
         # --- Pre-compute boundary flags ---
-        first_tile_needs_boundary = fx.Int32(kv_len) < fx.Int32(c_block_n)
-        has_multi_tiles = fx.Int32(kv_len) > fx.Int32(c_block_n)
-        # last_tile_partial: (kv_len & (BLOCK_N-1)) != 0
-        last_tile_partial = (fx.Int32(kv_len) & (BLOCK_N - 1)) != 0
+        first_tile_needs_boundary = kv_len_v < c_block_n_v
+        has_multi_tiles = kv_len_v > c_block_n_v
+        last_tile_partial = (kv_len_v & arith.constant(BLOCK_N - 1, type=T.i32)) != arith.constant(0, type=T.i32)
 
         # --- First tile: resolve KV row (branched on boundary) ---
-        row_kv_ld_first = fx.Int32(-1)
+        row_kv_ld_first = arith.constant(-1, type=T.i32)
         if first_tile_needs_boundary:
             row_kv_ld_first = _get_kv_ld_row(kv_start, kv_end, True)
         else:
-            kv_first_end = _raw(kv_start + c_block_n)
-            row_kv_ld_first = _get_kv_ld_row(kv_start, kv_first_end, False)
+            row_kv_ld_first = _get_kv_ld_row(kv_start, _raw(ArithValue(kv_start) + c_block_n_v), False)
 
         # Load Q to GPR (independent of boundary check)
         q_nope_packs, q_rope_packs = _load_q_to_regs(qo_start)
@@ -1772,17 +1470,13 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             )
 
         # --- Tile-1 row resolution (only meaningful for multi-tile) ---
-        # tile1_is_full: kv_start + 2*BN <= kv_end (equiv to num_tiles >= 3)
-        kv_start_plus_bn = _raw(kv_start + c_block_n)
-        c_2bn = arith.constant(2 * BLOCK_N, type=T.i32)
-        kv_start_plus_2bn = _raw(kv_start + c_2bn)
-        tile1_is_full = fx.Int32(kv_start_plus_2bn) <= fx.Int32(kv_end)
-        row_kv_ld_tile1 = fx.Int32(-1)
+        kv_start_plus_bn = _raw(ArithValue(kv_start) + c_block_n_v)
+        kv_start_plus_2bn = _raw(ArithValue(kv_start) + arith.constant(2 * BLOCK_N, type=T.i32))
+        tile1_is_full = ArithValue(kv_start_plus_2bn) <= ArithValue(kv_end)
+        row_kv_ld_tile1 = arith.constant(-1, type=T.i32)
         if tile1_is_full:
-            # Tile 1 is full -> no boundary check, tile_end = start+2*BN
             row_kv_ld_tile1 = _get_kv_ld_row(kv_start_plus_bn, kv_start_plus_2bn, False)
         else:
-            # Tile 1 may be partial -> boundary check, tile_end = kv_end
             row_kv_ld_tile1 = _get_kv_ld_row(kv_start_plus_bn, _raw(kv_end), True)
 
         # check_boundary_next for first tile: True only when
@@ -1797,17 +1491,13 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # cbn=True when !tile1_is_full. This is correct regardless of last_tile_partial because
         # when num_tiles==2 and !tile1_is_full, the next tile IS the last and IS partial.
         # !tile1_is_full: kv_start + 2*BN > kv_end (num_tiles == 2, next tile partial)
-        first_tile_cbn = fx.Int32(kv_start_plus_2bn) > fx.Int32(kv_end)
-
-        # 2-ahead resolve params for first tile (tile 0 -> resolve tile 2)
-        # nn_start = kv_start + 2*BN, nn_end = kv_end (always boundary check)
-        # do_resolve: tile 2 exists iff kv_start + 2*BN < kv_end
-        do_resolve_nn_first = fx.Int32(kv_start_plus_2bn) < fx.Int32(kv_end)
+        first_tile_cbn = ArithValue(kv_start_plus_2bn) > ArithValue(kv_end)
+        do_resolve_nn_first = ArithValue(kv_start_plus_2bn) < ArithValue(kv_end)
 
         # Branch on has_multi_tiles: multi-tile gets prefetch, single doesn't
-        p_pack_first = fx.Int64(0)
+        p_pack_first = arith.constant(0, type=T.i64)
         rescale_first = c_one_f32
-        row_kv_ld_nn_first = fx.Int32(-1)
+        row_kv_ld_nn_first = arith.constant(-1, type=T.i32)
         if _raw(has_multi_tiles):
             # Multi-tile: first tile is always full, prefetch tile 1.
             # Sub-branch on first_tile_cbn for compile-time check_boundary_next.
@@ -1873,14 +1563,17 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
         def _write_lse(pqo_loc_i32, rm, rse):
             """Write LSE for split output (first 16 lanes per warp)."""
-            if fx.Int32(lane_idx_i32) < 16:
+            if ArithValue(lane_idx_i32) < arith.constant(16, type=T.i32):
                 log2_sum = fmath.log2(rse, fastmath=fm_fast)
                 lse = fmath.fma(log2_sum, c_inv_log2e, rm, fastmath=fm_fast)
-                row_idx_i32 = lane_idx_i32 + warp_idx_i32 * 16 + fx.Int32(pqo_loc_i32) * NUM_QO_HEADS
+                row_idx_i32 = _raw(
+                    ArithValue(lane_idx_i32) + ArithValue(warp_idx_i32) * 16
+                    + ArithValue(pqo_loc_i32) * arith.constant(NUM_QO_HEADS, type=T.i32)
+                )
                 buffer_ops.buffer_store(lse, split_lse_rsrc, row_idx_i32)
 
         # LDS base for output reshape (reuse KV buffer 0 region)
-        p_lds_o_i32 = _index_cast_to_i32(p_lds_kv_0_base)
+        p_lds_o_i32 = _i32(p_lds_kv_0_base)
 
         def _do_last_gemm2_and_store(
             pp,
@@ -1895,10 +1588,10 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             Branches on partial_qo_loc to select bf16 vs f32 split output.
             """
             reci = arith.DivFOp(_raw(c_one_f32), _raw(rse), fastmath=fm_fast).result
-            is_not_split = fx.Int32(partial_qo_loc) < 0
+            is_not_split = ArithValue(partial_qo_loc) < arith.constant(0, type=T.i32)
             if is_not_split:
                 # bf16 final output: row_base = qo_start * NUM_QO_HEADS + warp*16
-                rb_bf16 = fx.Int32(qo_start) * NUM_QO_HEADS + warp_idx_i32 * 16
+                rb_bf16 = _raw(ArithValue(qo_start) * arith.constant(NUM_QO_HEADS, type=T.i32) + ArithValue(warp_idx_i32) * 16)
                 _gemm2_last_with_store(
                     pp,
                     rs,
@@ -1912,7 +1605,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                 )
             else:
                 # f32 split output: row_base = pqo_loc * NUM_QO_HEADS + warp*16
-                rb_split = fx.Int32(partial_qo_loc) * NUM_QO_HEADS + warp_idx_i32 * 16
+                rb_split = _raw(ArithValue(partial_qo_loc) * arith.constant(NUM_QO_HEADS, type=T.i32) + ArithValue(warp_idx_i32) * 16)
                 _gemm2_last_with_store(
                     pp,
                     rs,
@@ -1927,7 +1620,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                 _write_lse(_raw(partial_qo_loc), rm, rse)
 
         # ---- Multi-tile vs single-tile dispatch ----
-        if_multi = scf.IfOp(has_multi_tiles, [], has_else=True)
+        if_multi = scf.IfOp(_raw(has_multi_tiles), [], has_else=True)
         with ir.InsertionPoint(if_multi.regions[0].blocks[0]):
             # === Multi-tile path ===
 
@@ -1935,16 +1628,16 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             oaccu_mt = _gemm2_first_iter(p_pack_first, vt_base_i32)
 
             # --- Middle tiles [1, num_tiles-1) via scf.ForOp ---
-            c_one_idx = fx.Index(1)
-            num_tiles_m1 = num_tiles - 1
-            num_tiles_m1_idx = fx.Index(num_tiles_m1)
-            num_tiles_m2 = num_tiles - 2
+            c_one_idx = arith.index(1)
+            num_tiles_m1 = _raw(ArithValue(num_tiles) - arith.constant(1, type=T.i32))
+            num_tiles_m1_idx = arith.index_cast(T.index, num_tiles_m1)
+            num_tiles_m2 = _raw(ArithValue(num_tiles) - arith.constant(2, type=T.i32))
 
             init_args = [row_max, row_sum_e] + oaccu_mt + [row_kv_ld_nn_first]
 
             for tile_iv, state in range(c_one_idx, num_tiles_m1_idx, c_one_idx, init=init_args):
-                tile_iv_i32 = fx.Int32(tile_iv)
-                kv_tile_start_i32 = kv_start + tile_iv_i32 * c_block_n
+                tile_iv_i32 = arith.index_cast(T.i32, tile_iv)
+                kv_tile_start_i32 = _raw(ArithValue(kv_start) + ArithValue(tile_iv_i32) * c_block_n_v)
 
                 # Unpack carried state
                 rm_carried = state[0]
@@ -1956,24 +1649,24 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                 row_kv_ld_next = state[2 + NUM_PV_ITERS * 2]
 
                 # Buffer parity
-                is_odd = (tile_iv_i32 & 1) != 0
-                curr_base_idx = is_odd.select(p_lds_kv_1_base, p_lds_kv_0_base)
-                next_warp = is_odd.select(p_lds_kv_0_warp_i32, p_lds_kv_1_warp_i32)
+                tile_iv_av = ArithValue(tile_iv_i32)
+                is_odd = (tile_iv_av & arith.constant(1, type=T.i32)) != arith.constant(0, type=T.i32)
+                curr_base_idx = ArithValue(is_odd).select(p_lds_kv_1_base, p_lds_kv_0_base)
+                next_warp = ArithValue(is_odd).select(p_lds_kv_0_warp_i32, p_lds_kv_1_warp_i32)
 
                 # check_boundary_next: True when tile_idx == num_tiles-2 AND last_tile_partial
-                is_second_to_last = tile_iv_i32 == num_tiles_m2
-                mid_cbn = is_second_to_last & last_tile_partial
+                is_second_to_last = tile_iv_av == ArithValue(num_tiles_m2)
+                mid_cbn = _raw(ArithValue(is_second_to_last) & ArithValue(last_tile_partial))
 
-                # 2-ahead resolve params for this iteration:
-                nn_start_mid = kv_tile_start_i32 + c_2bn
-                do_resolve_nn_mid = nn_start_mid < kv_end
+                # 2-ahead resolve params
+                nn_start_mid = _raw(ArithValue(kv_tile_start_i32) + arith.constant(2 * BLOCK_N, type=T.i32))
+                do_resolve_nn_mid = ArithValue(nn_start_mid) < ArithValue(kv_end)
 
-                # Process tile: cb=False always, cbn is compile-time via sub-branch
-                rm_m = c_neg_inf_f32
+                rm_m = c_neg_inf
                 rse_m = c_zero_f32
-                pp_m = fx.Int64(0)
+                pp_m = arith.constant(0, type=T.i64)
                 rs_m = c_one_f32
-                nn_m = fx.Int32(-1)
+                nn_m = arith.constant(-1, type=T.i32)
                 if mid_cbn:
                     # cbn=True: next tile needs boundary check
                     _barrier(vmcnt=0, lgkmcnt=0)
@@ -2028,11 +1721,10 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             oaccu_mt = [results[2 + i] for i in range(NUM_PV_ITERS * 2)]
 
             # --- Last tile: GEMM1 + interleaved GEMM2 store ---
-            last_tile_iv_i32 = fx.Int32(num_tiles_m1)
-            kv_last_start = kv_start + last_tile_iv_i32 * c_block_n
-            last_parity = last_tile_iv_i32 & 1
-            last_is_odd = fx.Int32(last_parity) != 0
-            last_curr_base = last_is_odd.select(p_lds_kv_1_base, p_lds_kv_0_base)
+            last_tile_iv = ArithValue(num_tiles_m1)
+            kv_last_start = _raw(ArithValue(kv_start) + last_tile_iv * c_block_n_v)
+            last_is_odd = (last_tile_iv & arith.constant(1, type=T.i32)) != arith.constant(0, type=T.i32)
+            last_curr_base = ArithValue(last_is_odd).select(p_lds_kv_1_base, p_lds_kv_0_base)
 
             _barrier(vmcnt=0, lgkmcnt=0)
             rocdl.sched_barrier(0)

--- a/kernels/mla_fwd_decode_m16x8_fp8_fp8.py
+++ b/kernels/mla_fwd_decode_m16x8_fp8_fp8.py
@@ -323,8 +323,6 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     c_zero_v4f32 = Vec.filled(4, 0.0, fx.Float32)
     c_log2e = fx.Float32(LOG2E)
     c_inv_log2e = fx.Float32(1.0 / LOG2E)
-    c_dword_sz = fx.Int32(4)
-    c_aux_zero = c_zero_i32
 
     # ---- Buffer resources ----
     query_rsrc = buffer_ops.create_buffer_resource(query)
@@ -398,11 +396,9 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
         def _emit_vram_to_lds():
             voff = _raw(ArithValue(row_i32) * QK_HEAD_DIM + col_base_i32)
-            col_off = fx.Int32(block_idx_const * KV_NUM_COLS)
-            lds_ptr = _lds_ptr_from_i32(lds_base_i32)
-            rocdl.raw_ptr_buffer_load_lds(
-                kv_rsrc, lds_ptr, _raw(c_dword_sz), voff,
-                _raw(c_aux_zero), _raw(col_off), _raw(c_aux_zero),
+            rocdl.buffer_load_to_lds(
+                kv_rsrc, _lds_ptr_from_i32(lds_base_i32), voff,
+                offset=block_idx_const * KV_NUM_COLS,
             )
 
         if const_expr(check_boundary):

--- a/kernels/rmsnorm_kernel.py
+++ b/kernels/rmsnorm_kernel.py
@@ -60,8 +60,8 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
         elem_dtype = dtype_to_elem_type(dtype_str)
         elem_type = elem_dtype.ir_type
         fm_fast = arith.FastMathFlags.fast
-        eps_c = fx.Float32(EPS)
-        n_float = fx.Float32(float(N))
+        eps_c = EPS
+        n_float = float(N)
 
         base_ptr = allocator.get_base()
         s_red = SmemPtr(base_ptr, red_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
@@ -70,11 +70,10 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
         s_red2.get()
 
         def wave_reduce_add(x):
-            width_i32 = fx.Int32(WARP_SIZE)
             w = x
             for _sh_exp in range_constexpr(int(math.log2(WARP_SIZE))):
-                off = fx.Int32(WARP_SIZE // (2 << _sh_exp))
-                peer = w.shuffle_xor(off, width_i32)
+                off = WARP_SIZE // (2 << _sh_exp)
+                peer = w.shuffle_xor(off, WARP_SIZE)
                 w = w.addf(peer, fastmath=fm_fast)
             return w
 
@@ -93,32 +92,27 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
             w0 = wave_reduce_add(val0)
             w1 = wave_reduce_add(val1)
 
-            if lane == fx.Int32(0):
-                wave_idx = fx.Index(wave)
-                SmemPtr.store(s_red, w0, [wave_idx])
-                SmemPtr.store(s_red2, w1, [wave_idx])
+            if lane == 0:
+                SmemPtr.store(s_red, w0, [wave])
+                SmemPtr.store(s_red2, w1, [wave])
             gpu.barrier()
 
-            if wave == fx.Int32(0):
+            if wave == 0:
                 in_range = lane < RED_SLOTS
-                lane_safe = in_range.select(lane, fx.Int32(0))
-                lane_safe_idx = fx.Index(lane_safe)
-                v0 = SmemPtr.load(s_red, [lane_safe_idx])
-                v1 = SmemPtr.load(s_red2, [lane_safe_idx])
-                z = fx.Float32(0.0)
-                ww0 = in_range.select(v0, z)
-                ww1 = in_range.select(v1, z)
+                lane_safe = in_range.select(lane, 0)
+                v0 = SmemPtr.load(s_red, [lane_safe])
+                v1 = SmemPtr.load(s_red2, [lane_safe])
+                ww0 = in_range.select(v0, 0.0)
+                ww1 = in_range.select(v1, 0.0)
                 ww0 = wave_reduce_add(ww0)
                 ww1 = wave_reduce_add(ww1)
 
-                if lane == fx.Int32(0):
-                    c0_idx = fx.Index(0)
-                    SmemPtr.store(s_red, ww0, [c0_idx])
-                    SmemPtr.store(s_red2, ww1, [c0_idx])
+                if lane == 0:
+                    SmemPtr.store(s_red, ww0, [0])
+                    SmemPtr.store(s_red2, ww1, [0])
             gpu.barrier()
 
-            c0_idx = fx.Index(0)
-            return SmemPtr.load(s_red, [c0_idx]), SmemPtr.load(s_red2, [c0_idx])
+            return SmemPtr.load(s_red, [0]), SmemPtr.load(s_red2, [0])
 
         # ==================================================================
         # Fast path: N is a multiple of tile_cols
@@ -247,10 +241,8 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
 
             for base_idx_int in range_constexpr(0, N, BLOCK_THREADS):
                 idx = tid + base_idx_int
-                c_N_i32 = fx.Int32(N)
-                is_valid = idx < c_N_i32
-                c0_i = fx.Int32(0)
-                idx_safe = is_valid.select(idx, c0_i)
+                is_valid = idx < N
+                idx_safe = is_valid.select(idx, 0)
                 x_e = _load_scalar(row_div, idx_safe)
                 x = x_e if dtype_str == "f32" else x_e.to(fx.Float32)
                 x2 = x * x
@@ -264,8 +256,7 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
 
             for base_idx_int in range_constexpr(0, N, BLOCK_THREADS):
                 idx = tid + base_idx_int
-                c_N_i32 = fx.Int32(N)
-                if idx < c_N_i32:
+                if idx < N:
                     x_e = _load_scalar(row_div, idx)
                     g_e = _load_scalar(gamma_div, idx)
                     x = x_e if dtype_str == "f32" else x_e.to(fx.Float32)

--- a/kernels/silu_and_mul_fq.py
+++ b/kernels/silu_and_mul_fq.py
@@ -39,14 +39,12 @@ All arithmetic uses FlyDSL high-level APIs:
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, const_expr, vector, rocdl, range_constexpr
-from flydsl.expr import buffer_ops, math as fx_math
-from flydsl.expr.typing import T
-from flydsl.expr.arith import ArithValue
-from flydsl.compiler.kernel_function import CompilationContext
-
 from flydsl._mlir import ir
-
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, const_expr, range_constexpr, rocdl, vector
+from flydsl.expr import math as fx_math
+from flydsl.expr.arith import ArithValue
+from flydsl.expr.typing import T
 from kernels.kernels_common import get_warp_size
 
 BLOCK_THREADS = 256
@@ -172,7 +170,7 @@ def build_silu_and_mul_fq_module(
         tid_rsrc = buffer_ops.create_buffer_resource(sorted_ids, max_size=True)
         nv_rsrc = buffer_ops.create_buffer_resource(num_valid_ids, max_size=True)
 
-        num_valid = buffer_ops.buffer_load(nv_rsrc, fx.Int32(0), vec_width=1, dtype=T.i32)
+        num_valid = buffer_ops.buffer_load(nv_rsrc, 0, vec_width=1, dtype=T.i32)
         bid_i32 = ArithValue(bid)
 
         fused_tid_val = buffer_ops.buffer_load(tid_rsrc, bid_i32, vec_width=1, dtype=T.i32)
@@ -185,7 +183,7 @@ def build_silu_and_mul_fq_module(
         )
 
         def _store_scale(scale_rsrc, layout_scale, bid_i32, col0, val_i8):
-            if (col0 & 31) == fx.Int32(0):
+            if (col0 & 31) == 0:
                 s_off = _scale_byte_offset(layout_scale, bid_i32, col0 >> 5)
                 buffer_ops.buffer_store(
                     val_i8, scale_rsrc, s_off, offset_is_bytes=True,
@@ -263,7 +261,7 @@ def build_silu_and_mul_fq_module(
 
                         for sh_dist in SHUFFLE_DISTS:
                             local_max = local_max.maximumf(
-                                local_max.shuffle_xor(fx.Int32(sh_dist), fx.Int32(WARP_SIZE))
+                                local_max.shuffle_xor(sh_dist, WARP_SIZE)
                             )
 
                         # ── Compute e8m0 bias + quant_scale (fp4: h=2, fp8: h=8) ──

--- a/kernels/softmax_kernel.py
+++ b/kernels/softmax_kernel.py
@@ -65,15 +65,14 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
 
         c_zero_f = fx.Float32(0.0)
         c_neg_inf = fx.Float32(float("-inf"))
-        c_log2e = fx.Float32(1.4426950408889634)
+        c_log2e = 1.4426950408889634
 
         # ── wave / block reduction (supports max and sum) ─────────────────
         def wave_reduce(x, mode):
-            width_i32 = fx.Int32(WARP_SIZE)
             w = x
             for _sh_exp in range_constexpr(int(math.log2(WARP_SIZE))):
-                off = fx.Int32(WARP_SIZE // (2 << _sh_exp))
-                peer = w.shuffle_xor(off, width_i32)
+                off = WARP_SIZE // (2 << _sh_exp)
+                peer = w.shuffle_xor(off, WARP_SIZE)
                 if const_expr(mode == "max"):
                     w = w.maximumf(peer)
                 else:
@@ -90,27 +89,23 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
 
             w = wave_reduce(val, mode)
 
-            if lane == fx.Int32(0):
-                wave_idx = fx.Index(wave)
-                SmemPtr.store(s_red_buffer, w, [wave_idx])
+            if lane == 0:
+                SmemPtr.store(s_red_buffer, w, [wave])
             gpu.barrier()
 
-            if wave == fx.Int32(0):
+            if wave == 0:
                 in_range = lane < RED_SLOTS
-                lane_safe = in_range.select(lane, fx.Int32(0))
-                lane_safe_idx = fx.Index(lane_safe)
-                v = SmemPtr.load(s_red_buffer, [lane_safe_idx])
+                lane_safe = in_range.select(lane, 0)
+                v = SmemPtr.load(s_red_buffer, [lane_safe])
                 z = neutral
                 ww = in_range.select(v, z)
                 ww = wave_reduce(ww, mode)
 
-                if lane == fx.Int32(0):
-                    c0_idx = fx.Index(0)
-                    SmemPtr.store(s_red_buffer, ww, [c0_idx])
+                if lane == 0:
+                    SmemPtr.store(s_red_buffer, ww, [0])
             gpu.barrier()
 
-            c0_idx = fx.Index(0)
-            return SmemPtr.load(s_red_buffer, [c0_idx])
+            return SmemPtr.load(s_red_buffer, [0])
 
         # ==================================================================
         # Fast path: N is a multiple of tile_cols
@@ -171,8 +166,7 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
             global_sum = block_reduce(thread_sum, "sum", s_red)
 
             # 3. Normalize + store
-            c_one = fx.Float32(1.0)
-            inv_sum = c_one / fx.Float32(global_sum)
+            inv_sum = 1.0 / global_sum
 
             for tile_i in range_constexpr(num_tiles):
                 norm_vec = row_buffer[tile_i] * inv_sum
@@ -220,9 +214,8 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
 
             for base in range_constexpr(0, N, BLOCK_THREADS):
                 idx = tid + base
-                c_N = fx.Int32(N)
-                is_valid = idx < c_N
-                idx_safe = is_valid.select(idx, fx.Int32(0))
+                is_valid = idx < N
+                idx_safe = is_valid.select(idx, 0)
                 val_e = _load_scalar(a_div, idx_safe)
                 val = val_e if dtype_str == "f32" else val_e.to(fx.Float32)
                 safe_val = is_valid.select(val, c_neg_inf)
@@ -235,7 +228,7 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
             thread_sum = c_zero_f
             new_buffer = []
             for safe_val, is_valid in row_buffer:
-                sub = safe_val - fx.Float32(global_max)
+                sub = safe_val - global_max
                 scaled = sub * c_log2e
                 exp_val = scaled.exp2(fastmath=fm_fast)
                 safe_exp = is_valid.select(exp_val, c_zero_f)
@@ -243,8 +236,7 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
                 new_buffer.append((exp_val, is_valid))
 
             global_sum = block_reduce(thread_sum, "sum", s_red)
-            c_one = fx.Float32(1.0)
-            inv_sum = c_one / fx.Float32(global_sum)
+            inv_sum = 1.0 / global_sum
 
             # 3. Normalize + store
             buf_idx = 0
@@ -252,7 +244,7 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
                 idx = tid + base
                 exp_val, is_valid = new_buffer[buf_idx]
                 buf_idx += 1
-                if idx < fx.Int32(N):
+                if idx < N:
                     norm_val = fx.Float32(exp_val) * inv_sum
                     out_e = norm_val
                     if const_expr(dtype_str == "f32"):

--- a/python/flydsl/compiler/ast_rewriter.py
+++ b/python/flydsl/compiler/ast_rewriter.py
@@ -929,7 +929,8 @@ class InsertEmptyYieldForSCFFor(Transformer):
         stop_val = InsertEmptyYieldForSCFFor._to_index(stop)
         step_val = InsertEmptyYieldForSCFFor._to_index(step)
         if init is not None:
-            for_op = scf.ForOp(start_val, stop_val, step_val, list(init))
+            init = [_unwrap_value(v) for v in init]
+            for_op = scf.ForOp(start_val, stop_val, step_val, init)
             with ir.InsertionPoint(for_op.body):
                 yield for_op.induction_variable, list(for_op.inner_iter_args)
         else:

--- a/python/flydsl/expr/buffer_ops.py
+++ b/python/flydsl/expr/buffer_ops.py
@@ -422,8 +422,10 @@ def buffer_load(rsrc: ir.Value,
     elif hasattr(dtype, "ir_type"):
         dtype = dtype.ir_type
 
-    # Unwrap offset first (accept DSL Numeric values via ir_value())
-    if hasattr(offset, "ir_value"):
+    # Unwrap offset first (accept Python ints and DSL Numeric values).
+    if isinstance(offset, int):
+        offset = _create_i32_constant(offset)
+    elif hasattr(offset, "ir_value"):
         offset = offset.ir_value()
     offset = _unwrap_value(offset)
     
@@ -506,7 +508,9 @@ def buffer_store(data: ir.Value,
     # Unwrap all inputs (accept DSL Numeric values via ir_value())
     if hasattr(data, "ir_value"):
         data = data.ir_value()
-    if hasattr(offset, "ir_value"):
+    if isinstance(offset, int):
+        offset = _create_i32_constant(offset)
+    elif hasattr(offset, "ir_value"):
         offset = offset.ir_value()
     data = _unwrap_value(data)
     rsrc = _unwrap_value(rsrc)

--- a/python/flydsl/expr/rocdl.py
+++ b/python/flydsl/expr/rocdl.py
@@ -732,3 +732,30 @@ def raw_ptr_buffer_load_lds(rsrc, lds_ptr, size, voffset, soffset, offset, aux, 
     return _op(
         _to_ir(rsrc), _to_ir(lds_ptr), _to_ir(size), _to_ir(voffset), _to_ir(soffset), _to_ir(offset), _to_ir(aux), **kw
     )
+
+
+def buffer_load_to_lds(rsrc, lds_ptr, voffset, size_bytes=4, soffset=0, offset=0):
+    """Load ``size_bytes`` from a buffer resource into LDS (``buffer_load_dword lds``).
+
+    Simplified wrapper around :func:`raw_ptr_buffer_load_lds` with sensible
+    defaults.  ``soffset`` and ``offset`` accept Python ints and are
+    materialised as i32 constants automatically.
+
+    Args:
+        rsrc: Buffer resource descriptor (from ``buffer_ops.create_buffer_resource``).
+        lds_ptr: LDS destination pointer (``!llvm.ptr<3>``).
+        voffset: Per-lane byte offset into the buffer (i32 value).
+        size_bytes: Number of bytes to load per lane (Python int, default 4).
+        soffset: Scalar byte offset added to *voffset* (Python int or i32, default 0).
+        offset: Immediate byte offset (Python int or i32, default 0).
+    """
+    from .utils.arith import constant as _const
+
+    _size = _const(size_bytes, type=T.i32()) if isinstance(size_bytes, int) else _to_ir(size_bytes)
+    _soff = _const(soffset, type=T.i32()) if isinstance(soffset, int) else _to_ir(soffset)
+    _off = _const(offset, type=T.i32()) if isinstance(offset, int) else _to_ir(offset)
+    _aux = _const(0, type=T.i32())
+
+    from .._mlir.dialects.rocdl import raw_ptr_buffer_load_lds as _op
+
+    return _op(_to_ir(rsrc), _to_ir(lds_ptr), _size, _to_ir(voffset), _soff, _off, _aux)

--- a/python/flydsl/expr/rocdl/__init__.py
+++ b/python/flydsl/expr/rocdl/__init__.py
@@ -450,6 +450,16 @@ def raw_ptr_buffer_load_lds(rsrc, lds_ptr, size, voffset, soffset, offset, aux, 
     )
 
 
+def buffer_load_to_lds(rsrc, lds_ptr, voffset, size_bytes=4, soffset=0, offset=0):
+    """Load ``size_bytes`` from a buffer resource into LDS.
+
+    Simplified wrapper around :func:`raw_ptr_buffer_load_lds` with
+    sensible defaults (``soffset=0``, ``offset=0``, ``aux=0``).
+    Python int arguments are auto-materialised as i32 constants.
+    """
+    return raw_ptr_buffer_load_lds(rsrc, lds_ptr, size_bytes, voffset, soffset, offset, 0)
+
+
 def ds_bpermute(res, index, src, **kw):
     from ..._mlir.dialects.rocdl import ds_bpermute as _op
 

--- a/python/flydsl/expr/utils/arith.py
+++ b/python/flydsl/expr/utils/arith.py
@@ -288,6 +288,12 @@ def _invert_op(self, *, loc=None, ip=None):
     return arith.xori(self, arith_const(-1, self.type, loc=loc, ip=ip))
 
 
+def _select_raw_operand(value, other, *, loc=None):
+    if isinstance(value, (int, float, bool)):
+        return _to_raw(arith_const(value, _to_raw(other).type, loc=loc))
+    return _to_raw(value)
+
+
 @ir.register_value_caster(ir.Float4E2M1FNType.static_typeid)
 @ir.register_value_caster(ir.Float6E2M3FNType.static_typeid)
 @ir.register_value_caster(ir.Float6E3M2FNType.static_typeid)
@@ -356,8 +362,9 @@ class ArithValue(ir.Value):
 
     def select(self, true_value, false_value, *, loc=None):
         """Ternary select: self (i1 condition) ? true_value : false_value."""
-        return arith.SelectOp(_to_raw(self), _to_raw(true_value),
-                              _to_raw(false_value), loc=loc).result
+        true_value = _select_raw_operand(true_value, false_value, loc=loc)
+        false_value = _select_raw_operand(false_value, true_value, loc=loc)
+        return arith.SelectOp(_to_raw(self), true_value, false_value, loc=loc).result
 
     def extf(self, target_type, *, loc=None):
         """Extend float precision (e.g. bf16 → f32)."""
@@ -408,6 +415,10 @@ class ArithValue(ir.Value):
     def shuffle_xor(self, offset, width, *, loc=None):
         """GPU warp shuffle with XOR mode."""
         from ..._mlir.dialects.gpu import ShuffleOp
+        if isinstance(offset, int):
+            offset = constant(offset, type=T.i32(), loc=loc)
+        if isinstance(width, int):
+            width = constant(width, type=T.i32(), loc=loc)
         return ShuffleOp(_to_raw(self), _to_raw(offset),
                          _to_raw(width), mode="xor", loc=loc).shuffleResult
 
@@ -500,8 +511,9 @@ def index_cast(target_type, value, *, loc=None):
 @traced_op
 def select(condition, true_value, false_value, *, loc=None):
     """Select between two values based on a boolean condition."""
-    return arith.SelectOp(_to_raw(condition), _to_raw(true_value),
-                          _to_raw(false_value), loc=loc).result
+    true_value = _select_raw_operand(true_value, false_value, loc=loc)
+    false_value = _select_raw_operand(false_value, true_value, loc=loc)
+    return arith.SelectOp(_to_raw(condition), true_value, false_value, loc=loc).result
 
 
 @traced_op

--- a/python/flydsl/utils/smem_allocator.py
+++ b/python/flydsl/utils/smem_allocator.py
@@ -59,6 +59,16 @@ def get_op_result_or_value(op_or_val):
         return op_or_val.results[0]
     return op_or_val
 
+
+def get_index_value(op_or_val):
+    """Unwrap a value for memref indices, materializing/casting to index."""
+    if isinstance(op_or_val, int):
+        return get_op_result_or_value(arith.constant(T.index(), op_or_val))
+    val = get_op_result_or_value(op_or_val)
+    if isinstance(val, ir.Value) and not isinstance(val.type, ir.IndexType):
+        return get_op_result_or_value(arith.index_cast(T.index(), val))
+    return val
+
 # ==============================================================================
 # Pointer Abstraction
 # ==============================================================================
@@ -117,7 +127,7 @@ class SmemPtr:
                 for _ in range(len(self.shape) if self.shape else 1)
             ]
         else:
-            idxs = [get_op_result_or_value(i) for i in idxs]
+            idxs = [get_index_value(i) for i in idxs]
         return memref.load(get_op_result_or_value(view), idxs)
     
     def store(self, val, idxs=None):
@@ -129,7 +139,7 @@ class SmemPtr:
                 for _ in range(len(self.shape) if self.shape else 1)
             ]
         else:
-            idxs = [get_op_result_or_value(i) for i in idxs]
+            idxs = [get_index_value(i) for i in idxs]
         memref.store(get_op_result_or_value(val), get_op_result_or_value(view), idxs)
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

Comprehensive cleanup of `kernels/mla_fwd_decode_m16x8_fp8_fp8.py`:

- **Unify type system**: replace raw `arith.ArithValue(...)` with direct `ArithValue` import; eliminate verbose `arith.constant(N, type=T.i32)` in favor of `fx.Int32(N)` for standalone constants and Python int auto-coercion in `ArithValue` expressions
- **Remove `_get_element_ptr`**: replaced by `buffer_ops.get_element_ptr` (`_gep` alias)
- **Remove `_mlir_gpu` dependency**: `ShuffleOp` replaced by `ArithValue.shuffle_xor()`
- **Add `rocdl.buffer_load_to_lds()`**: simplified wrapper with default `soffset=0, offset=0, aux=0` and auto-materialisation of Python int args
- **Add `_pack_i32x2` / `_udiv` / `_urem` / `_lds_ptr_from_i32` helpers**: extract repeated patterns
- **Net reduction**: ~350 lines removed

## ISA impact (vs main)

| Metric | main | refactored |
|--------|------|-----------|
| ISA lines | 5765 | 5743 (-22) |
| vgpr_spill_count | **8** | **0** |
| private_segment | 36B | 0 |
| scratch ops | 16 | 0 |
| vgpr_count | 256 | 256 |
| sgpr_count | 80 | 80 |

Refactoring **eliminates all VGPR spills** present on main (8 scratch_store + 8 scratch_load).

## Test plan

- [x] Compilation verified
- [x] ISA dumped and compared vs main: no spills, fewer instructions
- [ ] `test_mla_decode` correctness + performance (needs idle GPU)