### PR TITLE
Use build-only runner for wheel builds

### DIFF
--- a/.github/workflows/build-whl.yaml
+++ b/.github/workflows/build-whl.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   build:
-    runs-on: linux-flydsl-mi325-1
+    runs-on: build-only-flydsl
     outputs:
       wheel_names: ${{ steps.collect-wheels.outputs.wheel_names }}
     permissions:


### PR DESCRIPTION
## Summary
- Move the reusable wheel build job from the MI325 GPU runner to the dedicated `build-only-flydsl` runner.
- Keep the wheel artifact and `wheel_names` output contract unchanged for test, promote, and publish workflows.
