### PR TITLE
ci: add RDNA4 flash attention benchmark

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -161,6 +161,12 @@ jobs:
             echo "logs.tgz not found; skipping log extraction"
           fi
 
+      - name: Prepare aiter for RDNA FA benchmarks
+        if: ${{ contains(matrix.runners, 'navi') }}
+        run: |
+          docker exec flydsl_test bash -c "rm -rf /tmp/aiter && git clone --depth 1 --recursive --shallow-submodules https://github.com/ROCm/aiter.git /tmp/aiter"
+          docker exec flydsl_test bash -c "python3 -c \"from pathlib import Path; src = Path('/tmp/aiter/requirements.txt'); dst = Path('/tmp/aiter/requirements-flydsl-ci.txt'); lines = [line for line in src.read_text().splitlines() if line.strip() and not line.strip().startswith('flydsl==')]; dst.write_text('\\n'.join(lines) + '\\n')\" && python3 -m pip install -r /tmp/aiter/requirements-flydsl-ci.txt"
+
       - name: Run benchmarks
         run: |
           docker exec flydsl_test bash -c "export PYTHONPATH=/tmp/aiter:\${PYTHONPATH:-} && export AITER_REPO=/tmp/aiter && cd /flydsl-test && bash scripts/run_benchmark.sh"

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -147,6 +147,15 @@ MOE_A8W4_SHAPES='
 8192,3072,3072,128,4,32,128,256,256,256
 '
 
+# RDNA4 Flash Attention shapes backed by AITER's FlyDSL kernel:
+# "seq_len,num_heads,head_dim,dtype"
+if [ -z "${RDNA_FA_SHAPES:-}" ]; then
+RDNA_FA_SHAPES='
+1024,12,128,bf16
+8192,12,128,bf16
+'
+fi
+
 # Memory bound threshold (M or tokens <= threshold => memory bound)
 MEMORY_BOUND_THRESHOLD=512
 
@@ -164,7 +173,7 @@ Usage:
   bash scripts/run_benchmark.sh --list
 
 Supported ops:
-  softmax | layernorm | rmsnorm | gemm | moe
+  softmax | layernorm | rmsnorm | gemm | moe | rdna_fa
 USAGE
 }
 
@@ -222,13 +231,14 @@ _normalize_op() {
   esac
 }
 
-# Default: run softmax, norms, and GEMM unless user selected a subset.
-# Use positional args or --only to enable others: softmax, layernorm, rmsnorm, gemm, moe
+# Default: run softmax, norms, GEMM, MoE, and RDNA FA where supported.
+# Use positional args or --only to enable others: softmax, layernorm, rmsnorm, gemm, moe, rdna_fa
 RUN_SOFTMAX=1
 RUN_LAYERNORM=1
 RUN_RMSNORM=1
 RUN_PRESHUFFLE_GEMM=1
 RUN_MOE=1
+RUN_RDNA_FA=1
 
 _enable_only_ops() {
   RUN_SOFTMAX=0
@@ -236,6 +246,7 @@ _enable_only_ops() {
   RUN_RMSNORM=0
   RUN_PRESHUFFLE_GEMM=0
   RUN_MOE=0
+  RUN_RDNA_FA=0
   for op in "$@"; do
     op="$(_normalize_op "${op}")"
     case "${op}" in
@@ -244,6 +255,7 @@ _enable_only_ops() {
       rmsnorm) RUN_RMSNORM=1 ;;
       gemm) RUN_PRESHUFFLE_GEMM=1 ;;
       moe) RUN_MOE=1 ;;
+      rdna_fa|rdna-fa|fa|flash_attn|flash-attn) RUN_RDNA_FA=1 ;;
       "" ) ;;
       *) _die "unknown op '${op}'" ;;
     esac
@@ -280,6 +292,7 @@ if [ "$#" -gt 0 ]; then
         echo "rmsnorm"
         echo "gemm"
         echo "moe"
+        echo "rdna_fa"
         exit 0
         ;;
       --only)
@@ -893,7 +906,7 @@ if [ "${RUN_MOE}" -eq 1 ] && [ "${IS_CDNA}" = "true" ]; then
 fi
 
 # RDNA4 WMMA GEMM benchmarks (via benchmark_common.py)
-if [ "${IS_RDNA4}" = "true" ]; then
+if [ "${RUN_PRESHUFFLE_GEMM}" -eq 1 ] && [ "${IS_RDNA4}" = "true" ]; then
   echo ""
   echo "========================================================================"
   echo "RDNA4 WMMA Benchmarks"
@@ -907,6 +920,34 @@ if [ "${IS_RDNA4}" = "true" ]; then
     echo "RDNA4 WMMA benchmark failed. Log: ${log}" >&2
     tail -20 "${log}" >&2
   fi
+fi
+
+# RDNA4 Flash Attention benchmark (AITER FlyDSL kernel).
+if [ "${RUN_RDNA_FA}" -eq 1 ] && [ "${IS_RDNA4}" = "true" ]; then
+  for shape in $RDNA_FA_SHAPES; do
+    oldIFS=$IFS
+    IFS=,
+    # shellcheck disable=SC2086 # intentional word-splitting on IFS=,
+    set -- $shape
+    IFS=$oldIFS
+    seq_len=$1; heads=$2; head_dim=$3; dtype=$4
+    shape_tag="${seq_len}x${heads}x${head_dim}"
+    log="${BENCH_LOG_DIR}/rdna_fa_${shape_tag}_${dtype}.log"
+    json="${BENCH_LOG_DIR}/rdna_fa_${shape_tag}_${dtype}.json"
+
+    if python3 tests/kernels/test_rdna_flash_attention.py \
+      --shapes "${shape}" \
+      --out-json "${json}" >"${log}" 2>&1; then
+      SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+    else
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      echo "RDNA FA benchmark failed. Log: ${log}" >&2
+      _show_fail_log "${log}" "rdna_fa"
+    fi
+    row="$(_py_parse_and_emit rdna_fa "${shape_tag}" "${dtype}" "${log}")"
+    set -- $row
+    _emit_row "$1" "$2" "$3" "$4" "$5"
+  done
 fi
 
 # Summary

--- a/tests/kernels/test_rdna_flash_attention.py
+++ b/tests/kernels/test_rdna_flash_attention.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""RDNA4 Flash Attention compatibility benchmark for AITER's FlyDSL kernel.
+
+The FA kernel lives in AITER, but it is implemented using FlyDSL and should stay
+compatible with FlyDSL compiler/runtime changes.  This benchmark is intended for
+FlyDSL CI on RDNA4 runners and compares AITER's FlyDSL FA wrapper against
+PyTorch SDPA for correctness and latency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+
+def _add_aiter_repo_to_path() -> None:
+    aiter_repo = os.environ.get("AITER_REPO", "").strip()
+    if aiter_repo and os.path.isdir(aiter_repo) and aiter_repo not in sys.path:
+        sys.path.insert(0, aiter_repo)
+
+
+def _get_arch() -> str:
+    try:
+        from flydsl.runtime.device import get_rocm_arch
+
+        return get_rocm_arch()
+    except Exception:
+        return getattr(torch.cuda.get_device_properties(0), "gcnArchName", "unknown")
+
+
+def _dtype_from_name(name: str) -> torch.dtype:
+    name = name.lower()
+    if name in ("bf16", "bfloat16"):
+        return torch.bfloat16
+    if name in ("f16", "fp16", "float16"):
+        return torch.float16
+    raise ValueError(f"unsupported dtype: {name}")
+
+
+def _parse_shapes(value: str) -> list[tuple[int, int, int, str]]:
+    shapes: list[tuple[int, int, int, str]] = []
+    for item in value.replace(";", " ").split():
+        seq_s, heads_s, head_dim_s, dtype_s = [part.strip() for part in item.split(",")]
+        shapes.append((int(seq_s), int(heads_s), int(head_dim_s), dtype_s))
+    return shapes
+
+
+def _time_call(fn, repeats: int) -> tuple[torch.Tensor, list[float]]:
+    out = None
+    times: list[float] = []
+    for _ in range(repeats):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        out = fn()
+        torch.cuda.synchronize()
+        times.append(time.perf_counter() - t0)
+    assert out is not None
+    return out, times
+
+
+def _estimate_attention_tflops(batch: int, seq_len: int, heads: int, head_dim: int, seconds: float) -> float:
+    # QK^T and PV dominate: 2 matmuls * 2 FLOPs per FMA.
+    flops = 4.0 * batch * heads * seq_len * seq_len * head_dim
+    return flops / seconds / 1e12
+
+
+def _estimate_io_tbps(batch: int, seq_len: int, heads: int, head_dim: int, dtype: torch.dtype, seconds: float) -> float:
+    element_size = torch.empty((), dtype=dtype).element_size()
+    # q/k/v reads plus output write. This is a conservative visible-IO estimate.
+    bytes_moved = 4.0 * batch * seq_len * heads * head_dim * element_size
+    return bytes_moved / seconds / 1e12
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--shapes",
+        default=os.environ.get("RDNA_FA_SHAPES", "1024,12,128,bf16 8192,12,128,bf16"),
+        help="Space- or semicolon-separated seq_len,num_heads,head_dim,dtype entries.",
+    )
+    parser.add_argument("--batch", type=int, default=int(os.environ.get("RDNA_FA_BATCH", "1")))
+    parser.add_argument("--warmup", type=int, default=int(os.environ.get("RDNA_FA_WARMUP", "3")))
+    parser.add_argument("--iters", type=int, default=int(os.environ.get("RDNA_FA_ITERS", "7")))
+    parser.add_argument("--seed", type=int, default=int(os.environ.get("RDNA_FA_SEED", "2029")))
+    parser.add_argument("--out-json", default=os.environ.get("RDNA_FA_OUT_JSON", ""))
+    parser.add_argument("--allow-non-rdna4-skip", action="store_true", default=True)
+    args = parser.parse_args()
+
+    arch = _get_arch()
+    if not torch.cuda.is_available():
+        if arch.startswith("gfx120"):
+            raise RuntimeError(
+                "RDNA FA benchmark detected an RDNA4 device through FlyDSL, "
+                "but PyTorch cannot initialize CUDA/HIP."
+            )
+        print("Skipping RDNA FA benchmark: CUDA/HIP device is not available.")
+        return 0
+
+    if not arch.startswith("gfx120"):
+        if args.allow_non_rdna4_skip:
+            print(f"Skipping RDNA FA benchmark: arch={arch!r} is not RDNA4/gfx120*.")
+            return 0
+        raise RuntimeError(f"RDNA FA benchmark requires gfx120*, got {arch!r}")
+
+    _add_aiter_repo_to_path()
+    try:
+        from aiter.ops.flydsl import flydsl_flash_attn_func
+    except Exception as exc:
+        raise RuntimeError(
+            "AITER FlyDSL Flash Attention is not importable. "
+            "Set AITER_REPO to an AITER checkout containing the RDNA FA kernel."
+        ) from exc
+
+    print(f"device {torch.cuda.get_device_name(0)} {arch}", flush=True)
+    results = []
+
+    for seq_len, heads, head_dim, dtype_name in _parse_shapes(args.shapes):
+        dtype = _dtype_from_name(dtype_name)
+        shape = (args.batch, seq_len, heads, head_dim)
+        gen = torch.Generator(device="cuda").manual_seed(args.seed + seq_len)
+        q = torch.randn(shape, generator=gen, device="cuda", dtype=dtype)
+        k = torch.randn(shape, generator=gen, device="cuda", dtype=dtype)
+        v = torch.randn(shape, generator=gen, device="cuda", dtype=dtype)
+
+        def run_aiter() -> torch.Tensor:
+            return flydsl_flash_attn_func(q, k, v, causal=False)
+
+        def run_sdpa() -> torch.Tensor:
+            return F.scaled_dot_product_attention(
+                q.transpose(1, 2),
+                k.transpose(1, 2),
+                v.transpose(1, 2),
+            ).transpose(1, 2).contiguous()
+
+        # First call compiles the FlyDSL kernel; exclude it from timing.
+        run_aiter()
+        torch.cuda.synchronize()
+        for _ in range(args.warmup):
+            run_aiter()
+            run_sdpa()
+        torch.cuda.synchronize()
+
+        out_aiter, aiter_times = _time_call(run_aiter, args.iters)
+        out_sdpa, sdpa_times = _time_call(run_sdpa, args.iters)
+
+        aiter_mean = statistics.mean(aiter_times)
+        sdpa_mean = statistics.mean(sdpa_times)
+        cos = F.cosine_similarity(
+            out_aiter.float().reshape(-1, head_dim),
+            out_sdpa.float().reshape(-1, head_dim),
+            dim=1,
+        )
+        mae = float((out_aiter.float() - out_sdpa.float()).abs().mean().item())
+        max_abs = float((out_aiter.float() - out_sdpa.float()).abs().max().item())
+        mean_cos = float(cos.mean().item())
+        min_cos = float(cos.min().item())
+        speedup = sdpa_mean / aiter_mean
+        tflops = _estimate_attention_tflops(args.batch, seq_len, heads, head_dim, aiter_mean)
+        tbps = _estimate_io_tbps(args.batch, seq_len, heads, head_dim, dtype, aiter_mean)
+
+        if mean_cos < 0.999 or mae > 5e-3:
+            raise AssertionError(
+                f"RDNA FA correctness failed for shape={shape}: "
+                f"mean_cos={mean_cos:.6f}, min_cos={min_cos:.6f}, mae={mae:.6g}, max_abs={max_abs:.6g}"
+            )
+
+        item = {
+            "shape": list(shape),
+            "dtype": dtype_name,
+            "aiter_mean_s": aiter_mean,
+            "aiter_median_s": statistics.median(aiter_times),
+            "sdpa_mean_s": sdpa_mean,
+            "sdpa_median_s": statistics.median(sdpa_times),
+            "speedup_vs_sdpa": speedup,
+            "estimated_tflops": tflops,
+            "estimated_tbps": tbps,
+            "mean_cos": mean_cos,
+            "min_cos": min_cos,
+            "mae": mae,
+            "max_abs": max_abs,
+        }
+        results.append(item)
+
+        shape_tag = f"{seq_len}x{heads}x{head_dim}"
+        print(
+            "RDNA FA "
+            f"{shape_tag} {dtype_name}: "
+            f"aiter={aiter_mean * 1e3:.3f} ms, "
+            f"sdpa={sdpa_mean * 1e3:.3f} ms, "
+            f"speedup={speedup:.3f}x, "
+            f"cos={mean_cos:.6f}, mae={mae:.6g}",
+            flush=True,
+        )
+        print(f"Throughput: estimated {tflops:.3f} TFLOPS, BW: {tbps:.3f} TB/s", flush=True)
+
+    if args.out_json:
+        out_path = Path(args.out_json)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps({"arch": arch, "results": results}, indent=2), encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Monitor AITER's FlyDSL RDNA FA kernel in FlyDSL CI so compiler/runtime regressions are caught on Navi runners.

## Motivation

- Add a FlyDSL-side RDNA4 Flash Attention benchmark that exercises AITER's FlyDSL FA kernel against PyTorch SDPA.

## Technical Details

## Summary

- Wire `rdna_fa` into `scripts/run_benchmark.sh` with default short and long sequence shapes and selective `--only rdna_fa` support.
## Test plan
- `bash -n scripts/run_benchmark.sh`
- `python3 -m py_compile tests/kernels/test_rdna_flash_attention.py`
- Container validation on gfx1201 GPU: `ROCR_VISIBLE_DEVICES=2 bash scripts/run_benchmark.sh --only rdna_fa`
  - `1024x12x128 bf16`: 50.582 TFLOPS, 0.099 TB/s
  - `8192x12x128 bf16`: 90.261 TFLOPS, 0.022 TB/s
  - Summary: Total 2, Success 2, Failed 0

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
