### PR TITLE
fixes shmem SIGSEGV

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -267,6 +267,26 @@ jobs:
         run: |
           docker exec flydsl_test bash -c "export MLIR_PATH=/llvm-project/mlir_install && cd /flydsl-test && python3 -m pip install -e . --use-pep517"
 
+      - name: Install mori (for shmem regression test)
+        timeout-minutes: 15
+        run: |
+          docker exec flydsl_test bash -c "
+            apt-get install -y libpci-dev libibverbs-dev &&
+            rm -rf /tmp/mori &&
+            git clone --depth 1 --recursive --shallow-submodules https://github.com/ROCm/mori.git /tmp/mori &&
+            cd /tmp/mori && python3 -m pip install . &&
+            MORI_PRECOMPILE=1 python3 -c 'import mori'
+          "
+
+      - name: Run multi-GPU shmem regression test
+        timeout-minutes: 10
+        run: |
+          docker exec flydsl_test bash -c "
+            cd /flydsl-test
+            python3 -m pytest tests/kernels/test_flydsl_shmem.py \
+              -m multi_gpu -v --no-header --tb=short
+          "
+
       - name: Run multi-GPU allreduce tests
         timeout-minutes: 30
         run: |

--- a/lib/Dialect/Fly/IR/FlyLLVMTranslation.cpp
+++ b/lib/Dialect/Fly/IR/FlyLLVMTranslation.cpp
@@ -79,36 +79,31 @@ LogicalResult embedExplicitModule(StringRef moduleName, gpu::ObjectAttr object,
       module, ptrTy, /*isConstant=*/false, llvm::GlobalValue::InternalLinkage,
       llvm::ConstantPointerNull::get(ptrTy), getModuleIdentifier(moduleName));
 
-  auto loadPackedArg = [&](llvm::Value *packed, uint32_t index) {
-    llvm::Value *slot = builder.CreateConstGEP1_32(ptrTy, packed, index);
-    return builder.CreateLoad(ptrTy, slot);
-  };
-
+  // init/load take their outputs as explicit pointer args
+  // (void** module_out, int32_t* err) so they fit MLIR's packed-args wrapper.
   auto *initFn = llvm::Function::Create(
-      llvm::FunctionType::get(voidTy, {ptrTy}, /*isVarArg=*/false),
+      llvm::FunctionType::get(voidTy, {ptrTy, ptrTy}, /*isVarArg=*/false),
       llvm::GlobalValue::ExternalLinkage, "flydsl_gpu_module_init", module);
   auto *initBlock =
       llvm::BasicBlock::Create(module.getContext(), "entry", initFn);
   builder.SetInsertPoint(initBlock);
   auto initArgs = initFn->arg_begin();
-  llvm::Value *initPacked = initArgs++;
-  llvm::Value *outModulePtr = loadPackedArg(initPacked, 0);
-  llvm::Value *errPtr = loadPackedArg(initPacked, 1);
+  llvm::Value *outModulePtr = initArgs++;
+  llvm::Value *errPtr = initArgs++;
   builder.CreateStore(llvm::ConstantPointerNull::get(ptrTy), outModulePtr);
   builder.CreateStore(llvm::ConstantInt::get(i32Ty, 0), errPtr);
   builder.CreateRetVoid();
 
   auto *loadFn = llvm::Function::Create(
-      llvm::FunctionType::get(voidTy, {ptrTy}, /*isVarArg=*/false),
+      llvm::FunctionType::get(voidTy, {ptrTy, ptrTy}, /*isVarArg=*/false),
       llvm::GlobalValue::ExternalLinkage, "flydsl_gpu_module_load_to_device",
       module);
   auto *loadBlock =
       llvm::BasicBlock::Create(module.getContext(), "entry", loadFn);
   builder.SetInsertPoint(loadBlock);
   auto loadArgs = loadFn->arg_begin();
-  llvm::Value *loadPacked = loadArgs++;
-  llvm::Value *moduleOutPtr = loadPackedArg(loadPacked, 0);
-  llvm::Value *loadErrPtr = loadPackedArg(loadPacked, 1);
+  llvm::Value *moduleOutPtr = loadArgs++;
+  llvm::Value *loadErrPtr = loadArgs++;
   llvm::Value *moduleObj = nullptr;
   if (object.getFormat() == gpu::CompilationTarget::Assembly) {
     llvm::FunctionCallee moduleLoadFn = module.getOrInsertFunction(

--- a/python/flydsl/compiler/jit_executor.py
+++ b/python/flydsl/compiler/jit_executor.py
@@ -73,19 +73,13 @@ def _resolve_runtime_libs() -> List[str]:
 
 
 def _pack_ciface_args(*args) -> ctypes.c_void_p:
-    """Pack argument addresses into a void** slot array.
-
-    The C++ side (flydsl_gpu_module_init / flydsl_gpu_module_load_to_device)
-    treats the incoming void* as a void** and indexes it directly:
-        slots[i] = ((void**)packed)[i]
-    So we return a pointer to the flat slot array — no extra indirection.
-    """
+    """Pack args for MLIR's packed-args wrapper (one holder cell per arg)."""
+    holders = [ctypes.c_void_p(ctypes.addressof(a)) for a in args]
     packed = (ctypes.c_void_p * len(args))()
-    for i, arg in enumerate(args):
-        packed[i] = ctypes.addressof(arg)
+    for i, h in enumerate(holders):
+        packed[i] = ctypes.addressof(h)
     result = ctypes.c_void_p(ctypes.addressof(packed))
-    # Keep the slot array and original args alive for the caller's scope.
-    result._keepalive = (packed, args)  # type: ignore[attr-defined]
+    result._keepalive = (packed, holders, args)  # keep intermediates alive  # type: ignore[attr-defined]
     return result
 
 

--- a/tests/kernels/test_flydsl_shmem.py
+++ b/tests/kernels/test_flydsl_shmem.py
@@ -274,5 +274,51 @@ def main():
         cleanup()
 
 
+# Pytest entrypoint: spawn torchrun in a subprocess so this file's
+# multi-PE main() actually runs under ``pytest -m multi_gpu``.
+
+
+def _count_physical_gpus() -> int:
+    """Physical GPU count (subprocess to bypass HIP_VISIBLE_DEVICES)."""
+    import subprocess as _sp
+
+    env = {k: v for k, v in os.environ.items() if k != "HIP_VISIBLE_DEVICES"}
+    try:
+        r = _sp.run(
+            [sys.executable, "-c", "import torch; print(torch.cuda.device_count())"],
+            capture_output=True, text=True, timeout=30, env=env,
+        )
+        return int(r.stdout.strip()) if r.returncode == 0 else 0
+    except Exception:
+        return 0
+
+
+@pytest.mark.multi_gpu
+def test_flydsl_shmem_two_pe():
+    """Regression guard for the FlyDSL+mori shmem SIGSEGV (2 PEs)."""
+    import subprocess as _sp
+
+    phys_ng = _count_physical_gpus()
+    if phys_ng < 2:
+        pytest.skip(f"Requires >= 2 physical GPUs, found {phys_ng}.")
+
+    env = {k: v for k, v in os.environ.items() if k != "HIP_VISIBLE_DEVICES"}
+    cmd = [
+        "torchrun",
+        "--nproc_per_node=2",
+        "--master_port=29790",
+        __file__,
+    ]
+    result = _sp.run(cmd, env=env, timeout=180, capture_output=True, text=True)
+    assert result.returncode == 0, (
+        f"flydsl shmem test FAILED (exit code {result.returncode})\n"
+        f"stdout (last 4000 chars):\n{result.stdout[-4000:]}\n"
+        f"stderr (last 4000 chars):\n{result.stderr[-4000:]}"
+    )
+    assert "All tests PASSED" in result.stdout, (
+        f"expected success banner in stdout, got:\n{result.stdout[-4000:]}"
+    )
+
+
 if __name__ == "__main__":
     main()

--- a/tests/unit/test_extern_runtime_integration.py
+++ b/tests/unit/test_extern_runtime_integration.py
@@ -13,16 +13,16 @@ from flydsl.expr.extern import ffi
 
 
 def test_explicit_module_loader_args_follow_ciface_packing():
-    """Verify the packed layout matches C++ expectations: void** slots."""
+    """Verify packed layout matches MLIR's packed-args wrapper:
+    packed -> [&holder0, &holder1]; *holder_i == &args[i]."""
     module = ctypes.c_void_p()
     err = ctypes.c_int32()
 
     packed = _pack_ciface_args(module, err)
-    # C++ side does: slots[i] = ((void**)packed)[i]
     slots = ctypes.cast(packed, ctypes.POINTER(ctypes.c_void_p))
 
-    assert slots[0] == ctypes.addressof(module)
-    assert slots[1] == ctypes.addressof(err)
+    assert ctypes.c_void_p.from_address(slots[0]).value == ctypes.addressof(module)
+    assert ctypes.c_void_p.from_address(slots[1]).value == ctypes.addressof(err)
     assert getattr(packed, "_keepalive")
 
 


### PR DESCRIPTION
## Motivation

FlyDSL's <#fly.explicit_module> declared its GPU-module loader helpers as single-arg void(void*) that hand-unpacked the outputs, but MLIR's ExecutionEngine already wraps every JIT entry in its own packed-args trampoline, so two layers of "packing" stacked up. Python packed the args once, the trampoline dereferenced once more, the real loader received NULL pointers and store-to-NULL segfaulted on the very first GPU module init.

## Technical Details

Change init/load's LLVM signature to a plain N-arg void(void** module_out, int32_t* err) so MLIR's wrapper sees a normal one-slot-per-arg function. Rewrite _pack_ciface_args to the canonical packed-args layout — one holder cell per argument — so the C++ and Python sides finally agree on a single, MLIR-standard ABI.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
