### PR TITLE
[Bugfix] [Test] add missing argument to test_blockscale_preshuffle_gemm

### DIFF
--- a/tests/kernels/test_blockscale_preshuffle_gemm.py
+++ b/tests/kernels/test_blockscale_preshuffle_gemm.py
@@ -281,6 +281,7 @@ if __name__ == "__main__":
     test_blockscale_preshuffle_gemm(
         M=args.M, N=args.N, K=args.K,
         out_dtype=args.out_dtype,
+        test_graph=False,
         bench_iters=args.num_iters,
         bench_warmup=args.num_warmup,
         use_async_copy=args.use_async_copy,


### PR DESCRIPTION
## Motivation

A call to test_blockscale_preshuffle_gemm was missing a required argument.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
