### PR TITLE
[DOC] Clean up MLA internal type usage and docs

### DIFF
--- a/.claude/skills/debug-flydsl-kernel/SKILL.md
+++ b/.claude/skills/debug-flydsl-kernel/SKILL.md
@@ -3,7 +3,7 @@ name: debug-flydsl-kernel
 description: >
   Debug FlyDSL GPU kernels that produce NaN, inf, wrong results, or crash.
   Covers cache invalidation, tracing pitfalls (runtime conditionals, range vs
-  range_constexpr), scf.for state packing, buffer_load addressing, MFMA operand
+  range_constexpr), loop-carried state packing, buffer_load addressing, MFMA operand
   layout verification, LDS bank conflict diagnosis, and systematic error
   isolation (all-1s test, single-partition test, host-side tensor inspection).
   Use when a FlyDSL kernel produces incorrect output or compilation errors.
@@ -34,7 +34,7 @@ compile_my_kernel.cache_clear()
 | All zeros output | Wrong output address, uninitialized temp buffer | Section 3 |
 | Partially wrong (>50% mismatch) | Wrong partition count, missing partitions, layout mismatch | Section 4 |
 | Small errors (1-5% mismatch) | FP8 quantization, scale factor, off-by-one masking | Section 5 |
-| Compilation error / crash | Type mismatch, scf.for state, range vs range_constexpr | Section 6 |
+| Compilation error / crash | Type mismatch, loop-carried state, range vs range_constexpr | Section 6 |
 | GPU hang | Infinite loop, deadlock in barrier, OOB memory access | Section 7 |
 
 ## 2. Debugging NaN
@@ -45,7 +45,7 @@ When ALL tokens in a partition are masked (out of context), `qk_max = -inf`. The
 
 **Fix**: Guard the exp calculation:
 ```python
-safe_diff = arith.select(qk_max > NEG_INF, diff, ZERO_F)
+safe_diff = (qk_max > NEG_INF).select(diff, ZERO_F)
 ```
 
 ### 2.2 Division by zero in normalization
@@ -54,8 +54,8 @@ When `exp_sum = 0` (all probs zero), `1/exp_sum = inf`.
 
 **Fix**:
 ```python
-safe_sum = arith.select(running_sum > ZERO_F, running_sum, arith.constant(1.0, type=T.f32))
-inv_sum = arith.constant(1.0, type=T.f32) / safe_sum
+safe_sum = (running_sum > ZERO_F).select(running_sum, fx.Float32(1.0))
+inv_sum = fx.Float32(1.0) / safe_sum
 ```
 
 ### 2.3 Host-side NaN check
@@ -143,7 +143,7 @@ Verify `_scale = softmax_scale * q_scale * k_scale` matches the reference. Commo
 
 ### 6.1 `range()` vs `range_constexpr()` inside @flyc.kernel
 
-FlyDSL's AST rewriter converts ALL `range()` to `scf.for` (runtime loops). Use `range_constexpr()` for compile-time unrolled loops:
+FlyDSL's AST rewriter converts runtime `range()` loops into MLIR loops. Use `range_constexpr()` for compile-time unrolled loops:
 ```python
 # WRONG: i becomes an ArithValue, can't index Python lists
 for i in range(4): result[i] = ...
@@ -160,15 +160,15 @@ FlyDSL tracing evaluates Python `if` at trace time. Runtime GPU values can't be 
 if kv_tok < context_len:  # runtime comparison
     fx.printf(...)
 
-# CORRECT: use arith.select for runtime conditionals
-val = arith.select(kv_tok < context_len, good_val, bad_val)
+# CORRECT: use ArithValue.select for runtime value selection
+val = (kv_tok < context_len).select(good_val, bad_val)
 ```
 
 Python `if` is fine for COMPILE-TIME decisions (e.g., `if trans_v:` where trans_v is a Python bool).
 
-### 6.3 scf.for state packing
+### 6.3 Loop-carried state packing
 
-All loop-carried values must be raw SSA values (not Python wrappers):
+Prefer FlyDSL internal types (`fx.Int32`, `fx.Float32`, `Vector`, `ArithValue`) for loop-carried state. Unwrap only when a low-level helper explicitly requires raw `ir.Value`:
 ```python
 def _unwrap(v):
     return v.ir_value() if hasattr(v, 'ir_value') else v
@@ -176,7 +176,7 @@ def _unwrap(v):
 init_state = [_unwrap(v) for v in [val1, val2, vec_val]]
 ```
 
-Supported state types: `f32` (scalar), `f32x4` (vector), `i32`, `i64`, `index`.
+Supported state types: `f32` (scalar), vector values, `i32`, `i64`, `index`.
 
 ### 6.4 buffer_load type mismatch
 
@@ -186,21 +186,21 @@ k_addr_bytes = ...  # address in FP8 elements (= bytes for FP8)
 k_4xi32 = buffer_ops.buffer_load(k_rsrc, k_addr_bytes // 4, vec_width=4, dtype=T.i32)
 ```
 
-### 6.5 vector.store requires vector type
+### 6.5 Vector stores require vector values
 
-LDS `vector.store` requires the value to be a vector, not scalar:
+`Vector.store` requires the value to be a vector, not scalar:
 ```python
 # WRONG
-vector.store(scalar_i32, lds_ptr, [idx])
+Vec(scalar_i32).store(lds_ptr, [idx])
 
 # CORRECT
-vec = vector.from_elements(T.vec(1, T.i32), [scalar_i32])
-vector.store(vec, lds_ptr, [idx])
+vec = Vec.from_elements([scalar_i32], fx.Int32)
+vec.store(lds_ptr, [idx])
 ```
 
 ## 7. GPU Hang
 
-### 7.1 Infinite scf.for loop
+### 7.1 Infinite runtime loop
 
 If loop bounds are wrong (`stop < start` with unsigned comparison issues, or `step=0`), the GPU hangs. Verify bounds on host:
 ```python
@@ -239,8 +239,8 @@ sudo amdgpu-reset  # or reboot
 - [ ] `range_constexpr()` for all compile-time loops (not `range()`)
 - [ ] No Python `if` on runtime GPU values
 - [ ] `buffer_load` offset units match dtype (bytes/4 for i32)
-- [ ] `vector.store` uses vector type (not scalar)
-- [ ] `scf.for` state packed with `_unwrap()` (raw SSA values)
+- [ ] Vector stores use `Vector` values (not scalars)
+- [ ] `range(..., init=...)` state uses internal types, unwrapped only at hard boundaries
 - [ ] Output written to correct partition slot (`part_z`, not absolute index)
 - [ ] `exp_sums`/`max_logits` strides match actual tensor layout
 - [ ] Softmax guards against `-inf - (-inf) = NaN`

--- a/.claude/skills/flydsl-internal-types-cleanup/SKILL.md
+++ b/.claude/skills/flydsl-internal-types-cleanup/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: flydsl-internal-types-cleanup
+description: >
+  Clean up FlyDSL kernel code by replacing direct scf/arith/vector/memref dialect calls
+  with FlyDSL internal types and helpers while preserving correctness, performance, and
+  generated ASM. Use when refactoring FlyDSL kernels, removing redundant wrappers, or
+  updating docs/skills to prefer fx.Int32/fx.Index/fx.Float32, ArithValue, Vector, and
+  range(..., init=...).
+---
+
+# FlyDSL Internal Types Cleanup
+
+## Default Rule
+
+Prefer FlyDSL internal types and high-level helpers in kernel code:
+
+- Constants and casts: `fx.Int32`, `fx.Int64`, `fx.Index`, `fx.Float32`
+- Arithmetic and comparisons: Python operators on `ArithValue` / `Numeric`
+- Runtime select: `cond.select(a, b)` or `arith.select(...)` only when a helper boundary requires it
+- Vectors: `Vector` (`Vec`) indexing, `Vec.from_elements`, `Vec.filled`, `.bitcast(...)`, `.to(...)`, `.store(...)`
+- Register memory: `fx.memref_alloca`, `fx.memref_load_vec`, `fx.memref_store_vec`
+- Runtime loops with carried state: `range(start, stop, step, init=[...])` using `fx.Index(...)` bounds
+- Compile-time loops: `range_constexpr(...)`
+
+Avoid new direct `scf.*`, `vector.*`, `memref.*`, `arith.index`, `arith.index_cast`, and `arith.trunc_f` in kernel bodies unless a lower-level boundary requires the exact op.
+
+## Replacement Map
+
+| Low-level form | Preferred form |
+|---|---|
+| `arith.constant(0, type=T.i32)` | `fx.Int32(0)` |
+| `arith.constant(0, index=True)` / `arith.index(0)` | `fx.Index(0)` |
+| `arith.constant(1.0, type=T.f32)` | `fx.Float32(1.0)` |
+| `arith.index_cast(T.i32, x)` | `fx.Int32(x)` |
+| `arith.index_cast(T.index, x)` | `fx.Index(x)` |
+| `vector.extract(v, static_position=[i], ...)` | `Vec(v)[i]` |
+| `vector.bitcast(T.vec(...), v)` | `Vec(v).bitcast(fx.Int32)` etc. |
+| `vector.from_elements(T.vec(n, T.i32), xs)` | `Vec.from_elements(xs, fx.Int32)` |
+| `vector.store(v, memref, [idx])` | `Vec(v).store(memref, [idx])` |
+| `arith.trunc_f(T.bf16x4, v)` | `Vec(v).to(fx.BFloat16)` |
+| `arith.addf/mulf` | `a + b`, `a * b` |
+| `arith.select(cond, a, b)` | `cond.select(a, b)` when `cond` is an `ArithValue` |
+
+## Important Exceptions
+
+Keep the exact lower-level op when it encodes semantics that internal types do not expose:
+
+- `llvm.InlineAsmOp` for hand-scheduled ISA snippets
+- `llvm.LoadOp` / `llvm.StoreOp` when `volatile`, `nontemporal`, address space, or alignment must be explicit
+- `arith.*FOp(..., fastmath=...)` when performance depends on fastmath flags
+- `arith.DivUIOp` / `arith.RemUIOp` for unsigned integer division/remainder
+- `rocdl.*` intrinsics and MFMA/WMMA/TDM ops
+- Backend dialect/C++ lowering docs and implementation code
+
+Do not hide these exceptions behind new helper wrappers just to remove the visible op. If exact semantics are required, keep the direct op at the boundary and document why.
+
+## Control Flow
+
+- Compile-time / constant conditions must be written as `if const_expr(condition): ...`. Do not rely on a plain Python `if` unless the condition is already a Python `bool`.
+- Use ordinary Python `if` on runtime values only when the AST rewriter keeps branch-local values and side effects correct.
+- For runtime branches inside nested helper functions, wrap the dispatch in a local `@flyc.jit` helper. This keeps branch side effects and loop-carried state in the right rewritten region.
+- For complex runtime branches with side effects, loop-carried state, or branch-local definitions, split branch bodies into local helper functions and dispatch through a local `@flyc.jit` helper. Verify correctness and ASM/perf.
+- Do not hand-write `scf.IfOp` in new kernel code unless the `@flyc.jit` helper pattern cannot express the required branch.
+- Use `range(..., init=[...])` for runtime loops with carried state; unwrap init values only if the API specifically requires raw `ir.Value`.
+
+Pattern:
+
+```python
+def _then_path():
+    ...
+
+def _else_path():
+    ...
+
+@flyc.jit
+def _dispatch():
+    if runtime_cond:
+        _then_path()
+    else:
+        _else_path()
+
+_dispatch()
+```
+
+## Verification Loop
+
+For performance-sensitive kernels:
+
+1. Record baseline shape coverage, timing, ASM hash, VGPR/SGPR counts, and spill counts.
+2. Apply one cleanup group at a time.
+3. Run correctness on small and large representative shapes.
+4. Compare performance; for strict cleanups, compare ASM hash.
+5. If performance drops or results change, revert that cleanup group and keep the lower-level op.
+
+Recommended checks:
+
+```bash
+PYTHONPATH=python:. FLYDSL_RUNTIME_ENABLE_CACHE=0 <kernel test command>
+FLYDSL_DUMP_IR=1 FLYDSL_RUNTIME_ENABLE_CACHE=0 PYTHONPATH=python:. <small compile command>
+sha256sum ~/.flydsl/debug/<kernel>/21_final_isa.s
+```

--- a/.claude/skills/flydsl-kernel-authoring/SKILL.md
+++ b/.claude/skills/flydsl-kernel-authoring/SKILL.md
@@ -2,7 +2,7 @@
 name: flydsl-kernel-authoring
 description: >
   Comprehensive reference for authoring FlyDSL GPU kernels on AMD GPUs.
-  Covers the layout algebra, tiled copy/MMA, buffer ops, scf.for loops,
+  Covers the layout algebra, tiled copy/MMA, buffer ops, loop-carried range loops,
   SmemAllocator, autotuning, and common patterns. Use when writing,
   reviewing, or understanding FlyDSL kernel code.
 allowed-tools: Read Edit Bash Grep Glob Agent
@@ -161,7 +161,7 @@ fx.slice(src, coord)                       # Slice at coordinate (None = keep mo
 ```python
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, gpu, buffer_ops, range_constexpr
+from flydsl.expr import gpu, buffer_ops, range_constexpr
 from flydsl.expr.typing import T
 
 @flyc.kernel
@@ -219,7 +219,7 @@ from flydsl.expr import range_constexpr
 for i in range_constexpr(N):
     ...
 
-# Runtime loop (lowered to scf.for via AST rewriting)
+# Runtime loop (lowered by AST rewriting)
 for i in range(runtime_value):
     ...
 ```
@@ -257,9 +257,29 @@ When writing or reviewing `@flyc.kernel` / `@flyc.jit` code, proactively avoid t
    return out
    ```
 
-### scf.for with Loop-Carried Values (Software Pipelining)
+4. **Compile-time conditions must use `const_expr(...)`.** Use `if const_expr(flag): ...` for constexpr flags and other static decisions. A plain Python `if` is only safe when the condition is already a Python `bool`.
 
-Use `init=` on `range()` to create an `scf.for` with explicit SSA phi nodes for loop-carried state. This is required for software pipelining (prefetch patterns) where data must flow across iterations.
+5. **Runtime branches inside helper functions should be dispatched via local `@flyc.jit`.** When a branch body has side effects, loop-carried values, or branch-local definitions, split the branch bodies into local helpers and wrap the `if` in a local JIT helper:
+   ```python
+   def then_path():
+       ...
+
+   def else_path():
+       ...
+
+   @flyc.jit
+   def dispatch():
+       if runtime_cond:
+           then_path()
+       else:
+           else_path()
+
+   dispatch()
+   ```
+
+### Runtime Loops with Loop-Carried Values (Software Pipelining)
+
+Use `init=` on `range()` to create a runtime loop with explicit SSA phi nodes for loop-carried state. This is required for software pipelining (prefetch patterns) where data must flow across iterations.
 
 **Pattern** (from `preshuffle_gemm.py`):
 ```python
@@ -267,11 +287,11 @@ Use `init=` on `range()` to create an `scf.for` with explicit SSA phi nodes for 
 tile_0 = prefetch(0)
 init_state = [acc_init, tile_0_flat_val1, tile_0_flat_val2, ...]
 
-# scf.for with loop-carried state
-# CRITICAL: bounds MUST be arith.index() values, NOT Python ints!
-_start = arith.index(0)
-_stop = arith.index(N - 1)
-_step = arith.index(1)
+# Runtime loop with loop-carried state
+# Use fx.Index(...) bounds so the AST rewriter does not treat this as a Python unrolled range.
+_start = fx.Index(0)
+_stop = fx.Index(N - 1)
+_step = fx.Index(1)
 for iv, state in range(_start, _stop, _step, init=init_state):
     acc_in = state[0]
     tile_in = state[1:]
@@ -290,47 +310,35 @@ compute(acc_final, tile_final)
 **How it works in MLIR:**
 | Element | Meaning |
 |---|---|
-| `init=init_state` | List of SSA values that seed the `scf.for` block arguments for iteration 0 |
+| `init=init_state` | List of SSA values that seed the runtime loop block arguments for iteration 0 |
 | `state` | The loop-carried block arguments (phi nodes) for THIS iteration |
-| `yield [...]` | `scf.yield` feeds values back as next iteration's `state` |
-| `results` | After loop exits, holds the last `yield`'s values (the `scf.for` op results) |
+| `yield [...]` | Feeds values back as next iteration's `state` |
+| `results` | After loop exits, holds the last yielded values |
 
 **Three critical pitfalls (all verified by debugging):**
 
-1. **Loop bounds must be `arith.index()`, NOT Python ints.** If you write `range(0, 15, 1, init=...)`, the AST rewriter treats constant bounds as a Python `range` and unrolls the loop — silently ignoring `init=`. Use `arith.index(0)`, `arith.index(15)`, `arith.index(1)` instead.
+1. **Loop bounds must be DSL index values, NOT Python ints.** If you write `range(0, 15, 1, init=...)`, the AST rewriter treats constant bounds as a Python `range` and unrolls the loop — silently ignoring `init=`. Use `fx.Index(0)`, `fx.Index(15)`, `fx.Index(1)` instead.
 
-2. **All `init` values must be raw MLIR `ir.Value`s.** FlyDSL wrappers like `Int32` / `Float32` don't have `.type` (only `.dtype`), and `scf.ForOp.__init__` calls `arg.type`. Unwrap via:
-   ```python
-   def _unwrap(v):
-       return v.ir_value() if hasattr(v, 'ir_value') else v
-   init_state = [_unwrap(v) for v in raw_list]
-   ```
+2. **Prefer internal types, but unwrap at hard boundaries.** Most `range(..., init=...)` uses accept DSL numeric/vector values. If a lower-level helper explicitly expects raw `ir.Value`, unwrap with `v.ir_value()` / `_raw(v)` at that boundary only.
 
-3. **Clear `SmemPtr._view_cache` before epilogue.** `SmemPtr.get()` caches the `memref.view` it creates. If called inside the `scf.for` body, the cached view is defined in the loop scope. Using it in the epilogue (outside the loop) causes an SSA dominance error. Fix:
+3. **Clear `SmemPtr._view_cache` before epilogue.** `SmemPtr.get()` caches the view it creates. If called inside the runtime loop body, the cached view is defined in the loop scope. Using it in the epilogue (outside the loop) causes an SSA dominance error. Fix:
    ```python
-   # After the scf.for loop, before epilogue compute:
+   # After the runtime loop, before epilogue compute:
    my_smem_ptr._view_cache = None
    ```
 
 ### Arithmetic Operations
 ```python
-from flydsl.expr import arith
-
 c42 = fx.Index(42)                              # index type constant (preferred)
 c3_14 = fx.Float32(3.14)                        # f32 constant (preferred)
 mask = fx.Int32(0xFF)                            # i32 constant (preferred)
-c42 = arith.constant(42, index=True)            # legacy index constant
-c3_14 = arith.constant(3.14, type=T.f32())     # legacy f32 constant
 
-# NOTE: arith.constant takes `type` as keyword arg, NOT positional
-result = arith.addf(a, b)    # float add
-result = arith.mulf(a, b)    # float multiply
-result = arith.negf(a)       # float negate
-result = arith.maximumf(a, b)  # float max (works on scalars AND vectors)
-result = arith.select(cond, true_val, false_val)
+# Prefer operators / Numeric methods
+result = a + b
+result = a * scale
+result = cond.select(true_val, false_val)
 
-# Compare floats (returns i1/vector<Nxi1>)
-is_less = arith.cmpf(a, b, predicate="olt")    # ordered less-than
+# Keep direct arith.*FOp only when explicit fastmath flags are required.
 ```
 
 ### Internal Types: Vector and Numeric (PREFERRED)
@@ -353,7 +361,7 @@ v_f32 = Vec(raw_vec).bitcast(Float32)  # vector<Nxi32> → vector<Nxf32>
 bf16_val = f32_val.to(BFloat16)        # f32 → bf16
 
 # Arithmetic — use Python operators, not arith.mulf/addf
-result = (val * scale_a) * scale_b     # auto-dispatches to mulf
+result = (val * scale_a) * scale_b
 
 # Splat constant vector
 zeros = Vec.filled(N, 0.0, Float32)
@@ -372,20 +380,20 @@ idx = fx.Int32(gpu.block_id("x") * tile_m)
 | `arith.addf(a, b)` | `a + b` |
 | `arith.index_cast(T.i32, v)` | `fx.Int32(v)` |
 
-Still use `arith.constant_vector` for splat and `vector.from_elements` for building vectors from scalars (no Vector equivalent yet).
+Use `Vec.filled(...)` for splats and `Vec.from_elements(...)` for vectors from scalars.
 
 ### Arith Ops Availability Table
 | Operation | Function | Works on Vectors | Notes |
 |-----------|----------|-----------------|-------|
-| Add | `a + b` or `arith.addf(a, b)` | Yes | |
-| Multiply | `a * b` or `arith.mulf(a, b)` | Yes | |
-| Negate | `arith.negf(a)` | Yes | |
-| Max | `arith.maximumf(a, b)` | Yes | Good for ReLU |
+| Add | `a + b` | Yes | Use direct FOp only for explicit fastmath |
+| Multiply | `a * b` | Yes | Use direct FOp only for explicit fastmath |
+| Negate | `-a` | Yes | |
+| Max | `a.maximumf(b)` | Yes | Good for ReLU |
 | Compare | `arith.cmpf(a, b, pred)` | Yes | Returns i1/vec<i1> |
-| Select | `arith.select(cond, t, f)` | Yes | |
-| Abs | `arith.absf(a)` | **NO - does not exist** | Use `negf+cmpf+select` |
-| FMA | `arith.fma(a, b, c)` | Not verified | Use `mulf+addf` instead |
-| Splat const | `arith.constant_vector(val, vty)` | Creates vector | For scalar broadcast |
+| Select | `cond.select(t, f)` | Yes | |
+| Abs | no direct helper | Use `-v`, comparison, and `cond.select(...)` |
+| FMA | `a * b + c` | Yes | Use direct FOp only when explicit fastmath is needed |
+| Splat const | `Vec.filled(width, val, dtype)` | Creates vector | For scalar broadcast |
 
 ### Printf Debugging
 ```python
@@ -556,11 +564,11 @@ The preshuffle GEMM pattern in `kernels/preshuffle_gemm.py`:
 ### Warp Reduction (AMD wave64)
 XOR-shuffle-based intra-wave reduction:
 ```python
-width_i32 = arith.constant(64, type=T.i32())
+width_i32 = fx.Int32(64)
 for sh in [32, 16, 8, 4, 2, 1]:
-    off = arith.constant(sh, type=T.i32())
+    off = fx.Int32(sh)
     peer = gpu.ShuffleOp(val, off, width_i32, mode="xor").shuffleResult
-    val = arith.AddFOp(val, peer).result  # or MaximumFOp for max
+    val = ArithValue(val) + peer  # use explicit FOp only if fastmath flags are needed
 ```
 
 ### Block Reduction
@@ -593,8 +601,8 @@ def elementwise_kernel(In: fx.Tensor, Out: fx.Tensor, BLOCK: fx.Constexpr[int], 
     rOut = fx.memref_alloca(MemTy, fx.make_layout(VEC, 1))
     fx.copy_atom_call(copy, fx.slice(tIn, (None, tid)), rIn)
     # Transform
-    v = fx.memref_load_vec(rIn)
-    v = fx.arith.mulf(v, v)  # example: square
+v = Vec(fx.memref_load_vec(rIn))
+v = v * v  # example: square
     fx.memref_store_vec(v, rOut)
     fx.copy_atom_call(copy, rOut, fx.slice(tOut, (None, tid)))
 ```
@@ -604,34 +612,29 @@ All recipes below follow the same vectorized copy_atom pattern (256 threads, vec
 Only the compute section between `memref_load_vec` and `memref_store_vec` differs.
 
 ```python
-from flydsl._mlir.ir import VectorType
-
 # --- Scale: C = A * scalar ---
-vA = fx.memref_load_vec(rA)
-vec_ty = VectorType.get([vec_width], fx.T.f32())
-scale = arith.constant_vector(2.0, vec_ty)
-vC = arith.mulf(vA, scale)
+vA = Vec(fx.memref_load_vec(rA))
+scale = Vec.filled(vec_width, 2.0, fx.Float32)
+vC = vA * scale
 
 # --- Multiply: C = A * B ---
-vC = arith.mulf(fx.memref_load_vec(rA), fx.memref_load_vec(rB))
+vC = Vec(fx.memref_load_vec(rA)) * Vec(fx.memref_load_vec(rB))
 
 # --- FMA: D = A * B + C ---
-vAB = arith.mulf(fx.memref_load_vec(rA), fx.memref_load_vec(rB))
-vD = arith.addf(vAB, fx.memref_load_vec(rC))
+vAB = Vec(fx.memref_load_vec(rA)) * Vec(fx.memref_load_vec(rB))
+vD = vAB + Vec(fx.memref_load_vec(rC))
 
 # --- ReLU: C = max(A, 0) ---
-vA = fx.memref_load_vec(rA)
-vec_ty = VectorType.get([vec_width], fx.T.f32())
-zero_vec = arith.constant_vector(0.0, vec_ty)
-vC = arith.maximumf(vA, zero_vec)
+vA = Vec(fx.memref_load_vec(rA))
+zero_vec = Vec.filled(vec_width, 0.0, fx.Float32)
+vC = vA.maximumf(zero_vec)
 
 # --- Abs: C = |A| (arith.absf does NOT exist) ---
 vA = fx.memref_load_vec(rA)
-vec_ty = VectorType.get([vec_width], fx.T.f32())
-zero_vec = arith.constant_vector(0.0, vec_ty)
-neg_vA = arith.negf(vA)
-is_neg = arith.cmpf(vA, zero_vec, predicate="olt")
-vC = arith.select(is_neg, neg_vA, vA)
+zero_vec = Vec.filled(vec_width, 0.0, fx.Float32)
+neg_vA = -vA
+is_neg = vA < zero_vec
+vC = is_neg.select(neg_vA, vA)
 ```
 
 ### Naive GEMM Template (for understanding, not performance)
@@ -647,11 +650,11 @@ def naive_gemm(A: fx.Tensor, B: fx.Tensor, C: fx.Tensor,
     rsrc_a = buffer_ops.create_buffer_resource(A)
     rsrc_b = buffer_ops.create_buffer_resource(B)
     rsrc_c = buffer_ops.create_buffer_resource(C)
-    acc = arith.constant(0.0, type=fx.T.f32())
+    acc = fx.Float32(0.0)
     for k in range_constexpr(K):
         a = buffer_ops.buffer_load(rsrc_a, row * K + k, vec_width=1)
         b = buffer_ops.buffer_load(rsrc_b, k * N + col, vec_width=1)
-        acc = arith.addf(acc, arith.mulf(a, b))
+        acc = acc + a * b
     buffer_ops.buffer_store(acc, rsrc_c, row * N + col)
 ```
 
@@ -749,7 +752,7 @@ Pass raw `torch.Tensor` objects instead.
 
 ### Common Issues
 
-1. **`arith.constant` signature**: Use `arith.constant(value, type=T.f32())` -- `type` is a keyword argument, NOT positional.
+1. **Constants/casts**: Prefer `fx.Int32(...)`, `fx.Int64(...)`, `fx.Index(...)`, and `fx.Float32(...)`. Use `arith.constant(...)` only at low-level boundaries.
 
 2. **`buffer_ops.buffer_load` offset**: The `offset` parameter is in ELEMENTS, not bytes.
 
@@ -769,9 +772,9 @@ Pass raw `torch.Tensor` objects instead.
 
 10. **INT4 (W4A8)**: A matrix is int8, B matrix is packed int4 (2 values/byte), unpacked to int8 in-kernel.
 
-11. **`arith.absf` does not exist**: FlyDSL does not expose `arith.absf`. Use `negf + cmpf("olt") + select` pattern instead. See Element-wise Kernel Cookbook.
+11. **`arith.absf` does not exist**: Prefer `Vector`/`ArithValue` operators: `neg = -v`, `is_neg = v < zero`, `out = is_neg.select(neg, v)`.
 
-12. **Scalar broadcast to vector**: Use `arith.constant_vector(value, VectorType.get([width], fx.T.f32()))` to create a splat constant vector. Do NOT try to use a scalar directly with vector `mulf`/`addf` — types must match.
+12. **Scalar broadcast to vector**: Use `Vec.filled(width, value, fx.Float32)` to create a splat constant vector. Do NOT use raw vector ops for ordinary arithmetic.
 
 ---
 

--- a/.claude/skills/flydsl-tile-programming/SKILL.md
+++ b/.claude/skills/flydsl-tile-programming/SKILL.md
@@ -57,8 +57,7 @@ The simplest pattern. Each thread processes `VEC_WIDTH` elements independently.
 import torch
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith
-from flydsl._mlir.ir import VectorType
+from flydsl.expr.typing import Vector as Vec
 
 BLOCK_DIM = 256
 VEC_WIDTH = 4
@@ -100,9 +99,9 @@ def elementwise_kernel(
     # === Step 5: Load -> Compute -> Store ===
     fx.copy_atom_call(copy_atom, fx.slice(tA, (None, tid)), rA)
 
-    vA = fx.memref_load_vec(rA)
+    vA = Vec(fx.memref_load_vec(rA))
     # --- YOUR COMPUTE HERE ---
-    vOut = arith.mulf(vA, vA)  # example: square
+    vOut = vA * vA  # example: square
     # --- END COMPUTE ---
     fx.memref_store_vec(vOut, rOut)
 
@@ -282,33 +281,31 @@ def buffer_kernel(A: fx.Tensor, B: fx.Tensor, N: fx.Constexpr[int]):
 Common compute recipes (all work on vectors):
 
 ```python
-from flydsl.expr import arith
-from flydsl._mlir.ir import VectorType
-
-vec_ty = VectorType.get([VEC_WIDTH], fx.T.f32())
+from flydsl.expr.typing import Vector as Vec
 
 # Scale: C = A * scalar
-scale = arith.constant_vector(2.0, vec_ty)
-vC = arith.mulf(vA, scale)
+scale = Vec.filled(VEC_WIDTH, 2.0, fx.Float32)
+vC = Vec(vA) * scale
 
 # Add: C = A + B
-vC = arith.addf(vA, vB)
+vC = Vec(vA) + Vec(vB)
 
 # FMA: D = A * B + C
-vC = arith.addf(arith.mulf(vA, vB), vC)
+vC = Vec(vA) * Vec(vB) + Vec(vC)
 
 # ReLU: C = max(A, 0)
-zero = arith.constant_vector(0.0, vec_ty)
-vC = arith.maximumf(vA, zero)
+zero = Vec.filled(VEC_WIDTH, 0.0, fx.Float32)
+vC = Vec(vA).maximumf(zero)
 
-# Abs: C = |A| (no arith.absf -- use this pattern)
-neg = arith.negf(vA)
-is_neg = arith.cmpf(vA, arith.constant_vector(0.0, vec_ty), predicate="olt")
-vC = arith.select(is_neg, neg, vA)
+# Abs: C = |A|
+v = Vec(vA)
+neg = -v
+is_neg = v < zero
+vC = is_neg.select(neg, v)
 
 # Type conversion
-vC = arith.sitofp(vI32, fx.T.f32())   # int -> float
-vC = arith.trunc_f(vF32, fx.T.f16())  # f32 -> f16
+vC = Vec(vI32).to(fx.Float32)  # int -> float
+vC = Vec(vF32).to(fx.Float16)  # f32 -> f16
 ```
 
 ---
@@ -322,13 +319,12 @@ from flydsl.expr import range_constexpr
 for i in range_constexpr(K):
     ...
 
-# Runtime loop (dynamic bounds -> scf.for)
+# Runtime loop (dynamic bounds)
 for i in range(runtime_N):
     ...
 
 # Loop with carried state (software pipelining)
-from flydsl.expr import arith as ar
-start, stop, step = ar.index(0), ar.index(N-1), ar.index(1)
+start, stop, step = fx.Index(0), fx.Index(N - 1), fx.Index(1)
 for iv, state in range(start, stop, step, init=[acc_init, ...]):
     acc = state[0]
     # ... compute ...
@@ -340,7 +336,7 @@ from flydsl.expr import const_expr
 if const_expr(USE_FAST_PATH):
     ...
 
-# Dynamic if (runtime -> scf.IfOp, automatic)
+# Dynamic if (runtime, rewritten by the frontend)
 if bid == 0:
     ...
 ```
@@ -420,13 +416,13 @@ FLYDSL_DUMP_IR=1 PYTHONPATH=./ python my_kernel.py
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `TypeError: 'int' has no attribute 'type'` | Passing Python int where MLIR Value expected | Use `arith.constant(N, type=T.i32())` |
+| `TypeError: 'int' has no attribute 'type'` | Passing Python int where a DSL value is expected | Use `fx.Int32(N)` / `fx.Index(N)` |
 | `NameError: name 'x' not defined` inside `__then_*` | AST rewriter extracted if-body as function, variable not captured | Use `const_expr()` for static conditions |
-| `arith.absf` not found | FlyDSL doesn't expose absf | Use `negf + cmpf + select` |
-| Scalar + vector type mismatch | Can't use scalar with vector arith ops | Use `arith.constant_vector()` to splat |
+| `arith.absf` not found | Prefer `Vector`/`ArithValue` operators | Use `-v`, comparison, and `cond.select(...)` |
+| Scalar + vector type mismatch | Can't use scalar with raw vector ops | Use `Vec.filled()` to splat |
 | LDS overflow / wrong results | Exceeds per-CU LDS capacity | Check total LDS bytes vs limit |
 | `buffer_load` returns wrong data | Offset is in elements, not bytes | Don't multiply by sizeof yourself |
-| `scf.for init=` ignored, loop unrolled | Bounds are Python int constants | Use `arith.index(N)` for bounds |
+| `range(..., init=...)` ignored, loop unrolled | Bounds are Python int constants | Use `fx.Index(N)` for bounds |
 | Cache stale after C++ pass edit | Disk cache not auto-invalidated for C++ changes | `rm -rf ~/.flydsl/cache` or `FLYDSL_RUNTIME_ENABLE_CACHE=0` |
 
 ---

--- a/.claude/skills/lds-optimization/SKILL.md
+++ b/.claude/skills/lds-optimization/SKILL.md
@@ -223,7 +223,6 @@ row index into the LDS address when computing store/load offsets:
 
 ```python
 from flydsl.utils.smem_allocator import SmemAllocator
-from flydsl.expr import arith
 
 allocator = SmemAllocator(None, arch="gfx942", global_sym_name="smem0")
 lds_key = allocator.allocate_array(T.f16, KV_BLOCK_SIZE * HEAD_SIZE)
@@ -236,7 +235,7 @@ def my_kernel(...):
     # XOR-swizzle address: distribute bank accesses
     # row_idx and col_idx are the logical 2D coordinates
     # XOR_BITS controls swizzle width (typically 4 for fp16 vec=8)
-    swizzled_col = arith.xori(col_idx, arith.andi(row_idx, XOR_MASK))
+    swizzled_col = col_idx ^ (row_idx & XOR_MASK)
     lds_offset = row_idx * PADDED_STRIDE + swizzled_col
     lds_key_ptr.store(data, [lds_offset])
 ```
@@ -273,7 +272,7 @@ After (swizzled, conflict-free):
 # XOR-swizzle distributes accesses across banks
 XOR_BITS = 4  # for fp16 vec=8: covers 4 banks per vec
 lds_key = allocator.allocate_array(T.f16, KV_BLOCK_SIZE * HEAD_SIZE)
-swizzled_col = arith.xori(col, arith.shli(arith.andi(row, 0x7), XOR_BITS))
+swizzled_col = col ^ ((row & 0x7) << XOR_BITS)
 lds_offset = row * HEAD_SIZE + swizzled_col
 lds_key_ptr.store(data, [lds_offset])  # now conflict-free
 ```

--- a/.claude/skills/port-to-layout-api/SKILL.md
+++ b/.claude/skills/port-to-layout-api/SKILL.md
@@ -59,7 +59,8 @@ For f32 with VEC_WIDTH=8 (256 bits), fall back to scalar path or split into two 
 **Before (raw buffer_ops):**
 ```python
 from flydsl.expr import buffer_ops
-from flydsl.expr.arith import ArithValue
+from flydsl.expr.utils.arith import ArithValue
+from flydsl.expr.typing import Vector as Vec
 
 rsrc = buffer_ops.create_buffer_resource(Input, max_size=True)
 
@@ -67,13 +68,13 @@ elem_bytes = 2  # f16
 row_soffset = ArithValue(bid) * (N * elem_bytes)
 thr_col_bytes = ArithValue(tid) * (VEC_WIDTH * elem_bytes)
 col_bytes = ArithValue(thr_col_bytes) + (tile_i * tile_cols * elem_bytes)
-dw = col_bytes.shrui(arith.constant(2, type=T.i32))
+dw = col_bytes.shrui(fx.Int32(2))
 
 raw_data = buffer_ops.buffer_load(
     rsrc, dw, vec_width=vec_dwords, dtype=T.i32,
     soffset_bytes=row_soffset, mask=is_valid,
 )
-vec_f16 = vector.bitcast(vec_type_f16, raw_data)
+vec_f16 = Vec(raw_data).bitcast(fx.Float16)
 ```
 
 **After (layout API):**
@@ -96,7 +97,7 @@ vec_reg_lay = fx.make_layout(VEC_WIDTH, 1)
 idx = tid + tile_i * BLOCK_THREADS
 r = fx.memref_alloca(vec_reg_ty, vec_reg_lay)
 fx.copy_atom_call(copy_atom, fx.slice(in_div, (None, idx)), r)
-vec_f16 = ArithValue(fx.memref_load_vec(r))
+vec_f16 = Vec(fx.memref_load_vec(r))
 ```
 
 ### Step 4: Handle Multi-Dimensional Tensors
@@ -130,7 +131,7 @@ The layout API's `copy_atom_call` does NOT accept a mask parameter.
 
 **For loads**: With `make_buffer_tensor` using max_size (0xFFFFFFFF num_records),
 out-of-bounds loads read adjacent memory or return 0 at allocation boundary.
-Guard results with `arith.select(is_valid, value, zero)` as needed.
+Guard results with `is_valid.select(value, zero)` as needed.
 
 **For stores**: Wrap in a conditional to prevent OOB writes:
 ```python
@@ -172,7 +173,7 @@ After porting, remove:
 - `elem_bytes` / `vec_dwords` constants (no longer needed)
 - `row_soffset` / `thr_col_bytes` byte-offset computations
 - `shrui(..., 2)` dword conversion
-- `vector.bitcast` from i32 to element type (loads produce the right type)
+- raw `vector.bitcast` from i32 to element type (use `Vec(...).bitcast(...)` when a bitcast is still needed)
 
 ## Known Limitation: Dynamic Tensor Shapes & JIT Cache
 

--- a/.claude/skills/prefetch-data-load/SKILL.md
+++ b/.claude/skills/prefetch-data-load/SKILL.md
@@ -3,7 +3,7 @@ name: prefetch-data-load
 description: >
   Apply prefetch optimization to FlyDSL kernel loops: pre-load the first
   iteration's data before the loop, issue async loads for the next iteration
-  inside the loop body, and swap buffers at the loop tail via scf.for
+  inside the loop body, and swap buffers at the loop tail via runtime
   loop-carried values. This overlaps data load latency with compute
   instructions. Use when a kernel has a loop where buffer_load feeds into
   MFMA/compute and load latency is exposed.
@@ -64,16 +64,16 @@ Timeline:
 The total time drops from `N * (load + compute)` to roughly
 `load + N * max(load, compute)`.
 
-## FlyDSL Implementation: scf.for with Loop-Carried Prefetch
+## FlyDSL Implementation: `range(..., init=...)` with Loop-Carried Prefetch
 
 In FlyDSL kernels, Python-level `for _pi in range(N)` gets traced into N flat
 copies that LLVM re-rolls. This makes the `data = next_data` swap **invisible**
 to MLIR — both variables alias the same SSA value, so LLVM hoists loads as
 loop-invariant.
 
-**Solution**: Use FlyDSL's `scf.for` with `init=` (loop-carried values) to
+**Solution**: Use FlyDSL's runtime `range(..., init=...)` (loop-carried values) to
 create genuine SSA phi nodes. See the `flydsl-kernel-authoring` skill, section
-"scf.for with Loop-Carried Values", for the full pattern and three critical
+"Runtime Loops with Loop-Carried Values", for the full pattern and three critical
 pitfalls.
 
 ### Transformation Steps
@@ -91,7 +91,7 @@ for i in range(START, END):
     result = rocdl.mfma_f32_16x16x16_f16(transform(data_A), transform(data_B), acc)
 ```
 
-Apply the following transformation using `scf.for` with `init=`:
+Apply the following transformation using `range(..., init=...)`:
 
 #### Step 1: Prologue — load first iteration before loop
 
@@ -103,12 +103,12 @@ next_data_B = buffer_ops.buffer_load(rsrc_B, offsets_0, vec_width=4)
 init_state = [_unwrap(v) for v in [next_data_A, next_data_B, acc]]
 ```
 
-#### Step 2: scf.for with loop-carried state
+#### Step 2: Runtime loop with loop-carried state
 
 ```python
-_start = arith.index(0)
-_stop = arith.index(N - 1)  # N-1 iterations; last handled in epilogue
-_step = arith.index(1)
+_start = fx.Index(0)
+_stop = fx.Index(N - 1)  # N-1 iterations; last handled in epilogue
+_step = fx.Index(1)
 
 for iv, state in range(_start, _stop, _step, init=init_state):
     # Swap: prefetched -> current
@@ -190,8 +190,8 @@ def _unpack(state):
 pf_0 = issue_bt_k_loads(partition_0)
 init_state = _pack(flatten(pf_0['kv']), pf_0['part_start'], ...)
 
-# scf.for (bounds MUST be arith.index, not Python ints!)
-for iv, state in range(arith.index(0), arith.index(N-1), arith.index(1), init=init_state):
+# Runtime loop (bounds MUST be fx.Index, not Python ints!)
+for iv, state in range(fx.Index(0), fx.Index(N - 1), fx.Index(1), init=init_state):
     kv, part_start, bt, rmax, rsum, acc = _unpack(state)
     rmax, rsum, acc = compute_qk_softmax_pv(kv, part_start, bt, rmax, rsum, acc)
     pf_next = issue_bt_k_loads(next_partition(iv + 1))
@@ -211,22 +211,17 @@ K loads needed).
 
 ### Three Critical Pitfalls
 
-1. **Loop bounds must be `arith.index()`, NOT Python ints.** If you write
+1. **Loop bounds must be `fx.Index(...)`, NOT Python ints.** If you write
    `range(0, 15, 1, init=...)`, the AST rewriter treats constant bounds as a
    Python `range` and unrolls the loop — silently ignoring `init=`. Use
-   `arith.index(0)`, `arith.index(15)`, `arith.index(1)` instead.
+   `fx.Index(0)`, `fx.Index(15)`, `fx.Index(1)` instead.
 
-2. **All `init` values must be raw MLIR `ir.Value`s.** FlyDSL wrappers like
-   `Int32` / `Float32` don't have `.type` (only `.dtype`), and
-   `scf.ForOp.__init__` calls `arg.type`. Unwrap via:
-   ```python
-   def _unwrap(v):
-       return v.ir_value() if hasattr(v, 'ir_value') else v
-   init_state = [_unwrap(v) for v in raw_list]
-   ```
+2. **Prefer internal types; unwrap only at hard boundaries.** Most loop-carried
+   values can remain `fx.Int32`, `fx.Float32`, `ArithValue`, or `Vector`. If a
+   low-level helper explicitly expects raw `ir.Value`, unwrap at that boundary.
 
 3. **Clear `SmemPtr._view_cache` before epilogue.** `SmemPtr.get()` caches the
-   `memref.view` it creates. If called inside the `scf.for` body, the cached
+   view it creates. If called inside the runtime loop body, the cached
    view is defined in the loop scope. Using it in the epilogue (outside the loop)
    causes an SSA dominance error. Fix:
    ```python
@@ -301,7 +296,7 @@ regression).
 ### What Prefetch Can and Cannot Do
 
 **CAN do:**
-- Restructure the loop so `buffer_load` is issued earlier via `scf.for` loop-carried values
+- Restructure the loop so `buffer_load` is issued earlier via `range(..., init=...)` loop-carried values
 - The compiler will then schedule the corresponding `s_waitcnt` further from the load
 - Overlap next iteration's loads with current iteration's MFMA compute
 
@@ -342,7 +337,7 @@ This works because:
 ### Do
 - **Prefetch ALL data** needed for the next iteration: keys, values, scales, block table entries
 - **Place prefetch loads** immediately after the swap, BEFORE any compute that consumes current data
-- **Use scf.for with init=** to carry prefetched data across iterations (Python variable swap is invisible to MLIR)
+- **Use `range(..., init=...)`** to carry prefetched data across iterations (Python variable swap is invisible to MLIR)
 - **Minimize work between load and consume**: the more compute between prefetch issue and data use, the better the overlap
 - **Keep the swap simple**: just unpack from `state`, no computation
 - **Check VGPR budget**: calculate `current_arch_vgpr + prefetch_vgprs <= 256` to avoid spills
@@ -355,8 +350,8 @@ This works because:
 - **Don't assume occupancy can increase**: on MI308 with 512 max VGPRs, adding prefetch buffers that push total VGPRs above 256 will drop occupancy from 2 to 1 wave/SIMD. This may or may not be acceptable — profile both configurations.
 - **Don't reorder loads that have data dependencies**: if `load_B` depends on the result of `load_A` (e.g., block table lookup -> cache load), they must stay sequential within the prefetch block.
 - **Don't forget to handle conditional branches**: if scale loads are conditional (`KV_QUANT_MODE`), the prefetch must replicate the same conditions.
-- **Don't break the prologue/epilogue semantics**: the prologue covers iteration 0; `scf.for` runs N-1 iterations carrying prefetched data; epilogue processes the last iteration from `results`.
-- **Don't use Python ints as scf.for bounds**: use `arith.index()` or the loop will be unrolled, silently ignoring `init=`.
+- **Don't break the prologue/epilogue semantics**: the prologue covers iteration 0; the runtime loop runs N-1 iterations carrying prefetched data; epilogue processes the last iteration from `results`.
+- **Don't use Python ints as loop bounds when using `init=`**: use `fx.Index(...)` or the loop will be unrolled, silently ignoring `init=`.
 
 ## Verification
 

--- a/docs/api/dsl.rst
+++ b/docs/api/dsl.rst
@@ -130,40 +130,42 @@ GPU Intrinsics (``flydsl.expr.gpu``)
 - **fx.gpu.barrier()** -- workgroup barrier synchronization
 - **fx.gpu.smem_space()** -- shared memory (LDS) address space attribute
 
-Arithmetic (``flydsl.expr.arith``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Arithmetic and Numeric Types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Operator-overloaded arithmetic via ``ArithValue``:
+Prefer typed DSL values and operator-overloaded arithmetic:
 
 .. code-block:: python
 
-   from flydsl.expr import arith
+   import flydsl.expr as fx
+   from flydsl.expr.typing import Vector as Vec
 
-   c = arith.constant(42, index=True)
-   v = arith.index_cast(T.index, val)
-   r = arith.select(cond, a, b)
+   c = fx.Index(42)
+   v = fx.Int32(idx)
+   f = fx.Float32(1.0)
+   r = cond.select(a, b)
+   y = (x + 1) * scale
 
-Key functions:
+Preferred APIs:
 
-- **arith.constant(value, type=None, index=False)** -- create constant
-- **arith.constant_vector(value, vec_type)** -- create splat vector constant
-- **arith.index_cast(target_type, value)** -- cast to/from index type
-- **arith.select(cond, true_val, false_val)** -- ternary select
+- **fx.Int32(value)**, **fx.Int64(value)**, **fx.Index(value)**, **fx.Float32(value)** -- constants and casts
+- **ArithValue / Numeric operators** -- ``+``, ``-``, ``*``, ``/``, ``%``, ``<<``, ``>>``
+- **cond.select(true_val, false_val)** -- ternary select when ``cond`` is an ``ArithValue``
 - **arith.cmpi(predicate, lhs, rhs)** -- integer comparison
 - **arith.cmpf(predicate, lhs, rhs)** -- float comparison
-- **arith.sitofp(type, value)** -- signed int to float
-- **arith.trunc_f(type, value)** -- truncate float precision
-- **ArithValue** -- wrapper class enabling ``+``, ``-``, ``*``, ``/``, ``%``, ``<<``, ``>>`` operators
+- **Direct ``arith.*FOp(..., fastmath=...)``** -- use only where explicit fastmath flags are required for performance
 
-Vector Operations (``flydsl.expr.vector``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Vector Values (``flydsl.expr.typing.Vector``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **vector.from_elements(type, elements)** -- construct vector from scalars (auto-unwraps ArithValue)
-- **vector.store(value, memref, indices)** -- store vector to memref
-- **vector.extract(vector, position)** -- extract element from vector
-- **vector.load_op(result_type, memref, indices)** -- load vector from memref
-- **vector.bitcast(result_type, source)** -- bitcast vector type
-- **vector.broadcast**, **vector.reduction** -- broadcast and reduce operations (from MLIR upstream)
+- **Vec.from_elements(elements, dtype)** -- construct vector from scalars
+- **Vec.filled(shape, value, dtype)** -- splat vector
+- **Vec(value)[i]** -- extract element
+- **Vec(value).bitcast(dtype)** -- bitcast vector element type
+- **Vec(value).to(dtype)** -- convert vector element type
+- **Vec(value).store(memref, indices)** -- store vector to memref
+
+Use direct ``flydsl.expr.vector`` only for low-level boundaries that ``Vector`` does not expose.
 
 Buffer Operations (``flydsl.expr.buffer_ops``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/kernel_authoring_guide.md
+++ b/docs/kernel_authoring_guide.md
@@ -18,7 +18,7 @@
 | **Tensor arg** | `fx.Tensor` | GPU tensor argument (via DLPack) |
 | **Stream arg** | `fx.Stream` | CUDA/HIP stream argument |
 | **Barrier** | `fx.gpu.barrier()` | Workgroup synchronization |
-| **Constants** | `arith.constant(val)` | Create MLIR constant value |
+| **Constants** | `fx.Int32` / `fx.Index` / `fx.Float32` | Create typed DSL constants |
 | **Range loop** | `range_constexpr(n)` | Compile-time unrolled loop |
 | **Buffer load** | `buffer_ops.buffer_load(rsrc, off)` | AMD buffer load intrinsic |
 
@@ -31,7 +31,7 @@
 ```python
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, gpu
+from flydsl.expr import gpu
 
 @flyc.kernel
 def vec_add_kernel(
@@ -43,7 +43,7 @@ def vec_add_kernel(
     tid = gpu.thread_idx.x
     bid = gpu.block_idx.x
     idx = bid * 256 + tid
-    # ... kernel body using arith/vector/buffer ops ...
+    # ... kernel body using fx.*, ArithValue, Vector, and buffer ops ...
 
 @flyc.jit
 def vec_add(
@@ -188,21 +188,15 @@ raw_bid = gpu.block_id("x")
 
 ## 4. Expression API (`flydsl.expr`)
 
-### 4.1 Arithmetic (`fx.arith`)
+### 4.1 Arithmetic and Numeric Types
 
 ```python
-from flydsl.expr import arith
-from flydsl.expr.typing import T
 import flydsl.expr as fx
 
 # Constants (prefer DSL numeric types)
 c42 = fx.Index(42)          # index type constant
 c3_14 = fx.Float32(3.14)    # f32 constant
 mask = fx.Int32(0xFF)       # i32 constant
-
-# Legacy constant API (still works)
-c42 = arith.constant(42, index=True)     # index type
-c3_14 = arith.constant(3.14, type=T.f32) # f32 type
 
 # Arithmetic (operator overloading via ArithValue / Numeric)
 result = a + b
@@ -215,28 +209,31 @@ idx = fx.Index(int_val)     # cast to index type
 i32_val = fx.Int32(idx)     # cast to i32
 
 # Select
-result = arith.select(cond, true_val, false_val)
+result = cond.select(true_val, false_val)  # when cond is an ArithValue
 
 # Bitwise
-result = arith.andi(a, b)
-result = arith.xori(a, b)
-result = arith.shli(a, b)
+result = a & b
+result = a ^ b
+result = a << 4
 ```
 
-### 4.2 Vector Operations (`fx.vector`)
+Use direct `arith.*FOp(..., fastmath=...)` only where explicit fastmath flags are performance-critical.
+
+### 4.2 Vector Values (`Vector`)
 
 ```python
-from flydsl.expr import vector
+from flydsl.expr.typing import Vector as Vec
 
 # Build vector from elements
-vec = vector.from_elements(vec_type, [a, b, c, d])
+vec = Vec.from_elements([a, b, c, d], fx.Float32)
 
 # Vector store to memref
-vector.store(vec, memref, [idx])
+vec.store(memref, [idx])
 
-# Extract/insert
-elem = vector.extractelement(vec, idx)
-vec2 = vector.insertelement(vec, elem, idx)
+# Extract, bitcast, and convert
+elem = vec[idx]
+as_i32 = vec.bitcast(fx.Int32)
+as_bf16 = vec.to(fx.BFloat16)
 ```
 
 ### 4.3 Buffer Operations (`fx.buffer_ops`)
@@ -342,7 +339,7 @@ addrspace_int = gpu.smem_space(int=True)
 
 ## 5. Control Flow
 
-### 5.1 Python Loops → MLIR SCF
+### 5.1 Python Loops
 
 The `ASTRewriter` automatically transforms Python `for` loops:
 
@@ -354,7 +351,7 @@ def my_kernel(data: fx.Tensor, N: fx.Constexpr[int]):
         # This loop is fully unrolled in the generated IR
         ...
 
-    # Runtime loop (lowered to scf.for)
+    # Runtime loop (lowered by the AST rewriter)
     for i in range(runtime_value):
         ...
 ```
@@ -402,7 +399,7 @@ lds_b_ptr.store(val, [idx])
 
 ### 6.2 Finalizing LDS Allocation
 
-For `@flyc.kernel` style kernels, emit `memref.global` in the GPU module:
+For `@flyc.kernel` style kernels, finalize the allocator in the GPU module:
 
 ```python
 comp_ctx = CompilationContext.get_current()
@@ -537,7 +534,7 @@ From `kernels/preshuffle_gemm.py`:
 ```python
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, vector, gpu, buffer_ops, rocdl, range_constexpr
+from flydsl.expr import gpu, buffer_ops, rocdl, range_constexpr
 from flydsl.expr.typing import T
 from flydsl.utils.smem_allocator import SmemAllocator
 

--- a/docs/layout_system_guide.md
+++ b/docs/layout_system_guide.md
@@ -76,7 +76,6 @@ IntTuples encode structure at the type level:
 
 ```python
 import flydsl.expr as fx
-from flydsl.expr import arith
 from flydsl.expr.typing import T
 
 # Shapes and strides (static constants auto-materialized)

--- a/docs/prebuilt_kernels_guide.md
+++ b/docs/prebuilt_kernels_guide.md
@@ -246,12 +246,12 @@ Used by `preshuffle_gemm.py`:
 ```python
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, gpu, buffer_ops, rocdl
+from flydsl.expr import gpu, buffer_ops, rocdl
 
 @flyc.kernel
 def gemm_kernel(arg_c: fx.Tensor, arg_a: fx.Tensor, ...):
     tid = gpu.thread_idx.x
-    # ... uses fx.*, arith.*, buffer_ops.*, rocdl.* ...
+    # ... uses fx.*, ArithValue/Vector, buffer_ops.*, rocdl.* ...
 
 @flyc.jit
 def launch_fn(arg_c: fx.Tensor, ..., stream: fx.Stream = fx.Stream(None)):

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,6 +16,7 @@ with ``@flyc.kernel``, use layout algebra to partition data, then launch with
    import torch
    import flydsl.compiler as flyc
    import flydsl.expr as fx
+   from flydsl.expr.typing import Vector as Vec
 
    @flyc.kernel
    def vectorAddKernel(
@@ -51,7 +52,7 @@ with ``@flyc.kernel``, use layout algebra to partition data, then launch with
        fx.copy_atom_call(copyAtom, fx.slice(tA, (None, tid)), rA)
        fx.copy_atom_call(copyAtom, fx.slice(tB, (None, tid)), rB)
 
-       vC = fx.arith.addf(fx.memref_load_vec(rA), fx.memref_load_vec(rB))
+       vC = Vec(fx.memref_load_vec(rA)) + Vec(fx.memref_load_vec(rB))
        fx.memref_store_vec(vC, rC)
        fx.copy_atom_call(copyAtom, rC, fx.slice(tC, (None, tid)))
 

--- a/docs/testing_benchmarking_guide.md
+++ b/docs/testing_benchmarking_guide.md
@@ -295,7 +295,7 @@ def test_my_layout_op(ctx, insert_point):
 import torch
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, gpu
+from flydsl.expr import gpu
 from tests.test_common import checkAllclose
 
 @flyc.kernel

--- a/kernels/fused_rope_cache_kernel.py
+++ b/kernels/fused_rope_cache_kernel.py
@@ -431,14 +431,15 @@ def build_fused_rope_cache_module(
                                 v_elem = vector.extract(v_e, static_position=[vi], dynamic_position=[])
                                 buffer_ops.buffer_store(v_elem, vc_rsrc, vc_nf_off)
 
-    def _dynamic_token_tensor(tensor):
-        leading_dim = len(tensor.shape) - 1 if hasattr(tensor, "shape") else None
+    def _mark_token_layout_dynamic(tensor):
         if hasattr(tensor, "mark_layout_dynamic"):
+            shape = getattr(tensor, "_orig_shape", None)
+            leading_dim = len(shape) - 1 if shape is not None else -1
             return tensor.mark_layout_dynamic(leading_dim=leading_dim)
-        return flyc.from_dlpack(tensor).mark_layout_dynamic(leading_dim=leading_dim)
+        return flyc.from_dlpack(tensor).mark_layout_dynamic(leading_dim=tensor.ndim - 1)
 
     @flyc.jit
-    def _launch_fused_rope_cache(
+    def _jit_launch_fused_rope_cache(
         Q: fx.Tensor,
         K: fx.Tensor,
         V: fx.Tensor,
@@ -482,18 +483,18 @@ def build_fused_rope_cache_module(
         VScale,
         stream=fx.Stream(None),
     ):
-        return _launch_fused_rope_cache(
-            _dynamic_token_tensor(Q),
-            _dynamic_token_tensor(K),
-            _dynamic_token_tensor(V),
-            _dynamic_token_tensor(Positions),
+        return _jit_launch_fused_rope_cache(
+            _mark_token_layout_dynamic(Q),
+            _mark_token_layout_dynamic(K),
+            _mark_token_layout_dynamic(V),
+            _mark_token_layout_dynamic(Positions),
             CosCache,
             SinCache,
-            _dynamic_token_tensor(SlotMapping),
+            _mark_token_layout_dynamic(SlotMapping),
             KeyCache,
             ValueCache,
-            _dynamic_token_tensor(Q_out),
-            _dynamic_token_tensor(K_out),
+            _mark_token_layout_dynamic(Q_out),
+            _mark_token_layout_dynamic(K_out),
             num_tokens,
             KScale,
             VScale,

--- a/kernels/fused_rope_cache_kernel.py
+++ b/kernels/fused_rope_cache_kernel.py
@@ -431,8 +431,14 @@ def build_fused_rope_cache_module(
                                 v_elem = vector.extract(v_e, static_position=[vi], dynamic_position=[])
                                 buffer_ops.buffer_store(v_elem, vc_rsrc, vc_nf_off)
 
+    def _dynamic_token_tensor(tensor):
+        leading_dim = len(tensor.shape) - 1 if hasattr(tensor, "shape") else None
+        if hasattr(tensor, "mark_layout_dynamic"):
+            return tensor.mark_layout_dynamic(leading_dim=leading_dim)
+        return flyc.from_dlpack(tensor).mark_layout_dynamic(leading_dim=leading_dim)
+
     @flyc.jit
-    def launch_fused_rope_cache(
+    def _launch_fused_rope_cache(
         Q: fx.Tensor,
         K: fx.Tensor,
         V: fx.Tensor,
@@ -456,6 +462,41 @@ def build_fused_rope_cache_module(
         launcher.launch(
             grid=(max_heads, num_tokens, 1),
             block=(BLOCK_THREADS, 1, 1),
+            stream=stream,
+        )
+
+    def launch_fused_rope_cache(
+        Q,
+        K,
+        V,
+        Positions,
+        CosCache,
+        SinCache,
+        SlotMapping,
+        KeyCache,
+        ValueCache,
+        Q_out,
+        K_out,
+        num_tokens,
+        KScale,
+        VScale,
+        stream=fx.Stream(None),
+    ):
+        return _launch_fused_rope_cache(
+            _dynamic_token_tensor(Q),
+            _dynamic_token_tensor(K),
+            _dynamic_token_tensor(V),
+            _dynamic_token_tensor(Positions),
+            CosCache,
+            SinCache,
+            _dynamic_token_tensor(SlotMapping),
+            KeyCache,
+            ValueCache,
+            _dynamic_token_tensor(Q_out),
+            _dynamic_token_tensor(K_out),
+            num_tokens,
+            KScale,
+            VScale,
             stream=stream,
         )
 

--- a/kernels/mla_fwd_decode_m16x8_fp8_fp8.py
+++ b/kernels/mla_fwd_decode_m16x8_fp8_fp8.py
@@ -16,10 +16,9 @@ NOTE: Do NOT use ``from __future__ import annotations`` here -- it breaks
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
-from flydsl._mlir.dialects import llvm, scf
-from flydsl._mlir.dialects import memref as _memref
+from flydsl._mlir.dialects import llvm, memref
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl, vector
+from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl
 from flydsl.expr import math as fmath
 from flydsl.expr.arith import _to_raw as _raw
 from flydsl.expr.typing import T
@@ -189,7 +188,7 @@ _gep = buffer_ops.get_element_ptr
 
 def _lds_load(byte_addr_index, vec_type, static_byte_offset=0):
     """LDS load via raw llvm.LoadOp on an LDS pointer (addr space 3)."""
-    addr_i64 = arith.index_cast(T.i64, byte_addr_index)
+    addr_i64 = _raw(fx.Int64(byte_addr_index))
     lds_ptr = _inttoptr_lds(addr_i64)
     if static_byte_offset != 0:
         lds_ptr = _gep(lds_ptr, static_byte_offset=static_byte_offset)
@@ -224,7 +223,7 @@ def _i32(value):
     raw = _raw(value) if not isinstance(value, ir.Value) else value
     if raw.type == T.i32:
         return raw
-    return arith.index_cast(T.i32, raw)
+    return _raw(fx.Int32(raw))
 
 
 def _fast_exp2(val):
@@ -234,8 +233,10 @@ def _fast_exp2(val):
 
 def _to_mlir(val):
     """Convert Python int/float, ArithValue, or ir.Value to raw MLIR Value."""
-    if isinstance(val, (int, float)):
-        return _raw(arith.constant(val))
+    if isinstance(val, int):
+        return _raw(fx.Int32(val))
+    if isinstance(val, float):
+        return _raw(fx.Float32(val))
     return _raw(val) if not isinstance(val, ir.Value) else val
 
 
@@ -298,7 +299,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         lds_allocator.finalize()
 
     lds_buffer = lds_allocator.get_base()
-    lds_base_idx = _memref.ExtractAlignedPointerAsIndexOp(lds_buffer).result
+    lds_base_idx = memref.extract_aligned_pointer_as_index(lds_buffer)
 
     # ---- V^T transpose perm constants ----
     c_perm0 = fx.Int32(0x05010400)
@@ -349,8 +350,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     work_range_vec = Vec(work_range)
     work_start_i32 = rocdl.readfirstlane(T.i32, work_range_vec[0])
     work_end_i32 = rocdl.readfirstlane(T.i32, work_range_vec[1])
-    work_start_idx = arith.index_cast(T.index, work_start_i32)
-    work_end_idx = arith.index_cast(T.index, work_end_i32)
+    work_start_idx = fx.Index(work_start_i32)
+    work_end_idx = fx.Index(work_end_i32)
 
     # ---- KvManagerV2 thread-to-data mapping ----
     # Each warp takes 4 rows: warp w -> rows {w*2, w*2+1, w*2+16, w*2+17}
@@ -367,7 +368,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         For OOB rows (row >= kv_end), returns -1 WITHOUT issuing a
         buffer_load -- avoids reading garbage from kv_page_indices.
         """
-        row_idx_i32 = _raw(ArithValue(kv_ld_row_base_i32) + kv_tile_start_i32)
+        row_idx_i32 = _i32(ArithValue(kv_ld_row_base_i32) + kv_tile_start_i32)
         if const_expr(check_boundary):
             phys_row = fx.Int32(-1)
             if ArithValue(row_idx_i32) < ArithValue(kv_tile_end_i32):
@@ -392,10 +393,10 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # p_lds_kv_warp points to warp's sub-block start.
         # Actual LDS target: p_lds_kv_warp + block*KV_BLOCK_BYTES - block*64
         lds_adjust = lds_warp_offset - block_idx_const * KV_NUM_COLS
-        lds_base_i32 = _raw(ArithValue(p_lds_kv_warp_i32) + lds_adjust)
+        lds_base_i32 = _i32(ArithValue(p_lds_kv_warp_i32) + lds_adjust)
 
         def _emit_vram_to_lds():
-            voff = _raw(ArithValue(row_i32) * QK_HEAD_DIM + col_base_i32)
+            voff = _i32(ArithValue(row_i32) * QK_HEAD_DIM + col_base_i32)
             rocdl.buffer_load_to_lds(
                 kv_rsrc, _lds_ptr_from_i32(lds_base_i32), voff,
                 offset=block_idx_const * KV_NUM_COLS,
@@ -405,7 +406,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
             is_oob = ArithValue(row_i32) == -1
             if is_oob:
                 # Write zero via ds_write_b32 at lane's position
-                lds_addr = _raw(
+                lds_addr = _i32(
                     ArithValue(lds_base_i32)
                     + block_idx_const * KV_NUM_COLS
                     + ArithValue(lane_idx_i32) * 4
@@ -446,15 +447,15 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
         check_boundary: controls OOB row==-1 check.
           - False (Python): skips check entirely -- caller guarantees valid row.
-          - True (Python): always emits scf.IfOp(row==-1).
-          - ir.Value (i1): emits scf.IfOp(check_boundary AND row==-1),
+          - True (Python): always emits a branch on row==-1.
+          - ir.Value (i1): emits a branch on check_boundary AND row==-1,
             allowing runtime bypass.
         """
         lds_adjust = block_idx_const * KV_BLOCK_BYTES - block_idx_const * KV_NUM_COLS
-        lds_base_i32 = _raw(ArithValue(p_lds_kv_warp_i32) + lds_adjust)
+        lds_base_i32 = _i32(ArithValue(p_lds_kv_warp_i32) + lds_adjust)
 
         def _emit_normal_load():
-            voff = _raw(ArithValue(row_i32) * QK_HEAD_DIM + col_base_i32)
+            voff = _i32(ArithValue(row_i32) * QK_HEAD_DIM + col_base_i32)
             col_off_imm = block_idx_const * KV_NUM_COLS
             asm_str = (
                 "s_mov_b32 m0, $0\n"
@@ -481,7 +482,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
             if is_oob:
                 # OOB: write zero to LDS via inline asm ds_write_b32
-                lds_zero_addr = _raw(
+                lds_zero_addr = _i32(
                     ArithValue(lds_base_i32)
                     + block_idx_const * KV_NUM_COLS
                     + ArithValue(lane_idx_i32) * 4
@@ -648,11 +649,11 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # ds_write_b128 x 2 (4 dwords each = 32 fp8)
         lo_packed = Vec.from_elements(vt8[0:4], fx.Int32)
         lo_i8 = Vec(lo_packed).bitcast(fx.Int8)
-        vector.store(lo_i8, lds_buffer, [_raw(lds_vt_addr)])
+        lo_i8.store(lds_buffer, [lds_vt_addr])
 
         hi_packed = Vec.from_elements(vt8[4:8], fx.Int32)
         hi_i8 = Vec(hi_packed).bitcast(fx.Int8)
-        vector.store(hi_i8, lds_buffer, [_raw(lds_vt_addr + 16)])
+        hi_i8.store(lds_buffer, [lds_vt_addr + 16])
 
     # ---- Helper: load transposed V from Vt LDS ----
     def _load_vt_from_lds(vt_base_i32, col_offset):
@@ -718,7 +719,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # s_offset = warp * 16 * QK_HEAD_DIM * sizeof(fp8)
         # v_offset = (row * QK_HEAD_DIM + col) * sizeof(fp8)
         # s_offset = warp * 16 * QK_HEAD_DIM + qo_start * NUM_QO_HEADS * QK_HEAD_DIM
-        s_offset_i32 = _raw(
+        s_offset_i32 = _i32(
             ArithValue(warp_idx_i32) * (16 * QK_HEAD_DIM)
             + ArithValue(qo_start_i32) * (NUM_QO_HEADS * QK_HEAD_DIM)
         )
@@ -755,18 +756,17 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # LLVM ISel only extracts immediate offsets when soffset is literal 0.
         # v_offset_i32 is in bytes; buffer_load auto-scales by element_bytes
         # (i32 = 4), so divide by 4.  s_offset_i32 is also in bytes.
-        voff_dw = _raw(
+        voff_dw = _i32(
             (ArithValue(v_offset_i32) + ArithValue(s_offset_i32)) // 4
         )
 
         # Pre-compute LDS pointers (constant across passes)
         lds_st_addr = p_lds_q_warp + lds_st_offset
-        lds_st_i64 = arith.index_cast(T.i64, lds_st_addr)
-        lds_st_ptr = _inttoptr_lds(_raw(lds_st_i64))
+        lds_st_ptr = _inttoptr_lds(_raw(fx.Int64(lds_st_addr)))
         lds_rd_addr = p_lds_q_warp + lds_ld_offset
 
         def _q_buf_load(pass_idx):
-            voff_pass = _raw(
+            voff_pass = _i32(
                 ArithValue(voff_dw) + pass_idx * Q_ELEM_PER_ROW // 4
             )
             return buffer_ops.buffer_load(
@@ -828,7 +828,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         if const_expr(check_boundary is not False):
             for i in range_constexpr(8):
                 sub_offset = (i // 4) * 16 + (i % 4)
-                pos_i32 = _raw(ArithValue(col_0_start_i32) + sub_offset)
+                pos_i32 = _i32(ArithValue(col_0_start_i32) + sub_offset)
                 is_oob = ArithValue(pos_i32) >= ArithValue(kv_end_i32)
                 if const_expr(check_boundary is not True):
                     is_oob = _raw(ArithValue(check_boundary) & ArithValue(is_oob))
@@ -851,7 +851,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         Returns: (p_exp_vals, row_max_new, row_sum_e_new, rescale)
         """
         # Column index for this thread's first element
-        col_0_start_i32 = _raw(ArithValue(_i32(lane_idx / 16 * 4)) + kv_tile_start_i32)
+        col_0_start_i32 = _i32(ArithValue(_i32(lane_idx / 16 * 4)) + kv_tile_start_i32)
 
         # Scale and mask
         scaled = _softmax_scale_p(p_vals, col_0_start_i32, kv_end_i32, check_boundary)
@@ -859,9 +859,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         # Local max of 8 values
         local_max = scaled[0]
         for i in range_constexpr(1, 8):
-            local_max = arith.MaximumFOp(
-                local_max, _raw(scaled[i]), fastmath=fm_no_inf
-            ).result
+            local_max = arith.MaximumFOp(local_max, _raw(scaled[i]), fastmath=fm_no_inf).result
 
         # Warp reduce max (within 16-lane groups)
         local_max = _warp_reduce_max_16(local_max)
@@ -882,7 +880,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         for i in range_constexpr(8):
             exp_arg = arith.MulFOp(
                 arith.SubFOp(_raw(scaled[i]), new_row_max, fastmath=fm_no_inf).result,
-                _raw(c_log2e), fastmath=fm_no_inf,
+                _raw(c_log2e),
+                fastmath=fm_no_inf,
             ).result
             p_exp_vals[i] = _fast_exp2(exp_arg)
             local_sum = arith.AddFOp(local_sum, p_exp_vals[i], fastmath=fm_fast).result
@@ -896,7 +895,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         else:
             row_sum_e_new = arith.AddFOp(
                 arith.MulFOp(rescale, _raw(row_sum_e_old), fastmath=fm_fast).result,
-                local_sum, fastmath=fm_fast,
+                local_sum,
+                fastmath=fm_fast,
             ).result
 
         return p_exp_vals, new_row_max, row_sum_e_new, rescale
@@ -953,7 +953,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         Returns (row_max, row_sum_e, p_pack, rescale).
         """
         # ---- K base VGPR (baked-in lane offset) ----
-        k_base_i32 = _raw(ArithValue(_i32(p_lds_kv_base)) + ArithValue(_i32(k_lds_lane_offset)))
+        k_base_i32 = _i32(ArithValue(_i32(p_lds_kv_base)) + ArithValue(_i32(k_lds_lane_offset)))
 
         do_prefetch = p_lds_kv_next_warp_i32 is not None
 
@@ -1147,7 +1147,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
     def _pack_f32x4_to_bf16_2dw(acc_val):
         """Convert f32x4 accumulator to 2 packed bf16 dwords."""
-        i16s = Vec(arith.trunc_f(T.bf16x4, acc_val)).bitcast(fx.Int16)
+        i16s = Vec(acc_val).to(fx.BFloat16).bitcast(fx.Int16)
         i16_0, i16_1, i16_2, i16_3 = (_raw(i16s[j]) for j in range(4))
         dw0 = _raw(ArithValue(i16_0).extui(T.i32) | (ArithValue(i16_1).extui(T.i32) << 16))
         dw1 = _raw(ArithValue(i16_2).extui(T.i32) | (ArithValue(i16_3).extui(T.i32) << 16))
@@ -1165,7 +1165,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
     # bf16 LDS write address (MFMA layout): row_st = lane%16, col_st = (lane/16)*4
     o16_row_st = _urem(lane_u, 16)
-    o16_col_st = _raw(ArithValue(_udiv(lane_u, 16)) * 4)
+    o16_col_st = _i32(ArithValue(_udiv(lane_u, 16)) * 4)
     # get_v_offset_lds(r,c) = ((r/2)*68 + (r%2)*32 + c) * 2  [bytes]
     o16_st_offset = _raw(
         (ArithValue(_udiv(o16_row_st, 2)) * O16_ELEM_PER_PAD_2ROWS
@@ -1175,7 +1175,7 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
 
     # bf16 LDS read address (coalesced layout): row_ld = lane/4, col_ld = (lane%4)*8
     o16_row_ld = _udiv(lane_u, 4)
-    o16_col_ld = _raw(ArithValue(_urem(lane_u, 4)) * 8)
+    o16_col_ld = _i32(ArithValue(_urem(lane_u, 4)) * 8)
     o16_rd_offset = _raw(
         (ArithValue(_udiv(o16_row_ld, 2)) * O16_ELEM_PER_PAD_2ROWS
          + ArithValue(_urem(o16_row_ld, 2)) * O16_NUM_COLS
@@ -1183,12 +1183,12 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     )
 
     # f32 LDS write address: row_st/col_st reused, different padding
-    o32_st_offset = _raw((ArithValue(o16_row_st) * O32_ELEM_PER_PAD_ROW + ArithValue(o16_col_st)) * 4)
+    o32_st_offset = _i32((ArithValue(o16_row_st) * O32_ELEM_PER_PAD_ROW + ArithValue(o16_col_st)) * 4)
 
     # f32 LDS read address: row_ld = lane/8, col_ld = (lane%8)*4
     o32_row_ld = _udiv(lane_u, 8)
-    o32_col_ld = _raw(ArithValue(_urem(lane_u, 8)) * 4)
-    o32_rd_offset = _raw((ArithValue(o32_row_ld) * O32_ELEM_PER_PAD_ROW + ArithValue(o32_col_ld)) * 4)
+    o32_col_ld = _i32(ArithValue(_urem(lane_u, 8)) * 4)
+    o32_rd_offset = _i32((ArithValue(o32_row_ld) * O32_ELEM_PER_PAD_ROW + ArithValue(o32_col_ld)) * 4)
 
     def _store_oaccu_pair_bf16(oaccu_a, oaccu_b, tile_idx, p_lds_o_i32, row_base_i32):
         """Store 2 oaccu groups (1 PV iter) as bf16 via LDS reshape.
@@ -1197,22 +1197,22 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         reads back in row-major coalesced layout, then buffer_store_dwordx4.
         """
         # Per-warp LDS base
-        lds_warp = _raw(ArithValue(p_lds_o_i32) + ArithValue(warp_idx_i32) * O16_LDS_PER_WARP)
-        lds_st_addr = _raw(ArithValue(lds_warp) + ArithValue(o16_st_offset))
+        lds_warp = _i32(ArithValue(p_lds_o_i32) + ArithValue(warp_idx_i32) * O16_LDS_PER_WARP)
+        lds_st_addr = _i32(ArithValue(lds_warp) + ArithValue(o16_st_offset))
 
         # LDS write: 2 sub-blocks -> 2x ds_write_b64
         for sub, acc_val in enumerate([oaccu_a, oaccu_b]):
             dw0, dw1 = _pack_f32x4_to_bf16_2dw(acc_val)
             vec_2dw = Vec.from_elements([dw0, dw1], fx.Int32)
             sub_offset = sub * O16_NUM_COLS
-            st_addr_sub = _raw(ArithValue(lds_st_addr) + sub_offset)
+            st_addr_sub = _i32(ArithValue(lds_st_addr) + sub_offset)
             st_ptr = _lds_ptr_from_i32(st_addr_sub)
             llvm.StoreOp(vec_2dw, st_ptr, alignment=8, volatile_=True)
 
         rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
         # LDS read: ds_read_b128 (4 dwords = 8 bf16 in coalesced layout)
-        lds_rd_addr = _raw(ArithValue(lds_warp) + ArithValue(o16_rd_offset))
+        lds_rd_addr = _i32(ArithValue(lds_warp) + ArithValue(o16_rd_offset))
         rd_ptr = _lds_ptr_from_i32(lds_rd_addr)
         data = llvm.LoadOp(T.i32x4, rd_ptr, alignment=16).result
 
@@ -1232,8 +1232,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         16 rows need 2 rounds (8 rows each) because 64 lanes / 8 lanes-per-row = 8.
         """
         # Per-warp LDS base
-        lds_warp = _raw(ArithValue(p_lds_o_i32) + ArithValue(warp_idx_i32) * O32_LDS_PER_WARP)
-        lds_st_addr = _raw(ArithValue(lds_warp) + ArithValue(o32_st_offset))
+        lds_warp = _i32(ArithValue(p_lds_o_i32) + ArithValue(warp_idx_i32) * O32_LDS_PER_WARP)
+        lds_st_addr = _i32(ArithValue(lds_warp) + ArithValue(o32_st_offset))
 
         col_offset_i32 = tile_idx * MFMA_N * 2
         O32_LD_DELTA = 8 * O32_ELEM_PER_PAD_ROW * 4  # 1152 bytes between round 0/1
@@ -1242,14 +1242,14 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
         rocdl.s_waitcnt(_encode_waitcnt(vmcnt=0))
         for sub, acc_val in enumerate([oaccu_a, oaccu_b]):
             sub_offset = sub * O32_NUM_COLS // 2 * 4
-            st_addr_sub = _raw(ArithValue(lds_st_addr) + sub_offset)
+            st_addr_sub = _i32(ArithValue(lds_st_addr) + sub_offset)
             st_ptr = _lds_ptr_from_i32(st_addr_sub)
             llvm.StoreOp(acc_val, st_ptr, alignment=16)
 
         rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))
 
         # LDS read: 2x ds_read_b128 (round 0 = rows 0-7, round 1 = rows 8-15)
-        lds_rd_addr = _raw(ArithValue(lds_warp) + ArithValue(o32_rd_offset))
+        lds_rd_addr = _i32(ArithValue(lds_warp) + ArithValue(o32_rd_offset))
         rd_ptr = _lds_ptr_from_i32(lds_rd_addr)
         data_0 = llvm.LoadOp(T.f32x4, rd_ptr, alignment=16).result
         data_1 = llvm.LoadOp(T.f32x4, _gep(rd_ptr, static_byte_offset=O32_LD_DELTA), alignment=16).result
@@ -1374,8 +1374,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
     # ==================================================================
     # KV LDS buffer pointers -- computed once, persist across work items
     # ==================================================================
-    p_lds_kv_0_base = lds_base_idx + arith.index(P_LDS_KV_0)
-    p_lds_kv_1_base = lds_base_idx + arith.index(P_LDS_KV_1)
+    p_lds_kv_0_base = lds_base_idx + P_LDS_KV_0
+    p_lds_kv_1_base = lds_base_idx + P_LDS_KV_1
 
     kv_warp_offset_i32 = _raw(ArithValue(warp_idx_i32) * KV_SUB_BYTES)
 
@@ -1601,22 +1601,21 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                 _write_lse(_raw(partial_qo_loc), rm, rse)
 
         # ---- Multi-tile vs single-tile dispatch ----
-        if_multi = scf.IfOp(_raw(has_multi_tiles), [], has_else=True)
-        with ir.InsertionPoint(if_multi.regions[0].blocks[0]):
+        def _multi_tile_path():
             # === Multi-tile path ===
 
             # GEMM2 for first tile: C=0 hardcoded, no rescale needed
             oaccu_mt = _gemm2_first_iter(p_pack_first, vt_base_i32)
 
-            # --- Middle tiles [1, num_tiles-1) via scf.ForOp ---
+            # --- Middle tiles [1, num_tiles-1) via loop-carried range ---
             num_tiles_v = ArithValue(num_tiles)
             num_tiles_m1 = _raw(num_tiles_v - 1)
             num_tiles_m2 = _raw(num_tiles_v - 2)
 
             init_args = [row_max, row_sum_e] + oaccu_mt + [row_kv_ld_nn_first]
 
-            for tile_iv, state in range(arith.index(1), arith.index_cast(T.index, num_tiles_m1), arith.index(1), init=init_args):
-                tile_iv_i32 = ArithValue(arith.index_cast(T.i32, tile_iv))
+            for tile_iv, state in range(fx.Index(1), fx.Index(num_tiles_m1), fx.Index(1), init=init_args):
+                tile_iv_i32 = ArithValue(fx.Int32(tile_iv))
                 kv_tile_start_i32 = _raw(kv_start_v + tile_iv_i32 * BLOCK_N)
 
                 # Unpack carried state
@@ -1723,9 +1722,8 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                 rse_l,
                 is_first_iter_flag=False,
             )
-            scf.YieldOp([])
 
-        with ir.InsertionPoint(if_multi.regions[1].blocks[0]):
+        def _single_tile_path():
             # === Single tile path: GEMM2 with interleaved store ===
             oaccu_st = [_raw(c_zero_v4f32)] * (NUM_PV_ITERS * 2)
             _do_last_gemm2_and_store(
@@ -1736,7 +1734,15 @@ def kn_mla_fwd_decode_m16x8_fp8_fp8(
                 row_sum_e,
                 is_first_iter_flag=True,
             )
-            scf.YieldOp([])
+
+        @flyc.jit
+        def _dispatch_multi_single():
+            if has_multi_tiles:
+                _multi_tile_path()
+            else:
+                _single_tile_path()
+
+        _dispatch_multi_single()
 
 
 # ---------------------------------------------------------------------------

--- a/kernels/topk_gating_softmax_kernel.py
+++ b/kernels/topk_gating_softmax_kernel.py
@@ -122,8 +122,9 @@ def build_topk_gating_softmax_module(
         bid = fx.block_idx.x
         tid = fx.thread_idx.x
 
-        elem_type = dtype_to_elem_type(dtype_str)
+        elem_type = dtype_to_elem_type(dtype_str).ir_type
         compute_type = T.f32
+        register_addr_space = int(fx.AddressSpace.Register)
 
         fm_fast = arith.FastMathFlags.fast
 
@@ -210,7 +211,7 @@ def build_topk_gating_softmax_module(
         atom_reg_ty_in = fx.MemRefType.get(
             elem_type,
             fx.LayoutType.get(ELEMS_PER_ATOM, 1),
-            fx.AddressSpace.Register,
+            register_addr_space,
         )
         atom_reg_lay_in = fx.make_layout(ELEMS_PER_ATOM, 1)
 
@@ -219,7 +220,7 @@ def build_topk_gating_softmax_module(
         # near `_store_scalar_i32` below).
         copy_atom_f32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), 32)
         scalar_reg_ty_f32 = fx.MemRefType.get(
-            T.f32, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
+            T.f32, fx.LayoutType.get(1, 1), register_addr_space
         )
         scalar_reg_lay = fx.make_layout(1, 1)
 


### PR DESCRIPTION
## Summary
- Clean up MLA decode kernel internal type usage while preserving the verified MLA performance profile.
- Add a project skill for FlyDSL internal-type cleanup and update kernel authoring docs/skills to prefer `fx.*`, `ArithValue`, `Vector`, and `range(..., init=...)` patterns.
- Document control-flow rules for `const_expr(...)` and local `@flyc.jit` dispatch around runtime helper branches.

## Test plan
- `python -m py_compile kernels/mla_fwd_decode_m16x8_fp8_fp8.py`
- `git diff --check`
- `FLYDSL_DUMP_IR=1 FLYDSL_RUNTIME_ENABLE_CACHE=0 PYTHONPATH=python:.` MLA small-shape compile; verified ASM hash `c97855f56b17874e1ae389cebba408aea055d06e03a909824f5a6048ec26b47d`
- `PYTHONPATH=python:.` MLA perf/correctness shapes: `b=1,c=128`, `b=4,c=2048`, `b=32,c=8192`


Made with [Cursor](https://cursor.com)