### PR TITLE
fix: mark fused rope token tensors dynamic

### DIFF
--- a/kernels/fused_rope_cache_kernel.py
+++ b/kernels/fused_rope_cache_kernel.py
@@ -431,14 +431,15 @@ def build_fused_rope_cache_module(
                                 v_elem = vector.extract(v_e, static_position=[vi], dynamic_position=[])
                                 buffer_ops.buffer_store(v_elem, vc_rsrc, vc_nf_off)
 
-    def _dynamic_token_tensor(tensor):
-        leading_dim = len(tensor.shape) - 1 if hasattr(tensor, "shape") else None
+    def _mark_token_layout_dynamic(tensor):
         if hasattr(tensor, "mark_layout_dynamic"):
+            shape = getattr(tensor, "_orig_shape", None)
+            leading_dim = len(shape) - 1 if shape is not None else -1
             return tensor.mark_layout_dynamic(leading_dim=leading_dim)
-        return flyc.from_dlpack(tensor).mark_layout_dynamic(leading_dim=leading_dim)
+        return flyc.from_dlpack(tensor).mark_layout_dynamic(leading_dim=tensor.ndim - 1)
 
     @flyc.jit
-    def _launch_fused_rope_cache(
+    def _jit_launch_fused_rope_cache(
         Q: fx.Tensor,
         K: fx.Tensor,
         V: fx.Tensor,
@@ -482,18 +483,18 @@ def build_fused_rope_cache_module(
         VScale,
         stream=fx.Stream(None),
     ):
-        return _launch_fused_rope_cache(
-            _dynamic_token_tensor(Q),
-            _dynamic_token_tensor(K),
-            _dynamic_token_tensor(V),
-            _dynamic_token_tensor(Positions),
+        return _jit_launch_fused_rope_cache(
+            _mark_token_layout_dynamic(Q),
+            _mark_token_layout_dynamic(K),
+            _mark_token_layout_dynamic(V),
+            _mark_token_layout_dynamic(Positions),
             CosCache,
             SinCache,
-            _dynamic_token_tensor(SlotMapping),
+            _mark_token_layout_dynamic(SlotMapping),
             KeyCache,
             ValueCache,
-            _dynamic_token_tensor(Q_out),
-            _dynamic_token_tensor(K_out),
+            _mark_token_layout_dynamic(Q_out),
+            _mark_token_layout_dynamic(K_out),
             num_tokens,
             KScale,
             VScale,

--- a/kernels/fused_rope_cache_kernel.py
+++ b/kernels/fused_rope_cache_kernel.py
@@ -431,8 +431,14 @@ def build_fused_rope_cache_module(
                                 v_elem = vector.extract(v_e, static_position=[vi], dynamic_position=[])
                                 buffer_ops.buffer_store(v_elem, vc_rsrc, vc_nf_off)
 
+    def _dynamic_token_tensor(tensor):
+        leading_dim = len(tensor.shape) - 1 if hasattr(tensor, "shape") else None
+        if hasattr(tensor, "mark_layout_dynamic"):
+            return tensor.mark_layout_dynamic(leading_dim=leading_dim)
+        return flyc.from_dlpack(tensor).mark_layout_dynamic(leading_dim=leading_dim)
+
     @flyc.jit
-    def launch_fused_rope_cache(
+    def _launch_fused_rope_cache(
         Q: fx.Tensor,
         K: fx.Tensor,
         V: fx.Tensor,
@@ -456,6 +462,41 @@ def build_fused_rope_cache_module(
         launcher.launch(
             grid=(max_heads, num_tokens, 1),
             block=(BLOCK_THREADS, 1, 1),
+            stream=stream,
+        )
+
+    def launch_fused_rope_cache(
+        Q,
+        K,
+        V,
+        Positions,
+        CosCache,
+        SinCache,
+        SlotMapping,
+        KeyCache,
+        ValueCache,
+        Q_out,
+        K_out,
+        num_tokens,
+        KScale,
+        VScale,
+        stream=fx.Stream(None),
+    ):
+        return _launch_fused_rope_cache(
+            _dynamic_token_tensor(Q),
+            _dynamic_token_tensor(K),
+            _dynamic_token_tensor(V),
+            _dynamic_token_tensor(Positions),
+            CosCache,
+            SinCache,
+            _dynamic_token_tensor(SlotMapping),
+            KeyCache,
+            ValueCache,
+            _dynamic_token_tensor(Q_out),
+            _dynamic_token_tensor(K_out),
+            num_tokens,
+            KScale,
+            VScale,
             stream=stream,
         )
 

--- a/kernels/topk_gating_softmax_kernel.py
+++ b/kernels/topk_gating_softmax_kernel.py
@@ -122,8 +122,9 @@ def build_topk_gating_softmax_module(
         bid = fx.block_idx.x
         tid = fx.thread_idx.x
 
-        elem_type = dtype_to_elem_type(dtype_str)
+        elem_type = dtype_to_elem_type(dtype_str).ir_type
         compute_type = T.f32
+        register_addr_space = int(fx.AddressSpace.Register)
 
         fm_fast = arith.FastMathFlags.fast
 
@@ -210,7 +211,7 @@ def build_topk_gating_softmax_module(
         atom_reg_ty_in = fx.MemRefType.get(
             elem_type,
             fx.LayoutType.get(ELEMS_PER_ATOM, 1),
-            fx.AddressSpace.Register,
+            register_addr_space,
         )
         atom_reg_lay_in = fx.make_layout(ELEMS_PER_ATOM, 1)
 
@@ -219,7 +220,7 @@ def build_topk_gating_softmax_module(
         # near `_store_scalar_i32` below).
         copy_atom_f32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), 32)
         scalar_reg_ty_f32 = fx.MemRefType.get(
-            T.f32, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
+            T.f32, fx.LayoutType.get(1, 1), register_addr_space
         )
         scalar_reg_lay = fx.make_layout(1, 1)
 


### PR DESCRIPTION
## Summary
- Wrap the fused RoPE cache launcher so only token-dependent tensors use dynamic layout.
- Preserve one compiled artifact across `num_tokens` values while keeping cache/static tensors unchanged.

## Test plan
- `PYTHONPATH=./python:./ FLYDSL_RUNTIME_ENABLE_CACHE=0 python3 -m pytest tests/kernels/test_fused_rope_cache.py --tb=short -q --confcutdir=/data/felix/dsl2/tests/kernels`


Made with [Cursor](https://cursor.com)