### PR TITLE
Update ATOM nightly models to MXFP4 variants

### DIFF
--- a/.github/workflows/flydsl-atom-integration.yaml
+++ b/.github/workflows/flydsl-atom-integration.yaml
@@ -38,11 +38,11 @@ jobs:
             accuracy_threshold: 0.93
             runner: linux-flydsl-mi355-8
             env_vars: ""
-          - model_name: gpt-oss-120b
-            model_path: openai/gpt-oss-120b
-            extra_args: --kv_cache_dtype fp8 --gpu-memory-utilization 0.3
-            accuracy_threshold: 0.38
-            runner: linux-flydsl-mi355-1
+          - model_name: Kimi-K2.5-MXFP4
+            model_path: amd/Kimi-K2.5-MXFP4
+            extra_args: --kv_cache_dtype fp8 -tp 4 --trust-remote-code
+            accuracy_threshold: 0.92
+            runner: linux-flydsl-mi355-8
             env_vars: ""
 
     env:

--- a/.github/workflows/flydsl-atom-integration.yaml
+++ b/.github/workflows/flydsl-atom-integration.yaml
@@ -32,10 +32,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - model_name: DeepSeek-R1-0528
-            model_path: deepseek-ai/DeepSeek-R1-0528
+          - model_name: DeepSeek-R1-0528-MXFP4
+            model_path: amd/DeepSeek-R1-0528-MXFP4
             extra_args: --kv_cache_dtype fp8 -tp 8
-            accuracy_threshold: 0.94
+            accuracy_threshold: 0.93
             runner: linux-flydsl-mi355-8
             env_vars: ""
           - model_name: gpt-oss-120b


### PR DESCRIPTION
## Summary
- Switch the FlyDSL ATOM nightly DeepSeek accuracy job to the AMD MXFP4 DeepSeek-R1-0528 model.
- Replace the flaky GPT-OSS accuracy job with AMD Kimi-K2.5-MXFP4 on the MI355 8-GPU runner.
- Keep FP8 KV cache launch args and use MXFP4-oriented accuracy thresholds.

## Test plan
- Not run locally; workflow-only CI configuration change.