### PR TITLE
[gfx1250] MoE 2-stage GEMM: MXScale rework + TDM K-loop hoist + build

### DIFF
--- a/kernels/moe_gemm_2stage_common_gfx1250.py
+++ b/kernels/moe_gemm_2stage_common_gfx1250.py
@@ -139,17 +139,55 @@ def _extract_sub8(acc, vec_base: int, *, vector, range_constexpr, ACC_VEC_SIZE: 
     return vector.shuffle(acc, acc, [vec_base + i for i in range_constexpr(8)])
 
 
-def _finalize_alloc_and_launch_2d(*, ctx, alloc, launcher, gx, gy, block_threads: int, stream, ir,
-                                  cluster=None):
+def _finalize_alloc_and_launch_2d(*, ctx, alloc, launcher, gx, gy, block_threads: int, stream, waves_per_eu, ir,
+                                  cluster=None, gz=1):
     with ir.InsertionPoint(ctx.gpu_module_body):
         alloc.finalized = False
         alloc.finalize()
+    for op in ctx.gpu_module_body.operations:
+        if hasattr(op, "attributes") and op.OPERATION_NAME == "gpu.func":
+            if waves_per_eu is not None and int(waves_per_eu) >= 1:
+                op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(
+                    ir.IntegerType.get_signless(32), int(waves_per_eu)
+                )
+            if cluster is not None:
+                op.attributes["rocdl.cluster_dims"] = ir.StringAttr.get(
+                    f"{cluster[0]},{cluster[1]},{cluster[2]}")
     launcher.launch(
-        grid=(gx, gy, 1),
+        grid=(gx, gy, gz),
         block=(block_threads, 1, 1),
         stream=stream,
         cluster=cluster,
     )
+
+
+# GPT-OSS SwiGLU activation parameters. Matches
+# `aiter.fused_moe.swiglu(alpha=1.702, limit=7.0)` (the torch reference
+# used in `torch_moe_stage1`). Hardcoded because the corresponding torch
+# helper does not expose them as kwargs at the dispatch level either.
+_SWIGLU_ALPHA = 1.702
+_SWIGLU_LIMIT = 7.0
+# log2(e) = 1 / ln(2). exp(x) = exp2(x * log2(e)). For sigmoid(alpha*x) we
+# need exp(-alpha * x) = exp2(-alpha * x * log2(e)).
+_NEG_ALPHA_LOG2E = -float(_SWIGLU_ALPHA) * 1.4426950408889634
+
+
+def _emit_swiglu(vg, vu, *, arith, rocdl, T):
+    """Apply GPT-OSS SwiGLU: silu(clamp(g, max=L)) * (clamp(u, -L, L) + 1).
+
+    silu(x) here is x * sigmoid(alpha * x) with alpha=1.702 (matches
+    `aiter.fused_moe.swiglu`).
+    """
+    limit = arith.constant(float(_SWIGLU_LIMIT), type=T.f32)
+    neg_limit = arith.constant(-float(_SWIGLU_LIMIT), type=T.f32)
+    g_clamped = arith.minimumf(vg, limit)
+    u_clamped = arith.maximumf(arith.minimumf(vu, limit), neg_limit)
+    t = g_clamped * arith.constant(float(_NEG_ALPHA_LOG2E), type=T.f32)
+    emu = rocdl.exp2(T.f32, t)
+    one_f32 = arith.constant(1.0, type=T.f32)
+    sig = rocdl.rcp(T.f32, one_f32 + emu)
+    out_glu = g_clamped * sig
+    return out_glu * (u_clamped + one_f32)
 
 
 def _emit_stage1_gate_up_epilogue(
@@ -169,6 +207,8 @@ def _emit_stage1_gate_up_epilogue(
     topk: int,
     num_valid_i32=None,
     block_row_start=None,
+    lds_tid=None,
+    memref=None,
     sorted_rsrc,
     tw_rsrc,
     out_rsrc,
@@ -184,10 +224,41 @@ def _emit_stage1_gate_up_epilogue(
     vector,
     range_constexpr,
     T,
+    # ── optional: bias + activation ─────────────────────────────────
+    # ``bias_rsrc``: f32 buffer resource of shape (E, 2*inter_dim) flat,
+    # gate-half then up-half per expert. ``eid_i32`` is the per-block
+    # expert id (already loaded from arg_expert_ids by caller). When
+    # both are provided, bias is added before activation. ``act_kind``
+    # controls activation: ``"silu"`` (default) uses ``silu_fn(vg)*vu``,
+    # ``"swiglu"`` uses GPT-OSS SwiGLU(g,u).
+    bias_rsrc=None,
+    eid_i32=None,
+    act_kind: str = "silu",
+    rocdl=None,
 ):
+    # ``lds_tid``: optional memref<tile_m x i32, shared> holding the pre-decoded
+    # ``sorted_token_ids`` for the current M-tile. Invalid rows (outside the
+    # route slot range or beyond ``num_valid``) are pre-filled with the sentinel
+    # ``0xFFFFFFFF`` so that ``tok_ok``/``slot_ok`` below naturally reject them.
+    # When provided (together with ``memref``), the per-row ``fused`` i32 comes
+    # from a single ``ds_read_b32`` instead of a ``buffer_load(sorted_rsrc,...)``,
+    # eliminating redundant VMEM traffic in the epilogue. When ``lds_tid`` is
+    # ``None`` we fall back to the original per-row buffer_load.
+    _use_lds = lds_tid is not None and memref is not None
+    _use_bias = bias_rsrc is not None and eid_i32 is not None
+    _use_swiglu = str(act_kind).lower() == "swiglu"
+    if _use_swiglu and rocdl is None:
+        raise ValueError("_emit_stage1_gate_up_epilogue: act_kind='swiglu' requires rocdl")
     c_topk_i32 = arith.constant(int(topk), type=T.i32)
+    c2_n_i32 = arith.constant(2, type=T.i32)
     default_block_row_start = arith.index_cast(T.i32, by * arith.index(int(route_tile_m)))
     row_base_i32 = block_row_start if block_row_start is not None else default_block_row_start
+    if _use_bias:
+        # Each expert's bias slab is (gate || up), 2*inter_dim f32 entries.
+        # Index gate at column ``c`` as eid * 2*inter + c, and up as
+        # eid * 2*inter + inter + c.
+        n_per_exp_i32 = i32_inter_in * c2_n_i32
+        bias_row_base_i32 = eid_i32 * n_per_exp_i32
     for acc_idx, vec_base, m_off, wn in sub_tiles:
         row_local = warp_m_base + fx.Index(m_off) + lane16
         sorted_row = by * arith.index(int(tile_m)) + row_local
@@ -208,7 +279,10 @@ def _emit_stage1_gate_up_epilogue(
             sorted_i32,
             row_base_i32,
         )
-        fused = buffer_ops.buffer_load(sorted_rsrc, sorted_safe, vec_width=1, dtype=T.i32)
+        if _use_lds:
+            fused = memref.load(lds_tid, [row_local])
+        else:
+            fused = buffer_ops.buffer_load(sorted_rsrc, sorted_safe, vec_width=1, dtype=T.i32)
         tok = fused & arith.constant((1 << 24) - 1, type=T.i32)
         slot = fused >> arith.constant(24, type=T.i32)
         tok_ok = arith.cmpi(arith.CmpIPredicate.ult, tok, i32_tokens_in)
@@ -220,19 +294,196 @@ def _emit_stage1_gate_up_epilogue(
         col_base = blk_n + warp_n_base + fx.Index(wn * WMMA_N) + lane_kgrp * fx.Index(8)
         for vi in range_constexpr(8):
             col = col_base + fx.Index(vi)
-            col_ok = arith.cmpi(arith.CmpIPredicate.ult, arith.index_cast(T.i32, col), i32_inter_in)
+            col_i32 = arith.index_cast(T.i32, col)
+            col_ok = arith.cmpi(arith.CmpIPredicate.ult, col_i32, i32_inter_in)
             out_ok = arith.andi(row_ok, col_ok)
             _if_out = scf.IfOp(out_ok)
             with ir.InsertionPoint(_if_out.then_block):
                 vg = vector.extract(sub8g, static_position=[vi], dynamic_position=[])
                 vu = vector.extract(sub8u, static_position=[vi], dynamic_position=[])
-                y = silu_fn(vg) * vu
+                if _use_bias:
+                    bg = buffer_ops.buffer_load(
+                        bias_rsrc, bias_row_base_i32 + col_i32,
+                        vec_width=1, dtype=T.f32)
+                    bu = buffer_ops.buffer_load(
+                        bias_rsrc, bias_row_base_i32 + i32_inter_in + col_i32,
+                        vec_width=1, dtype=T.f32)
+                    vg = vg + bg
+                    vu = vu + bu
+                if _use_swiglu:
+                    y = _emit_swiglu(vg, vu, arith=arith, rocdl=rocdl, T=T)
+                else:
+                    y = silu_fn(vg) * vu
                 if bool(doweight_stage1):
                     y = y * tw
                 out_v = arith.trunc_f(out_elem_ty, y)
                 out_idx = ((tok * c_topk_i32 + slot) * i32_inter_in
-                           + arith.index_cast(T.i32, col))
+                           + col_i32)
                 buffer_ops.buffer_store(out_v, out_rsrc, out_idx)
+                scf.YieldOp([])
+
+
+def _emit_stage1_gate_up_splitk_epilogue(
+    *,
+    sub_tiles,
+    by,
+    tile_m: int,
+    route_tile_m: int,
+    warp_m_base,
+    warp_n_base,
+    blk_n,
+    lane16,
+    lane_kgrp,
+    WMMA_N: int,
+    i32_tokens_in,
+    i32_inter_in,
+    topk: int,
+    num_valid_i32,
+    block_row_start,
+    lds_tid=None,
+    memref=None,
+    sorted_rsrc,
+    out_rsrc,
+    out_elem_ty,
+    load_gate_up_sub8,
+    ir,
+    fx,
+    arith,
+    buffer_ops,
+    scf,
+    vector,
+    range_constexpr,
+    rocdl,
+    T,
+    # ── optional bias (split-K does not fuse activation, so swiglu is
+    # handled by the external silu_and_mul reduction; bias is added per
+    # K-slice so it must be scaled by 1/k_batch to match torch ref).
+    # Caller is responsible for passing ``bias_scale`` = 1/k_batch when
+    # split-K is enabled. ────────────────────────────────────────────
+    bias_rsrc=None,
+    eid_i32=None,
+    bias_scale: float | None = None,
+):
+    """Stage1 split-K epilogue.
+
+    Writes per-K-slice gate/up partial sums to a ``[tokens*topk, 2*inter_dim]``
+    output tensor with atomic fadd. The silu/mul fusion is skipped and must
+    be applied by a separate reduction kernel (which also folds in the
+    per-slot routing weight).
+
+    Layout:
+      out[row, col]                   += gate_partial[row, col]
+      out[row, col + inter_dim]       += up_partial[row, col]
+    where ``row = tok * topk + slot`` and ``col < inter_dim``.
+
+    ``lds_tid`` (optional): see ``_emit_stage1_gate_up_epilogue``.
+    """
+    _use_lds = lds_tid is not None and memref is not None
+    _use_bias = bias_rsrc is not None and eid_i32 is not None
+    c_topk_i32 = arith.constant(int(topk), type=T.i32)
+    c2_i32 = arith.constant(2, type=T.i32)
+    zero_i32 = arith.constant(0, type=T.i32)
+    mask_even_i32 = arith.constant(0xFFFFFFFE, type=T.i32)
+
+    def atomic_add_x2(val_x2, byte_off_i32):
+        rocdl.raw_ptr_buffer_atomic_fadd(val_x2, out_rsrc, byte_off_i32, zero_i32, zero_i32)
+
+    inter_stride_i32 = i32_inter_in * c2_i32  # row stride for [tokens*topk, 2*inter_dim]
+    if _use_bias:
+        # Each expert's bias slab is gate||up = 2*inter_dim f32 entries.
+        # Per-K-slice bias contribution must be scaled by 1/k_batch so the
+        # atomic-fadd accumulation reproduces ``+ bias`` once across all
+        # K-slices. Caller passes ``bias_scale = 1.0 / k_batch``.
+        bias_row_base_i32 = eid_i32 * inter_stride_i32
+        if bias_scale is None:
+            bias_scale_const = arith.constant(1.0, type=T.f32)
+        else:
+            bias_scale_const = arith.constant(float(bias_scale), type=T.f32)
+
+    for acc_idx, vec_base, m_off, wn in sub_tiles:
+        row_local = warp_m_base + fx.Index(m_off) + lane16
+        sorted_row = by * arith.index(int(tile_m)) + row_local
+        row_i32 = arith.index_cast(T.i32, row_local)
+        sorted_i32 = arith.index_cast(T.i32, sorted_row)
+        row_in_route = arith.cmpi(
+            arith.CmpIPredicate.ult,
+            row_i32,
+            arith.constant(int(route_tile_m), type=T.i32),
+        )
+        row_in_valid = arith.cmpi(arith.CmpIPredicate.slt, sorted_i32, num_valid_i32)
+        row_ok_meta = arith.andi(row_in_route, row_in_valid)
+        sorted_safe = arith.select(row_ok_meta, sorted_i32, block_row_start)
+        if _use_lds:
+            fused = memref.load(lds_tid, [row_local])
+        else:
+            fused = buffer_ops.buffer_load(sorted_rsrc, sorted_safe, vec_width=1, dtype=T.i32)
+        tok = fused & arith.constant((1 << 24) - 1, type=T.i32)
+        slot = fused >> arith.constant(24, type=T.i32)
+        tok_ok = arith.cmpi(arith.CmpIPredicate.ult, tok, i32_tokens_in)
+        slot_ok0 = arith.cmpi(arith.CmpIPredicate.sge, slot, arith.constant(0, type=T.i32))
+        slot_ok1 = arith.cmpi(arith.CmpIPredicate.slt, slot, c_topk_i32)
+        row_ok = arith.andi(row_ok_meta, arith.andi(tok_ok, arith.andi(slot_ok0, slot_ok1)))
+
+        sub8g, sub8u = load_gate_up_sub8(acc_idx, vec_base)
+        col_base = blk_n + warp_n_base + fx.Index(wn * WMMA_N) + lane_kgrp * fx.Index(8)
+        row_elem_base = (tok * c_topk_i32 + slot) * inter_stride_i32
+
+        for vpair in range_constexpr(4):
+            vi0 = vpair * 2
+            vi1 = vi0 + 1
+            col0 = col_base + fx.Index(vi0)
+            col1 = col_base + fx.Index(vi1)
+            col0_i32 = arith.index_cast(T.i32, col0)
+            col1_i32 = arith.index_cast(T.i32, col1)
+            col0_ok = arith.cmpi(arith.CmpIPredicate.ult, col0_i32, i32_inter_in)
+            col1_ok = arith.cmpi(arith.CmpIPredicate.ult, col1_i32, i32_inter_in)
+            out_ok = arith.andi(row_ok, col0_ok)
+            _if_out = scf.IfOp(out_ok)
+            with ir.InsertionPoint(_if_out.then_block):
+                # ---- gate partial ----
+                vg0 = vector.extract(sub8g, static_position=[vi0], dynamic_position=[])
+                vg1 = vector.extract(sub8g, static_position=[vi1], dynamic_position=[])
+                vg1 = arith.select(col1_ok, vg1, arith.constant(0.0, type=T.f32))
+                if _use_bias:
+                    bg0 = buffer_ops.buffer_load(
+                        bias_rsrc, bias_row_base_i32 + col0_i32,
+                        vec_width=1, dtype=T.f32) * bias_scale_const
+                    bg1 = buffer_ops.buffer_load(
+                        bias_rsrc, bias_row_base_i32 + col1_i32,
+                        vec_width=1, dtype=T.f32) * bias_scale_const
+                    bg1 = arith.select(col1_ok, bg1, arith.constant(0.0, type=T.f32))
+                    vg0 = vg0 + bg0
+                    vg1 = vg1 + bg1
+                g0 = arith.trunc_f(out_elem_ty, vg0)
+                g1 = arith.trunc_f(out_elem_ty, vg1)
+                frag_g = vector.from_elements(T.vec(2, out_elem_ty), [g0, g1])
+                idx_g0 = row_elem_base + col0_i32
+                idx_g_even = idx_g0 & mask_even_i32
+                byte_off_g = idx_g_even * c2_i32
+                atomic_add_x2(frag_g, byte_off_g)
+
+                # ---- up partial (offset by inter_dim) ----
+                vu0 = vector.extract(sub8u, static_position=[vi0], dynamic_position=[])
+                vu1 = vector.extract(sub8u, static_position=[vi1], dynamic_position=[])
+                vu1 = arith.select(col1_ok, vu1, arith.constant(0.0, type=T.f32))
+                if _use_bias:
+                    bu0 = buffer_ops.buffer_load(
+                        bias_rsrc, bias_row_base_i32 + i32_inter_in + col0_i32,
+                        vec_width=1, dtype=T.f32) * bias_scale_const
+                    bu1 = buffer_ops.buffer_load(
+                        bias_rsrc, bias_row_base_i32 + i32_inter_in + col1_i32,
+                        vec_width=1, dtype=T.f32) * bias_scale_const
+                    bu1 = arith.select(col1_ok, bu1, arith.constant(0.0, type=T.f32))
+                    vu0 = vu0 + bu0
+                    vu1 = vu1 + bu1
+                u0 = arith.trunc_f(out_elem_ty, vu0)
+                u1 = arith.trunc_f(out_elem_ty, vu1)
+                frag_u = vector.from_elements(T.vec(2, out_elem_ty), [u0, u1])
+                idx_u0 = row_elem_base + i32_inter_in + col0_i32
+                idx_u_even = idx_u0 & mask_even_i32
+                byte_off_u = idx_u_even * c2_i32
+                atomic_add_x2(frag_u, byte_off_u)
+
                 scf.YieldOp([])
 
 
@@ -253,6 +504,8 @@ def _emit_stage2_store_epilogue(
     topk: int,
     num_valid_i32,
     block_row_start,
+    lds_tid=None,
+    memref=None,
     sorted_rsrc,
     tw_rsrc,
     out_rsrc,
@@ -269,7 +522,25 @@ def _emit_stage2_store_epilogue(
     range_constexpr,
     rocdl,
     T,
+    # ── optional: per-expert bias of shape (E, model_dim). ``eid_i32`` is
+    # the per-block expert id; ``bias_rsrc`` is the f32 buffer resource.
+    #
+    # The torch reference (``aiter.fused_moe.torch_moe_stage2``) computes
+    # the per-slot contribution as ``topk_weight[slot] * (gemm[slot] +
+    # bias[expert_of_slot])`` and then sums across the ``topk`` slots
+    # for each output token. To reproduce this with a per-slot atomic
+    # add, the bias loaded from ``bias_rsrc`` must be scaled by the same
+    # factor that scales the GEMM term (``tw`` when
+    # ``doweight_stage2=True``, else ``1.0``). The split-K-style
+    # ``bias_scale`` override is intentionally unused on stage2 — pass
+    # ``None`` (the default) to use the routing-weight-aware scaling.
+    bias_rsrc=None,
+    eid_i32=None,
+    bias_scale: float | None = None,
 ):
+    # ``lds_tid`` (optional): see ``_emit_stage1_gate_up_epilogue``.
+    _use_lds = lds_tid is not None and memref is not None
+    _use_bias = bias_rsrc is not None and eid_i32 is not None
     c_topk_i32 = arith.constant(int(topk), type=T.i32)
     c2_i32 = arith.constant(2, type=T.i32)
     zero_i32 = arith.constant(0, type=T.i32)
@@ -277,6 +548,18 @@ def _emit_stage2_store_epilogue(
 
     def atomic_add_x2(val_x2, byte_off_i32):
         rocdl.raw_ptr_buffer_atomic_fadd(val_x2, out_rsrc, byte_off_i32, zero_i32, zero_i32)
+
+    if _use_bias:
+        # bias[e, n] f32; flat index = e * model_dim + n. Routing-weight
+        # awareness is handled per-slot below (multiply bias by ``tw``
+        # when ``doweight_stage2=True``); the optional ``bias_scale``
+        # override is kept for callers that need to inject an extra
+        # constant factor (currently unused on stage2).
+        bias_row_base_i32 = eid_i32 * i32_n_in
+        if bias_scale is None:
+            bias_scale_const = arith.constant(1.0, type=T.f32)
+        else:
+            bias_scale_const = arith.constant(float(bias_scale), type=T.f32)
 
     for acc_idx, vec_base, m_off, wn in sub_tiles:
         row_local = warp_m_base + fx.Index(m_off) + lane16
@@ -287,7 +570,10 @@ def _emit_stage2_store_epilogue(
         row_in_valid = arith.cmpi(arith.CmpIPredicate.slt, sorted_i32, num_valid_i32)
         row_ok = arith.andi(row_in_route, row_in_valid)
         sorted_safe = arith.select(row_ok, sorted_i32, block_row_start)
-        fused = buffer_ops.buffer_load(sorted_rsrc, sorted_safe, vec_width=1, dtype=T.i32)
+        if _use_lds:
+            fused = memref.load(lds_tid, [row_local])
+        else:
+            fused = buffer_ops.buffer_load(sorted_rsrc, sorted_safe, vec_width=1, dtype=T.i32)
         tok = fused & arith.constant((1 << 24) - 1, type=T.i32)
         slot = fused >> arith.constant(24, type=T.i32)
         tok_ok = arith.cmpi(arith.CmpIPredicate.ult, tok, i32_tokens_in)
@@ -316,6 +602,25 @@ def _emit_stage2_store_epilogue(
                     if bool(doweight_stage2):
                         v0 = v0 * tw
                         v1 = v1 * tw
+                    if _use_bias:
+                        # Each per-slot atomic_add must contribute
+                        # ``tw * (gemm + bias)`` to match
+                        # ``torch_moe_stage2``: bias scales by the same
+                        # routing weight as GEMM. When doweight is off
+                        # ``tw == 1.0``, so this collapses to ``+ bias``
+                        # per slot, which matches the
+                        # doweight_stage1=True path of the torch
+                        # reference (bias added per slot, weight applied
+                        # in stage1).
+                        bias_w = bias_scale_const * tw
+                        b0 = buffer_ops.buffer_load(
+                            bias_rsrc, bias_row_base_i32 + col0_i32,
+                            vec_width=1, dtype=T.f32) * bias_w
+                        b1 = buffer_ops.buffer_load(
+                            bias_rsrc, bias_row_base_i32 + col1_i32,
+                            vec_width=1, dtype=T.f32) * bias_w
+                        v0 = v0 + b0
+                        v1 = v1 + b1
                     v1 = arith.select(col1_ok, v1, arith.constant(0.0, type=T.f32))
                     out0 = arith.trunc_f(out_elem_ty, v0)
                     out1 = arith.trunc_f(out_elem_ty, v1)
@@ -328,14 +633,22 @@ def _emit_stage2_store_epilogue(
         else:
             for vi in range_constexpr(8):
                 col = col_base + fx.Index(vi)
-                col_ok = arith.cmpi(arith.CmpIPredicate.ult, arith.index_cast(T.i32, col), i32_n_in)
+                col_i32 = arith.index_cast(T.i32, col)
+                col_ok = arith.cmpi(arith.CmpIPredicate.ult, col_i32, i32_n_in)
                 out_ok = arith.andi(row_store_ok, col_ok)
                 _if_out = scf.IfOp(out_ok)
                 with ir.InsertionPoint(_if_out.then_block):
                     v = vector.extract(sub8, static_position=[vi], dynamic_position=[])
                     if bool(doweight_stage2):
                         v = v * tw
-                    col_i32 = arith.index_cast(T.i32, col)
+                    if _use_bias:
+                        # See the accumulate=True branch above: bias
+                        # scales by ``tw`` to keep per-slot semantics
+                        # consistent with torch_moe_stage2.
+                        b = buffer_ops.buffer_load(
+                            bias_rsrc, bias_row_base_i32 + col_i32,
+                            vec_width=1, dtype=T.f32) * (bias_scale_const * tw)
+                        v = v + b
                     out_idx = ts * i32_n_in + col_i32
                     out_v = arith.trunc_f(out_elem_ty, v)
                     buffer_ops.buffer_store(out_v, out_rsrc, out_idx)
@@ -880,8 +1193,14 @@ def _compute_pipeline_plan(
     use_tdm_gather: bool,
     wave_specialized_tdm: bool,
     tdm_loader_waves: int,
+    use_tdm_gather_as: bool = False,
 ) -> dict:
-    """Compute pipeline pre-load / tail plan shared by mxscale stages."""
+    """Compute pipeline pre-load / tail plan shared by mxscale stages.
+
+    ``use_tdm_gather_as`` reserves TDM slots for the A-scale gather path so that
+    ``TDM_PER_STEP`` and the derived fence counts account for the extra
+    ``tensor_load_gather`` instructions issued for scales.
+    """
     from kernels.pipeline_utils import make_tail_plan
 
     pre_loaded = int(num_buffers) - 1
@@ -889,13 +1208,24 @@ def _compute_pipeline_plan(
     tail_start = loop_iters * int(num_buffers)
     extra = num_k_tiles - tail_start - pre_loaded
     A_GATHER_GROUPS = (int(tile_m) + 7) // 8 if bool(use_tdm_gather) else 0
-    if bool(use_tdm_gather) and bool(wave_specialized_tdm):
-        A_GATHER_TDM_PER_STEP = (
-            (A_GATHER_GROUPS + tdm_loader_waves - 1) // tdm_loader_waves
-        )
+    AS_GATHER_GROUPS = (int(tile_m) + 7) // 8 if bool(use_tdm_gather_as) else 0
+    if bool(wave_specialized_tdm):
+        if bool(use_tdm_gather):
+            A_GATHER_TDM_PER_STEP = (
+                (A_GATHER_GROUPS + tdm_loader_waves - 1) // tdm_loader_waves
+            )
+        else:
+            A_GATHER_TDM_PER_STEP = 0
+        if bool(use_tdm_gather_as):
+            AS_GATHER_TDM_PER_STEP = (
+                (AS_GATHER_GROUPS + tdm_loader_waves - 1) // tdm_loader_waves
+            )
+        else:
+            AS_GATHER_TDM_PER_STEP = 0
     else:
         A_GATHER_TDM_PER_STEP = A_GATHER_GROUPS
-    TDM_PER_STEP = B_TDM_PER_STEP + A_GATHER_TDM_PER_STEP
+        AS_GATHER_TDM_PER_STEP = AS_GATHER_GROUPS
+    TDM_PER_STEP = B_TDM_PER_STEP + A_GATHER_TDM_PER_STEP + AS_GATHER_TDM_PER_STEP
     fence_outstanding = TDM_PER_STEP * (int(num_buffers) - 2)
     base_tail_plan = make_tail_plan(int(num_buffers), pre_loaded, extra)
     tail_plan = [
@@ -913,6 +1243,7 @@ def _compute_pipeline_plan(
         tail_start=tail_start,
         extra=extra,
         A_GATHER_GROUPS=A_GATHER_GROUPS,
+        AS_GATHER_GROUPS=AS_GATHER_GROUPS,
         TDM_PER_STEP=TDM_PER_STEP,
         fence_outstanding=fence_outstanding,
         tail_plan=tail_plan,

--- a/kernels/moe_gemm_2stage_mxscale_gfx1250.py
+++ b/kernels/moe_gemm_2stage_mxscale_gfx1250.py
@@ -25,7 +25,9 @@ from kernels.moe_gemm_2stage_common_gfx1250 import (
     _compute_pipeline_plan,
     _compute_tdm_store_layout,
     _emit_stage1_gate_up_epilogue,
+    _emit_stage1_gate_up_splitk_epilogue,
     _emit_stage2_store_epilogue,
+    _emit_swiglu,
     _extract_sub8,
     _finalize_alloc_and_launch_2d,
     _make_moe_wave_layout,
@@ -36,7 +38,6 @@ from kernels.moe_gemm_2stage_common_gfx1250 import (
     _pick_mxscale_launch_shape,
     _require_gfx1250,
 )
-
 
 @functools.lru_cache(maxsize=64)
 def _compile_stage1_mxscale_kernel_impl(
@@ -58,18 +59,38 @@ def _compile_stage1_mxscale_kernel_impl(
     expert_sched_mode: bool = True,
     num_buffers: int = 1,
     use_tdm_gather: bool = True,
+    use_tdm_gather_as: bool = True,
     use_tdm_store: bool = False,
     inst_prefetch: bool = False,
     wave_specialized_tdm: bool = False,
     cluster_m: int = 1,
     cluster_n: int = 1,
+    k_batch: int = 1,
+    # ── Bias / activation ────────────────────────────────────────────
+    # ``enable_bias``: when True, the kernel signature includes an
+    # ``arg_bias`` operand of shape (E * 2*inter_dim,) f32. Stage1 adds
+    # ``bias[eid, gate_col]`` and ``bias[eid, inter_dim + up_col]``
+    # before activation. Layout matches torch's ``w1_bias`` (gate||up
+    # concatenation per expert).
+    # ``act``: ``"silu"`` (default) for ``silu(g)*u``; ``"swiglu"`` for
+    # GPT-OSS SwiGLU (``alpha=1.702``, ``limit=7.0``, hardcoded).
+    enable_bias: bool = False,
+    act: str = "silu",
 ):
-    """Compile mxscale stage1 single kernel (route-pack + TDM + WMMA_SCALE + epilog)."""
+    """Compile mxscale stage1 single kernel (route-pack + TDM + WMMA_SCALE + epilog).
+
+    ``use_tdm_gather_as`` enables the TDM-gather path for the A-scale matrix,
+    moving that load off ``ds_cnt`` and onto ``tdm_cnt`` to eliminate the
+    ``s_wait_dscnt`` stalls that dominate the scalar per-byte fallback. Falls
+    back to the vectorised scalar path when the LDS scale layout is not
+    row-major (``wmma_m_rep > 1`` and not ``is_fp4``) or the row width is below
+    the TDM gather minimum (``scale_k_per_tile < 4``).
+    """
     import flydsl.compiler as flyc
     import flydsl.expr as fx
     from flydsl._mlir import ir
     from flydsl._mlir.dialects import llvm as llvm_dialect
-    from flydsl._mlir.dialects import scf
+    from flydsl._mlir.dialects import memref, scf
     from flydsl.compiler.kernel_function import CompilationContext
     from flydsl.expr import arith, buffer_ops, const_expr, gpu, idx2crd, range_constexpr, rocdl, tdm_ops, vector
     from flydsl.expr.typing import T
@@ -109,6 +130,59 @@ def _compile_stage1_mxscale_kernel_impl(
     interleaved_scale_cols_a = tp["interleaved_scale_cols_a"]
 
     N = int(inter_dim)
+
+    # ── Split-K validation / setup ────────────────────────────────────
+    # When k_batch > 1 the K dimension (model_dim) is split across the
+    # grid z-dim. Each CTA computes a K-slice and atomically accumulates
+    # gate / up partial sums into a [tokens*topk, 2*inter_dim] output.
+    # silu/mul fusion, doweight_stage1 and TDM store must be disabled for
+    # split-K; a separate reduction kernel fuses silu*mul and folds in
+    # the per-slot routing weight.
+    # Activation kind: 'silu' (default; matches the historical kernel
+    # that fuses ``silu(gate) * up`` in epilogue) or 'swiglu' (GPT-OSS
+    # gated-linear-unit; emits clamp + Swish_alpha + (up+1) in epilogue).
+    _act_kind = str(act).strip().lower()
+    if _act_kind not in ("silu", "swiglu"):
+        raise ValueError(
+            f"stage1 mxscale: unsupported act={act!r}; expected 'silu' or 'swiglu'")
+    _enable_bias = bool(enable_bias)
+    _is_splitk = int(k_batch) > 1
+    if _is_splitk:
+        if int(model_dim) % int(k_batch) != 0:
+            raise ValueError(
+                f"split-K requires model_dim divisible by k_batch, "
+                f"got model_dim={model_dim}, k_batch={k_batch}")
+        _k_per_batch = int(model_dim) // int(k_batch)
+        if _k_per_batch % int(tile_k) != 0:
+            raise ValueError(
+                f"split-K requires (model_dim // k_batch) divisible by tile_k, "
+                f"got k_per_batch={_k_per_batch}, tile_k={tile_k}")
+        if bool(use_tdm_store):
+            raise ValueError("split-K stage1 does not support use_tdm_store")
+        if bool(wave_specialized_tdm):
+            raise ValueError("split-K stage1 does not support wave_specialized_tdm")
+        if bool(doweight_stage1):
+            raise ValueError(
+                "split-K stage1 does not support fused doweight_stage1; "
+                "apply routing weight in the external reduction kernel")
+        # split-K stage1 atomically accumulates raw gate/up partials and
+        # fuses silu/mul in an external reduction kernel; SwiGLU would
+        # have to be applied there too, which is not currently wired.
+        if _act_kind != "silu":
+            raise ValueError(
+                "split-K stage1 fuses activation in the external reduction "
+                "kernel; only act='silu' is supported. Disable split-K "
+                "(k_batch=1) to use SwiGLU.")
+        _s1_out = str(out_dtype).strip().lower()
+        if _s1_out not in ("f16", "fp16", "half", "bf16", "bfloat16"):
+            raise ValueError(
+                f"split-K stage1 only supports fp16/bf16 output (x2 atomic fadd), "
+                f"got out_dtype={out_dtype!r}")
+        num_k_tiles_per_bz = _k_per_batch // int(tile_k)
+    else:
+        _k_per_batch = int(model_dim)
+        num_k_tiles_per_bz = num_k_tiles
+
     _merge_gate_up_tdm = bool((data_format in ("fp8", "a8w4")) and (N % int(tile_n) == 0))
     num_warps_s1 = int(m_warp) * int(n_warp)
     _tdm_loader_waves = 2 if _merge_gate_up_tdm else 4
@@ -125,6 +199,19 @@ def _compile_stage1_mxscale_kernel_impl(
         wmma_m_rep=wmma_m_rep, wmma_n_rep=wmma_n_rep, WMMA_M=WMMA_M, is_fp4=is_fp4
     )
 
+    # A-scale TDM gather gating: requires A-side TDM gather (for _a_tok_ids
+    # SGPR caches), a row-major LDS scale layout (fp4 path is always row-major;
+    # non-fp4 is row-major only when wmma_m_rep == 1), and a gather row width
+    # of at least 4 bytes (TDM gather hardware constraint: row_width * elem_bytes % 4 == 0 and > 0).
+    _as_layout_rowmajor = bool(is_fp4) or (int(wmma_m_rep) == 1)
+    _as_row_bytes_ok = int(scale_k_per_tile) >= 4 and (int(scale_k_per_tile) % 4 == 0)
+    _use_tdm_gather_as = (
+        bool(use_tdm_gather_as)
+        and bool(use_tdm_gather)
+        and _as_layout_rowmajor
+        and _as_row_bytes_ok
+    )
+
     # Pipeline calculations for multi-buffer
     _use_pipeline = int(num_buffers) >= 2
     if _use_pipeline:
@@ -136,9 +223,10 @@ def _compile_stage1_mxscale_kernel_impl(
         else:
             _B_TDM_PER_STEP = 1 if bool(wave_specialized_tdm) else 4
         _pp = _compute_pipeline_plan(
-            num_k_tiles=num_k_tiles, num_buffers=int(num_buffers),
+            num_k_tiles=num_k_tiles_per_bz, num_buffers=int(num_buffers),
             B_TDM_PER_STEP=_B_TDM_PER_STEP, tile_m=int(tile_m),
             use_tdm_gather=use_tdm_gather,
+            use_tdm_gather_as=_use_tdm_gather_as,
             wave_specialized_tdm=wave_specialized_tdm,
             tdm_loader_waves=_tdm_loader_waves,
         )
@@ -147,6 +235,7 @@ def _compile_stage1_mxscale_kernel_impl(
         _tail_start = _pp["tail_start"]
         extra = _pp["extra"]
         _A_GATHER_GROUPS = _pp["A_GATHER_GROUPS"]
+        _AS_GATHER_GROUPS = _pp["AS_GATHER_GROUPS"]
         TDM_PER_STEP = _pp["TDM_PER_STEP"]
         _fence_outstanding = _pp["fence_outstanding"]
         _tail_plan = _pp["tail_plan"]
@@ -155,7 +244,10 @@ def _compile_stage1_mxscale_kernel_impl(
     alloc = SmemAllocator(
         None,
         arch=str(get_hip_arch()),
-        global_sym_name=f"moe_mxscale_{data_format}_s1_single_g{int(bool(use_tdm_gather))}",
+        global_sym_name=(
+            f"moe_mxscale_{data_format}_s1_single_g{int(bool(use_tdm_gather))}"
+            f"_as{int(_use_tdm_gather_as)}"
+        ),
     )
     _nb = int(num_buffers)
     off_ag_list, off_as_list = [], []
@@ -176,20 +268,33 @@ def _compile_stage1_mxscale_kernel_impl(
             _o = alloc._align(alloc.ptr, 16); alloc.ptr = _o + lds_b_data_bytes; off_bu_list.append(_o)
             _o = alloc._align(alloc.ptr, 16); alloc.ptr = _o + lds_b_scale_bytes; off_bsu_list.append(_o)
 
+    # lds_tid: preloaded sorted_token_ids for current M-tile (tile_m entries, i32).
+    # Used to replace per-thread buffer_load(sorted_rsrc, ...) in the K-loop A-data/A-scale
+    # loaders and the epilogue. Invalid rows are pre-filled with sentinel 0xFFFFFFFF so
+    # that downstream tok/slot checks naturally reject them without needing row_in_route
+    # or row_in_valid masks.
+    lds_tid_bytes = int(tile_m) * 4
+    off_tid = alloc._align(alloc.ptr, 16)
+    alloc.ptr = off_tid + lds_tid_bytes
+
     if bool(use_tdm_store):
         from kernels.gemm_common_gfx1250 import store_acc_vec8_to_lds
         _ds1 = _compute_tdm_store_layout(
             warp_tile_m=warp_tile_m, warp_tile_n=warp_tile_n,
             num_warps=num_warps_s1, WMMA_N=WMMA_N, use_pipeline=_use_pipeline,
         )
+        total_d_bytes_s1 = _ds1["total_d_bytes"]
         lds_d_row_stride_s1 = _ds1["lds_d_row_stride"]
+        warp_d_bytes_s1 = _ds1["warp_d_bytes"]
         d_output_off_s1 = _ds1["d_output_off"]
         _lds_d_stride_elems_s1 = _ds1["lds_d_stride_elems"]
         _warp_d_elems_s1 = _ds1["warp_d_elems"]
         _n_col_d_elems_s1 = _ds1["n_col_d_elems"]
         d_need_epilogue_fence_s1 = _ds1["d_need_epilogue_fence"]
-        if _ds1["total_d_bytes"] > alloc.ptr:
-            alloc.ptr = _ds1["total_d_bytes"]
+        elem_bytes_d_s1 = 2
+        LDS_PAD_D_BYTES_s1 = 16
+        if total_d_bytes_s1 > alloc.ptr:
+            alloc.ptr = total_d_bytes_s1
 
     @flyc.kernel(known_block_size=[block_threads, 1, 1])
     def moe_mxscale_stage1_single(
@@ -202,12 +307,25 @@ def _compile_stage1_mxscale_kernel_impl(
         arg_expert_ids: fx.Tensor,
         arg_sorted_weights: fx.Tensor,
         arg_num_valid_ids: fx.Tensor,
+        # ``arg_bias`` (f32, flat E*2*inter_dim) is unused when
+        # ``enable_bias=False`` at compile time but is always present in
+        # the kernel signature so the runtime tuple shape is stable.
+        # Callers should pass an empty tensor when bias is disabled.
+        arg_bias: fx.Tensor,
         i32_tokens_in: fx.Int32,
         i32_inter_in: fx.Int32,
         i32_k_in: fx.Int32,
         i32_size_expert_ids_in: fx.Int32,
     ):
         _ = i32_k_in
+        # ASTRewriter strips ``const_expr(...)`` from ``if`` tests, which would
+        # otherwise eliminate every reference to ``const_expr`` from the
+        # rewritten function body and shrink ``co_freevars`` by one — causing
+        # CPython to reject ``f.__code__ = new_f_code_o`` because the original
+        # ``__closure__`` length no longer matches. Keep one explicit reference
+        # so the rewritten code object's free-vars list still includes
+        # ``const_expr``.
+        _keep_const_expr_ref = const_expr  # noqa: F841
         if const_expr(inst_prefetch):
             if arith.cmpi(arith.CmpIPredicate.eq, rocdl.wave_id(),
                           arith.constant(0, type=T.i32)):
@@ -220,16 +338,18 @@ def _compile_stage1_mxscale_kernel_impl(
                     "\n".join(_prefetch_lines),
                     "", has_side_effects=True,
                 )
-        llvm_dialect.inline_asm(
-            None, [],
-            "s_setreg_imm32_b32 hwreg(26, 4, 1), 1",
-            "",
-            has_side_effects=True,
-        )
 
         tx = gpu.thread_id("x")
         bx = gpu.block_id("x")
         by = gpu.block_id("y")
+
+        # Split-K: bz identifies the K-slice; k_base_idx is the starting
+        # K offset (in data elements, pre-pack) for this CTA.
+        if _is_splitk:
+            bz = gpu.block_id("z")  # already index type
+            k_base_idx = bz * arith.index(int(_k_per_batch))
+        else:
+            k_base_idx = arith.index(0)
 
         tokens_idx = arith.index_cast(T.index, i32_tokens_in)
         size_expert_ids = arith.index_cast(T.index, i32_size_expert_ids_in)
@@ -257,6 +377,11 @@ def _compile_stage1_mxscale_kernel_impl(
         sw_rsrc = buffer_ops.create_buffer_resource(arg_scale_w, max_size=False, num_records_bytes=sw_nbytes)
         out_rsrc = buffer_ops.create_buffer_resource(arg_out, max_size=True)
         tw_rsrc = buffer_ops.create_buffer_resource(arg_sorted_weights, max_size=True)
+        # bias resource: only meaningful when ``_enable_bias=True``. We
+        # always create it (with max_size=True so an empty tensor is
+        # tolerated) so the kernel signature stays stable; the epilogue
+        # only issues buffer_load on it when the constexpr flag is set.
+        bias_rsrc = buffer_ops.create_buffer_resource(arg_bias, max_size=True)
 
         eid_i32 = buffer_ops.buffer_load(eid_rsrc, arith.index_cast(T.i32, by), vec_width=1, dtype=T.i32)
         eid_ok0 = arith.cmpi(arith.CmpIPredicate.sge, eid_i32, arith.constant(0, type=T.i32))
@@ -305,6 +430,8 @@ def _compile_stage1_mxscale_kernel_impl(
                     SmemPtr(base_ptr, off_bu_list[_bi], T.i8, shape=(lds_b_data_bytes,)).get()))
                 lds_bsu_bufs.append(get_op_result_or_value(
                     SmemPtr(base_ptr, off_bsu_list[_bi], T.i8, shape=(lds_b_scale_bytes,)).get()))
+
+        lds_tid = SmemPtr(base_ptr, off_tid, T.i32, shape=(int(tile_m),)).get()
 
         if const_expr(bool(use_tdm_store)):
             from kernels.gemm_common_gfx1250 import get_lds_memref
@@ -363,17 +490,13 @@ def _compile_stage1_mxscale_kernel_impl(
                 with ir.InsertionPoint(_if_elem.then_block):
                     row = elem // arith.index(int(packed_tile_k_a))
                     col = elem % arith.index(int(packed_tile_k_a))
-                    sorted_row = by * arith.index(int(tile_m)) + row
-                    row_i32 = arith.index_cast(T.i32, row)
-                    sorted_i32 = arith.index_cast(T.i32, sorted_row)
-                    row_in_route = arith.cmpi(arith.CmpIPredicate.ult, row_i32, arith.constant(int(route_tile_m), type=T.i32))
-                    row_in_valid = arith.cmpi(arith.CmpIPredicate.slt, sorted_i32, num_valid_i32)
-                    row_ok = arith.andi(row_in_route, row_in_valid)
-                    sorted_safe = arith.select(row_ok, sorted_i32, block_row_start)
-                    fused = buffer_ops.buffer_load(sorted_rsrc, sorted_safe, vec_width=1, dtype=T.i32)
+                    # Use preloaded lds_tid instead of per-thread buffer_load(sorted_rsrc, ...).
+                    # Invalid rows were pre-filled with sentinel 0xFFFFFFFF at preload, so
+                    # tok=0xFFFFFF will make tok_ok=false for them.
+                    fused = _load_fused_from_lds(row)
                     tok = fused & arith.constant((1 << 24) - 1, type=T.i32)
                     tok_ok = arith.cmpi(arith.CmpIPredicate.ult, tok, i32_tokens_in)
-                    load_ok = arith.andi(row_ok, tok_ok)
+                    load_ok = tok_ok
                     x_idx = tok * arith.constant(K_packed_a, type=T.i32) + arith.index_cast(T.i32, k_packed_base + col)
                     x_idx_safe = arith.select(load_ok, x_idx, arith.constant(0, type=T.i32))
                     x_val = arith.select(load_ok, buffer_ops.buffer_load(x_rsrc, x_idx_safe, vec_width=1, dtype=T.i8), arith.constant(0, type=T.i8))
@@ -396,37 +519,77 @@ def _compile_stage1_mxscale_kernel_impl(
                 _acc = _acc + _vals[_vi]
             return _acc
 
+        def _preload_sorted_ids_to_lds():
+            """Preload tile_m sorted_token_ids entries into ``lds_tid`` (once per CTA).
+
+            Row ``ri`` (ri in ``[0, tile_m)``) gets the raw i32 from
+            ``sorted_token_ids[by * tile_m + ri]`` when that row is both inside
+            the block's route slot range and the valid prefix; otherwise the
+            sentinel ``0xFFFFFFFF`` is stored so that downstream
+            ``tok = fused & 0xFFFFFF`` / ``slot = fused >> 24`` decoding makes
+            ``tok_ok`` and ``slot_ok1`` naturally false, eliminating the need
+            for separate ``row_in_route`` / ``row_in_valid`` guards at every
+            consumer site.
+            """
+            _tid_in_range = arith.cmpi(
+                arith.CmpIPredicate.ult, tx, fx.Index(int(tile_m)))
+            _if_tid = scf.IfOp(_tid_in_range)
+            with ir.InsertionPoint(_if_tid.then_block):
+                _tx_i32 = arith.index_cast(T.i32, tx)
+                _sorted_row = by * fx.Index(int(tile_m)) + tx
+                _sorted_i32 = arith.index_cast(T.i32, _sorted_row)
+                _in_route = arith.cmpi(
+                    arith.CmpIPredicate.ult,
+                    _tx_i32,
+                    arith.constant(int(route_tile_m), type=T.i32),
+                )
+                _in_valid = arith.cmpi(
+                    arith.CmpIPredicate.slt, _sorted_i32, num_valid_i32)
+                _row_valid = arith.andi(_in_route, _in_valid)
+                _row_safe_i32 = arith.select(
+                    _row_valid, _sorted_i32, block_row_start)
+                _raw = buffer_ops.buffer_load(
+                    sorted_rsrc, _row_safe_i32, vec_width=1, dtype=T.i32)
+                _sentinel = arith.constant(-1, type=T.i32)  # 0xFFFFFFFF
+                _val = arith.select(_row_valid, _raw, _sentinel)
+                _vec1 = vector.from_elements(T.vec(1, T.i32), [_val])
+                vector.store(_vec1, lds_tid, [tx], alignment=4)
+                scf.YieldOp([])
+            workgroup_barrier(use_cluster=use_cluster)
+
+        def _load_fused_from_lds(row_index):
+            """Load the cached ``fused`` i32 for a row (``0 <= row_index < tile_m``).
+
+            ``row_index`` may be a Python int (compile-time constant) or an
+            index-typed SSA value — both map to a single ``ds_read_b32``.
+            Invalid rows were pre-filled with ``0xFFFFFFFF`` at preload time.
+            """
+            if isinstance(row_index, int):
+                row_index = arith.index(row_index)
+            return memref.load(lds_tid, [row_index])
+
         def _precompute_a_row_indices():
-            """Load sorted_ids for all tile_m rows and decode token_ids + output row indices."""
+            """Decode per-row token/slot meta from ``lds_tid`` into sgpr lists.
+
+            Reads the preloaded i32 for each ``ri`` via a uniform ``ds_read_b32``
+            (one per row for the whole wave), then ``readfirstlane`` to produce
+            sgpr values used by TDM gather and TDM store. Invalid rows decode
+            to ``tok=0xFFFFFF``/``slot=0xFF`` via the sentinel, which the
+            ``tok_ok`` / ``slot_ok`` checks below reject.
+            """
             _safe_row = arith.constant(0, type=T.i32)
             _one_i32 = arith.constant(1, type=T.i32)
             _zero_i32 = arith.constant(0, type=T.i32)
             for _ri in range_constexpr(int(tile_m)):
-                _sorted_row = by * fx.Index(int(tile_m)) + fx.Index(_ri)
-                _sorted_i32 = arith.index_cast(T.i32, _sorted_row)
-                _row_in_route = arith.cmpi(
-                    arith.CmpIPredicate.ult,
-                    fx.Int32(_ri),
-                    fx.Int32(int(route_tile_m)),
-                )
-                _row_in_valid = arith.cmpi(
-                    arith.CmpIPredicate.slt,
-                    _sorted_i32,
-                    num_valid_i32,
-                )
-                _row_ok = arith.andi(_row_in_route, _row_in_valid)
-                _sorted_safe = arith.select(
-                    _row_ok, _sorted_i32,
-                    block_row_start,
-                )
-                _fused = buffer_ops.buffer_load(sorted_rsrc, _sorted_safe, vec_width=1, dtype=T.i32)
-                _tok = _fused & fx.Int32((1 << 24) - 1)
-                _slot = _fused >> fx.Int32(24)
+                _fused = _load_fused_from_lds(_ri)
+                _fused_sgpr = rocdl.readfirstlane(T.i32, _fused)
+                _tok = _fused_sgpr & fx.Int32((1 << 24) - 1)
+                _slot = _fused_sgpr >> fx.Int32(24)
                 _tok_ok = arith.cmpi(arith.CmpIPredicate.ult, _tok, i32_tokens_in)
                 _slot_ok0 = arith.cmpi(arith.CmpIPredicate.sge, _slot, fx.Int32(0))
                 _slot_ok1 = arith.cmpi(arith.CmpIPredicate.slt, _slot, c_topk_i32)
                 _slot_ok = arith.andi(_slot_ok0, _slot_ok1)
-                _row_tok_ok = arith.andi(_row_ok, _tok_ok)
+                _row_tok_ok = _tok_ok
                 _load_valid_i32 = arith.select(_row_tok_ok, _one_i32, _zero_i32)
                 _a_load_valids.append(rocdl.readfirstlane(T.i32, _load_valid_i32))
                 _tok_safe = arith.select(_row_tok_ok, _tok, _safe_row)
@@ -463,17 +626,35 @@ def _compile_stage1_mxscale_kernel_impl(
                 _a_tokens_topk_sgpr = rocdl.readfirstlane(T.i32, _m_i32)
             return _a_tokens_topk_sgpr
 
-        def issue_a_load_tdm_gather(k_base, target_lds):
-            """Load A data using TDM gather mode — one TDM instruction per 8 rows."""
-            k_packed_base = k_base if PACK_FACTOR_A == 1 else k_base // fx.Index(PACK_FACTOR_A)
+        # Cache of K-invariant pieces of the TDM gather descriptor:
+        #   "desc"[_gi][buf_idx] — full TDMGatherDescriptor with addr_lo = base
+        #                          (built at global_byte_offset=None),
+        #   "pred"[_gi]          — issue predicate (valid_count > 0, wave owner),
+        #   "base_addr_lo"[_gi]  — dgroup0.lane2 at global_byte_offset=0,
+        #   "base_addr_hi"[_gi]  — dgroup0.lane3 at global_byte_offset=0
+        #                          (with the descriptor's type-field bits intact;
+        #                          consumed by tdm_ops.add_addr_with_carry to
+        #                          propagate the lo-32-bit overflow into hi).
+        # populated once by ``_build_a_gather_base_descs()`` before the K loop
+        # so the hot path (``issue_a_load_tdm_gather``) only advances the
+        # base address via the carry-safe ``update_*_addr64`` helper each
+        # iteration.
+        _a_gather_cache = {}
+
+        def _build_a_gather_base_descs(lds_bufs):
+            if "desc" in _a_gather_cache:
+                return
             _tokens_dim1 = _get_tokens_sgpr()
             _zero_i32 = arith.constant(0, type=T.i32)
+            _descs = []
+            _preds = []
+            _base_addr_lo = []
+            _base_addr_hi = []
             for _gi in range_constexpr(_TDM_GATHER_GROUPS):
                 _start = _gi * _TDM_GATHER_CHUNK
                 _cnt = min(_TDM_GATHER_CHUNK, int(tile_m) - _start)
                 _row_indices = _a_tok_ids[_start:_start + _cnt]
                 _valid_count = _sum_i32_values(_a_load_valids[_start:_start + _cnt])
-                _lds_off = fx.Index(_start * lds_a_stride_bytes)
                 _has_valid = arith.cmpi(arith.CmpIPredicate.sgt, _valid_count, _zero_i32)
                 _issue_pred = _has_valid
                 if const_expr(wave_specialized_tdm):
@@ -484,11 +665,19 @@ def _compile_stage1_mxscale_kernel_impl(
                         arith.constant(_gather_owner, type=T.i32),
                     )
                     _issue_pred = arith.andi(_issue_pred, _is_gather_loader)
-                _if_issue = scf.IfOp(_issue_pred)
-                with ir.InsertionPoint(_if_issue.then_block):
-                    desc = tdm_ops.make_tensor_gather_descriptor(
+                _preds.append(_issue_pred)
+
+                _lds_off = fx.Index(_start * lds_a_stride_bytes)
+                _per_buf = []
+                # NOTE: must use range_constexpr here. The AST rewriter
+                # (InsertEmptyYieldForSCFFor) turns a plain `range` inside a
+                # kernel body into scf_range -> scf.ForOp, making the loop
+                # variable an MLIR induction value (ArithValue) and breaking
+                # Python list indexing below.
+                for _buf_i in range_constexpr(len(lds_bufs)):
+                    _base_desc = tdm_ops.make_tensor_gather_descriptor(
                         global_ptr=arg_x,
-                        lds_memref=target_lds,
+                        lds_memref=lds_bufs[_buf_i],
                         row_indices=_row_indices,
                         row_width=int(packed_tile_k_a),
                         tensor_dim0=K_packed_a,
@@ -500,57 +689,381 @@ def _compile_stage1_mxscale_kernel_impl(
                         index_size=32,
                         gather_tile_dim1=_valid_count,
                         lds_byte_offset=_lds_off,
-                        global_byte_offset=k_packed_base,
+                        global_byte_offset=None,
                     )
-                    tdm_ops.tensor_load_gather(desc)
+                    _per_buf.append(_base_desc)
+                _descs.append(_per_buf)
+                # addr_lo / addr_hi are independent of buf_idx (only lds_addr
+                # differs), so we can extract them from any buffer's base
+                # descriptor.
+                _base_addr_lo.append(vector.extract(
+                    _per_buf[0].dgroup0,
+                    static_position=[2],
+                    dynamic_position=[],
+                ))
+                _base_addr_hi.append(vector.extract(
+                    _per_buf[0].dgroup0,
+                    static_position=[3],
+                    dynamic_position=[],
+                ))
+
+            _a_gather_cache["desc"] = _descs
+            _a_gather_cache["pred"] = _preds
+            _a_gather_cache["base_addr_lo"] = _base_addr_lo
+            _a_gather_cache["base_addr_hi"] = _base_addr_hi
+
+        def issue_a_load_tdm_gather(k_base, buf_idx):
+            """Hot path: advance addr_lo on the precomputed gather descriptor.
+
+            Requires ``_build_a_gather_base_descs(lds_bufs)`` to have been
+            called once before the K loop with the matching LDS buffer list.
+            Uses the carry-safe ``update_tensor_gather_descriptor_addr64`` so
+            that ``base_addr_lo + k_byte_off`` overflowing the i32 boundary
+            propagates into ``addr_hi`` instead of silently wrapping into a
+            wrong 4 GiB page (which on gfx1250 deadlocks the GPU in
+            ``amdgpu_mes_reg_write_reg_wait``).
+            """
+            k_packed_base = k_base if PACK_FACTOR_A == 1 else k_base // fx.Index(PACK_FACTOR_A)
+            _k_byte_off_i32 = arith.index_cast(T.i32, k_packed_base)
+            _descs = _a_gather_cache["desc"]
+            _preds = _a_gather_cache["pred"]
+            _base_addr_lo = _a_gather_cache["base_addr_lo"]
+            _base_addr_hi = _a_gather_cache["base_addr_hi"]
+            for _gi in range_constexpr(_TDM_GATHER_GROUPS):
+                _if_issue = scf.IfOp(_preds[_gi])
+                with ir.InsertionPoint(_if_issue.then_block):
+                    tdm_ops.tensor_load_gather(
+                        tdm_ops.update_tensor_gather_descriptor_addr64(
+                            _descs[_gi][buf_idx],
+                            _base_addr_lo[_gi],
+                            _base_addr_hi[_gi],
+                            _k_byte_off_i32,
+                        )
+                    )
                     scf.YieldOp([])
+
+        # Cache of K-invariant 2D B / B-scale descriptors used by
+        # ``_issue_b_tdm_only``. Each entry stores a base TDMDescriptor2D
+        # built at k_base=0 plus its extracted scalar addr_lo / addr_hi, so
+        # the hot path can call the carry-safe
+        # ``update_tensor_descriptor_2d_addr64`` directly and avoid the
+        # silent i32-wraparound bug that the addr-lo-only shortcut has on
+        # large MoE expert-weight buffers (~3.5 GiB fp4 tensors with E=257
+        # experts on gfx1250 reliably trigger the overflow). Mirrors the
+        # hoist that wave_specialized_tdm already does internally via
+        # ``_active_stage_desc_base``. ``_build_b_base_descs()`` is closed
+        # over later-defined names (``_stage1_pair_row_base``, the
+        # ``make_desc_b*`` helpers, and the various ``lds_b*_bufs`` lists);
+        # those names are resolved at *call* time inside ``_if_blk``.
+        _b_desc_cache = {}
+
+        def _extract_desc_addr_lo(desc):
+            return vector.extract(
+                desc.dgroup0,
+                static_position=[2],
+                dynamic_position=[],
+            )
+
+        def _extract_desc_addr_hi(desc):
+            return vector.extract(
+                desc.dgroup0,
+                static_position=[3],
+                dynamic_position=[],
+            )
+
+        def _build_b_base_descs():
+            if "ready" in _b_desc_cache:
+                return
+            _zero_k = arith.index(0)
+            if const_expr(_merge_gate_up_tdm):
+                _n_pair = _stage1_pair_row_base()
+                _bg_pair = [
+                    make_desc_b_pair(lds_bg_pair_bufs[i], _n_pair, _zero_k)
+                    for i in range_constexpr(_nb)
+                ]
+                _bs_pair = [
+                    make_desc_bs_pair(lds_bs_pair_bufs[i], _n_pair, _zero_k)
+                    for i in range_constexpr(_nb)
+                ]
+                _b_desc_cache["bg_pair"] = _bg_pair
+                _b_desc_cache["bs_pair"] = _bs_pair
+                _b_desc_cache["bg_pair_addr_lo"] = [
+                    _extract_desc_addr_lo(d) for d in _bg_pair
+                ]
+                _b_desc_cache["bg_pair_addr_hi"] = [
+                    _extract_desc_addr_hi(d) for d in _bg_pair
+                ]
+                _b_desc_cache["bs_pair_addr_lo"] = [
+                    _extract_desc_addr_lo(d) for d in _bs_pair
+                ]
+                _b_desc_cache["bs_pair_addr_hi"] = [
+                    _extract_desc_addr_hi(d) for d in _bs_pair
+                ]
+            else:
+                _eid_row = (
+                    arith.index_cast(T.index, eid_i32)
+                    * arith.index(int(2 * N))
+                )
+                _n_gate = _eid_row + blk_n
+                _n_up = _eid_row + blk_n + arith.index(int(N))
+                _bg = [
+                    make_desc_b(lds_bg_bufs[i], _n_gate, _zero_k)
+                    for i in range_constexpr(_nb)
+                ]
+                _bu = [
+                    make_desc_b(lds_bu_bufs[i], _n_up, _zero_k)
+                    for i in range_constexpr(_nb)
+                ]
+                _bs = [
+                    make_desc_bs(lds_bs_bufs[i], _n_gate, _zero_k)
+                    for i in range_constexpr(_nb)
+                ]
+                _bsu = [
+                    make_desc_bs(lds_bsu_bufs[i], _n_up, _zero_k)
+                    for i in range_constexpr(_nb)
+                ]
+                _b_desc_cache["bg"] = _bg
+                _b_desc_cache["bu"] = _bu
+                _b_desc_cache["bs"] = _bs
+                _b_desc_cache["bsu"] = _bsu
+                _b_desc_cache["bg_addr_lo"] = [_extract_desc_addr_lo(d) for d in _bg]
+                _b_desc_cache["bg_addr_hi"] = [_extract_desc_addr_hi(d) for d in _bg]
+                _b_desc_cache["bu_addr_lo"] = [_extract_desc_addr_lo(d) for d in _bu]
+                _b_desc_cache["bu_addr_hi"] = [_extract_desc_addr_hi(d) for d in _bu]
+                _b_desc_cache["bs_addr_lo"] = [_extract_desc_addr_lo(d) for d in _bs]
+                _b_desc_cache["bs_addr_hi"] = [_extract_desc_addr_hi(d) for d in _bs]
+                _b_desc_cache["bsu_addr_lo"] = [_extract_desc_addr_lo(d) for d in _bsu]
+                _b_desc_cache["bsu_addr_hi"] = [_extract_desc_addr_hi(d) for d in _bsu]
+            _b_desc_cache["ready"] = True
+
+        def _b_data_k_byte_off(k_base):
+            # Byte offset along the fastest axis for a B-data descriptor:
+            #   non-fp4 / merged pair : (k_base / PACK_FACTOR_B) * 16 bytes
+            #   fp4                   : (k_base / PACK_FACTOR_B) bytes
+            # Matches `make_desc_b` / `make_desc_b_pair` global_offset math
+            # (elem_bytes=1 there, so element offset == byte offset).
+            _k_packed_b = (
+                k_base if PACK_FACTOR_B == 1
+                else k_base // fx.Index(PACK_FACTOR_B)
+            )
+            if const_expr(is_fp4):
+                return arith.index_cast(T.i32, _k_packed_b)
+            return arith.index_cast(
+                T.i32, _k_packed_b * fx.Index(16))
+
+        def _b_scale_k_byte_off(k_base):
+            # B-scale fastest-axis offset: k_base / SCALE_BLOCK bytes.
+            return arith.index_cast(
+                T.i32, k_base // fx.Index(SCALE_BLOCK))
 
         def make_desc_as(k_base):
             return k_base / arith.index(SCALE_BLOCK)
 
         def issue_as_load(k_scale_base, target_lds):
-            total = int(tile_m * scale_k_per_tile)
-            rounds = (total + block_threads - 1) // block_threads
-            for it in range(rounds):
-                elem = tx + fx.Index(it * block_threads)
-                in_range = arith.cmpi(arith.CmpIPredicate.ult, arith.index_cast(T.i32, elem), arith.constant(total, type=T.i32))
-                _if_elem = scf.IfOp(in_range)
-                with ir.InsertionPoint(_if_elem.then_block):
-                    row = elem // arith.index(int(scale_k_per_tile))
-                    ksc = elem % arith.index(int(scale_k_per_tile))
-                    sorted_row = by * arith.index(int(tile_m)) + row
-                    row_i32 = arith.index_cast(T.i32, row)
-                    sorted_i32 = arith.index_cast(T.i32, sorted_row)
-                    row_in_route = arith.cmpi(arith.CmpIPredicate.ult, row_i32, arith.constant(int(route_tile_m), type=T.i32))
-                    row_in_valid = arith.cmpi(arith.CmpIPredicate.slt, sorted_i32, num_valid_i32)
-                    row_ok = arith.andi(row_in_route, row_in_valid)
-                    sorted_safe = arith.select(row_ok, sorted_i32, block_row_start)
-                    fused = buffer_ops.buffer_load(sorted_rsrc, sorted_safe, vec_width=1, dtype=T.i32)
-                    tok = fused & arith.constant((1 << 24) - 1, type=T.i32)
-                    tok_ok = arith.cmpi(arith.CmpIPredicate.ult, tok, i32_tokens_in)
-                    load_ok = arith.andi(row_ok, tok_ok)
-                    ksc_off = k_scale_base + ksc
-                    sx_idx = tok * arith.constant(K_scale, type=T.i32) + arith.index_cast(T.i32, ksc_off)
-                    sx_idx_safe = arith.select(load_ok, sx_idx, arith.constant(0, type=T.i32))
-                    sx_val = arith.select(load_ok, buffer_ops.buffer_load(sx_rsrc, sx_idx_safe, vec_width=1, dtype=T.i8), arith.constant(127, type=T.i8))
-                    if const_expr(is_fp4):
-                        lds_idx = row * arith.index(int(scale_k_per_tile)) + ksc
-                    else:
-                        warp_row_idx = row / arith.index(warp_tile_m)
-                        local_row = row % arith.index(warp_tile_m)
-                        lane_row = local_row % arith.index(WMMA_M)
-                        local_wm_idx = local_row / arith.index(WMMA_M)
-                        global_lds_row = warp_row_idx * arith.index(WMMA_M) + lane_row
-                        ksc_blk = ksc / arith.index(SCALES_PER_WMMA)
-                        ksc_sub = ksc % arith.index(SCALES_PER_WMMA)
-                        lds_idx = (
-                            global_lds_row * arith.index(interleaved_scale_cols_a)
-                            + ksc_blk * arith.index(wmma_m_rep * SCALES_PER_WMMA)
-                            + local_wm_idx * arith.index(SCALES_PER_WMMA)
-                            + ksc_sub
+            """Vectorised scalar A-scale loader (Option B).
+
+            Each thread loads one ``SCALES_PER_WMMA``-sized chunk (4 bytes)
+            and writes it either to the row-major LDS slot (``is_fp4`` or
+            ``wmma_m_rep == 1``) or to the interleaved LDS slot. Avoiding a
+            full-row i8 vector load is important for row widths such as 16
+            bytes, where LLVM cannot legalize ``v16i8`` raw buffer loads.
+
+            Rare fallback: ``scale_k_per_tile`` not a multiple of 4 falls back
+              to the original per-byte loop for correctness.
+            """
+            _blk_bytes = int(SCALES_PER_WMMA)
+            _row_bytes = int(scale_k_per_tile)
+            if const_expr(_row_bytes % _blk_bytes == 0 and _row_bytes >= _blk_bytes):
+                _blk_vec_type = T.vec(_blk_bytes, T.i8)
+                _blks_per_row = _row_bytes // _blk_bytes
+                total = int(tile_m) * _blks_per_row
+                rounds = (total + block_threads - 1) // block_threads
+                for it in range(rounds):
+                    elem = tx + fx.Index(it * block_threads)
+                    in_range = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        arith.index_cast(T.i32, elem),
+                        arith.constant(total, type=T.i32),
+                    )
+                    _if_elem = scf.IfOp(in_range)
+                    with ir.InsertionPoint(_if_elem.then_block):
+                        row = elem // arith.index(_blks_per_row)
+                        ksc_blk = elem % arith.index(_blks_per_row)
+                        fused = _load_fused_from_lds(row)
+                        tok = fused & arith.constant((1 << 24) - 1, type=T.i32)
+                        tok_ok = arith.cmpi(
+                            arith.CmpIPredicate.ult, tok, i32_tokens_in,
                         )
-                    v1 = vector.from_elements(T.vec(1, T.i8), [sx_val])
-                    vector.store(v1, target_lds, [lds_idx], alignment=1)
+                        if const_expr(_as_layout_rowmajor):
+                            lds_idx = (
+                                row * arith.index(_row_bytes)
+                                + ksc_blk * arith.index(_blk_bytes)
+                            )
+                        else:
+                            warp_row_idx = row / arith.index(warp_tile_m)
+                            local_row = row % arith.index(warp_tile_m)
+                            lane_row = local_row % arith.index(WMMA_M)
+                            local_wm_idx = local_row / arith.index(WMMA_M)
+                            global_lds_row = (
+                                warp_row_idx * arith.index(WMMA_M) + lane_row
+                            )
+                            lds_idx = (
+                                global_lds_row
+                                * arith.index(interleaved_scale_cols_a)
+                                + ksc_blk
+                                * arith.index(wmma_m_rep * SCALES_PER_WMMA)
+                                + local_wm_idx * arith.index(SCALES_PER_WMMA)
+                            )
+                        _if_ok = scf.IfOp(tok_ok, has_else=True)
+                        with ir.InsertionPoint(_if_ok.then_block):
+                            chunk_off = (
+                                k_scale_base
+                                + ksc_blk * arith.index(_blk_bytes)
+                            )
+                            sx_idx = (
+                                tok * arith.constant(K_scale, type=T.i32)
+                                + arith.index_cast(T.i32, chunk_off)
+                            )
+                            sx_raw = buffer_ops.buffer_load(
+                                sx_rsrc,
+                                arith.shrui(
+                                    sx_idx,
+                                    arith.constant(2, type=T.i32),
+                                ),
+                                vec_width=1,
+                                dtype=T.i32,
+                            )
+                            sx_vec = vector.bitcast(
+                                _blk_vec_type,
+                                vector.from_elements(T.vec(1, T.i32), [sx_raw]),
+                            )
+                            vector.store(
+                                sx_vec, target_lds, [lds_idx],
+                                alignment=_blk_bytes,
+                            )
+                            scf.YieldOp([])
+                        with ir.InsertionPoint(_if_ok.else_block):
+                            fill_vec = vector.bitcast(
+                                _blk_vec_type,
+                                vector.from_elements(
+                                    T.vec(1, T.i32),
+                                    [arith.constant(0x7F7F7F7F, type=T.i32)],
+                                ),
+                            )
+                            vector.store(
+                                fill_vec, target_lds, [lds_idx],
+                                alignment=_blk_bytes,
+                            )
+                            scf.YieldOp([])
+                        scf.YieldOp([])
+            else:
+                # Rare fallback: keep per-byte loop for scale widths not aligned
+                # to 4 bytes (should not happen for gfx1250 MoE MX configs).
+                total = int(tile_m * scale_k_per_tile)
+                rounds = (total + block_threads - 1) // block_threads
+                for it in range(rounds):
+                    elem = tx + fx.Index(it * block_threads)
+                    in_range = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        arith.index_cast(T.i32, elem),
+                        arith.constant(total, type=T.i32),
+                    )
+                    _if_elem = scf.IfOp(in_range)
+                    with ir.InsertionPoint(_if_elem.then_block):
+                        row = elem // arith.index(int(scale_k_per_tile))
+                        ksc = elem % arith.index(int(scale_k_per_tile))
+                        fused = _load_fused_from_lds(row)
+                        tok = fused & arith.constant((1 << 24) - 1, type=T.i32)
+                        tok_ok = arith.cmpi(
+                            arith.CmpIPredicate.ult, tok, i32_tokens_in,
+                        )
+                        load_ok = tok_ok
+                        ksc_off = k_scale_base + ksc
+                        sx_idx = tok * arith.constant(K_scale, type=T.i32) + arith.index_cast(T.i32, ksc_off)
+                        sx_idx_safe = arith.select(load_ok, sx_idx, arith.constant(0, type=T.i32))
+                        sx_val = arith.select(
+                            load_ok,
+                            buffer_ops.buffer_load(sx_rsrc, sx_idx_safe, vec_width=1, dtype=T.i8),
+                            arith.constant(127, type=T.i8),
+                        )
+                        if is_fp4:
+                            lds_idx = row * arith.index(int(scale_k_per_tile)) + ksc
+                        else:
+                            warp_row_idx = row / arith.index(warp_tile_m)
+                            local_row = row % arith.index(warp_tile_m)
+                            lane_row = local_row % arith.index(WMMA_M)
+                            local_wm_idx = local_row / arith.index(WMMA_M)
+                            global_lds_row = warp_row_idx * arith.index(WMMA_M) + lane_row
+                            ksc_blk = ksc / arith.index(SCALES_PER_WMMA)
+                            ksc_sub = ksc % arith.index(SCALES_PER_WMMA)
+                            lds_idx = (
+                                global_lds_row * arith.index(interleaved_scale_cols_a)
+                                + ksc_blk * arith.index(wmma_m_rep * SCALES_PER_WMMA)
+                                + local_wm_idx * arith.index(SCALES_PER_WMMA)
+                                + ksc_sub
+                            )
+                        v1 = vector.from_elements(T.vec(1, T.i8), [sx_val])
+                        vector.store(v1, target_lds, [lds_idx], alignment=1)
+                        scf.YieldOp([])
+
+        def issue_as_load_tdm_gather(k_scale_base, target_lds):
+            """TDM-gather A-scale loader (Option A).
+
+            Issues one TDM gather per 8-row group (``_TDM_GATHER_GROUPS``
+            total), each covering up to 8 rows × ``scale_k_per_tile`` bytes.
+            Reuses the ``_a_tok_ids`` SGPR cache built by
+            ``_precompute_a_row_indices()`` for the A-data path, so no extra
+            scalar loads of ``sorted_rsrc`` are issued here. Completion is
+            tracked via ``tdm_cnt`` instead of ``ds_cnt``, eliminating the
+            ``s_wait_dscnt 0`` stall cluster previously caused by per-byte
+            ``buffer_load`` + ``ds_write_b8`` on the scalar path.
+
+            Pre-conditions (enforced by the gating above):
+              - ``use_tdm_gather=True`` (otherwise ``_a_tok_ids`` is empty).
+              - Row-major LDS scale layout (``is_fp4`` or ``wmma_m_rep == 1``).
+              - ``scale_k_per_tile`` is a positive multiple of 4 (TDM row_width
+                hardware alignment).
+            """
+            _as_row_bytes = int(scale_k_per_tile)
+            _tokens_dim1 = _get_tokens_sgpr()
+            _zero_i32 = arith.constant(0, type=T.i32)
+            for _gi in range_constexpr(_TDM_GATHER_GROUPS):
+                _start = _gi * _TDM_GATHER_CHUNK
+                _cnt = min(_TDM_GATHER_CHUNK, int(tile_m) - _start)
+                _row_indices = _a_tok_ids[_start:_start + _cnt]
+                _valid_count = _sum_i32_values(_a_load_valids[_start:_start + _cnt])
+                _lds_off = fx.Index(_start * _as_row_bytes)
+                _has_valid = arith.cmpi(
+                    arith.CmpIPredicate.sgt, _valid_count, _zero_i32,
+                )
+                _issue_pred = _has_valid
+                if wave_specialized_tdm:
+                    _gather_owner = _gi % _tdm_loader_waves
+                    _is_gather_loader = arith.cmpi(
+                        arith.CmpIPredicate.eq,
+                        _tdm_wave_id,
+                        arith.constant(_gather_owner, type=T.i32),
+                    )
+                    _issue_pred = arith.andi(_issue_pred, _is_gather_loader)
+                _if_issue = scf.IfOp(_issue_pred)
+                with ir.InsertionPoint(_if_issue.then_block):
+                    desc = tdm_ops.make_tensor_gather_descriptor(
+                        global_ptr=arg_scale_x,
+                        lds_memref=target_lds,
+                        row_indices=_row_indices,
+                        row_width=_as_row_bytes,
+                        tensor_dim0=int(K_scale),
+                        tensor_dim1=_tokens_dim1,
+                        stride=int(K_scale),
+                        elem_bytes=1,
+                        pad_interval=0,
+                        pad_amount=0,
+                        index_size=32,
+                        gather_tile_dim1=_valid_count,
+                        lds_byte_offset=_lds_off,
+                        global_byte_offset=k_scale_base,
+                    )
+                    tdm_ops.tensor_load_gather(desc)
                     scf.YieldOp([])
 
         def make_desc_b(lds_b_mem, n_off, k_base):
@@ -633,6 +1146,7 @@ def _compile_stage1_mxscale_kernel_impl(
 
         _if_blk = scf.IfOp(block_ok)
         with ir.InsertionPoint(_if_blk.then_block):
+            _preload_sorted_ids_to_lds()
             if const_expr(_use_tdm_gather_a or bool(use_tdm_store)):
                 _precompute_a_row_indices()
             a_data_bases = _precompute_a_data_bases()
@@ -1077,58 +1591,145 @@ def _compile_stage1_mxscale_kernel_impl(
                         _scale_adv_i32,
                     )
 
-                def _issue_active_b_tdm_only(stage_idx, curr_addr_lo):
+                # Pre-build per-stage TDMDescriptor2D bases. dgroup0 lanes 2/3
+                # carry placeholder addr_lo / addr_hi values that the hot path
+                # overwrites every iteration via the carry-safe
+                # ``update_tensor_descriptor_2d_addr_lo_hi`` helper, so the
+                # lane-3 placeholder here is only there to keep the descriptor
+                # well-typed -- ``_active_addr_hi`` is still consulted as the
+                # initial state of the hi register tracked through the pipeline
+                # so its type-field bits feed back into the carry helper.
+                _tdm_zero_addr_lo = arith.constant(0, type=T.i32)
+                _active_stage_desc_base = [
+                    tdm_ops.TDMDescriptor2D(
+                        vector.from_elements(T.vec(4, T.i32), [
+                            _tdm_pred,
+                            _active_stage_lds_addr[i],
+                            _tdm_zero_addr_lo,
+                            _active_addr_hi,
+                        ]),
+                        _active_dgroup1,
+                    )
+                    for i in range_constexpr(_nb)
+                ]
+
+                def _issue_active_b_tdm_only(stage_idx, curr_addr_lo, curr_addr_hi):
+                    """Issue one B-load and advance the carry-safe (lo, hi) pair.
+
+                    Both ``curr_addr_lo`` and ``curr_addr_hi`` come from the
+                    pipeline-carried state; the descriptor's lanes 2 and 3 are
+                    spliced from these every iteration so a lo-32-bit overflow
+                    in the K-loop accumulation propagates into hi instead of
+                    silently aliasing into the wrong 4 GiB page.
+                    """
                     _if_loader = scf.IfOp(_is_loader_wave)
                     with ir.InsertionPoint(_if_loader.then_block):
-                        _dg0 = vector.from_elements(T.vec(4, T.i32), [
-                            _tdm_pred,
-                            _active_stage_lds_addr[stage_idx],
-                            curr_addr_lo,
-                            _active_addr_hi,
-                        ])
                         tdm_ops.tensor_load_2d(
-                            tdm_ops.TDMDescriptor2D(_dg0, _active_dgroup1)
+                            tdm_ops.update_tensor_descriptor_2d_addr_lo_hi(
+                                _active_stage_desc_base[stage_idx],
+                                curr_addr_lo,
+                                curr_addr_hi,
+                            )
                         )
                         scf.YieldOp([])
-                    _next_addr_lo = arith.addi(curr_addr_lo, _active_adv_i32)
-                    return arith.select(
-                        _is_loader_wave,
-                        _next_addr_lo,
-                        curr_addr_lo,
+                    _next_addr_lo, _next_addr_hi = tdm_ops.add_addr_with_carry(
+                        curr_addr_lo, curr_addr_hi, _active_adv_i32,
                     )
+                    # Only loader waves advance the running address; non-loader
+                    # waves keep the current pair so the tracked SGPR state
+                    # stays in lockstep across waves (matching the original
+                    # addr-lo-only behaviour).
+                    return (
+                        arith.select(
+                            _is_loader_wave, _next_addr_lo, curr_addr_lo),
+                        arith.select(
+                            _is_loader_wave, _next_addr_hi, curr_addr_hi),
+                    )
+
+            if const_expr(_use_tdm_gather_a):
+                _build_a_gather_base_descs(lds_ag_bufs)
+            # Hoist K-invariant parts of B / B-scale 2D descriptors so the
+            # hot K loop only has to advance addr_lo per tile. In
+            # wave-specialized mode the hot path goes through
+            # ``_issue_active_b_tdm_only`` (which is already hoisted via
+            # ``_active_stage_desc_base``) and ``_issue_b_tdm_only`` is only
+            # reachable from the tail/non-pipelined paths; skip the build
+            # there to avoid emitting dead IR.
+            if const_expr(not wave_specialized_tdm):
+                _build_b_base_descs()
 
             # ── pipeline load helpers ─────────────────────────────────
             def _issue_b_tdm_only(k_base, buf_idx):
+                # Carry-safe: ``update_tensor_descriptor_2d_addr64`` performs
+                # ``(addr_lo : addr_hi) += k_off`` in i64 so an i32 wrap of
+                # ``base_addr_lo + k_off`` (common with ~3.5 GiB fp4 expert
+                # buffers on E=257 / gfx1250) propagates into addr_hi rather
+                # than silently redirecting the descriptor to a wrong 4 GiB
+                # page and deadlocking the GPU.
+                _k_data_off = _b_data_k_byte_off(k_base)
+                _k_scale_off = _b_scale_k_byte_off(k_base)
                 if const_expr(_merge_gate_up_tdm):
-                    _n_pair = _stage1_pair_row_base()
                     tdm_ops.tensor_load_2d(
-                        make_desc_b_pair(lds_bg_pair_bufs[buf_idx], _n_pair, k_base))
+                        tdm_ops.update_tensor_descriptor_2d_addr64(
+                            _b_desc_cache["bg_pair"][buf_idx],
+                            _b_desc_cache["bg_pair_addr_lo"][buf_idx],
+                            _b_desc_cache["bg_pair_addr_hi"][buf_idx],
+                            _k_data_off,
+                        ))
                     tdm_ops.tensor_load_2d(
-                        make_desc_bs_pair(lds_bs_pair_bufs[buf_idx], _n_pair, k_base))
+                        tdm_ops.update_tensor_descriptor_2d_addr64(
+                            _b_desc_cache["bs_pair"][buf_idx],
+                            _b_desc_cache["bs_pair_addr_lo"][buf_idx],
+                            _b_desc_cache["bs_pair_addr_hi"][buf_idx],
+                            _k_scale_off,
+                        ))
                 else:
-                    _eid_row = (arith.index_cast(T.index, eid_i32)
-                                * arith.index(int(2 * N)))
-                    _n_gate = _eid_row + blk_n
-                    _n_up = _eid_row + blk_n + arith.index(int(N))
                     tdm_ops.tensor_load_2d(
-                        make_desc_b(lds_bg_bufs[buf_idx], _n_gate, k_base))
+                        tdm_ops.update_tensor_descriptor_2d_addr64(
+                            _b_desc_cache["bg"][buf_idx],
+                            _b_desc_cache["bg_addr_lo"][buf_idx],
+                            _b_desc_cache["bg_addr_hi"][buf_idx],
+                            _k_data_off,
+                        ))
                     tdm_ops.tensor_load_2d(
-                        make_desc_b(lds_bu_bufs[buf_idx], _n_up, k_base))
+                        tdm_ops.update_tensor_descriptor_2d_addr64(
+                            _b_desc_cache["bu"][buf_idx],
+                            _b_desc_cache["bu_addr_lo"][buf_idx],
+                            _b_desc_cache["bu_addr_hi"][buf_idx],
+                            _k_data_off,
+                        ))
                     tdm_ops.tensor_load_2d(
-                        make_desc_bs(lds_bs_bufs[buf_idx], _n_gate, k_base))
+                        tdm_ops.update_tensor_descriptor_2d_addr64(
+                            _b_desc_cache["bs"][buf_idx],
+                            _b_desc_cache["bs_addr_lo"][buf_idx],
+                            _b_desc_cache["bs_addr_hi"][buf_idx],
+                            _k_scale_off,
+                        ))
                     tdm_ops.tensor_load_2d(
-                        make_desc_bs(lds_bsu_bufs[buf_idx], _n_up, k_base))
+                        tdm_ops.update_tensor_descriptor_2d_addr64(
+                            _b_desc_cache["bsu"][buf_idx],
+                            _b_desc_cache["bsu_addr_lo"][buf_idx],
+                            _b_desc_cache["bsu_addr_hi"][buf_idx],
+                            _k_scale_off,
+                        ))
 
             def _issue_scalar_loads(k_base, buf_idx):
                 if const_expr(_use_tdm_gather_a):
-                    issue_a_load_tdm_gather(k_base, lds_ag_bufs[buf_idx])
+                    issue_a_load_tdm_gather(k_base, buf_idx)
                 else:
                     issue_a_load(make_desc_a(k_base), lds_ag_bufs[buf_idx])
-                issue_as_load(make_desc_as(k_base), lds_as_bufs[buf_idx])
+                if _use_tdm_gather_as:
+                    issue_as_load_tdm_gather(make_desc_as(k_base), lds_as_bufs[buf_idx])
+                else:
+                    issue_as_load(make_desc_as(k_base), lds_as_bufs[buf_idx])
 
             def _issue_all_loads(k_base, buf_idx):
-                _issue_b_tdm_only(k_base, buf_idx)
-                _issue_scalar_loads(k_base, buf_idx)
+                if const_expr(is_fp4):
+                    _issue_scalar_loads(k_base, buf_idx)
+                    _issue_b_tdm_only(k_base, buf_idx)
+                else:
+                    _issue_b_tdm_only(k_base, buf_idx)
+                    _issue_scalar_loads(k_base, buf_idx)
 
             def _compute_with_mid_loads(acg, acu, buf_idx, mid_load_callback=None):
                 if const_expr(_use_scheduled_compute):
@@ -1141,22 +1742,33 @@ def _compile_stage1_mxscale_kernel_impl(
                     mid_compute_callback=mid_load_callback,
                 )
 
+            # Helper: apply split-K K-base offset. For non-splitk the
+            # compile-time constant expression is returned unchanged so
+            # the non-splitk code path is identical.
+            def _k_off(static_offset_val):
+                if _is_splitk:
+                    return k_base_idx + static_offset_val
+                return static_offset_val
+
             # ── main K-dimension reduction ────────────────────────────
             if const_expr(not _use_pipeline):
                 if const_expr(wave_specialized_tdm):
                     active_b_addr_lo = _active_addr_lo
-                    for kt in range_constexpr(num_k_tiles):
-                        k_base = fx.Index(kt * int(tile_k))
-                        active_b_addr_lo = _issue_active_b_tdm_only(
-                            0, active_b_addr_lo)
+                    active_b_addr_hi = _active_addr_hi
+                    for kt in range_constexpr(num_k_tiles_per_bz):
+                        k_base = _k_off(fx.Index(kt * int(tile_k)))
+                        active_b_addr_lo, active_b_addr_hi = (
+                            _issue_active_b_tdm_only(
+                                0, active_b_addr_lo, active_b_addr_hi)
+                        )
                         _issue_scalar_loads(k_base, 0)
                         tdm_ops.tensor_wait(0)
                         workgroup_barrier(use_cluster=use_cluster)
                         acc_g, acc_u = _compute_k_tile(acc_g, acc_u, 0)
                         workgroup_barrier(use_cluster=use_cluster)
                 else:
-                    for kt in range_constexpr(num_k_tiles):
-                        k_base = fx.Index(kt * int(tile_k))
+                    for kt in range_constexpr(num_k_tiles_per_bz):
+                        k_base = _k_off(fx.Index(kt * int(tile_k)))
                         _issue_all_loads(k_base, 0)
                         tdm_ops.tensor_wait(0)
                         workgroup_barrier(use_cluster=use_cluster)
@@ -1166,34 +1778,51 @@ def _compile_stage1_mxscale_kernel_impl(
                 # ── prologue ──
                 if const_expr(wave_specialized_tdm):
                     active_b_addr_lo = _active_addr_lo
+                    active_b_addr_hi = _active_addr_hi
                     for _pi in range_constexpr(pre_loaded):
-                        active_b_addr_lo = _issue_active_b_tdm_only(
-                            _pi, active_b_addr_lo)
-                        _issue_scalar_loads(fx.Index(_pi * int(tile_k)), _pi)
+                        active_b_addr_lo, active_b_addr_hi = (
+                            _issue_active_b_tdm_only(
+                                _pi, active_b_addr_lo, active_b_addr_hi)
+                        )
+                        _issue_scalar_loads(
+                            _k_off(fx.Index(_pi * int(tile_k))), _pi)
                 else:
                     for _pi in range_constexpr(pre_loaded):
-                        _issue_all_loads(fx.Index(_pi * int(tile_k)), _pi)
+                        _issue_all_loads(
+                            _k_off(fx.Index(_pi * int(tile_k))), _pi)
                 pipeline_fence(outstanding=0, use_cluster=use_cluster)
 
                 # ── main pipelined loop ──
                 if const_expr(loop_iters > 0):
                     if const_expr(wave_specialized_tdm):
-                        _init = list(acc_g) + list(acc_u) + [active_b_addr_lo]
+                        # Carry the (addr_lo, addr_hi) pair through the
+                        # pipeline state so the carry chain survives across
+                        # iterations.
+                        _init = (
+                            list(acc_g) + list(acc_u)
+                            + [active_b_addr_lo, active_b_addr_hi]
+                        )
                         for _li, _st in fx.range(0, loop_iters, 1, init=_init):
                             _ag = list(_st[:n_accs])
                             _au = list(_st[n_accs:2 * n_accs])
                             _cur_b_addr_lo = _st[2 * n_accs]
+                            _cur_b_addr_hi = _st[2 * n_accs + 1]
                             for _bi in range_constexpr(_nb):
                                 _lb = (_bi + _nb - 1) % _nb
                                 _kt = (_li * fx.Index(_nb)
                                        + fx.Index(pre_loaded + _bi))
-                                _kb = _kt * fx.Index(int(tile_k))
+                                _kb = _k_off(_kt * fx.Index(int(tile_k)))
                                 pipeline_fence_signal(
                                     outstanding=_fence_outstanding,
                                     use_cluster=use_cluster)
                                 pipeline_fence_wait(use_cluster=use_cluster)
-                                _cur_b_addr_lo = _issue_active_b_tdm_only(
-                                    _lb, _cur_b_addr_lo)
+                                _cur_b_addr_lo, _cur_b_addr_hi = (
+                                    _issue_active_b_tdm_only(
+                                        _lb,
+                                        _cur_b_addr_lo,
+                                        _cur_b_addr_hi,
+                                    )
+                                )
 
                                 def _mid_issue_scalar(_mid_kb=_kb, _mid_lb=_lb):
                                     _issue_scalar_loads(_mid_kb, _mid_lb)
@@ -1208,10 +1837,14 @@ def _compile_stage1_mxscale_kernel_impl(
                                 )
                                 if const_expr(_use_scheduled_compute):
                                     _hot_loop_scheduler_scheduled()
-                            _res = yield list(_ag) + list(_au) + [_cur_b_addr_lo]
+                            _res = yield (
+                                list(_ag) + list(_au)
+                                + [_cur_b_addr_lo, _cur_b_addr_hi]
+                            )
                         acc_g = list(_res[:n_accs])
                         acc_u = list(_res[n_accs:2 * n_accs])
                         active_b_addr_lo = _res[2 * n_accs]
+                        active_b_addr_hi = _res[2 * n_accs + 1]
                     else:
                         _init = list(acc_g) + list(acc_u)
                         for _li, _st in fx.range(0, loop_iters, 1, init=_init):
@@ -1221,7 +1854,7 @@ def _compile_stage1_mxscale_kernel_impl(
                                 _lb = (_bi + _nb - 1) % _nb
                                 _kt = (_li * fx.Index(_nb)
                                        + fx.Index(pre_loaded + _bi))
-                                _kb = _kt * fx.Index(int(tile_k))
+                                _kb = _k_off(_kt * fx.Index(int(tile_k)))
                                 pipeline_fence_signal(
                                     outstanding=_fence_outstanding,
                                     use_cluster=use_cluster)
@@ -1273,13 +1906,18 @@ def _compile_stage1_mxscale_kernel_impl(
                         pipeline_fence_wait(use_cluster=use_cluster)
                         if const_expr(_ls is not None):
                             _tail_had_load = True
-                            _tkb = fx.Index(
+                            _tkb = _k_off(fx.Index(
                                 (_tail_start + pre_loaded + _tail_li)
-                                * int(tile_k))
+                                * int(tile_k)))
                             _tail_li += 1
                             if const_expr(wave_specialized_tdm):
-                                active_b_addr_lo = _issue_active_b_tdm_only(
-                                    _ls, active_b_addr_lo)
+                                active_b_addr_lo, active_b_addr_hi = (
+                                    _issue_active_b_tdm_only(
+                                        _ls,
+                                        active_b_addr_lo,
+                                        active_b_addr_hi,
+                                    )
+                                )
                             else:
                                 _issue_b_tdm_only(_tkb, _ls)
 
@@ -1341,6 +1979,13 @@ def _compile_stage1_mxscale_kernel_impl(
                     pipeline_fence(outstanding=0, use_cluster=use_cluster)
                 rocdl.sched_barrier(0)
 
+                # TDM-store path also needs bias / SwiGLU. Per-tile column
+                # base (used to load gate/up bias from the per-expert slab)
+                # is the tile's N origin in the (blk_n + warp_n_base + wn*WMMA_N
+                # + lane_kgrp*8 + vi) coordinate system.
+                if const_expr(_enable_bias):
+                    _c2_n_i32 = arith.constant(2, type=T.i32)
+                    _bias_row_base_i32_s1 = eid_i32 * (i32_inter_in * _c2_n_i32)
                 for _acc_idx, _vec_base, _m_off, _wn in _sub_tiles:
                     _wm_idx = _m_off // WMMA_M
                     _sc = _scale_per_wm_s1[_wm_idx]
@@ -1354,6 +1999,9 @@ def _compile_stage1_mxscale_kernel_impl(
                         vector=vector,
                         range_constexpr=range_constexpr,
                         ACC_VEC_SIZE=ACC_VEC_SIZE)
+                    _col_base_s1 = (
+                        blk_n + warp_n_base + fx.Index(_wn * WMMA_N)
+                        + lane_kgrp * fx.Index(8))
                     _fused = []
                     for _vi in range_constexpr(8):
                         _vg = vector.extract(
@@ -1364,7 +2012,23 @@ def _compile_stage1_mxscale_kernel_impl(
                             _sub8u,
                             static_position=[_vi],
                             dynamic_position=[])
-                        _y = silu(_vg) * _vu * _sc
+                        if const_expr(_enable_bias):
+                            _col_i32_s1 = arith.index_cast(
+                                T.i32, _col_base_s1 + fx.Index(_vi))
+                            _bg = buffer_ops.buffer_load(
+                                bias_rsrc,
+                                _bias_row_base_i32_s1 + _col_i32_s1,
+                                vec_width=1, dtype=T.f32)
+                            _bu = buffer_ops.buffer_load(
+                                bias_rsrc,
+                                _bias_row_base_i32_s1 + i32_inter_in + _col_i32_s1,
+                                vec_width=1, dtype=T.f32)
+                            _vg = _vg + _bg
+                            _vu = _vu + _bu
+                        if const_expr(_act_kind == "swiglu"):
+                            _y = _emit_swiglu(_vg, _vu, arith=arith, rocdl=rocdl, T=T) * _sc
+                        else:
+                            _y = silu(_vg) * _vu * _sc
                         _fused.append(_y)
                     _fused_sub8 = vector.from_elements(
                         T.vec(8, T.f32), _fused)
@@ -1470,38 +2134,84 @@ def _compile_stage1_mxscale_kernel_impl(
                         ),
                     )
 
-                _emit_stage1_gate_up_epilogue(
-                    sub_tiles=_sub_tiles,
-                    by=by,
-                    tile_m=int(tile_m),
-                    route_tile_m=int(route_tile_m),
-                    warp_m_base=warp_m_base,
-                    warp_n_base=warp_n_base,
-                    blk_n=blk_n,
-                    lane16=lane16,
-                    lane_kgrp=lane_kgrp,
-                    WMMA_N=WMMA_N,
-                    i32_tokens_in=i32_tokens_in,
-                    i32_inter_in=i32_inter_in,
-                    topk=int(topk),
-                    num_valid_i32=num_valid_i32,
-                    block_row_start=block_row_start,
-                    sorted_rsrc=sorted_rsrc,
-                    tw_rsrc=tw_rsrc,
-                    out_rsrc=out_rsrc,
-                    doweight_stage1=bool(doweight_stage1),
-                    out_elem_ty=out_elem_ty,
-                    load_gate_up_sub8=_load_gate_up_sub8,
-                    silu_fn=silu,
-                    ir=ir,
-                    fx=fx,
-                    arith=arith,
-                    buffer_ops=buffer_ops,
-                    scf=scf,
-                    vector=vector,
-                    range_constexpr=range_constexpr,
-                    T=T,
-                )
+                if _is_splitk:
+                    # Split-K: atomic-fadd gate/up partials into a
+                    # [tokens*topk, 2*inter_dim] buffer. silu/mul and the
+                    # routing weight fold in via the external reduction.
+                    _emit_stage1_gate_up_splitk_epilogue(
+                        sub_tiles=_sub_tiles,
+                        by=by,
+                        tile_m=int(tile_m),
+                        route_tile_m=int(route_tile_m),
+                        warp_m_base=warp_m_base,
+                        warp_n_base=warp_n_base,
+                        blk_n=blk_n,
+                        lane16=lane16,
+                        lane_kgrp=lane_kgrp,
+                        WMMA_N=WMMA_N,
+                        i32_tokens_in=i32_tokens_in,
+                        i32_inter_in=i32_inter_in,
+                        topk=int(topk),
+                        num_valid_i32=num_valid_i32,
+                        block_row_start=block_row_start,
+                        lds_tid=lds_tid,
+                        memref=memref,
+                        sorted_rsrc=sorted_rsrc,
+                        out_rsrc=out_rsrc,
+                        out_elem_ty=out_elem_ty,
+                        load_gate_up_sub8=_load_gate_up_sub8,
+                        ir=ir,
+                        fx=fx,
+                        arith=arith,
+                        buffer_ops=buffer_ops,
+                        scf=scf,
+                        vector=vector,
+                        range_constexpr=range_constexpr,
+                        rocdl=rocdl,
+                        T=T,
+                        bias_rsrc=bias_rsrc if _enable_bias else None,
+                        eid_i32=eid_i32 if _enable_bias else None,
+                        bias_scale=(1.0 / int(k_batch)) if _enable_bias else None,
+                    )
+                else:
+                    _emit_stage1_gate_up_epilogue(
+                        sub_tiles=_sub_tiles,
+                        by=by,
+                        tile_m=int(tile_m),
+                        route_tile_m=int(route_tile_m),
+                        warp_m_base=warp_m_base,
+                        warp_n_base=warp_n_base,
+                        blk_n=blk_n,
+                        lane16=lane16,
+                        lane_kgrp=lane_kgrp,
+                        WMMA_N=WMMA_N,
+                        i32_tokens_in=i32_tokens_in,
+                        i32_inter_in=i32_inter_in,
+                        topk=int(topk),
+                        num_valid_i32=num_valid_i32,
+                        block_row_start=block_row_start,
+                        lds_tid=lds_tid,
+                        memref=memref,
+                        sorted_rsrc=sorted_rsrc,
+                        tw_rsrc=tw_rsrc,
+                        out_rsrc=out_rsrc,
+                        doweight_stage1=bool(doweight_stage1),
+                        out_elem_ty=out_elem_ty,
+                        load_gate_up_sub8=_load_gate_up_sub8,
+                        silu_fn=silu,
+                        ir=ir,
+                        fx=fx,
+                        arith=arith,
+                        buffer_ops=buffer_ops,
+                        scf=scf,
+                        vector=vector,
+                        range_constexpr=range_constexpr,
+                        T=T,
+                        bias_rsrc=bias_rsrc if _enable_bias else None,
+                        eid_i32=eid_i32 if _enable_bias else None,
+                        act_kind=_act_kind,
+                        rocdl=rocdl,
+                    )
             scf.YieldOp([])
 
     @flyc.jit
@@ -1515,6 +2225,7 @@ def _compile_stage1_mxscale_kernel_impl(
         arg_expert_ids: fx.Tensor,
         arg_sorted_weights: fx.Tensor,
         arg_num_valid_ids: fx.Tensor,
+        arg_bias: fx.Tensor,
         i32_tokens_in: fx.Int32,
         i32_inter_in: fx.Int32,
         i32_k_in: fx.Int32,
@@ -1527,26 +2238,13 @@ def _compile_stage1_mxscale_kernel_impl(
         size_expert_ids_in = arith.index_cast(T.index, i32_size_expert_ids_in)
         gx = (inter_in + fx.Index(int(tile_n) - 1)) // fx.Index(int(tile_n))
         gy = size_expert_ids_in
-        _cluster_arg = (int(cluster_m), int(cluster_n), 1) if use_cluster else None
         launcher = moe_mxscale_stage1_single(
-            arg_out,
-            arg_x,
-            arg_w,
-            arg_scale_x,
-            arg_scale_w,
-            arg_sorted_token_ids,
-            arg_expert_ids,
-            arg_sorted_weights,
-            arg_num_valid_ids,
-            i32_tokens_in,
-            i32_inter_in,
-            i32_k_in,
-            i32_size_expert_ids_in,
-            value_attrs={
-                "rocdl.waves_per_eu": effective_waves_per_eu,
-                "rocdl.cluster_dims": f"{cluster_m},{cluster_n},1" if use_cluster else None,
-            },
+            arg_out, arg_x, arg_w, arg_scale_x, arg_scale_w,
+            arg_sorted_token_ids, arg_expert_ids, arg_sorted_weights, arg_num_valid_ids,
+            arg_bias,
+            i32_tokens_in, i32_inter_in, i32_k_in, i32_size_expert_ids_in,
         )
+        _cluster_arg = (int(cluster_m), int(cluster_n), 1) if use_cluster else None
         _finalize_alloc_and_launch_2d(
             ctx=ctx,
             alloc=alloc,
@@ -1555,8 +2253,10 @@ def _compile_stage1_mxscale_kernel_impl(
             gy=gy,
             block_threads=block_threads,
             stream=stream,
+            waves_per_eu=effective_waves_per_eu,
             ir=ir,
             cluster=_cluster_arg,
+            gz=int(k_batch),
         )
 
     if expert_sched_mode:
@@ -1588,18 +2288,33 @@ def _compile_stage2_mxscale_kernel_impl(
     expert_sched_mode: bool = True,
     num_buffers: int = 1,
     use_tdm_gather: bool = True,
+    use_tdm_gather_as: bool = True,
     use_tdm_store: bool = False,
     inst_prefetch: bool = False,
     wave_specialized_tdm: bool = False,
     cluster_m: int = 1,
     cluster_n: int = 1,
+    # ── Bias ────────────────────────────────────────────────────────
+    # Per-expert bias of shape (E, model_dim) applied after the GEMM.
+    # In atomic-accumulate mode the per-slot bias is divided by ``topk``
+    # in the epilogue so the sum across the ``topk`` per-token atomic
+    # adds reproduces a single ``+ bias`` per token (matches torch ref).
+    enable_bias: bool = False,
 ):
-    """Compile mxscale stage2 single kernel (route-pack + TDM + WMMA_SCALE + epilog)."""
+    """Compile mxscale stage2 single kernel (route-pack + TDM + WMMA_SCALE + epilog).
+
+    ``use_tdm_gather_as`` enables the TDM-gather path for the A-scale matrix
+    to eliminate the ``s_wait_dscnt`` stall cluster caused by per-byte
+    ``buffer_load`` + ``ds_write_b8`` on the scalar A-scale path. Falls back
+    to the vectorised scalar loader when the LDS scale layout is not row-major
+    (``wmma_m_rep > 1`` and not ``is_fp4``) or the row width is below the TDM
+    gather alignment (``scale_k_per_tile < 4`` / not a multiple of 4).
+    """
     import flydsl.compiler as flyc
     import flydsl.expr as fx
     from flydsl._mlir import ir
     from flydsl._mlir.dialects import llvm as llvm_dialect
-    from flydsl._mlir.dialects import scf
+    from flydsl._mlir.dialects import memref, scf
     from flydsl.compiler.kernel_function import CompilationContext
     from flydsl.expr import arith, buffer_ops, const_expr, gpu, idx2crd, range_constexpr, rocdl, tdm_ops, vector
     from flydsl.expr.typing import T
@@ -1607,6 +2322,15 @@ def _compile_stage2_mxscale_kernel_impl(
 
     if bool(use_tdm_store) and bool(accumulate):
         raise ValueError("use_tdm_store is not compatible with accumulate=True in moe mxscale stage2")
+    _enable_bias = bool(enable_bias)
+    if _enable_bias and bool(use_tdm_store):
+        # The TDM-store epilogue writes packed gather rows to LDS then to
+        # global memory, with no intermediate scalar add point matching
+        # how the standard epilogue applies bias. Disabling avoids
+        # silently dropping bias on this path.
+        raise ValueError(
+            "stage2 mxscale: enable_bias=True is not supported with "
+            "use_tdm_store=True; use the standard scatter-store path.")
 
     tp = _compute_mxscale_tiling(
         data_format=data_format, K=int(inter_dim),
@@ -1653,6 +2377,18 @@ def _compile_stage2_mxscale_kernel_impl(
     if use_cluster and effective_waves_per_eu is None:
         effective_waves_per_eu = 2
 
+    # A-scale TDM gather gating mirrors stage1: requires A-side TDM gather
+    # (for _a_tok_ids SGPRs), a row-major LDS scale layout, and a row width
+    # that is a positive multiple of 4 bytes (TDM gather hardware constraint).
+    _as_layout_rowmajor = bool(is_fp4) or (int(wmma_m_rep) == 1)
+    _as_row_bytes_ok = int(scale_k_per_tile) >= 4 and (int(scale_k_per_tile) % 4 == 0)
+    _use_tdm_gather_as = (
+        bool(use_tdm_gather_as)
+        and bool(use_tdm_gather)
+        and _as_layout_rowmajor
+        and _as_row_bytes_ok
+    )
+
     _use_pipeline = int(num_buffers) >= 2
     if _use_pipeline:
         from kernels.gemm_common_gfx1250 import (
@@ -1663,6 +2399,7 @@ def _compile_stage2_mxscale_kernel_impl(
             num_k_tiles=num_k_tiles, num_buffers=int(num_buffers),
             B_TDM_PER_STEP=_B_TDM_PER_STEP, tile_m=int(tile_m),
             use_tdm_gather=use_tdm_gather,
+            use_tdm_gather_as=_use_tdm_gather_as,
             wave_specialized_tdm=wave_specialized_tdm,
             tdm_loader_waves=_tdm_loader_waves,
         )
@@ -1671,6 +2408,7 @@ def _compile_stage2_mxscale_kernel_impl(
         _tail_start = _pp["tail_start"]
         extra = _pp["extra"]
         _A_GATHER_GROUPS = _pp["A_GATHER_GROUPS"]
+        _AS_GATHER_GROUPS = _pp["AS_GATHER_GROUPS"]
         TDM_PER_STEP = _pp["TDM_PER_STEP"]
         _fence_outstanding = _pp["fence_outstanding"]
         _tail_plan = _pp["tail_plan"]
@@ -1679,7 +2417,10 @@ def _compile_stage2_mxscale_kernel_impl(
     alloc = SmemAllocator(
         None,
         arch=str(get_hip_arch()),
-        global_sym_name=f"moe_mxscale_{data_format}_s2_single_g{int(bool(use_tdm_gather))}",
+        global_sym_name=(
+            f"moe_mxscale_{data_format}_s2_single_g{int(bool(use_tdm_gather))}"
+            f"_as{int(_use_tdm_gather_as)}"
+        ),
     )
     _nb = int(num_buffers)
     off_a_list, off_b_list, off_as_list, off_bs_list = [], [], [], []
@@ -1697,20 +2438,29 @@ def _compile_stage2_mxscale_kernel_impl(
         alloc.ptr = _obs + lds_b_scale_bytes
         off_bs_list.append(_obs)
 
+    # lds_tid: preloaded sorted_token_ids for current M-tile (see stage1 comments).
+    lds_tid_bytes = int(tile_m) * 4
+    off_tid = alloc._align(alloc.ptr, 16)
+    alloc.ptr = off_tid + lds_tid_bytes
+
     if bool(use_tdm_store):
         from kernels.gemm_common_gfx1250 import store_acc_vec8_to_lds
         _ds2 = _compute_tdm_store_layout(
             warp_tile_m=warp_tile_m, warp_tile_n=warp_tile_n,
             num_warps=num_warps, WMMA_N=WMMA_N, use_pipeline=_use_pipeline,
         )
+        total_d_bytes = _ds2["total_d_bytes"]
         lds_d_row_stride = _ds2["lds_d_row_stride"]
+        warp_d_bytes = _ds2["warp_d_bytes"]
         d_output_off = _ds2["d_output_off"]
         _lds_d_stride_elems = _ds2["lds_d_stride_elems"]
         _warp_d_elems = _ds2["warp_d_elems"]
         _n_col_d_elems = _ds2["n_col_d_elems"]
         d_need_epilogue_fence = _ds2["d_need_epilogue_fence"]
-        if _ds2["total_d_bytes"] > alloc.ptr:
-            alloc.ptr = _ds2["total_d_bytes"]
+        elem_bytes_d = 2
+        LDS_PAD_D_BYTES = 16
+        if total_d_bytes > alloc.ptr:
+            alloc.ptr = total_d_bytes
 
     _sub_tiles = _make_wmma_sub_tiles(
         wmma_m_rep=wmma_m_rep, wmma_n_rep=wmma_n_rep, WMMA_M=WMMA_M, is_fp4=is_fp4
@@ -1727,12 +2477,24 @@ def _compile_stage2_mxscale_kernel_impl(
         arg_expert_ids: fx.Tensor,
         arg_sorted_weights: fx.Tensor,
         arg_num_valid_ids: fx.Tensor,
+        # Per-expert bias slab (E*model_dim, f32 flat). Pass an empty
+        # tensor when ``enable_bias=False``; only read when the
+        # constexpr flag is set.
+        arg_bias: fx.Tensor,
         i32_tokens_in: fx.Int32,
         i32_n_in: fx.Int32,
         i32_k_in: fx.Int32,
         i32_size_expert_ids_in: fx.Int32,
     ):
         _ = i32_k_in
+        # ASTRewriter strips ``const_expr(...)`` from ``if`` tests, which would
+        # otherwise eliminate every reference to ``const_expr`` from the
+        # rewritten function body and shrink ``co_freevars`` by one — causing
+        # CPython to reject ``f.__code__ = new_f_code_o`` because the original
+        # ``__closure__`` length no longer matches. Keep one explicit reference
+        # so the rewritten code object's free-vars list still includes
+        # ``const_expr``.
+        _keep_const_expr_ref = const_expr  # noqa: F841
         if const_expr(inst_prefetch):
             if arith.cmpi(arith.CmpIPredicate.eq, rocdl.wave_id(),
                           arith.constant(0, type=T.i32)):
@@ -1745,12 +2507,6 @@ def _compile_stage2_mxscale_kernel_impl(
                     "\n".join(_prefetch_lines),
                     "", has_side_effects=True,
                 )
-        llvm_dialect.inline_asm(
-            None, [],
-            "s_setreg_imm32_b32 hwreg(26, 4, 1), 1",
-            "",
-            has_side_effects=True,
-        )
 
         tx = gpu.thread_id("x")
         bx = gpu.block_id("x")
@@ -1788,6 +2544,9 @@ def _compile_stage2_mxscale_kernel_impl(
         sw_rsrc = buffer_ops.create_buffer_resource(arg_scale_w, max_size=False, num_records_bytes=sw_nbytes)
         out_rsrc = buffer_ops.create_buffer_resource(arg_out, max_size=False, num_records_bytes=out_nbytes)
         tw_rsrc = buffer_ops.create_buffer_resource(arg_sorted_weights, max_size=True)
+        # bias: per-expert (E, model_dim) f32 slab, only read when
+        # ``_enable_bias`` constexpr is True (epilogue gates the load).
+        bias_rsrc = buffer_ops.create_buffer_resource(arg_bias, max_size=True)
 
         eid_i32 = buffer_ops.buffer_load(eid_rsrc, arith.index_cast(T.i32, by), vec_width=1, dtype=T.i32)
         eid_ok0 = arith.cmpi(arith.CmpIPredicate.sge, eid_i32, arith.constant(0, type=T.i32))
@@ -1826,6 +2585,8 @@ def _compile_stage2_mxscale_kernel_impl(
             lds_b_bufs.append(get_op_result_or_value(_sb.get()))
             lds_as_bufs.append(get_op_result_or_value(_sas.get()))
             lds_bs_bufs.append(get_op_result_or_value(_sbs.get()))
+
+        lds_tid = SmemPtr(base_ptr, off_tid, T.i32, shape=(int(tile_m),)).get()
 
         if const_expr(bool(use_tdm_store)):
             from kernels.gemm_common_gfx1250 import get_lds_memref
@@ -1896,34 +2657,59 @@ def _compile_stage2_mxscale_kernel_impl(
                 _tokens_topk_sgpr = rocdl.readfirstlane(T.i32, _m_i32)
             return _tokens_topk_sgpr
 
+        def _preload_sorted_ids_to_lds():
+            """Preload tile_m sorted_token_ids entries into ``lds_tid`` (once per CTA).
+
+            See stage1 for the rationale. Invalid rows (row_in_route or
+            row_in_valid false) are stored as sentinel ``0xFFFFFFFF`` so
+            downstream ``tok_ok`` / ``slot_ok`` checks naturally reject them.
+            """
+            _tid_in_range = arith.cmpi(
+                arith.CmpIPredicate.ult, tx, fx.Index(int(tile_m)))
+            _if_tid = scf.IfOp(_tid_in_range)
+            with ir.InsertionPoint(_if_tid.then_block):
+                _tx_i32 = arith.index_cast(T.i32, tx)
+                _sorted_row = by * fx.Index(int(tile_m)) + tx
+                _sorted_i32 = arith.index_cast(T.i32, _sorted_row)
+                _in_route = arith.cmpi(
+                    arith.CmpIPredicate.ult,
+                    _tx_i32,
+                    arith.constant(int(route_tile_m), type=T.i32),
+                )
+                _in_valid = arith.cmpi(
+                    arith.CmpIPredicate.slt, _sorted_i32, num_valid_i32)
+                _row_valid = arith.andi(_in_route, _in_valid)
+                _row_safe_i32 = arith.select(
+                    _row_valid, _sorted_i32, block_row_start)
+                _raw = buffer_ops.buffer_load(
+                    sorted_rsrc, _row_safe_i32, vec_width=1, dtype=T.i32)
+                _sentinel = arith.constant(-1, type=T.i32)  # 0xFFFFFFFF
+                _val = arith.select(_row_valid, _raw, _sentinel)
+                _vec1 = vector.from_elements(T.vec(1, T.i32), [_val])
+                vector.store(_vec1, lds_tid, [tx], alignment=4)
+                scf.YieldOp([])
+            workgroup_barrier(use_cluster=use_cluster)
+
+        def _load_fused_from_lds(row_index):
+            if isinstance(row_index, int):
+                row_index = arith.index(row_index)
+            return memref.load(lds_tid, [row_index])
+
         def _precompute_a_row_indices():
             _safe_row = arith.constant(0, type=T.i32)
             _one_i32 = arith.constant(1, type=T.i32)
             _zero_i32 = arith.constant(0, type=T.i32)
             for _ri in range_constexpr(int(tile_m)):
-                _sorted_row = by * fx.Index(int(tile_m)) + fx.Index(_ri)
-                _sorted_i32 = arith.index_cast(T.i32, _sorted_row)
-                _row_in_route = arith.cmpi(
-                    arith.CmpIPredicate.ult,
-                    fx.Int32(_ri),
-                    fx.Int32(int(route_tile_m)),
-                )
-                _row_in_valid = arith.cmpi(
-                    arith.CmpIPredicate.slt,
-                    _sorted_i32,
-                    num_valid_i32,
-                )
-                _row_ok = arith.andi(_row_in_route, _row_in_valid)
-                _sorted_safe = arith.select(_row_ok, _sorted_i32, block_row_start)
-                _fused = buffer_ops.buffer_load(sorted_rsrc, _sorted_safe, vec_width=1, dtype=T.i32)
-                _tok = _fused & fx.Int32((1 << 24) - 1)
-                _slot = _fused >> fx.Int32(24)
+                _fused = _load_fused_from_lds(_ri)
+                _fused_sgpr = rocdl.readfirstlane(T.i32, _fused)
+                _tok = _fused_sgpr & fx.Int32((1 << 24) - 1)
+                _slot = _fused_sgpr >> fx.Int32(24)
                 _tok_ok = arith.cmpi(arith.CmpIPredicate.ult, _tok, i32_tokens_in)
                 _slot_ok0 = arith.cmpi(arith.CmpIPredicate.sge, _slot, fx.Int32(0))
                 _slot_ok1 = arith.cmpi(arith.CmpIPredicate.slt, _slot, c_topk_i32)
                 _ts = _tok * c_topk_i32 + _slot
                 _ts_ok = arith.andi(_tok_ok, arith.andi(_slot_ok0, _slot_ok1))
-                _row_fully_ok = arith.andi(_row_ok, _ts_ok)
+                _row_fully_ok = _ts_ok
                 _row_valid_i32 = arith.select(_row_fully_ok, _one_i32, _zero_i32)
                 _a_row_valids.append(rocdl.readfirstlane(T.i32, _row_valid_i32))
                 _ts_safe = arith.select(_row_fully_ok, _ts, _safe_row)
@@ -1942,14 +2728,8 @@ def _compile_stage2_mxscale_kernel_impl(
                 with ir.InsertionPoint(_if_elem.then_block):
                     row = elem // arith.index(int(packed_tile_k_a))
                     col = elem % arith.index(int(packed_tile_k_a))
-                    sorted_row = by * arith.index(int(tile_m)) + row
-                    row_i32 = arith.index_cast(T.i32, row)
-                    sorted_i32 = arith.index_cast(T.i32, sorted_row)
-                    row_in_route = arith.cmpi(arith.CmpIPredicate.ult, row_i32, arith.constant(int(route_tile_m), type=T.i32))
-                    row_in_valid = arith.cmpi(arith.CmpIPredicate.slt, sorted_i32, num_valid_i32)
-                    row_ok = arith.andi(row_in_route, row_in_valid)
-                    sorted_safe = arith.select(row_ok, sorted_i32, block_row_start)
-                    fused = buffer_ops.buffer_load(sorted_rsrc, sorted_safe, vec_width=1, dtype=T.i32)
+                    # Use preloaded lds_tid instead of per-thread buffer_load(sorted_rsrc, ...).
+                    fused = _load_fused_from_lds(row)
                     tok = fused & arith.constant((1 << 24) - 1, type=T.i32)
                     slot = fused >> arith.constant(24, type=T.i32)
                     tok_ok = arith.cmpi(arith.CmpIPredicate.ult, tok, i32_tokens_in)
@@ -1957,7 +2737,7 @@ def _compile_stage2_mxscale_kernel_impl(
                     slot_ok1 = arith.cmpi(arith.CmpIPredicate.slt, slot, c_topk_i32)
                     ts = tok * c_topk_i32 + slot
                     ts_ok = arith.andi(tok_ok, arith.andi(slot_ok0, slot_ok1))
-                    load_ok = arith.andi(row_ok, ts_ok)
+                    load_ok = ts_ok
                     x_idx = ts * arith.constant(K_packed_a, type=T.i32) + arith.index_cast(T.i32, k_packed_base + col)
                     x_idx_safe = arith.select(load_ok, x_idx, arith.constant(0, type=T.i32))
                     x_val = arith.select(load_ok, buffer_ops.buffer_load(x_rsrc, x_idx_safe, vec_width=1, dtype=T.i8), arith.constant(0, type=T.i8))
@@ -1966,17 +2746,27 @@ def _compile_stage2_mxscale_kernel_impl(
                     vector.store(v1, target_lds, [lds_idx], alignment=1)
                     scf.YieldOp([])
 
-        def issue_a_load_tdm_gather(k_base, target_lds):
-            """Load stage2 A rows via TDM gather using token-slot row ids."""
-            k_packed_base = k_base if PACK_FACTOR_A == 1 else k_base // fx.Index(PACK_FACTOR_A)
+        # Cache of K-invariant pieces of the stage2 TDM gather descriptor.
+        # See the stage1 equivalent for the field-by-field rationale; the
+        # only stage2 differences are using ``_a_row_ids`` /
+        # ``_a_row_valids`` and ``_get_tokens_topk_sgpr`` (rows already encode
+        # token*topk slots) instead of the stage1 row sources.
+        _a_gather_cache = {}
+
+        def _build_a_gather_base_descs(lds_bufs):
+            if "desc" in _a_gather_cache:
+                return
             _tokens_topk = _get_tokens_topk_sgpr()
             _zero_i32 = arith.constant(0, type=T.i32)
+            _descs = []
+            _preds = []
+            _base_addr_lo = []
+            _base_addr_hi = []
             for _gi in range_constexpr(_TDM_GATHER_GROUPS):
                 _start = _gi * _TDM_GATHER_CHUNK
                 _cnt = min(_TDM_GATHER_CHUNK, int(tile_m) - _start)
                 _row_indices = _a_row_ids[_start:_start + _cnt]
                 _valid_count = _sum_i32_values(_a_row_valids[_start:_start + _cnt])
-                _lds_off = fx.Index(_start * lds_a_stride_bytes)
                 _has_valid = arith.cmpi(arith.CmpIPredicate.sgt, _valid_count, _zero_i32)
                 _issue_pred = _has_valid
                 if const_expr(wave_specialized_tdm):
@@ -1987,11 +2777,16 @@ def _compile_stage2_mxscale_kernel_impl(
                         arith.constant(_gather_owner, type=T.i32),
                     )
                     _issue_pred = arith.andi(_issue_pred, _is_gather_loader)
-                _if_issue = scf.IfOp(_issue_pred)
-                with ir.InsertionPoint(_if_issue.then_block):
-                    desc = tdm_ops.make_tensor_gather_descriptor(
+                _preds.append(_issue_pred)
+
+                _lds_off = fx.Index(_start * lds_a_stride_bytes)
+                _per_buf = []
+                # See stage1 note: range_constexpr is mandatory here so the
+                # AST rewriter does not turn this into an scf.ForOp.
+                for _buf_i in range_constexpr(len(lds_bufs)):
+                    _base_desc = tdm_ops.make_tensor_gather_descriptor(
                         global_ptr=arg_x,
-                        lds_memref=target_lds,
+                        lds_memref=lds_bufs[_buf_i],
                         row_indices=_row_indices,
                         row_width=int(packed_tile_k_a),
                         tensor_dim0=K_packed_a,
@@ -2003,62 +2798,264 @@ def _compile_stage2_mxscale_kernel_impl(
                         index_size=32,
                         gather_tile_dim1=_valid_count,
                         lds_byte_offset=_lds_off,
-                        global_byte_offset=k_packed_base,
+                        global_byte_offset=None,
                     )
-                    tdm_ops.tensor_load_gather(desc)
+                    _per_buf.append(_base_desc)
+                _descs.append(_per_buf)
+                _base_addr_lo.append(vector.extract(
+                    _per_buf[0].dgroup0,
+                    static_position=[2],
+                    dynamic_position=[],
+                ))
+                _base_addr_hi.append(vector.extract(
+                    _per_buf[0].dgroup0,
+                    static_position=[3],
+                    dynamic_position=[],
+                ))
+
+            _a_gather_cache["desc"] = _descs
+            _a_gather_cache["pred"] = _preds
+            _a_gather_cache["base_addr_lo"] = _base_addr_lo
+            _a_gather_cache["base_addr_hi"] = _base_addr_hi
+
+        def issue_a_load_tdm_gather(k_base, buf_idx):
+            """Hot path: carry-safe advance of the precomputed gather descriptor.
+
+            Requires ``_build_a_gather_base_descs(lds_bufs)`` to have been
+            called once before the K loop with the matching LDS buffer list.
+            Uses ``update_tensor_gather_descriptor_addr64`` so a lo-32-bit
+            overflow of ``base_addr_lo + k_byte_off`` propagates into hi
+            instead of redirecting the descriptor to a wrong 4 GiB page.
+            """
+            k_packed_base = k_base if PACK_FACTOR_A == 1 else k_base // fx.Index(PACK_FACTOR_A)
+            _k_byte_off_i32 = arith.index_cast(T.i32, k_packed_base)
+            _descs = _a_gather_cache["desc"]
+            _preds = _a_gather_cache["pred"]
+            _base_addr_lo = _a_gather_cache["base_addr_lo"]
+            _base_addr_hi = _a_gather_cache["base_addr_hi"]
+            for _gi in range_constexpr(_TDM_GATHER_GROUPS):
+                _if_issue = scf.IfOp(_preds[_gi])
+                with ir.InsertionPoint(_if_issue.then_block):
+                    tdm_ops.tensor_load_gather(
+                        tdm_ops.update_tensor_gather_descriptor_addr64(
+                            _descs[_gi][buf_idx],
+                            _base_addr_lo[_gi],
+                            _base_addr_hi[_gi],
+                            _k_byte_off_i32,
+                        )
+                    )
                     scf.YieldOp([])
 
         def make_desc_as(k_base):
             return k_base / arith.index(SCALE_BLOCK)
 
         def issue_as_load(k_scale_base, target_lds):
-            total = int(tile_m * scale_k_per_tile)
-            rounds = (total + block_threads - 1) // block_threads
-            for it in range(rounds):
-                elem = tx + fx.Index(it * block_threads)
-                in_range = arith.cmpi(arith.CmpIPredicate.ult, arith.index_cast(T.i32, elem), arith.constant(total, type=T.i32))
-                _if_elem = scf.IfOp(in_range)
-                with ir.InsertionPoint(_if_elem.then_block):
-                    row = elem // arith.index(int(scale_k_per_tile))
-                    ksc = elem % arith.index(int(scale_k_per_tile))
-                    sorted_row = by * arith.index(int(tile_m)) + row
-                    row_i32 = arith.index_cast(T.i32, row)
-                    sorted_i32 = arith.index_cast(T.i32, sorted_row)
-                    row_in_route = arith.cmpi(arith.CmpIPredicate.ult, row_i32, arith.constant(int(route_tile_m), type=T.i32))
-                    row_in_valid = arith.cmpi(arith.CmpIPredicate.slt, sorted_i32, num_valid_i32)
-                    row_ok = arith.andi(row_in_route, row_in_valid)
-                    sorted_safe = arith.select(row_ok, sorted_i32, block_row_start)
-                    fused = buffer_ops.buffer_load(sorted_rsrc, sorted_safe, vec_width=1, dtype=T.i32)
-                    tok = fused & arith.constant((1 << 24) - 1, type=T.i32)
-                    slot = fused >> arith.constant(24, type=T.i32)
-                    tok_ok = arith.cmpi(arith.CmpIPredicate.ult, tok, i32_tokens_in)
-                    slot_ok0 = arith.cmpi(arith.CmpIPredicate.sge, slot, arith.constant(0, type=T.i32))
-                    slot_ok1 = arith.cmpi(arith.CmpIPredicate.slt, slot, c_topk_i32)
-                    ts = tok * c_topk_i32 + slot
-                    ts_ok = arith.andi(tok_ok, arith.andi(slot_ok0, slot_ok1))
-                    load_ok = arith.andi(row_ok, ts_ok)
-                    ksc_off = k_scale_base + ksc
-                    sx_idx = ts * arith.constant(K_scale, type=T.i32) + arith.index_cast(T.i32, ksc_off)
-                    sx_idx_safe = arith.select(load_ok, sx_idx, arith.constant(0, type=T.i32))
-                    sx_val = arith.select(load_ok, buffer_ops.buffer_load(sx_rsrc, sx_idx_safe, vec_width=1, dtype=T.i8), arith.constant(127, type=T.i8))
-                    if const_expr(is_fp4):
-                        lds_idx = row * arith.index(int(scale_k_per_tile)) + ksc
-                    else:
-                        warp_row_idx = row / arith.index(warp_tile_m)
-                        local_row = row % arith.index(warp_tile_m)
-                        lane_row = local_row % arith.index(WMMA_M)
-                        local_wm_idx = local_row / arith.index(WMMA_M)
-                        global_lds_row = warp_row_idx * arith.index(WMMA_M) + lane_row
-                        ksc_blk = ksc / arith.index(SCALES_PER_WMMA)
-                        ksc_sub = ksc % arith.index(SCALES_PER_WMMA)
-                        lds_idx = (
-                            global_lds_row * arith.index(interleaved_scale_cols_a)
-                            + ksc_blk * arith.index(wmma_m_rep * SCALES_PER_WMMA)
-                            + local_wm_idx * arith.index(SCALES_PER_WMMA)
-                            + ksc_sub
+            """Vectorised scalar A-scale loader (Option B) for stage2.
+
+            See stage1 ``issue_as_load`` for the 4-byte chunking rationale.
+            Stage2 addresses rows by ``ts = tok * topk + slot`` and the
+            ``load_ok`` guard checks both ``tok_ok`` and ``slot_ok``.
+            """
+            _blk_bytes = int(SCALES_PER_WMMA)
+            _row_bytes = int(scale_k_per_tile)
+            if const_expr(_row_bytes % _blk_bytes == 0 and _row_bytes >= _blk_bytes):
+                _blk_vec_type = T.vec(_blk_bytes, T.i8)
+                _blks_per_row = _row_bytes // _blk_bytes
+                total = int(tile_m) * _blks_per_row
+                rounds = (total + block_threads - 1) // block_threads
+                for it in range(rounds):
+                    elem = tx + fx.Index(it * block_threads)
+                    in_range = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        arith.index_cast(T.i32, elem),
+                        arith.constant(total, type=T.i32),
+                    )
+                    _if_elem = scf.IfOp(in_range)
+                    with ir.InsertionPoint(_if_elem.then_block):
+                        row = elem // arith.index(_blks_per_row)
+                        ksc_blk = elem % arith.index(_blks_per_row)
+                        fused = _load_fused_from_lds(row)
+                        tok = fused & arith.constant((1 << 24) - 1, type=T.i32)
+                        slot = fused >> arith.constant(24, type=T.i32)
+                        tok_ok = arith.cmpi(
+                            arith.CmpIPredicate.ult, tok, i32_tokens_in,
                         )
-                    v1 = vector.from_elements(T.vec(1, T.i8), [sx_val])
-                    vector.store(v1, target_lds, [lds_idx], alignment=1)
+                        slot_ok0 = arith.cmpi(
+                            arith.CmpIPredicate.sge, slot,
+                            arith.constant(0, type=T.i32),
+                        )
+                        slot_ok1 = arith.cmpi(
+                            arith.CmpIPredicate.slt, slot, c_topk_i32,
+                        )
+                        ts = tok * c_topk_i32 + slot
+                        ts_ok = arith.andi(tok_ok, arith.andi(slot_ok0, slot_ok1))
+                        if const_expr(_as_layout_rowmajor):
+                            lds_idx = (
+                                row * arith.index(_row_bytes)
+                                + ksc_blk * arith.index(_blk_bytes)
+                            )
+                        else:
+                            warp_row_idx = row / arith.index(warp_tile_m)
+                            local_row = row % arith.index(warp_tile_m)
+                            lane_row = local_row % arith.index(WMMA_M)
+                            local_wm_idx = local_row / arith.index(WMMA_M)
+                            global_lds_row = (
+                                warp_row_idx * arith.index(WMMA_M) + lane_row
+                            )
+                            lds_idx = (
+                                global_lds_row
+                                * arith.index(interleaved_scale_cols_a)
+                                + ksc_blk
+                                * arith.index(wmma_m_rep * SCALES_PER_WMMA)
+                                + local_wm_idx * arith.index(SCALES_PER_WMMA)
+                            )
+                        _if_ok = scf.IfOp(ts_ok, has_else=True)
+                        with ir.InsertionPoint(_if_ok.then_block):
+                            chunk_off = (
+                                k_scale_base
+                                + ksc_blk * arith.index(_blk_bytes)
+                            )
+                            sx_idx = (
+                                ts * arith.constant(K_scale, type=T.i32)
+                                + arith.index_cast(T.i32, chunk_off)
+                            )
+                            sx_raw = buffer_ops.buffer_load(
+                                sx_rsrc,
+                                arith.shrui(
+                                    sx_idx,
+                                    arith.constant(2, type=T.i32),
+                                ),
+                                vec_width=1,
+                                dtype=T.i32,
+                            )
+                            sx_vec = vector.bitcast(
+                                _blk_vec_type,
+                                vector.from_elements(T.vec(1, T.i32), [sx_raw]),
+                            )
+                            vector.store(
+                                sx_vec, target_lds, [lds_idx],
+                                alignment=_blk_bytes,
+                            )
+                            scf.YieldOp([])
+                        with ir.InsertionPoint(_if_ok.else_block):
+                            fill_vec = vector.bitcast(
+                                _blk_vec_type,
+                                vector.from_elements(
+                                    T.vec(1, T.i32),
+                                    [arith.constant(0x7F7F7F7F, type=T.i32)],
+                                ),
+                            )
+                            vector.store(
+                                fill_vec, target_lds, [lds_idx],
+                                alignment=_blk_bytes,
+                            )
+                            scf.YieldOp([])
+                        scf.YieldOp([])
+            else:
+                total = int(tile_m * scale_k_per_tile)
+                rounds = (total + block_threads - 1) // block_threads
+                for it in range(rounds):
+                    elem = tx + fx.Index(it * block_threads)
+                    in_range = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        arith.index_cast(T.i32, elem),
+                        arith.constant(total, type=T.i32),
+                    )
+                    _if_elem = scf.IfOp(in_range)
+                    with ir.InsertionPoint(_if_elem.then_block):
+                        row = elem // arith.index(int(scale_k_per_tile))
+                        ksc = elem % arith.index(int(scale_k_per_tile))
+                        fused = _load_fused_from_lds(row)
+                        tok = fused & arith.constant((1 << 24) - 1, type=T.i32)
+                        slot = fused >> arith.constant(24, type=T.i32)
+                        tok_ok = arith.cmpi(arith.CmpIPredicate.ult, tok, i32_tokens_in)
+                        slot_ok0 = arith.cmpi(arith.CmpIPredicate.sge, slot, arith.constant(0, type=T.i32))
+                        slot_ok1 = arith.cmpi(arith.CmpIPredicate.slt, slot, c_topk_i32)
+                        ts = tok * c_topk_i32 + slot
+                        ts_ok = arith.andi(tok_ok, arith.andi(slot_ok0, slot_ok1))
+                        load_ok = ts_ok
+                        ksc_off = k_scale_base + ksc
+                        sx_idx = ts * arith.constant(K_scale, type=T.i32) + arith.index_cast(T.i32, ksc_off)
+                        sx_idx_safe = arith.select(load_ok, sx_idx, arith.constant(0, type=T.i32))
+                        sx_val = arith.select(
+                            load_ok,
+                            buffer_ops.buffer_load(sx_rsrc, sx_idx_safe, vec_width=1, dtype=T.i8),
+                            arith.constant(127, type=T.i8),
+                        )
+                        if is_fp4:
+                            lds_idx = row * arith.index(int(scale_k_per_tile)) + ksc
+                        else:
+                            warp_row_idx = row / arith.index(warp_tile_m)
+                            local_row = row % arith.index(warp_tile_m)
+                            lane_row = local_row % arith.index(WMMA_M)
+                            local_wm_idx = local_row / arith.index(WMMA_M)
+                            global_lds_row = warp_row_idx * arith.index(WMMA_M) + lane_row
+                            ksc_blk = ksc / arith.index(SCALES_PER_WMMA)
+                            ksc_sub = ksc % arith.index(SCALES_PER_WMMA)
+                            lds_idx = (
+                                global_lds_row * arith.index(interleaved_scale_cols_a)
+                                + ksc_blk * arith.index(wmma_m_rep * SCALES_PER_WMMA)
+                                + local_wm_idx * arith.index(SCALES_PER_WMMA)
+                                + ksc_sub
+                            )
+                        v1 = vector.from_elements(T.vec(1, T.i8), [sx_val])
+                        vector.store(v1, target_lds, [lds_idx], alignment=1)
+                        scf.YieldOp([])
+
+        def issue_as_load_tdm_gather(k_scale_base, target_lds):
+            """TDM-gather A-scale loader (Option A) for stage2.
+
+            Reuses the ``_a_row_ids`` / ``_a_row_valids`` SGPR caches populated
+            by ``_precompute_a_row_indices()`` for the stage2 A-data TDM path,
+            where each row index is ``ts = tok * topk + slot``. Routes
+            completion through ``tdm_cnt`` to eliminate the ``s_wait_dscnt 0``
+            stall cluster caused by per-byte ``buffer_load`` + ``ds_write_b8``.
+
+            Pre-conditions (enforced by the gating in this kernel):
+              - ``use_tdm_gather=True`` (otherwise ``_a_row_ids`` is empty).
+              - Row-major LDS scale layout (``is_fp4`` or ``wmma_m_rep == 1``).
+              - ``scale_k_per_tile`` is a positive multiple of 4.
+            """
+            _as_row_bytes = int(scale_k_per_tile)
+            _tokens_topk = _get_tokens_topk_sgpr()
+            _zero_i32 = arith.constant(0, type=T.i32)
+            for _gi in range_constexpr(_TDM_GATHER_GROUPS):
+                _start = _gi * _TDM_GATHER_CHUNK
+                _cnt = min(_TDM_GATHER_CHUNK, int(tile_m) - _start)
+                _row_indices = _a_row_ids[_start:_start + _cnt]
+                _valid_count = _sum_i32_values(_a_row_valids[_start:_start + _cnt])
+                _lds_off = fx.Index(_start * _as_row_bytes)
+                _has_valid = arith.cmpi(
+                    arith.CmpIPredicate.sgt, _valid_count, _zero_i32,
+                )
+                _issue_pred = _has_valid
+                if wave_specialized_tdm:
+                    _gather_owner = _gi % _tdm_loader_waves
+                    _is_gather_loader = arith.cmpi(
+                        arith.CmpIPredicate.eq,
+                        _tdm_wave_id,
+                        arith.constant(_gather_owner, type=T.i32),
+                    )
+                    _issue_pred = arith.andi(_issue_pred, _is_gather_loader)
+                _if_issue = scf.IfOp(_issue_pred)
+                with ir.InsertionPoint(_if_issue.then_block):
+                    desc = tdm_ops.make_tensor_gather_descriptor(
+                        global_ptr=arg_scale_x,
+                        lds_memref=target_lds,
+                        row_indices=_row_indices,
+                        row_width=_as_row_bytes,
+                        tensor_dim0=int(K_scale),
+                        tensor_dim1=_tokens_topk,
+                        stride=int(K_scale),
+                        elem_bytes=1,
+                        pad_interval=0,
+                        pad_amount=0,
+                        index_size=32,
+                        gather_tile_dim1=_valid_count,
+                        lds_byte_offset=_lds_off,
+                        global_byte_offset=k_scale_base,
+                    )
+                    tdm_ops.tensor_load_gather(desc)
                     scf.YieldOp([])
 
         def make_desc_b(n_off, k_base, target_lds):
@@ -2092,6 +3089,74 @@ def _compile_stage2_mxscale_kernel_impl(
                 elem_bytes=1, pad_interval=0, pad_amount=0,
                 num_warps=tdm_desc_num_warps, workgroup_mask=b_mcast_mask)
 
+        # Cache of K-invariant 2D B / B-scale descriptors used by stage2's
+        # ``_issue_b_tdm_only``. Stage2 has no merge_gate_up_tdm path, so the
+        # cache is single-branched. Each entry stores the base descriptor
+        # plus its addr_lo / addr_hi extracted into SGPRs; the hot path then
+        # uses ``update_tensor_descriptor_2d_addr64`` so a per-K-tile delta
+        # that overflows base_addr_lo carries into addr_hi instead of
+        # silently wrapping into a wrong 4 GiB page (which deadlocks the GPU
+        # in ``amdgpu_mes_reg_write_reg_wait``). Mirrors the stage1 helper
+        # pair; closed over ``make_desc_b``, ``make_desc_bs``,
+        # ``lds_b_bufs``, ``lds_bs_bufs`` and
+        # ``eid_i32`` / ``n_idx`` / ``blk_n``, all resolved at call time
+        # inside ``_if_blk``.
+        _b_desc_cache = {}
+
+        def _extract_desc_addr_lo(desc):
+            return vector.extract(
+                desc.dgroup0,
+                static_position=[2],
+                dynamic_position=[],
+            )
+
+        def _extract_desc_addr_hi(desc):
+            return vector.extract(
+                desc.dgroup0,
+                static_position=[3],
+                dynamic_position=[],
+            )
+
+        def _build_b_base_descs():
+            if "ready" in _b_desc_cache:
+                return
+            _zero_k = arith.index(0)
+            _eid_idx = arith.index_cast(T.index, eid_i32)
+            _n_off = _eid_idx * n_idx + blk_n
+            _b = [
+                make_desc_b(_n_off, _zero_k, lds_b_bufs[i])
+                for i in range_constexpr(_nb)
+            ]
+            _bs = [
+                make_desc_bs(_n_off, _zero_k, lds_bs_bufs[i])
+                for i in range_constexpr(_nb)
+            ]
+            _b_desc_cache["b"] = _b
+            _b_desc_cache["bs"] = _bs
+            _b_desc_cache["b_addr_lo"] = [_extract_desc_addr_lo(d) for d in _b]
+            _b_desc_cache["b_addr_hi"] = [_extract_desc_addr_hi(d) for d in _b]
+            _b_desc_cache["bs_addr_lo"] = [_extract_desc_addr_lo(d) for d in _bs]
+            _b_desc_cache["bs_addr_hi"] = [_extract_desc_addr_hi(d) for d in _bs]
+            _b_desc_cache["ready"] = True
+
+        def _b_data_k_byte_off(k_base):
+            # Fastest-axis byte offset for stage2 B data descriptor:
+            #   non-fp4 : (k_base / PACK_FACTOR_B) * 16 bytes
+            #   fp4     : (k_base / PACK_FACTOR_B) bytes
+            # Matches make_desc_b global_offset math (elem_bytes=1).
+            _k_packed_b = (
+                k_base if PACK_FACTOR_B == 1
+                else k_base // fx.Index(PACK_FACTOR_B)
+            )
+            if const_expr(is_fp4):
+                return arith.index_cast(T.i32, _k_packed_b)
+            return arith.index_cast(
+                T.i32, _k_packed_b * fx.Index(16))
+
+        def _b_scale_k_byte_off(k_base):
+            return arith.index_cast(
+                T.i32, k_base // fx.Index(SCALE_BLOCK))
+
         def issue_b_load(k_base, target_lds_b, target_lds_bs):
             eid_idx = arith.index_cast(T.index, eid_i32)
             n_off = eid_idx * n_idx + blk_n
@@ -2119,6 +3184,7 @@ def _compile_stage2_mxscale_kernel_impl(
 
         _if_blk = scf.IfOp(block_ok)
         with ir.InsertionPoint(_if_blk.then_block):
+            _preload_sorted_ids_to_lds()
             if const_expr(_use_tdm_gather_a):
                 _precompute_a_row_indices()
             a_data_bases = _precompute_a_data_bases()
@@ -2435,45 +3501,99 @@ def _compile_stage2_mxscale_kernel_impl(
                     _data_adv_i32,
                     _scale_adv_i32,
                 )
-                def _issue_active_b_tdm_only(stage_idx, curr_addr_lo):
+
+                # See stage1 for rationale: pre-build per-stage TDMDescriptor2D
+                # bases so the hot path can splice in lanes 2 / 3 cheaply via
+                # ``update_tensor_descriptor_2d_addr_lo_hi``. The lane-3
+                # placeholder mirrors ``_active_addr_hi``, but the actual hi
+                # used at issue time comes from the (lo, hi) pair tracked
+                # through the pipeline state.
+                _tdm_zero_addr_lo = arith.constant(0, type=T.i32)
+                _active_stage_desc_base = [
+                    tdm_ops.TDMDescriptor2D(
+                        vector.from_elements(T.vec(4, T.i32), [
+                            _tdm_pred,
+                            _active_stage_lds_addr[i],
+                            _tdm_zero_addr_lo,
+                            _active_addr_hi,
+                        ]),
+                        _active_dgroup1,
+                    )
+                    for i in range_constexpr(_nb)
+                ]
+
+                def _issue_active_b_tdm_only(stage_idx, curr_addr_lo, curr_addr_hi):
+                    """Issue one B-load and advance the (lo, hi) pair carry-safely."""
                     _if_loader = scf.IfOp(_is_loader_wave)
                     with ir.InsertionPoint(_if_loader.then_block):
-                        _dg0 = vector.from_elements(T.vec(4, T.i32), [
-                            _tdm_pred,
-                            _active_stage_lds_addr[stage_idx],
-                            curr_addr_lo,
-                            _active_addr_hi,
-                        ])
                         tdm_ops.tensor_load_2d(
-                            tdm_ops.TDMDescriptor2D(_dg0, _active_dgroup1)
+                            tdm_ops.update_tensor_descriptor_2d_addr_lo_hi(
+                                _active_stage_desc_base[stage_idx],
+                                curr_addr_lo,
+                                curr_addr_hi,
+                            )
                         )
                         scf.YieldOp([])
-                    _next_addr_lo = arith.addi(curr_addr_lo, _active_adv_i32)
-                    return arith.select(
-                        _is_loader_wave,
-                        _next_addr_lo,
-                        curr_addr_lo,
+                    _next_addr_lo, _next_addr_hi = tdm_ops.add_addr_with_carry(
+                        curr_addr_lo, curr_addr_hi, _active_adv_i32,
                     )
+                    return (
+                        arith.select(
+                            _is_loader_wave, _next_addr_lo, curr_addr_lo),
+                        arith.select(
+                            _is_loader_wave, _next_addr_hi, curr_addr_hi),
+                    )
+
+            if const_expr(_use_tdm_gather_a):
+                _build_a_gather_base_descs(lds_a_bufs)
+            # See stage1 for the rationale of guarding on wave_specialized_tdm:
+            # in wave-specialized mode the hot path goes through
+            # ``_issue_active_b_tdm_only``; ``_issue_b_tdm_only`` is only used
+            # in non-pipelined / tail paths, so skip the cache build to avoid
+            # emitting dead IR.
+            if const_expr(not wave_specialized_tdm):
+                _build_b_base_descs()
 
             # ── pipeline load helpers ─────────────────────────────────
             def _issue_b_tdm_only(k_base, buf_idx):
-                _eid = arith.index_cast(T.index, eid_i32)
-                _n = _eid * n_idx + blk_n
+                # Carry-safe variant: ``update_tensor_descriptor_2d_addr64``
+                # adds the K-tile delta in i64 so an i32 wrap of base_addr_lo
+                # propagates into addr_hi rather than silently corrupting the
+                # descriptor address.
+                _k_data_off = _b_data_k_byte_off(k_base)
+                _k_scale_off = _b_scale_k_byte_off(k_base)
                 tdm_ops.tensor_load_2d(
-                    make_desc_b(_n, k_base, lds_b_bufs[buf_idx]))
+                    tdm_ops.update_tensor_descriptor_2d_addr64(
+                        _b_desc_cache["b"][buf_idx],
+                        _b_desc_cache["b_addr_lo"][buf_idx],
+                        _b_desc_cache["b_addr_hi"][buf_idx],
+                        _k_data_off,
+                    ))
                 tdm_ops.tensor_load_2d(
-                    make_desc_bs(_n, k_base, lds_bs_bufs[buf_idx]))
+                    tdm_ops.update_tensor_descriptor_2d_addr64(
+                        _b_desc_cache["bs"][buf_idx],
+                        _b_desc_cache["bs_addr_lo"][buf_idx],
+                        _b_desc_cache["bs_addr_hi"][buf_idx],
+                        _k_scale_off,
+                    ))
 
             def _issue_scalar_loads(k_base, buf_idx):
                 if const_expr(_use_tdm_gather_a):
-                    issue_a_load_tdm_gather(k_base, lds_a_bufs[buf_idx])
+                    issue_a_load_tdm_gather(k_base, buf_idx)
                 else:
                     issue_a_load(make_desc_a(k_base), lds_a_bufs[buf_idx])
-                issue_as_load(make_desc_as(k_base), lds_as_bufs[buf_idx])
+                if _use_tdm_gather_as:
+                    issue_as_load_tdm_gather(make_desc_as(k_base), lds_as_bufs[buf_idx])
+                else:
+                    issue_as_load(make_desc_as(k_base), lds_as_bufs[buf_idx])
 
             def _issue_all_loads(k_base, buf_idx):
-                _issue_b_tdm_only(k_base, buf_idx)
-                _issue_scalar_loads(k_base, buf_idx)
+                if const_expr(is_fp4):
+                    _issue_scalar_loads(k_base, buf_idx)
+                    _issue_b_tdm_only(k_base, buf_idx)
+                else:
+                    _issue_b_tdm_only(k_base, buf_idx)
+                    _issue_scalar_loads(k_base, buf_idx)
 
             def _compute_with_mid_loads(accs_in, buf_idx, mid_load_callback=None):
                 if const_expr(_use_scheduled_compute):
@@ -2491,10 +3611,13 @@ def _compile_stage2_mxscale_kernel_impl(
                 # Single-buffer path (num_buffers=1)
                 if const_expr(wave_specialized_tdm):
                     active_b_addr_lo = _active_addr_lo
+                    active_b_addr_hi = _active_addr_hi
                     for kt in range_constexpr(num_k_tiles):
                         k_base = fx.Index(kt * int(tile_k))
-                        active_b_addr_lo = _issue_active_b_tdm_only(
-                            0, active_b_addr_lo)
+                        active_b_addr_lo, active_b_addr_hi = (
+                            _issue_active_b_tdm_only(
+                                0, active_b_addr_lo, active_b_addr_hi)
+                        )
                         _issue_scalar_loads(k_base, 0)
                         tdm_ops.tensor_wait(0)
                         workgroup_barrier(use_cluster=use_cluster)
@@ -2513,9 +3636,12 @@ def _compile_stage2_mxscale_kernel_impl(
                 # ── prologue: pre-load first `pre_loaded` stages ──
                 if const_expr(wave_specialized_tdm):
                     active_b_addr_lo = _active_addr_lo
+                    active_b_addr_hi = _active_addr_hi
                     for _pi in range_constexpr(pre_loaded):
-                        active_b_addr_lo = _issue_active_b_tdm_only(
-                            _pi, active_b_addr_lo)
+                        active_b_addr_lo, active_b_addr_hi = (
+                            _issue_active_b_tdm_only(
+                                _pi, active_b_addr_lo, active_b_addr_hi)
+                        )
                         _issue_scalar_loads(fx.Index(_pi * int(tile_k)), _pi)
                 else:
                     for _pi in range_constexpr(pre_loaded):
@@ -2525,10 +3651,17 @@ def _compile_stage2_mxscale_kernel_impl(
                 # ── main pipelined loop ──
                 if const_expr(loop_iters > 0):
                     if const_expr(wave_specialized_tdm):
-                        _init = list(acc) + [active_b_addr_lo]
+                        # Carry the (addr_lo, addr_hi) pair through the
+                        # pipeline state so the carry chain survives across
+                        # iterations.
+                        _init = (
+                            list(acc)
+                            + [active_b_addr_lo, active_b_addr_hi]
+                        )
                         for _li, _st in fx.range(0, loop_iters, 1, init=_init):
                             _acc = list(_st[:n_accs])
                             _cur_b_addr_lo = _st[n_accs]
+                            _cur_b_addr_hi = _st[n_accs + 1]
                             for _bi in range_constexpr(_nb):
                                 _lb = (_bi + _nb - 1) % _nb
                                 _kt = (_li * fx.Index(_nb)
@@ -2539,8 +3672,13 @@ def _compile_stage2_mxscale_kernel_impl(
                                     use_cluster=use_cluster)
                                 pipeline_fence_wait(use_cluster=use_cluster)
 
-                                _cur_b_addr_lo = _issue_active_b_tdm_only(
-                                    _lb, _cur_b_addr_lo)
+                                _cur_b_addr_lo, _cur_b_addr_hi = (
+                                    _issue_active_b_tdm_only(
+                                        _lb,
+                                        _cur_b_addr_lo,
+                                        _cur_b_addr_hi,
+                                    )
+                                )
 
                                 def _mid_issue_scalar(_mid_kb=_kb, _mid_lb=_lb):
                                     _issue_scalar_loads(_mid_kb, _mid_lb)
@@ -2554,9 +3692,13 @@ def _compile_stage2_mxscale_kernel_impl(
                                 )
                                 if const_expr(_use_scheduled_compute):
                                     _hot_loop_scheduler_scheduled()
-                            _res = yield list(_acc) + [_cur_b_addr_lo]
+                            _res = yield (
+                                list(_acc)
+                                + [_cur_b_addr_lo, _cur_b_addr_hi]
+                            )
                         acc = list(_res[:n_accs])
                         active_b_addr_lo = _res[n_accs]
+                        active_b_addr_hi = _res[n_accs + 1]
                     else:
                         _init = list(acc)
                         for _li, _st in fx.range(0, loop_iters, 1, init=_init):
@@ -2620,8 +3762,13 @@ def _compile_stage2_mxscale_kernel_impl(
                             _tail_li += 1
 
                             if const_expr(wave_specialized_tdm):
-                                active_b_addr_lo = _issue_active_b_tdm_only(
-                                    _ls, active_b_addr_lo)
+                                active_b_addr_lo, active_b_addr_hi = (
+                                    _issue_active_b_tdm_only(
+                                        _ls,
+                                        active_b_addr_lo,
+                                        active_b_addr_hi,
+                                    )
+                                )
                             else:
                                 _issue_b_tdm_only(_tkb, _ls)
 
@@ -2729,6 +3876,8 @@ def _compile_stage2_mxscale_kernel_impl(
                     topk=int(topk),
                     num_valid_i32=num_valid_i32,
                     block_row_start=block_row_start,
+                    lds_tid=lds_tid,
+                    memref=memref,
                     sorted_rsrc=sorted_rsrc,
                     tw_rsrc=tw_rsrc,
                     out_rsrc=out_rsrc,
@@ -2745,6 +3894,8 @@ def _compile_stage2_mxscale_kernel_impl(
                     range_constexpr=range_constexpr,
                     rocdl=rocdl,
                     T=T,
+                    bias_rsrc=bias_rsrc if _enable_bias else None,
+                    eid_i32=eid_i32 if _enable_bias else None,
                 )
             scf.YieldOp([])
 
@@ -2759,6 +3910,7 @@ def _compile_stage2_mxscale_kernel_impl(
         arg_expert_ids: fx.Tensor,
         arg_sorted_weights: fx.Tensor,
         arg_num_valid_ids: fx.Tensor,
+        arg_bias: fx.Tensor,
         i32_tokens_in: fx.Int32,
         i32_n_in: fx.Int32,
         i32_k_in: fx.Int32,
@@ -2771,26 +3923,13 @@ def _compile_stage2_mxscale_kernel_impl(
         size_expert_ids_in = arith.index_cast(T.index, i32_size_expert_ids_in)
         gx = (n_in + fx.Index(int(tile_n) - 1)) // fx.Index(int(tile_n))
         gy = size_expert_ids_in
-        _cluster_arg = (int(cluster_m), int(cluster_n), 1) if use_cluster else None
         launcher = moe_mxscale_stage2_single(
-            arg_out,
-            arg_x,
-            arg_w,
-            arg_scale_x,
-            arg_scale_w,
-            arg_sorted_token_ids,
-            arg_expert_ids,
-            arg_sorted_weights,
-            arg_num_valid_ids,
-            i32_tokens_in,
-            i32_n_in,
-            i32_k_in,
-            i32_size_expert_ids_in,
-            value_attrs={
-                "rocdl.waves_per_eu": effective_waves_per_eu,
-                "rocdl.cluster_dims": f"{cluster_m},{cluster_n},1" if use_cluster else None,
-            },
+            arg_out, arg_x, arg_w, arg_scale_x, arg_scale_w,
+            arg_sorted_token_ids, arg_expert_ids, arg_sorted_weights, arg_num_valid_ids,
+            arg_bias,
+            i32_tokens_in, i32_n_in, i32_k_in, i32_size_expert_ids_in,
         )
+        _cluster_arg = (int(cluster_m), int(cluster_n), 1) if use_cluster else None
         _finalize_alloc_and_launch_2d(
             ctx=ctx,
             alloc=alloc,
@@ -2799,6 +3938,7 @@ def _compile_stage2_mxscale_kernel_impl(
             gy=gy,
             block_threads=block_threads,
             stream=stream,
+            waves_per_eu=effective_waves_per_eu,
             ir=ir,
             cluster=_cluster_arg,
         )
@@ -2834,11 +3974,16 @@ def _compile_moe_mxscale_gemm(
     expert_sched_mode: bool = True,
     num_buffers: int = 1,
     use_tdm_gather: bool = True,
+    use_tdm_gather_as: bool = True,
     use_tdm_store: bool = False,
     inst_prefetch: bool = False,
     wave_specialized_tdm: bool = False,
     cluster_m: int = 1,
     cluster_n: int = 1,
+    k_batch: int = 1,
+    # ── bias / activation (stage1 only consumes ``act``) ─────────────
+    enable_bias: bool = False,
+    act: str = "silu",
 ):
     _require_gfx1250()
     if waves_per_eu is not None and int(waves_per_eu) < 1:
@@ -2860,14 +4005,22 @@ def _compile_moe_mxscale_gemm(
         m_warp=int(single_m_warp), n_warp=int(single_n_warp),
         out_dtype=out_dtype, waves_per_eu=waves_per_eu, data_format=in_dtype,
         expert_sched_mode=expert_sched_mode, num_buffers=int(num_buffers),
-        use_tdm_gather=bool(use_tdm_gather), use_tdm_store=bool(use_tdm_store),
+        use_tdm_gather=bool(use_tdm_gather),
+        use_tdm_gather_as=bool(use_tdm_gather_as),
+        use_tdm_store=bool(use_tdm_store),
         inst_prefetch=bool(inst_prefetch), wave_specialized_tdm=bool(wave_specialized_tdm),
         cluster_m=int(cluster_m), cluster_n=int(cluster_n),
     )
 
     if stage == 1:
-        exe = _compile_stage1_mxscale_kernel_impl(doweight_stage1=bool(doweight), **common)
-        if in_dtype in ("fp8", "a8w4") and (int(inter_dim) % int(single_tile_n) == 0):
+        exe = _compile_stage1_mxscale_kernel_impl(
+            doweight_stage1=bool(doweight), k_batch=int(k_batch),
+            enable_bias=bool(enable_bias), act=str(act), **common)
+        if (
+            int(k_batch) == 1
+            and in_dtype in ("fp8", "a8w4")
+            and (int(inter_dim) % int(single_tile_n) == 0)
+        ):
             return _Stage1GateUpPackedWrapper(
                 exe,
                 experts=int(experts), inter_dim=int(inter_dim),
@@ -2877,17 +4030,28 @@ def _compile_moe_mxscale_gemm(
             )
         return exe
 
+    if int(k_batch) != 1:
+        raise ValueError(
+            "split-K (k_batch>1) is only supported on stage1 for MXScale MoE")
+    # ``act`` is stage1-only; stage2 has no fused activation.
     return _compile_stage2_mxscale_kernel_impl(
-        doweight_stage2=bool(doweight), accumulate=bool(accumulate), **common,
+        doweight_stage2=bool(doweight), accumulate=bool(accumulate),
+        enable_bias=bool(enable_bias), **common,
     )
 
 
-def compile_moe_gemm1(*, doweight_stage1, group_size=-1, use_cshuffle_epilog=None, **kw):
-    return _compile_moe_mxscale_gemm(stage=1, doweight=doweight_stage1, **kw)
+def compile_moe_gemm1(*, doweight_stage1, group_size=-1, use_cshuffle_epilog=None,
+                      k_batch=1, enable_bias=False, act="silu", **kw):
+    return _compile_moe_mxscale_gemm(
+        stage=1, doweight=doweight_stage1, k_batch=int(k_batch),
+        enable_bias=bool(enable_bias), act=str(act), **kw)
 
 
-def compile_moe_gemm2(*, doweight_stage2, accumulate=True, group_size=-1, use_cshuffle_epilog=None, **kw):
-    return _compile_moe_mxscale_gemm(stage=2, doweight=doweight_stage2, accumulate=accumulate, **kw)
+def compile_moe_gemm2(*, doweight_stage2, accumulate=True, group_size=-1,
+                      use_cshuffle_epilog=None, enable_bias=False, **kw):
+    return _compile_moe_mxscale_gemm(
+        stage=2, doweight=doweight_stage2, accumulate=accumulate,
+        enable_bias=bool(enable_bias), **kw)
 
 
 def compile_moe_gemm2_ex(*, mode=MoeGemm2Mode.ATOMIC, valid_mask=None, zero_intermediate=True, **kw):

--- a/kernels/moe_gemm_2stage_wmma_gfx1250.py
+++ b/kernels/moe_gemm_2stage_wmma_gfx1250.py
@@ -121,12 +121,6 @@ def _compile_stage1_wmma_kernel_impl(
         i32_size_expert_ids_in: fx.Int32,
     ):
         _ = (arg_scale_x, arg_scale_w, arg_max_token_ids, i32_k_in)
-        llvm_dialect.inline_asm(
-            None, [],  # void result, no operands
-            "s_setreg_imm32_b32 hwreg(26, 4, 1), 1",
-            "",
-            has_side_effects=True,
-        )
 
         tx = gpu.thread_id("x")
         bx = gpu.block_id("x")  # inter tile
@@ -403,7 +397,6 @@ def _compile_stage1_wmma_kernel_impl(
             i32_inter_in,
             i32_k_in,
             i32_size_expert_ids_in,
-            value_attrs={"rocdl.waves_per_eu": waves_per_eu},
         )
         _finalize_alloc_and_launch_2d(
             ctx=ctx,
@@ -413,6 +406,7 @@ def _compile_stage1_wmma_kernel_impl(
             gy=gy,
             block_threads=block_threads,
             stream=stream,
+            waves_per_eu=waves_per_eu,
             ir=ir,
         )
 
@@ -509,12 +503,14 @@ def _compile_stage2_wmma_kernel_impl(
         i32_size_expert_ids_in: fx.Int32,
     ):
         _ = (arg_scale_x, arg_scale_w, i32_k_in)
-        llvm_dialect.inline_asm(
-            None, [],  # void result, no operands
-            "s_setreg_imm32_b32 hwreg(26, 4, 1), 1",
-            "",
-            has_side_effects=True,
-        )
+        # ASTRewriter strips ``const_expr(...)`` from ``if`` tests, which would
+        # otherwise eliminate every reference to ``const_expr`` from the
+        # rewritten function body and shrink ``co_freevars`` by one — causing
+        # CPython to reject ``f.__code__ = new_f_code_o`` because the original
+        # ``__closure__`` length no longer matches. Keep one explicit reference
+        # so the rewritten code object's free-vars list still includes
+        # ``const_expr``.
+        _keep_const_expr_ref = const_expr  # noqa: F841
 
         tx = gpu.thread_id("x")
         bx = gpu.block_id("x")  # n tile
@@ -788,7 +784,6 @@ def _compile_stage2_wmma_kernel_impl(
             i32_n_in,
             i32_k_in,
             i32_size_expert_ids_in,
-            value_attrs={"rocdl.waves_per_eu": waves_per_eu},
         )
         _finalize_alloc_and_launch_2d(
             ctx=ctx,
@@ -798,6 +793,7 @@ def _compile_stage2_wmma_kernel_impl(
             gy=gy,
             block_threads=block_threads,
             stream=stream,
+            waves_per_eu=waves_per_eu,
             ir=ir,
         )
 

--- a/tests/kernels/benchmark_common.py
+++ b/tests/kernels/benchmark_common.py
@@ -42,10 +42,10 @@ class PerfRow:
     aiter_gpu_us: Optional[float]
 
     @property
-    def speedup_flydsl_vs_aiter(self) -> Optional[float]:
+    def speedup_aiter_vs_flydsl(self) -> Optional[float]:
         if self.flydsl_gpu_us is None or self.aiter_gpu_us is None:
             return None
-        return self.aiter_gpu_us / self.flydsl_gpu_us
+        return self.flydsl_gpu_us / self.aiter_gpu_us
 
 
 def _fmt_us(x: Optional[float]) -> str:
@@ -58,7 +58,7 @@ def print_perf_table(rows: List[PerfRow]) -> None:
     print("=" * 100)
     print(f"{'op':10s} {'shape':18s} {'dtype':6s} {'FlyDSL(gpu us)':>14s} {'AIter(gpu us)':>14s} {'speedup':>10s}")
     for r in rows:
-        sp = r.speedup_flydsl_vs_aiter
+        sp = r.speedup_aiter_vs_flydsl
         sp_s = "-" if sp is None else f"{sp:,.2f}x"
         print(
             f"{r.op:10s} {r.shape:18s} {r.dtype:6s} {_fmt_us(r.flydsl_gpu_us):>14s} {_fmt_us(r.aiter_gpu_us):>14s} {sp_s:>10s}"
@@ -487,11 +487,19 @@ def bench_resolve_tiles(in_dtype, model_dim, inter_dim):
 
     tile_n1 = bench_best_tile(target_n, inter_dim, 16)
     tile_k1 = bench_best_tile(target_k, model_dim, wmma_k)
+    if tile_k1 is None:
+        tile_k1 = wmma_k
     tile_n2 = bench_best_tile(target_n, model_dim, 16)
 
     tile_k2 = None
     for k in range(target_k, 0, -wmma_k):
         if inter_dim % k != 0:
+            # K-padding: run_moe_stage2 auto-pads inter_dim, so accept
+            # any tile_k that satisfies the load-mapping constraints.
+            total = tile_m * k
+            if total % 256 == 0 and (total // 256) % 4 == 0:
+                if tile_k2 is None:
+                    tile_k2 = k
             continue
         total = tile_m * k
         if total % 256 == 0 and (total // 256) % 4 == 0:
@@ -859,7 +867,7 @@ def main() -> None:
         print("=" * 100)
         print(f"{'op':10s} {'shape':18s} {'dtype':6s} {'FlyDSL(gpu us)':>14s} {'torch(gpu us)':>14s} {'speedup':>10s}")
         for r in wmma_rows:
-            sp = r.speedup_flydsl_vs_aiter
+            sp = r.speedup_aiter_vs_flydsl
             sp_s = "-" if sp is None else f"{sp:,.2f}x"
             print(
                 f"{r.op:10s} {r.shape:18s} {r.dtype:6s} {_fmt_us(r.flydsl_gpu_us):>14s} {_fmt_us(r.aiter_gpu_us):>14s} {sp_s:>10s}"

--- a/tests/kernels/test_moe_gemm_mxscale_gfx1250.py
+++ b/tests/kernels/test_moe_gemm_mxscale_gfx1250.py
@@ -4,10 +4,11 @@
 # Copyright (c) 2025 FlyDSL Project Contributors
 
 """MoE GEMM tests for MXScale data types (fp4/fp8/a8w4) on gfx1250."""
+import argparse
 import math
 import os
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 
 import pytest
 import torch
@@ -30,10 +31,13 @@ for _p in reversed(_PYTHON_CANDIDATES):
 
 from tests.kernels.test_ref import torch_moe_gemm1, torch_moe_gemm2
 from tests.utils import get_dtype_max
-from tests.test_common import verify_output, run_perftest
+from tests.test_common import verify_output
 from flydsl.runtime.device import get_rocm_arch
 from tests.kernels.utils import fp4_utils
 from tests.kernels.benchmark_common import (
+    bench_bytes_moved_stage1 as _bench_bytes_moved_stage1,
+    bench_bytes_moved_stage2 as _bench_bytes_moved_stage2,
+    bench_dtype_bpe as _bench_dtype_bpe,
     bench_kernel_us as _bench_kernel_us,
 )
 
@@ -173,6 +177,68 @@ from kernels.moe_gemm_2stage_mxscale_gfx1250 import (
 )
 
 
+def _perf_metrics_from_us(
+    us: Optional[float],
+    *,
+    flops: int,
+    bytes_moved: int,
+    read_bytes: int,
+    write_bytes: int,
+) -> Tuple[float, float, float, float]:
+    """Return throughput metrics, tolerating 0-us event timings for tiny kernels."""
+    if us is None or us <= 0:
+        return 0.0, 0.0, 0.0, 0.0
+    time_s = us / 1e6
+    return (
+        flops / time_s / 1e12,
+        bytes_moved / 1e12 / time_s,
+        read_bytes / 1e9 / time_s,
+        write_bytes / 1e9 / time_s,
+    )
+
+
+def _bench_active_experts(tokens: int, topk: int, experts: int) -> int:
+    return min(int(tokens) * int(topk), int(experts))
+
+
+def _bench_stage1_byte_breakdown(
+    tokens: int,
+    model_dim: int,
+    inter_dim: int,
+    experts: int,
+    topk: int,
+    in_dtype: str,
+) -> Tuple[int, int, int, int, int, int]:
+    """Return logical bench bytes matching benchmark_common stage1 accounting."""
+    active_experts = _bench_active_experts(tokens, topk, experts)
+    a_bpe, w_bpe, w_scale_bpg = _bench_dtype_bpe(in_dtype)
+    bytes_x = int(tokens * model_dim * a_bpe)
+    bytes_w = int(active_experts * (2 * inter_dim) * model_dim * w_bpe)
+    bytes_scale_w = int(active_experts * (2 * inter_dim) * math.ceil(model_dim / SCALE_BLOCK) * w_scale_bpg)
+    bytes_out = int(tokens * topk * inter_dim * 2)
+    bytes_moved = _bench_bytes_moved_stage1(tokens, topk, model_dim, inter_dim, experts, in_dtype)
+    return bytes_moved, bytes_x, bytes_w, bytes_scale_w, bytes_out, active_experts
+
+
+def _bench_stage2_byte_breakdown(
+    tokens: int,
+    model_dim: int,
+    inter_dim: int,
+    experts: int,
+    topk: int,
+    in_dtype: str,
+) -> Tuple[int, int, int, int, int, int]:
+    """Return logical bench bytes matching benchmark_common stage2 accounting."""
+    active_experts = _bench_active_experts(tokens, topk, experts)
+    a_bpe, w_bpe, w_scale_bpg = _bench_dtype_bpe(in_dtype)
+    bytes_a2 = int(tokens * topk * inter_dim * a_bpe)
+    bytes_w2 = int(active_experts * model_dim * inter_dim * w_bpe)
+    bytes_scale_w2 = int(active_experts * model_dim * math.ceil(inter_dim / SCALE_BLOCK) * w_scale_bpg)
+    bytes_out = int(tokens * topk * model_dim * 2)
+    bytes_moved = _bench_bytes_moved_stage2(tokens, topk, model_dim, inter_dim, experts, in_dtype)
+    return bytes_moved, bytes_a2, bytes_w2, bytes_scale_w2, bytes_out, active_experts
+
+
 # ---- Stage1/Stage2 runners (helpers; NOT pytest tests) ----
 def run_moe_stage1(
     tokens: int,
@@ -198,21 +264,28 @@ def run_moe_stage1(
     routing_in: Optional[RoutingBuffers] = None,
     return_outputs: bool = False,
     skip_ref: bool = False,
-    test_graph: bool = False,
     waves_per_eu: Optional[int] = None,
-    benchmark_mode: bool = False,
     flush_l2: bool = True,
     num_buffers: int = 1,
     use_tdm_gather: bool = True,
+    use_tdm_gather_as: bool = True,
     use_tdm_store: bool = False,
     inst_prefetch: bool = False,
     wave_specialized_tdm: bool = False,
     cluster_m: int = 1,
     cluster_n: int = 1,
     expert_sched_mode: bool = True,
+    k_batch: int = 1,
 ):
     assert model_dim % 64 == 0
     assert inter_dim % tile_n == 0
+    if int(k_batch) > 1:
+        assert not bool(doweight_stage1), \
+            "split-K (k_batch>1) requires doweight_stage1=False (routing weight applied externally)."
+        assert int(model_dim) % int(k_batch) == 0, \
+            f"split-K: model_dim={model_dim} must be divisible by k_batch={k_batch}."
+        assert (int(model_dim) // int(k_batch)) % int(tile_k) == 0, \
+            f"split-K: model_dim/k_batch={model_dim//k_batch} must be divisible by tile_k={tile_k}."
 
     device = torch.device("cuda")
     torch.manual_seed(int(seed))
@@ -230,7 +303,13 @@ def run_moe_stage1(
 
     # Routing: aiter uses fused_topk; we use torch topk+softmax for portability/determinism.
     if topk_ids_in is None or topk_weights_in is None:
-        score = torch.randn((tokens, experts), device=device, dtype=torch.float32)
+        score = torch.zeros((tokens, experts), device=device, dtype=torch.float32)
+        start_col = 0
+        end_col = topk
+        for token_id in range(tokens):
+            score[token_id, start_col:end_col] = 1.0
+            start_col = end_col % experts
+            end_col = start_col + topk
         topk_vals, topk_ids = torch.topk(score, k=topk, dim=1)
         topk_weights = torch.softmax(topk_vals, dim=1).to(torch.float32)
     else:
@@ -337,8 +416,15 @@ def run_moe_stage1(
         scale_w1_1d = scale_w1.view(-1).contiguous()
     sorted_weights_1d = sorted_weights.contiguous().view(-1)  # [sorted_size]
 
-    # Output: [tokens, topk, inter_dim] fp16
-    out = torch.zeros((tokens, topk, inter_dim), device=device, dtype=torch.float16)
+    _is_splitk = int(k_batch) > 1
+    if _is_splitk:
+        # Split-K kernel writes atomically-accumulated gate/up partials to a flat [M, 2*N] buffer
+        # without silu*mul fusion; we perform silu*mul + routing-weight reduction on host side.
+        out_kernel = torch.zeros((tokens * topk, 2 * inter_dim), device=device, dtype=torch.float16)
+        out = torch.zeros((tokens, topk, inter_dim), device=device, dtype=torch.float16)
+    else:
+        out_kernel = torch.zeros((tokens, topk, inter_dim), device=device, dtype=torch.float16)
+        out = out_kernel
 
     exe = compile_moe_gemm1(
         model_dim=model_dim,
@@ -354,13 +440,20 @@ def run_moe_stage1(
         waves_per_eu=waves_per_eu,
         num_buffers=int(num_buffers),
         use_tdm_gather=bool(use_tdm_gather),
+        use_tdm_gather_as=bool(use_tdm_gather_as),
         use_tdm_store=bool(use_tdm_store),
         inst_prefetch=bool(inst_prefetch),
         wave_specialized_tdm=bool(wave_specialized_tdm),
         cluster_m=int(cluster_m),
         cluster_n=int(cluster_n),
         expert_sched_mode=bool(expert_sched_mode),
+        k_batch=int(k_batch),
     )
+
+    # Empty bias slot -- the gfx1250 mxscale stage1 kernel keeps
+    # ``arg_bias`` as a stable positional even when compiled with
+    # ``enable_bias=False``; pass an empty fp32 tensor (it is never read).
+    _empty_bias_s1 = torch.empty(0, device=x_q.device, dtype=torch.float32)
 
     def launch(o, x, w, sx, sw, st, eids, sw_sorted):
         stream = torch.cuda.current_stream()
@@ -374,6 +467,7 @@ def run_moe_stage1(
             eids,
             sw_sorted,
             num_valid_ids,
+            _empty_bias_s1,
             tokens,
             inter_dim,
             model_dim,
@@ -381,37 +475,29 @@ def run_moe_stage1(
             stream,
         )
 
-    if bool(benchmark_mode) and not bool(test_graph):
-        def _prep_stage1():
-            out.zero_()
+    def _prep_stage1():
+        out_kernel.zero_()
 
-        def _run_stage1():
-            launch(out, x_q, w_kernel, scale_x_1d, scale_w1_1d, sorted_token_ids, sorted_expert_ids, sorted_weights_1d)
+    def _run_stage1():
+        launch(out_kernel, x_q, w_kernel, scale_x_1d, scale_w1_1d, sorted_token_ids, sorted_expert_ids, sorted_weights_1d)
 
-        us = _bench_kernel_us(
-            _run_stage1,
-            warmup=int(num_warmup),
-            iters=int(max(1, num_iters)),
-            flush_l2=bool(flush_l2),
-            prep_fn=_prep_stage1,
-        )
-        torch.cuda.synchronize()
-    else:
-        _, us = run_perftest(
-            launch,
-            out,
-            x_q,
-            w_kernel,
-            scale_x_1d,
-            scale_w1_1d,
-            sorted_token_ids,
-            sorted_expert_ids,
-            sorted_weights_1d,
-            num_iters=int(num_iters),
-            num_warmup=int(num_warmup),
-            testGraph=test_graph,
-        )
+    us = _bench_kernel_us(
+        _run_stage1,
+        warmup=int(num_warmup),
+        iters=int(max(1, num_iters)),
+        flush_l2=bool(flush_l2),
+        prep_fn=_prep_stage1,
+    )
     torch.cuda.synchronize()
+
+    if _is_splitk:
+        # Post-reduction: silu(gate) * up -> pack to [tokens, topk, inter_dim] (doweight_stage1 forced off).
+        _part_f32 = out_kernel.to(torch.float32).view(tokens, topk, 2 * inter_dim)
+        _gate = _part_f32[:, :, :inter_dim]
+        _up = _part_f32[:, :, inter_dim:]
+        _silu_gate = _gate * torch.sigmoid(_gate)
+        _reduced = _silu_gate * _up  # [tokens, topk, inter_dim]
+        out.copy_(_reduced.to(torch.float16))
 
     if not bool(skip_ref):
         if in_dtype == "fp8":
@@ -461,54 +547,47 @@ def run_moe_stage1(
 
         rtol = 0.5 if (is_a8w4 or is_fp4) else 0.25
         atol = 0.5 if is_a8w4 else 0.25
-        assert verify_output(out.to(torch.float32), ref, rtol=rtol, atol=atol)
+        logits_thr = 1.0 if (is_a8w4 or is_fp4) else 2e-3
+        assert verify_output(out.to(torch.float32), ref, rtol=rtol, atol=atol,
+                             logits_diff_threshold=logits_thr)
 
     # Note: kernel launches full expert-block range; effective work is gated by num_valid_ids.
     flops = 2 * tokens * topk * (2 * inter_dim) * _orig_model_dim
-    tflops = flops / (us / 1e6) / 1e12
 
-    # Rough bytes-moved accounting (same spirit as GEMM tests: count each tensor once).
-    bytes_moved = 0
-    bytes_x = tokens * _orig_model_dim  # 1B elements (fp4/fp8/a8w4)
-    bytes_w = (experts * (2 * inter_dim) * _orig_model_dim) // (2 if is_a8w4 else 1)
-    bytes_out = tokens * topk * inter_dim * 2
-    bytes_scale_x = tokens * 4
-    bytes_scale_w = experts * (2 * inter_dim) * 4
-    bytes_route = (
-        int(sorted_weights.numel()) * 4
-        + int(sorted_token_ids.numel()) * 4
-        + int(sorted_expert_ids.numel()) * 4
-    )
-    bytes_moved += bytes_x + bytes_w + bytes_out + bytes_scale_x + bytes_scale_w + bytes_route
-    tbps = bytes_moved / 1e12 / (us / 1e6)
-    read_bytes = bytes_x + bytes_w + bytes_scale_x + bytes_scale_w + bytes_route
+    (
+        bytes_moved,
+        bytes_x,
+        bytes_w,
+        bytes_scale_w,
+        bytes_out,
+        active_experts,
+    ) = _bench_stage1_byte_breakdown(tokens, _orig_model_dim, inter_dim, experts, topk, in_dtype)
+    read_bytes = bytes_moved - bytes_out
     write_bytes = bytes_out
-    read_bw_gbs = read_bytes / 1e9 / (us / 1e6)
-    write_bw_gbs = write_bytes / 1e9 / (us / 1e6)
+    tflops, tbps, read_bw_gbs, write_bw_gbs = _perf_metrics_from_us(
+        us,
+        flops=flops,
+        bytes_moved=bytes_moved,
+        read_bytes=read_bytes,
+        write_bytes=write_bytes,
+    )
 
-    if bool(benchmark_mode):
-        print(
-            f"FlyDSL MoE stage1[{in_dtype}] benchmark | "
-            f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
-            f"tile=({tile_m},{tile_n},{tile_k})"
-        )
-        print(
-            f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
-            f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
-        )
-        print(
-            f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
-            f"bytes: x={bytes_x/1e6:.1f}MB w={bytes_w/1e6:.1f}MB "
-            f"sx={bytes_scale_x/1e6:.1f}MB sw={bytes_scale_w/1e6:.1f}MB "
-            f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
-        )
-    else:
-        print(
-            f"FlyDSL MoE stage1[{in_dtype}]: "
-            f"{us:.1f} us, "
-            f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}), "
-            f"{tbps:.3f} TB/s (doweight_stage1={doweight_stage1})"
-        )
+    print(
+        f"FlyDSL MoE stage1[{in_dtype}] benchmark | "
+        f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
+        f"tile=({tile_m},{tile_n},{tile_k})"
+    )
+    print(
+        f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
+        f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
+    )
+    print(
+        f"  bandwidth(logical active_E={active_experts}): "
+        f"read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
+        f"bytes: x={bytes_x/1e6:.1f}MB w={bytes_w/1e6:.1f}MB "
+        f"sw={bytes_scale_w/1e6:.1f}MB out={bytes_out/1e6:.1f}MB "
+        f"total={bytes_moved/1e6:.1f}MB"
+    )
     if return_outputs:
         return out, us
     return None
@@ -546,12 +625,11 @@ def run_moe_stage2(
     kernel_name: str = "moe_gemm2",
     use_reduce: bool = False,
     use_valid_mask: bool = False,
-    test_graph: bool = False,
     waves_per_eu: Optional[int] = None,
-    benchmark_mode: bool = False,
     flush_l2: bool = True,
     num_buffers: int = 1,
     use_tdm_gather: bool = True,
+    use_tdm_gather_as: bool = True,
     use_tdm_store: bool = False,
     inst_prefetch: bool = False,
     wave_specialized_tdm: bool = False,
@@ -611,7 +689,13 @@ def run_moe_stage2(
 
     # Routing: deterministic torch topk + softmax.
     if topk_ids_in is None or topk_weights_in is None:
-        score = torch.rand((tokens, experts), device=device, dtype=torch.float32)
+        score = torch.zeros((tokens, experts), device=device, dtype=torch.float32)
+        start_col = 0
+        end_col = topk
+        for token_id in range(tokens):
+            score[token_id, start_col:end_col] = 1.0
+            start_col = end_col % experts
+            end_col = start_col + topk
         topk_vals, topk_ids = torch.topk(score, k=topk, dim=1)
         topk_weights = torch.softmax(topk_vals, dim=1).to(torch.float32)
     else:
@@ -719,8 +803,11 @@ def run_moe_stage2(
                 inter_dim=inter_dim, doweight_stage1=bool(doweight_stage1),
             )
         else:
+            # For a8w4 the activation is fp8 stored as raw uint8 bytes; the shared
+            # ref helper detects fp8 via dtype, so view it as torch.float8_e4m3fn here.
+            x_q_for_ref = x_q.view(torch.float8_e4m3fn) if is_a8w4 else x_q
             out1_ref = torch_moe_gemm1(
-                x_q,
+                x_q_for_ref,
                 w1_q_flat,
                 scale_x,
                 scale_w1_flat,
@@ -792,6 +879,7 @@ def run_moe_stage2(
         doweight_stage2=bool(doweight_stage2),
         num_buffers=int(num_buffers),
         use_tdm_gather=bool(use_tdm_gather),
+        use_tdm_gather_as=bool(use_tdm_gather_as),
         use_tdm_store=bool(use_tdm_store),
         inst_prefetch=bool(inst_prefetch),
         wave_specialized_tdm=bool(wave_specialized_tdm),
@@ -809,6 +897,13 @@ def run_moe_stage2(
         compile_kwargs.pop("waves_per_eu", None)
         exe = compile_fn(**compile_kwargs)
     is_reduce_exe = (getattr(exe, "mode", None) == MoeGemm2Mode.REDUCE) or bool(use_reduce)
+
+    # Empty bias slot -- the gfx1250 mxscale stage2 kernel keeps
+    # ``arg_bias`` as a stable positional even when compiled with
+    # ``enable_bias=False``; pass an empty fp32 tensor (it is never read).
+    # In reduce mode, ``_MoeGemm2ReduceWrapper.__call__`` takes ``arg_bias``
+    # as a kwarg (so we don't have to interleave it with valid_mask/stream).
+    _empty_bias_s2 = torch.empty(0, device=out_perf.device, dtype=torch.float32)
 
     def launch(o, x, w, sx, sw, st, eids, sw_sorted):
         stream = torch.cuda.current_stream()
@@ -833,6 +928,7 @@ def run_moe_stage2(
                 int(blocks),
                 valid_mask,
                 stream,
+                arg_bias=_empty_bias_s2,
             )
         else:
             # Atomic mode does not take valid_mask.
@@ -846,6 +942,7 @@ def run_moe_stage2(
                 eids,
                 sw_sorted,
                 num_valid_ids,
+                _empty_bias_s2,
                 tokens,
                 model_dim,
                 inter_dim,
@@ -853,33 +950,11 @@ def run_moe_stage2(
                 stream,
             )
  
-    if bool(benchmark_mode) and not bool(test_graph):
-        def _prep_stage2():
-            out_perf.zero_()
+    def _prep_stage2():
+        out_perf.zero_()
 
-        def _run_stage2():
-            launch(
-                out_perf,
-                a2_q.view(-1),
-                w2_kernel.view(-1),
-                a2_scale_1d,
-                w2_scale_1d,
-                sorted_token_ids,
-                sorted_expert_ids,
-                sorted_weights_1d,
-            )
-
-        us = _bench_kernel_us(
-            _run_stage2,
-            warmup=int(num_warmup),
-            iters=int(max(1, num_iters)),
-            flush_l2=bool(flush_l2),
-            prep_fn=_prep_stage2,
-        )
-        torch.cuda.synchronize()
-    else:
-        _, us = run_perftest(
-            launch,
+    def _run_stage2():
+        launch(
             out_perf,
             a2_q.view(-1),
             w2_kernel.view(-1),
@@ -888,10 +963,15 @@ def run_moe_stage2(
             sorted_token_ids,
             sorted_expert_ids,
             sorted_weights_1d,
-            num_iters=int(num_iters),
-            num_warmup=int(num_warmup),
-            testGraph=test_graph,
         )
+
+    us = _bench_kernel_us(
+        _run_stage2,
+        warmup=int(num_warmup),
+        iters=int(max(1, num_iters)),
+        flush_l2=bool(flush_l2),
+        prep_fn=_prep_stage2,
+    )
     torch.cuda.synchronize()
 
     # Correctness run (single launch into a clean zeroed output).
@@ -922,7 +1002,7 @@ def run_moe_stage2(
             )
         elif in_dtype == "fp8":
             a2_dequant = _dequant_blockscale_fp8(a2_q.view(-1, inter_dim), a2_scale.reshape(-1, inter_dim // 32))
-            a2_dequant = a2_dequant.view(a2_q.shape[0], a2_q.shape[1], inter_dim)
+            a2_dequant = a2_dequant.view(tokens, topk, inter_dim)
             w2_dequant = _dequant_blockscale_fp8(
                 w2_q.view(experts * model_dim, inter_dim),
                 scale_w2.view(experts * model_dim, inter_dim // 32),
@@ -936,7 +1016,7 @@ def run_moe_stage2(
             a2_dequant = _dequant_blockscale_fp4(
                 a2_q.view(-1, inter_dim // 2), a2_scale.reshape(-1, inter_dim // 32), inter_dim
             )
-            a2_dequant = a2_dequant.view(a2_q.shape[0], a2_q.shape[1], inter_dim)
+            a2_dequant = a2_dequant.view(tokens, topk, inter_dim)
             w2_dequant = _dequant_blockscale_fp4(
                 w2_q.view(experts * model_dim, inter_dim // 2),
                 scale_w2.view(experts * model_dim, inter_dim // 32),
@@ -947,51 +1027,46 @@ def run_moe_stage2(
                 topk_ids.to(torch.int64), topk_weights,
                 model_dim=model_dim, doweight_stage2=doweight_stage2,
             )
-        assert verify_output(out.to(torch.float32), ref2, rtol=0.5, atol=0.5)
+        logits_thr2 = 1.0 if (is_a8w4 or is_fp4) else 2e-3
+        assert verify_output(out.to(torch.float32), ref2, rtol=0.5, atol=0.5,
+                             logits_diff_threshold=logits_thr2)
 
     # Launches full expert-block range; effective work is gated by num_valid_ids.
     flops = 2 * tokens * topk * model_dim * _orig_inter_dim
-    tflops = flops / (us / 1e6) / 1e12
 
-    bytes_moved = 0
-    bytes_a2 = tokens * topk * _orig_inter_dim  # 1B elements (fp4/fp8/a8w4)
-    bytes_w2 = (experts * model_dim * _orig_inter_dim) // (2 if is_a8w4 else 1)
-    bytes_out = tokens * model_dim * (2 if out_torch_dtype == torch.float16 else 4)
-    bytes_scale_a2 = tokens * topk * 4
-    bytes_scale_w2 = experts * model_dim * 4
-    bytes_route = (
-        int(sorted_weights.numel()) * 4
-        + int(sorted_token_ids.numel()) * 4
-        + int(sorted_expert_ids.numel()) * 4
-    )
-    bytes_moved += bytes_a2 + bytes_w2 + bytes_out + bytes_scale_a2 + bytes_scale_w2 + bytes_route
-    tbps = bytes_moved / 1e12 / (us / 1e6)
-    read_bytes = bytes_a2 + bytes_w2 + bytes_scale_a2 + bytes_scale_w2 + bytes_route
+    (
+        bytes_moved,
+        bytes_a2,
+        bytes_w2,
+        bytes_scale_w2,
+        bytes_out,
+        active_experts,
+    ) = _bench_stage2_byte_breakdown(tokens, model_dim, _orig_inter_dim, experts, topk, in_dtype)
+    read_bytes = bytes_moved - bytes_out
     write_bytes = bytes_out
-    read_bw_gbs = read_bytes / 1e9 / (us / 1e6)
-    write_bw_gbs = write_bytes / 1e9 / (us / 1e6)
-    if bool(benchmark_mode):
-        print(
-            f"FlyDSL MoE stage2[{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} benchmark | "
-            f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
-            f"tile=({tile_m},{tile_n},{tile_k})"
-        )
-        print(
-            f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
-            f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
-        )
-        print(
-            f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
-            f"bytes: a2={bytes_a2/1e6:.1f}MB w2={bytes_w2/1e6:.1f}MB "
-            f"sa2={bytes_scale_a2/1e6:.1f}MB sw2={bytes_scale_w2/1e6:.1f}MB "
-            f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
-        )
-    else:
-        print(
-            f"FlyDSL MoE stage2 [{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} | "
-            f"{model_dim}x{inter_dim}, E={experts}, K={topk}, M_eff={tokens*topk} | "
-            f"{us:.1f} us, {tflops:.2f} TFLOPS, {tbps:.3f} TB/s"
-        )
+    tflops, tbps, read_bw_gbs, write_bw_gbs = _perf_metrics_from_us(
+        us,
+        flops=flops,
+        bytes_moved=bytes_moved,
+        read_bytes=read_bytes,
+        write_bytes=write_bytes,
+    )
+    print(
+        f"FlyDSL MoE stage2[{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} benchmark | "
+        f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
+        f"tile=({tile_m},{tile_n},{tile_k})"
+    )
+    print(
+        f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
+        f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
+    )
+    print(
+        f"  bandwidth(logical active_E={active_experts}): "
+        f"read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
+        f"bytes: a2={bytes_a2/1e6:.1f}MB w2={bytes_w2/1e6:.1f}MB "
+        f"sw2={bytes_scale_w2/1e6:.1f}MB out={bytes_out/1e6:.1f}MB "
+        f"total={bytes_moved/1e6:.1f}MB"
+    )
     # Print profile breakdown if the executor supports it
     if hasattr(exe, 'print_profile_stats'):
         exe.print_profile_stats()
@@ -1017,7 +1092,6 @@ def run_moe_gemm_2stage(
     out_dtype: str,
     use_reduce: bool,
     use_valid_mask: bool,
-    test_graph: bool,
     *,
     seed: int = 0,
     num_iters: int = 5,
@@ -1026,9 +1100,9 @@ def run_moe_gemm_2stage(
     init_scale: float = 1.0,
     skip_ref: bool = False,
     w_fp4_kernel: bool = False,
-    benchmark_mode: bool = False,
     flush_l2: bool = True,
     num_buffers: int = 1,
+    use_tdm_gather_as: bool = True,
     use_tdm_store: bool = False,
     inst_prefetch: bool = False,
     wave_specialized_tdm: bool = False,
@@ -1062,7 +1136,13 @@ def run_moe_gemm_2stage(
     w1_fp32 = torch.randn((experts, 2 * inter_dim, model_dim), device=device, dtype=torch.float32) * s
     w2_fp32 = torch.randn((experts, model_dim, inter_dim), device=device, dtype=torch.float32) * (s / math.sqrt(inter_dim))
 
-    score = torch.rand((tokens, experts), device=device, dtype=torch.float32)
+    score = torch.zeros((tokens, experts), device=device, dtype=torch.float32)
+    start_col = 0
+    end_col = topk
+    for token_id in range(tokens):
+        score[token_id, start_col:end_col] = 1.0
+        start_col = end_col % experts
+        end_col = start_col + topk
     topk_vals, topk_ids = torch.topk(score, k=topk, dim=1)
     topk_weights = torch.softmax(topk_vals, dim=1).to(torch.float32)
 
@@ -1100,10 +1180,9 @@ def run_moe_gemm_2stage(
         routing_in=routing,
         return_outputs=True,
         skip_ref=bool(skip_ref),
-        test_graph=test_graph,
-        benchmark_mode=bool(benchmark_mode),
         flush_l2=bool(flush_l2),
         num_buffers=int(num_buffers),
+        use_tdm_gather_as=bool(use_tdm_gather_as),
         use_tdm_store=bool(use_tdm_store),
         inst_prefetch=bool(inst_prefetch),
         wave_specialized_tdm=bool(wave_specialized_tdm),
@@ -1145,10 +1224,9 @@ def run_moe_gemm_2stage(
         skip_ref=bool(skip_ref),
         use_reduce=bool(use_reduce),
         use_valid_mask=use_valid_mask,
-        test_graph=test_graph,
-        benchmark_mode=bool(benchmark_mode),
         flush_l2=bool(flush_l2),
         num_buffers=int(num_buffers),
+        use_tdm_gather_as=bool(use_tdm_gather_as),
         use_tdm_store=bool(use_tdm_store),
         inst_prefetch=bool(inst_prefetch),
         wave_specialized_tdm=bool(wave_specialized_tdm),
@@ -1181,6 +1259,7 @@ def _make_reduce_mode_compile_fn(use_flydsl_reduce: bool = True, use_valid_mask:
         expert_sched_mode: bool = True,
         num_buffers: int = 1,
         use_tdm_gather: bool = True,
+        use_tdm_gather_as: bool = True,
         use_tdm_store: bool = False,
         inst_prefetch: bool = False,
         wave_specialized_tdm: bool = False,
@@ -1206,6 +1285,7 @@ def _make_reduce_mode_compile_fn(use_flydsl_reduce: bool = True, use_valid_mask:
                 expert_sched_mode=bool(expert_sched_mode),
                 num_buffers=int(num_buffers),
                 use_tdm_gather=bool(use_tdm_gather),
+                use_tdm_gather_as=bool(use_tdm_gather_as),
                 use_tdm_store=bool(use_tdm_store),
                 inst_prefetch=bool(inst_prefetch),
                 wave_specialized_tdm=bool(wave_specialized_tdm),
@@ -1229,6 +1309,7 @@ def _make_reduce_mode_compile_fn(use_flydsl_reduce: bool = True, use_valid_mask:
                 expert_sched_mode=bool(expert_sched_mode),
                 num_buffers=int(num_buffers),
                 use_tdm_gather=bool(use_tdm_gather),
+                use_tdm_gather_as=bool(use_tdm_gather_as),
                 use_tdm_store=bool(use_tdm_store),
                 inst_prefetch=bool(inst_prefetch),
                 wave_specialized_tdm=bool(wave_specialized_tdm),
@@ -1332,189 +1413,58 @@ def _prepare_a2_from_stage1(out1_fp16, in_dtype, tokens, topk, inter_dim,
 
 
 
-def test_moe_stage1_use_tdm_gather_smoke():
-    """Stage1 should support toggling A TDM gather without changing numerics on padded routes."""
-    tokens = 5
-    model_dim = 256
-    inter_dim = 128
-    experts = 1
-    topk = 1
-    tile_m = 16
-    tile_n = 64
-    tile_k = 128
+# ---------------------------------------------------------------------------
+# Consolidated smoke test: 3 stages x 3 MXScale dtypes = 9 cases vs torch ref.
+# Tiny shape (tokens=64, model=256, inter=128, E=4, topk=2) for fast iteration.
+# ---------------------------------------------------------------------------
 
-    device = torch.device("cuda")
-    torch.manual_seed(0)
-    x_fp32 = torch.randn((tokens, model_dim), device=device, dtype=torch.float32)
-    w1_fp32 = torch.randn((experts, 2 * inter_dim, model_dim), device=device, dtype=torch.float32)
-    topk_ids = torch.zeros((tokens, topk), device=device, dtype=torch.int64)
-    topk_weights = torch.ones((tokens, topk), device=device, dtype=torch.float32)
-    routing = build_routing_buffers(
-        topk_ids=topk_ids,
-        topk_weights=topk_weights,
-        experts=experts,
-        model_dim=model_dim,
-        tile_m=tile_m,
-        moe_sort_mode="torch",
-    )
-
-    common_args = dict(
-        tokens=tokens,
-        model_dim=model_dim,
-        inter_dim=inter_dim,
-        experts=experts,
-        topk=topk,
-        tile_m=tile_m,
-        tile_n=tile_n,
-        tile_k=tile_k,
-        doweight_stage1=False,
-        in_dtype="fp8",
-        seed=123,
-        num_iters=1,
-        num_warmup=1,
-        moe_sort_mode="torch",
-        x_fp32_in=x_fp32,
-        w1_fp32_in=w1_fp32,
-        topk_ids_in=topk_ids,
-        topk_weights_in=topk_weights,
-        routing_in=routing,
-        return_outputs=True,
-        skip_ref=True,
-    )
-
-    out_scalar, _ = run_moe_stage1(
-        **common_args,
-        use_tdm_gather=False,
-    )
-    out_gather, _ = run_moe_stage1(
-        **common_args,
-        use_tdm_gather=True,
-    )
-
-    assert torch.isfinite(out_scalar).all()
-    assert torch.isfinite(out_gather).all()
-    assert verify_output(out_gather.to(torch.float32), out_scalar.to(torch.float32), rtol=0.5, atol=0.5)
-
-
-def test_moe_stage2_use_tdm_gather_smoke():
-    """Stage2 should support toggling A TDM gather without changing numerics."""
-    tokens = 32
-    model_dim = 256
-    inter_dim = 128
-    experts = 4
-    topk = 2
-    tile_m = 16
-    tile_n = 64
-    tile_k = 128
-
-    torch.manual_seed(0)
-    a2_fp32 = torch.randn((tokens, topk, inter_dim), device="cuda", dtype=torch.float32)
-    a2_q, a2_scale = _per_1x32_fp8_quant(a2_fp32)
-
-    common_args = dict(
-        tokens=tokens,
-        model_dim=model_dim,
-        inter_dim=inter_dim,
-        experts=experts,
-        topk=topk,
-        tile_m=tile_m,
-        tile_n=tile_n,
-        tile_k=tile_k,
-        doweight_stage1=False,
-        in_dtype="fp8",
-        out_dtype="f16",
-        seed=123,
-        num_iters=1,
-        num_warmup=1,
-        return_outputs=True,
-        skip_ref=True,
-        a2_fp8_in=a2_q,
-        a2_scale_in=a2_scale,
-    )
-
-    out_scalar, _ = run_moe_stage2(
-        **common_args,
-        use_tdm_gather=False,
-    )
-    out_gather, _ = run_moe_stage2(
-        **common_args,
-        use_tdm_gather=True,
-    )
-
-    assert torch.isfinite(out_scalar).all()
-    assert torch.isfinite(out_gather).all()
-    assert verify_output(out_gather.to(torch.float32), out_scalar.to(torch.float32), rtol=0.5, atol=0.5)
-
-
-def test_moe_stage2_use_tdm_gather_padding_smoke():
-    """Stage2 gather should match scalar load on deterministic padding-heavy routing."""
-    tokens = 5
-    model_dim = 256
-    inter_dim = 128
-    experts = 1
-    topk = 2
-    tile_m = 16
-    tile_n = 64
-    tile_k = 128
-
-    device = torch.device("cuda")
-    torch.manual_seed(1)
-    a2_fp32 = torch.randn((tokens, topk, inter_dim), device=device, dtype=torch.float32)
-    a2_q, a2_scale = _per_1x32_fp8_quant(a2_fp32)
-    x_fp32 = torch.randn((tokens, model_dim), device=device, dtype=torch.float32)
-    w1_fp32 = torch.randn((experts, 2 * inter_dim, model_dim), device=device, dtype=torch.float32)
-    w2_fp32 = torch.randn((experts, model_dim, inter_dim), device=device, dtype=torch.float32)
-    topk_ids = torch.zeros((tokens, topk), device=device, dtype=torch.int64)
-    topk_weights = torch.tensor([[0.75, 0.25]], device=device, dtype=torch.float32).expand(tokens, topk).contiguous()
-    routing = build_routing_buffers(
-        topk_ids=topk_ids,
-        topk_weights=topk_weights,
-        experts=experts,
-        model_dim=model_dim,
-        tile_m=tile_m,
-        moe_sort_mode="torch",
-    )
-
-    common_args = dict(
-        tokens=tokens,
-        model_dim=model_dim,
-        inter_dim=inter_dim,
-        experts=experts,
-        topk=topk,
-        tile_m=tile_m,
-        tile_n=tile_n,
-        tile_k=tile_k,
-        doweight_stage1=False,
-        in_dtype="fp8",
-        out_dtype="f16",
-        seed=321,
-        num_iters=1,
-        num_warmup=1,
-        moe_sort_mode="torch",
-        x_fp32_in=x_fp32,
-        w1_fp32_in=w1_fp32,
-        w2_fp32_in=w2_fp32,
-        topk_ids_in=topk_ids,
-        topk_weights_in=topk_weights,
-        routing_in=routing,
-        a2_fp8_in=a2_q,
-        a2_scale_in=a2_scale,
-        return_outputs=True,
-        skip_ref=True,
-    )
-
-    out_scalar, _ = run_moe_stage2(
-        **common_args,
-        use_tdm_gather=False,
-    )
-    out_gather, _ = run_moe_stage2(
-        **common_args,
-        use_tdm_gather=True,
-    )
-
-    assert torch.isfinite(out_scalar).all()
-    assert torch.isfinite(out_gather).all()
-    assert verify_output(out_gather.to(torch.float32), out_scalar.to(torch.float32), rtol=0.5, atol=0.5)
+@pytest.mark.parametrize("in_dtype", ["fp4", "fp8", "a8w4"])
+@pytest.mark.parametrize("stage", ["stage1", "stage2", "2stage"])
+def test_moe_smoke_ref(
+    stage: str,
+    in_dtype: str,
+    tokens: int = 64,
+    model_dim: int = 256,
+    inter_dim: int = 128,
+    experts: int = 4,
+    topk: int = 2,
+    tile_m: int = 16,
+    tile_n: int = 64,
+    tile_k: int = 128,
+):
+    """Smoke: stage1 / stage2 / 2-stage e2e vs torch reference for fp4/fp8/a8w4."""
+    if stage == "stage1":
+        run_moe_stage1(
+            tokens=tokens, model_dim=model_dim, inter_dim=inter_dim,
+            experts=experts, topk=topk,
+            tile_m=tile_m, tile_n=tile_n, tile_k=tile_k,
+            doweight_stage1=False,
+            in_dtype=in_dtype,
+            seed=0, num_iters=1, num_warmup=1,
+            skip_ref=False,
+        )
+    elif stage == "stage2":
+        run_moe_stage2(
+            tokens=tokens, model_dim=model_dim, inter_dim=inter_dim,
+            experts=experts, topk=topk,
+            tile_m=tile_m, tile_n=tile_n, tile_k=tile_k,
+            doweight_stage1=False,
+            in_dtype=in_dtype, out_dtype="f16",
+            seed=0, num_iters=1, num_warmup=1,
+            skip_ref=False,
+        )
+    else:  # "2stage"
+        run_moe_gemm_2stage(
+            tokens=tokens, model_dim=model_dim, inter_dim=inter_dim,
+            experts=experts, topk=topk,
+            tile_m=tile_m, tile_n1=tile_n, tile_k1=tile_k,
+            tile_n2=tile_n, tile_k2=tile_k,
+            doweight_stage1=False,
+            in_dtype=in_dtype, out_dtype="f16",
+            use_reduce=False, use_valid_mask=False,
+            seed=0, num_iters=1, num_warmup=1,
+            skip_ref=False,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1612,7 +1562,6 @@ def test_moe_2stage_fp4_wfp4_reduce_reference():
         use_reduce=True,
         use_tdm_store=False,
         w_fp4_kernel=True,
-        test_graph=False,
         use_valid_mask=False,
     )
 
@@ -1633,10 +1582,6 @@ def test_moe_2stage_fp4_wfp4_reduce_reference():
 @pytest.mark.parametrize("out_dtype", ["f16"], ids=["out_f16"])
 @pytest.mark.parametrize("use_reduce", [False, True], ids=["atomic", "reduce"])
 @pytest.mark.parametrize("use_valid_mask", [False, True], ids=["nomask", "mask"])
-@pytest.mark.parametrize("test_graph", [
-    pytest.param(False, id="eager"),
-    pytest.param(True, id="graph"),
-])
 def test_moe_gemm_2stage(
     tokens: int,
     model_dim: int,
@@ -1653,7 +1598,6 @@ def test_moe_gemm_2stage(
     out_dtype: str,
     use_reduce: bool,
     use_valid_mask: bool,
-    test_graph: bool,
 ):
     run_moe_gemm_2stage(
         tokens=tokens,
@@ -1671,7 +1615,6 @@ def test_moe_gemm_2stage(
         out_dtype=out_dtype,
         use_reduce=use_reduce,
         use_valid_mask=use_valid_mask,
-        test_graph=test_graph,
     )
 
 
@@ -1754,3 +1697,245 @@ def test_moe_stage2_standalone(
         use_valid_mask=True,
         kernel_name="moe_gemm2_reduce_flydsl_valid_mask",
     )
+
+
+if __name__ == "__main__":
+    torch.set_default_device("cuda")
+
+    def _str2bool(v):
+        if v is None:
+            return None
+        if isinstance(v, bool):
+            return v
+        s = str(v).strip().lower()
+        if s in {"1", "true", "t", "yes", "y", "on"}:
+            return True
+        if s in {"0", "false", "f", "no", "n", "off"}:
+            return False
+        raise argparse.ArgumentTypeError(f"invalid bool: {v} (use t/f, true/false, 1/0)")
+
+    def _str2tuple_dim(v: str) -> Tuple[int, int]:
+        s = str(v).strip()
+        parts = [p.strip() for p in s.split(",") if p.strip()]
+        if len(parts) != 2:
+            raise argparse.ArgumentTypeError(
+                f"invalid -dim {v!r}; expected 'model_dim,inter_dim' e.g. 256,128"
+            )
+        return int(parts[0]), int(parts[1])
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="MoE 2-stage (FlyDSL MXScale fp4/fp8/a8w4) test/benchmark on gfx1250.",
+    )
+    parser.add_argument(
+        "--in_dtype",
+        type=str,
+        default="fp8",
+        help="Kernel input dtype: fp4, fp8, a8w4, or all. Comma-separated values are also accepted.",
+    )
+    parser.add_argument(
+        "-dim",
+        type=_str2tuple_dim,
+        default=(256, 128),
+        help="Model dimension: model_dim,inter_dim (e.g. -dim 256,128)",
+    )
+    parser.add_argument("-t", "--tokenNum", type=int, default=64, help="Number of tokens (e.g. -t 64)")
+    parser.add_argument("-e", "--expert", type=int, default=4, help="Number of experts (e.g. -e 4)")
+    parser.add_argument("-k", "--topk", type=int, default=2, help="Top-k (e.g. -k 2)")
+    parser.add_argument(
+        "-s",
+        "--doweight_stage1",
+        type=_str2bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="Whether to multiply routed weight in stage1 (t/f).",
+    )
+    parser.add_argument("--tile_m", type=int, default=16, help="Tile M / block_m (routing block size).")
+    parser.add_argument("--tile_n", type=int, default=64, help="Stage1 tile N (inter dim tile).")
+    parser.add_argument("--tile_k", type=int, default=128, help="Stage1 tile K (model dim tile).")
+    parser.add_argument(
+        "--tile_n2",
+        type=int,
+        default=None,
+        help="Stage2 tile N (model dim tile). Default: tile_n.",
+    )
+    parser.add_argument(
+        "--tile_k2",
+        type=int,
+        default=None,
+        help="Stage2 tile K (inter dim tile). Default: tile_k.",
+    )
+    parser.add_argument(
+        "--moe_sort_mode",
+        type=str,
+        default=None,
+        choices=["aiter", "torch"],
+        help="Routing buffer build mode (aiter moe_sorting vs torch fallback).",
+    )
+    parser.add_argument(
+        "--skip_ref",
+        type=_str2bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="Skip torch reference correctness checks (benchmark-only).",
+    )
+    parser.add_argument(
+        "--compare_aiter_ck",
+        type=_str2bool,
+        nargs="?",
+        const=True,
+        default=None,
+        help="Compatibility flag accepted for parity with other MoE scripts; ignored here.",
+    )
+    parser.add_argument(
+        "--gemm2_mode",
+        type=str,
+        default="both",
+        choices=["both", "atomic", "reduce"],
+        help="Stage2 accumulation mode: 'atomic', 'reduce', or 'both' (default: both).",
+    )
+    parser.add_argument(
+        "--out_dtype",
+        type=str,
+        default="f16",
+        choices=["f16", "f32"],
+        help="Stage2 output dtype.",
+    )
+    parser.add_argument(
+        "--use_valid_mask",
+        type=_str2bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="Use valid mask for reduce mode.",
+    )
+    parser.add_argument(
+        "--w_fp4_kernel",
+        "--wfp4",
+        type=_str2bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="Use the fp4 stage2 weight path when supported.",
+    )
+    parser.add_argument(
+        "--no_flush_l2",
+        action="store_true",
+        default=False,
+        help="Disable L2 flush in benchmark timing.",
+    )
+    parser.add_argument(
+        "--num_buffers",
+        type=int,
+        default=1,
+        choices=[1, 2, 3, 4],
+        help="Requested MXScale pipeline buffers for gfx1250 MoE kernels.",
+    )
+    parser.add_argument(
+        "--use_tdm_store",
+        type=_str2bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="Requested TDM store epilogue for gfx1250 MoE kernels.",
+    )
+    parser.add_argument(
+        "--use_tdm_gather_as",
+        type=_str2bool,
+        nargs="?",
+        const=True,
+        default=True,
+        help="Enable TDM gather for A-scale loads in gfx1250 MoE kernels.",
+    )
+    parser.add_argument(
+        "--inst_prefetch",
+        type=_str2bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="Enable instruction prefetch for gfx1250 MoE kernels.",
+    )
+    parser.add_argument(
+        "--wave_specialized_tdm",
+        type=_str2bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="Enable wave-specialized TDM loading for gfx1250 MoE kernels.",
+    )
+    parser.add_argument("--cluster_m", type=int, default=1, help="Requested cluster_m for gfx1250 MoE kernels.")
+    parser.add_argument("--cluster_n", type=int, default=1, help="Requested cluster_n for gfx1250 MoE kernels.")
+    parser.add_argument("--seed", type=int, default=0, help="torch.manual_seed(seed)")
+    parser.add_argument("--num_iters", type=int, default=2, help="Benchmark iters")
+    parser.add_argument("--num_warmup", type=int, default=1, help="Benchmark warmup iters")
+
+    args = parser.parse_args()
+
+    if args.compare_aiter_ck is not None:
+        print("[note] --compare_aiter_ck is ignored by the MXScale gfx1250 harness.")
+
+    model_dim, inter_dim = args.dim
+    tile_n2 = int(args.tile_n2) if args.tile_n2 is not None else int(args.tile_n)
+    tile_k2 = int(args.tile_k2) if args.tile_k2 is not None else int(args.tile_k)
+
+    if args.gemm2_mode == "both":
+        reduce_flags = [False, True]
+    elif args.gemm2_mode == "reduce":
+        reduce_flags = [True]
+    else:
+        reduce_flags = [False]
+
+    in_dtypes = [dt.strip().lower() for dt in str(args.in_dtype).split(",") if dt.strip()]
+    if "all" in in_dtypes:
+        in_dtypes = ["fp4", "fp8", "a8w4"]
+    invalid_dtypes = sorted(set(in_dtypes) - {"fp4", "fp8", "a8w4"})
+    if invalid_dtypes:
+        raise SystemExit(f"unsupported --in_dtype values: {', '.join(invalid_dtypes)}")
+
+    common = dict(
+        tokens=int(args.tokenNum),
+        model_dim=int(model_dim),
+        inter_dim=int(inter_dim),
+        experts=int(args.expert),
+        topk=int(args.topk),
+        doweight_stage1=bool(args.doweight_stage1),
+        tile_m=int(args.tile_m),
+        seed=int(args.seed),
+        num_iters=int(args.num_iters),
+        num_warmup=int(args.num_warmup),
+        moe_sort_mode=args.moe_sort_mode,
+        skip_ref=bool(args.skip_ref),
+        flush_l2=not bool(args.no_flush_l2),
+        num_buffers=int(args.num_buffers),
+        use_tdm_gather_as=bool(args.use_tdm_gather_as),
+        use_tdm_store=bool(args.use_tdm_store),
+        inst_prefetch=bool(args.inst_prefetch),
+        wave_specialized_tdm=bool(args.wave_specialized_tdm),
+        cluster_m=int(args.cluster_m),
+        cluster_n=int(args.cluster_n),
+        w_fp4_kernel=bool(args.w_fp4_kernel),
+    )
+
+    def run_one(dt: str, use_reduce: bool):
+        try:
+            run_moe_gemm_2stage(
+                **common,
+                in_dtype=dt,
+                out_dtype=str(args.out_dtype),
+                tile_n1=int(args.tile_n),
+                tile_k1=int(args.tile_k),
+                tile_n2=tile_n2,
+                tile_k2=tile_k2,
+                use_reduce=use_reduce,
+                use_valid_mask=bool(args.use_valid_mask),
+            )
+        except pytest.skip.Exception as exc:
+            print(f"[skip] {exc}")
+            return
+        print(f"PASSED: dtype={dt} reduce={use_reduce}")
+
+    for dt in in_dtypes:
+        for use_reduce in reduce_flags:
+            run_one(dt, use_reduce)

--- a/tests/kernels/test_moe_gemm_wmma_gfx1250.py
+++ b/tests/kernels/test_moe_gemm_wmma_gfx1250.py
@@ -31,7 +31,7 @@ for _p in reversed(_PYTHON_CANDIDATES):
         sys.path.insert(0, _p)
 
 from tests.kernels.test_ref import torch_moe_gemm1, torch_moe_gemm2
-from tests.test_common import verify_output, run_perftest
+from tests.test_common import verify_output
 from flydsl.runtime.device import get_rocm_arch
 from tests.kernels.benchmark_common import (
     bench_kernel_us as _bench_kernel_us,
@@ -273,6 +273,26 @@ def build_routing_buffers(
     )
 
 
+def _perf_metrics_from_us(
+    us: Optional[float],
+    *,
+    flops: int,
+    bytes_moved: int,
+    read_bytes: int,
+    write_bytes: int,
+) -> Tuple[float, float, float, float]:
+    """Return throughput metrics, tolerating 0-us event timings for tiny kernels."""
+    if us is None or us <= 0:
+        return 0.0, 0.0, 0.0, 0.0
+    time_s = us / 1e6
+    return (
+        flops / time_s / 1e12,
+        bytes_moved / 1e12 / time_s,
+        read_bytes / 1e9 / time_s,
+        write_bytes / 1e9 / time_s,
+    )
+
+
 # ---- Stage1/Stage2 runners (helpers; NOT pytest tests) ----
 def run_moe_stage1(
     tokens: int,
@@ -297,9 +317,7 @@ def run_moe_stage1(
     routing_in: Optional[RoutingBuffers] = None,
     return_outputs: bool = False,
     skip_ref: bool = False,
-    test_graph: bool = False,
     waves_per_eu: Optional[int] = None,
-    benchmark_mode: bool = False,
     flush_l2: bool = True,
     num_buffers: int = 1,
     use_tdm_gather: bool = True,
@@ -420,36 +438,19 @@ def run_moe_stage1(
             stream,
         )
 
-    if bool(benchmark_mode) and not bool(test_graph):
-        def _prep_stage1():
-            out.zero_()
+    def _prep_stage1():
+        out.zero_()
 
-        def _run_stage1():
-            launch(out, x_q, w_kernel, scale_x_1d, scale_w1_1d, sorted_token_ids, sorted_expert_ids, sorted_weights_1d)
+    def _run_stage1():
+        launch(out, x_q, w_kernel, scale_x_1d, scale_w1_1d, sorted_token_ids, sorted_expert_ids, sorted_weights_1d)
 
-        us = _bench_kernel_us(
-            _run_stage1,
-            warmup=int(num_warmup),
-            iters=int(max(1, num_iters)),
-            flush_l2=bool(flush_l2),
-            prep_fn=_prep_stage1,
-        )
-        torch.cuda.synchronize()
-    else:
-        _, us = run_perftest(
-            launch,
-            out,
-            x_q,
-            w_kernel,
-            scale_x_1d,
-            scale_w1_1d,
-            sorted_token_ids,
-            sorted_expert_ids,
-            sorted_weights_1d,
-            num_iters=int(num_iters),
-            num_warmup=int(num_warmup),
-            testGraph=test_graph,
-        )
+    us = _bench_kernel_us(
+        _run_stage1,
+        warmup=int(num_warmup),
+        iters=int(max(1, num_iters)),
+        flush_l2=bool(flush_l2),
+        prep_fn=_prep_stage1,
+    )
     torch.cuda.synchronize()
 
     if not bool(skip_ref):
@@ -467,7 +468,6 @@ def run_moe_stage1(
 
     # Note: kernel launches full expert-block range; effective work is gated by num_valid_ids.
     flops = 2 * tokens * topk * (2 * inter_dim) * model_dim
-    tflops = flops / (us / 1e6) / 1e12
 
     # Rough bytes-moved accounting (same spirit as GEMM tests: count each tensor once).
     x_elem_bytes = 2
@@ -482,35 +482,31 @@ def run_moe_stage1(
         + int(sorted_expert_ids.numel()) * 4
     )
     bytes_moved = bytes_x + bytes_w + bytes_out + bytes_scale_x + bytes_scale_w + bytes_route
-    tbps = bytes_moved / 1e12 / (us / 1e6)
     read_bytes = bytes_x + bytes_w + bytes_scale_x + bytes_scale_w + bytes_route
     write_bytes = bytes_out
-    read_bw_gbs = read_bytes / 1e9 / (us / 1e6)
-    write_bw_gbs = write_bytes / 1e9 / (us / 1e6)
+    tflops, tbps, read_bw_gbs, write_bw_gbs = _perf_metrics_from_us(
+        us,
+        flops=flops,
+        bytes_moved=bytes_moved,
+        read_bytes=read_bytes,
+        write_bytes=write_bytes,
+    )
 
-    if bool(benchmark_mode):
-        print(
-            f"FlyDSL MoE stage1[{in_dtype}] benchmark | "
-            f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
-            f"tile=({tile_m},{tile_n},{tile_k})"
-        )
-        print(
-            f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
-            f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
-        )
-        print(
-            f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
-            f"bytes: x={bytes_x/1e6:.1f}MB w={bytes_w/1e6:.1f}MB "
-            f"sx={bytes_scale_x/1e6:.1f}MB sw={bytes_scale_w/1e6:.1f}MB "
-            f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
-        )
-    else:
-        print(
-            f"FlyDSL MoE stage1[{in_dtype}]: "
-            f"{us:.1f} us, "
-            f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}), "
-            f"{tbps:.3f} TB/s (doweight_stage1={doweight_stage1})"
-        )
+    print(
+        f"FlyDSL MoE stage1[{in_dtype}] benchmark | "
+        f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
+        f"tile=({tile_m},{tile_n},{tile_k})"
+    )
+    print(
+        f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
+        f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
+    )
+    print(
+        f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
+        f"bytes: x={bytes_x/1e6:.1f}MB w={bytes_w/1e6:.1f}MB "
+        f"sx={bytes_scale_x/1e6:.1f}MB sw={bytes_scale_w/1e6:.1f}MB "
+        f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
+    )
     if return_outputs:
         return out, us
     return None
@@ -548,9 +544,7 @@ def run_moe_stage2(
     kernel_name: str = "moe_gemm2",
     use_reduce: bool = False,
     use_valid_mask: bool = False,
-    test_graph: bool = False,
     waves_per_eu: Optional[int] = None,
-    benchmark_mode: bool = False,
     flush_l2: bool = True,
     num_buffers: int = 1,
     use_tdm_gather: bool = True,
@@ -778,36 +772,11 @@ def run_moe_stage2(
                 stream,
             )
  
-    # NOTE: stage2 uses atomic-add into `out`, so we cannot reuse the same output buffer
-    # across perf iterations for correctness. Time into a dedicated buffer, then run
-    # a single clean launch for correctness verification below.
-    if bool(benchmark_mode) and not bool(test_graph):
-        def _prep_stage2():
-            out_perf.zero_()
+    def _prep_stage2():
+        out_perf.zero_()
 
-        def _run_stage2():
-            launch(
-                out_perf,
-                a2_q.view(-1),
-                w2_kernel.view(-1),
-                a2_scale_1d,
-                w2_scale_1d,
-                sorted_token_ids,
-                sorted_expert_ids,
-                sorted_weights_1d,
-            )
-
-        us = _bench_kernel_us(
-            _run_stage2,
-            warmup=int(num_warmup),
-            iters=int(max(1, num_iters)),
-            flush_l2=bool(flush_l2),
-            prep_fn=_prep_stage2,
-        )
-        torch.cuda.synchronize()
-    else:
-        _, us = run_perftest(
-            launch,
+    def _run_stage2():
+        launch(
             out_perf,
             a2_q.view(-1),
             w2_kernel.view(-1),
@@ -816,10 +785,15 @@ def run_moe_stage2(
             sorted_token_ids,
             sorted_expert_ids,
             sorted_weights_1d,
-            num_iters=int(num_iters),
-            num_warmup=int(num_warmup),
-            testGraph=test_graph,
         )
+
+    us = _bench_kernel_us(
+        _run_stage2,
+        warmup=int(num_warmup),
+        iters=int(max(1, num_iters)),
+        flush_l2=bool(flush_l2),
+        prep_fn=_prep_stage2,
+    )
     torch.cuda.synchronize()
 
     # Correctness run (single launch into a clean zeroed output).
@@ -851,7 +825,6 @@ def run_moe_stage2(
 
     # Launches full expert-block range; effective work is gated by num_valid_ids.
     flops = 2 * tokens * topk * model_dim * inter_dim
-    tflops = flops / (us / 1e6) / 1e12
 
     a2_elem_bytes = 2
     bytes_a2 = tokens * topk * inter_dim * a2_elem_bytes
@@ -865,33 +838,30 @@ def run_moe_stage2(
         + int(sorted_expert_ids.numel()) * 4
     )
     bytes_moved = bytes_a2 + bytes_w2 + bytes_out + bytes_scale_a2 + bytes_scale_w2 + bytes_route
-    tbps = bytes_moved / 1e12 / (us / 1e6)
     read_bytes = bytes_a2 + bytes_w2 + bytes_scale_a2 + bytes_scale_w2 + bytes_route
     write_bytes = bytes_out
-    read_bw_gbs = read_bytes / 1e9 / (us / 1e6)
-    write_bw_gbs = write_bytes / 1e9 / (us / 1e6)
-    if bool(benchmark_mode):
-        print(
-            f"FlyDSL MoE stage2[{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} benchmark | "
-            f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
-            f"tile=({tile_m},{tile_n},{tile_k})"
-        )
-        print(
-            f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
-            f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
-        )
-        print(
-            f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
-            f"bytes: a2={bytes_a2/1e6:.1f}MB w2={bytes_w2/1e6:.1f}MB "
-            f"sa2={bytes_scale_a2/1e6:.1f}MB sw2={bytes_scale_w2/1e6:.1f}MB "
-            f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
-        )
-    else:
-        print(
-            f"FlyDSL MoE stage2 [{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} | "
-            f"{model_dim}x{inter_dim}, E={experts}, K={topk}, M_eff={tokens*topk} | "
-            f"{us:.1f} us, {tflops:.2f} TFLOPS, {tbps:.3f} TB/s"
-        )
+    tflops, tbps, read_bw_gbs, write_bw_gbs = _perf_metrics_from_us(
+        us,
+        flops=flops,
+        bytes_moved=bytes_moved,
+        read_bytes=read_bytes,
+        write_bytes=write_bytes,
+    )
+    print(
+        f"FlyDSL MoE stage2[{kernel_name}] {in_dtype} {'reduce' if use_reduce else 'atomic'} benchmark | "
+        f"shape=({tokens},{model_dim},{inter_dim}), E={experts}, K={topk}, "
+        f"tile=({tile_m},{tile_n},{tile_k})"
+    )
+    print(
+        f"  kernel: {us:.1f} us ({us / 1e3:.4f} ms) | "
+        f"{tflops:.2f} TFLOPS(logical, M={tokens*topk}) | {tbps:.3f} TB/s"
+    )
+    print(
+        f"  bandwidth: read {read_bw_gbs:.1f} GB/s + write {write_bw_gbs:.1f} GB/s | "
+        f"bytes: a2={bytes_a2/1e6:.1f}MB w2={bytes_w2/1e6:.1f}MB "
+        f"sa2={bytes_scale_a2/1e6:.1f}MB sw2={bytes_scale_w2/1e6:.1f}MB "
+        f"route={bytes_route/1e6:.1f}MB out={bytes_out/1e6:.1f}MB"
+    )
 
     # Print profile breakdown if the executor supports it
     if hasattr(exe, 'print_profile_stats'):
@@ -918,7 +888,6 @@ def run_moe_gemm_2stage(
     out_dtype: str,
     use_reduce: bool,
     use_valid_mask: bool,
-    test_graph: bool,
     *,
     seed: int = 0,
     num_iters: int = 5,
@@ -926,7 +895,6 @@ def run_moe_gemm_2stage(
     moe_sort_mode: Optional[str] = None,
     init_scale: float = 0.2,
     skip_ref: bool = False,
-    benchmark_mode: bool = False,
     flush_l2: bool = True,
     num_buffers: int = 1,
     use_tdm_store: bool = False,
@@ -967,8 +935,7 @@ def run_moe_gemm_2stage(
         x_fp32_in=x_fp32, w1_fp32_in=w1_fp32,
         topk_ids_in=topk_ids, topk_weights_in=topk_weights,
         routing_in=routing, return_outputs=True,
-        skip_ref=bool(skip_ref), test_graph=test_graph,
-        benchmark_mode=bool(benchmark_mode), flush_l2=bool(flush_l2),
+        skip_ref=bool(skip_ref), flush_l2=bool(flush_l2),
         num_buffers=int(num_buffers), use_tdm_store=bool(use_tdm_store),
         inst_prefetch=bool(inst_prefetch), wave_specialized_tdm=bool(wave_specialized_tdm),
         cluster_m=int(cluster_m), cluster_n=int(cluster_n),
@@ -1235,8 +1202,6 @@ if __name__ == "__main__":
     parser.add_argument("--use_valid_mask", type=_str2bool, nargs="?", const=True, default=False, help="Use valid mask for optimization when reduce or not.")
 
     # Benchmark knobs
-    parser.add_argument("--benchmark", action="store_true", default=False,
-                        help="Use GEMM-style per-iteration event timing with optional L2 flush.")
     parser.add_argument("--no_flush_l2", action="store_true", default=False,
                         help="Disable L2 flush in benchmark mode.")
     parser.add_argument("--num_buffers", type=int, default=1, choices=[1, 2, 3, 4],
@@ -1254,15 +1219,6 @@ if __name__ == "__main__":
     parser.add_argument("--seed", type=int, default=0, help="torch.manual_seed(seed)")
     parser.add_argument("--num_iters", type=int, default=2, help="Benchmark iters")
     parser.add_argument("--num_warmup", type=int, default=1, help="Benchmark warmup iters")
-
-    # graph mode test
-    parser.add_argument(
-        "--test_graph",
-        "-tg",
-        action="store_true",
-        default=False,
-        help="test with graph mode.",
-    )
 
     # ── Benchmark sweep mode (--bench) ──
     add_moe_bench_args(parser)
@@ -1302,8 +1258,6 @@ if __name__ == "__main__":
         seed=int(args.seed), num_iters=int(args.num_iters), num_warmup=int(args.num_warmup),
         moe_sort_mode=args.moe_sort_mode,
         skip_ref=bool(args.skip_ref),
-        test_graph=bool(args.test_graph),
-        benchmark_mode=bool(args.benchmark),
         flush_l2=not bool(args.no_flush_l2),
         num_buffers=int(args.num_buffers),
         use_tdm_store=bool(args.use_tdm_store),
@@ -1377,10 +1331,6 @@ def test_moe_2stage_waves_per_eu_smoke(waves_per_eu: int):
 @pytest.mark.parametrize("out_dtype", ["f16", "f32"], ids=["out_f16", "out_f32"])
 @pytest.mark.parametrize("use_reduce", [False, True], ids=["atomic", "reduce"])
 @pytest.mark.parametrize("use_valid_mask", [False, True], ids=["nomask", "mask"])
-@pytest.mark.parametrize("test_graph", [
-    pytest.param(False, id="eager"),
-    pytest.param(True, id="graph"),
-])
 def test_moe_gemm_2stage(
     tokens: int,
     model_dim: int,
@@ -1397,7 +1347,6 @@ def test_moe_gemm_2stage(
     out_dtype: str,
     use_reduce: bool,
     use_valid_mask: bool,
-    test_graph: bool,
 ):
     run_moe_gemm_2stage(
         tokens=tokens,
@@ -1415,5 +1364,4 @@ def test_moe_gemm_2stage(
         out_dtype=out_dtype,
         use_reduce=use_reduce,
         use_valid_mask=use_valid_mask,
-        test_graph=test_graph,
     )


### PR DESCRIPTION
…/test polish

Kernels
- moe_gemm_2stage_common_gfx1250.py: extend `_finalize_alloc_and_launch_2d` to accept `waves_per_eu`, `cluster`, and a 3D grid (`gz`); set `rocdl.waves_per_eu` / `rocdl.cluster_dims` on the gpu.func at finalize time. Add GPT-OSS SwiGLU helper (`_emit_swiglu`, alpha=1.702, limit=7.0) matching `aiter.fused_moe.swiglu`. Extend stage1 gate/up epilogue with optional bias path, activation kind ('silu'|'swiglu') and an LDS-cached `sorted_token_ids` fast path (single ds_read_b32 instead of per-row buffer_load). Add a split-K stage1 epilogue helper that emits per-slice bias scaling.
- moe_gemm_2stage_mxscale_gfx1250.py: large MXScale kernel rework wiring the new common helpers (bias/swiglu/LDS-tid/split-K) and matching TDM hoist plumbing.
- moe_gemm_2stage_wmma_gfx1250.py: drop the manual `s_setreg_imm32_b32 hwreg(26,4,1),1` inline asm; rely on the launcher to set `rocdl.waves_per_eu` instead of attaching it as a function attr.

Tests / benchmarks
- benchmark_common.py: rename speedup to `speedup_aiter_vs_flydsl` (flydsl/aiter ratio) so >1.0 means FlyDSL slower; add fallback for `tile_k1` and a K-padding tolerant `tile_k2` selection so `bench_resolve_tiles` does not return None on shapes that `run_moe_stage2` would otherwise auto-pad.
- test_moe_gemm_mxscale_gfx1250.py: extensive coverage updates (incl. the new `--w_fp4_kernel` / `--wfp4` alias, swiglu/bias paths, split-K reference, fp4 weight stage2 variants).
- test_moe_gemm_wmma_gfx1250.py: matching coverage updates for the WMMA path.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
