### PR TITLE
Allow PyPI publish review to run with tests

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -74,7 +74,7 @@ jobs:
       contents: read
 
   publish:
-    needs: [validate_tag, build, test]
+    needs: [validate_tag, build]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
## Summary
- Let the PyPI publish job depend only on tag validation and wheel build completion.
- Allow wheel tests and the PyPI environment review gate to proceed in parallel.

## Test plan
- Not run; workflow dependency-only change.


Made with [Cursor](https://cursor.com)