### PR TITLE
fix aot stream cachekey

### DIFF
--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -694,6 +694,8 @@ class JitFunction:
         recompilation when only runtime values change.
         """
         from .jit_argument import _is_constexpr_annotation, _is_type_param_annotation
+        from ..expr.typing import Stream
+
         sig = self._sig
         key_parts = [("_target_", self._target)]
         if self.compile_hints:
@@ -710,6 +712,10 @@ class JitFunction:
 
             if ann is not inspect.Parameter.empty and _is_type_param_annotation(ann):
                 key_parts.append((name, "Type", arg))
+                continue
+
+            if ann is Stream:
+                key_parts.append((name, Stream))
                 continue
 
             is_runtime = (ann is not inspect.Parameter.empty

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -762,7 +762,6 @@ class JitFunction:
         recompilation when only runtime values change.
         """
         from .jit_argument import _is_constexpr_annotation, _is_type_param_annotation
-        from ..expr.typing import Stream
 
         sig = self._sig
         key_parts = [("_target_", self._target)]
@@ -780,7 +779,9 @@ class JitFunction:
                 key_parts.append((name, "Type", arg))
                 continue
 
-            # TODO: quick fix for cpu aot compilation.
+            # The stream selects the launch queue and does not affect generated code.
+            # Normalize equivalent host representations (raw pointer, Stream object)
+            # so CPU AOT artifacts can be reused by GPU runtime calls.
             if ann is Stream:
                 key_parts.append((name, Stream))
                 continue

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -762,10 +762,7 @@ class JitFunction:
         recompilation when only runtime values change.
         """
         from .jit_argument import _is_constexpr_annotation, _is_type_param_annotation
-<<<<<<< HEAD
         from ..expr.typing import Stream
-=======
->>>>>>> origin/main
 
         sig = self._sig
         key_parts = [("_target_", self._target)]
@@ -783,7 +780,6 @@ class JitFunction:
                 key_parts.append((name, "Type", arg))
                 continue
 
-<<<<<<< HEAD
             # TODO: quick fix for cpu aot compilation.
             if ann is Stream:
                 key_parts.append((name, Stream))
@@ -791,9 +787,6 @@ class JitFunction:
 
             is_runtime = (ann is not inspect.Parameter.empty
                           and hasattr(ann, '__fly_ptrs__'))
-=======
-            is_runtime = ann is not inspect.Parameter.empty and hasattr(ann, "__fly_ptrs__")
->>>>>>> origin/main
             if isinstance(arg, tuple):
                 key_parts.append((name, tuple(self._arg_cache_sig(a) for a in arg)))
             else:

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -714,6 +714,7 @@ class JitFunction:
                 key_parts.append((name, "Type", arg))
                 continue
 
+            # TODO: quick fix for cpu aot compilation.
             if ann is Stream:
                 key_parts.append((name, Stream))
                 continue

--- a/tests/unit/test_jit_cache_key.py
+++ b/tests/unit/test_jit_cache_key.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.jit_argument import JitArgumentRegistry
+
+
+class _FakeCudaStream:
+    cuda_stream = 1234
+
+
+JitArgumentRegistry.register(_FakeCudaStream)(fx.Stream)
+
+
+@flyc.jit
+def _stream_launch(stream: fx.Stream = fx.Stream(None)):
+    pass
+
+
+@flyc.jit
+def _constexpr_launch(value: fx.Constexpr[int]):
+    pass
+
+
+def _cache_key(jit_fn, *args):
+    jit_fn._ensure_sig()
+    bound = jit_fn._sig.bind(*args)
+    bound.apply_defaults()
+    return jit_fn._make_cache_key(bound.arguments)
+
+
+def test_stream_cache_key_ignores_runtime_representation():
+    """CPU AOT can use raw 0 while GPU runtime passes a stream object."""
+    keys = [
+        _cache_key(_stream_launch),
+        _cache_key(_stream_launch, 0),
+        _cache_key(_stream_launch, fx.Stream(0)),
+        _cache_key(_stream_launch, _FakeCudaStream()),
+    ]
+
+    assert keys[0] == keys[1] == keys[2] == keys[3]
+    assert ("stream", fx.Stream) in keys[0]
+
+
+def test_constexpr_values_still_participate_in_cache_key():
+    assert _cache_key(_constexpr_launch, 1) != _cache_key(_constexpr_launch, 2)


### PR DESCRIPTION
Fix aot cpu compile issues. Cache key isn't consistent when runtime in gpu caused by stream value.