### PR TITLE
[Kernel][Dialect] Support RDNA 3 / 3.5 WMMA (PoC): fix atom + add baseline GEMM kernel

### DIFF
--- a/include/flydsl/Dialect/FlyROCDL/IR/MmaAtom.td
+++ b/include/flydsl/Dialect/FlyROCDL/IR/MmaAtom.td
@@ -90,4 +90,39 @@ def FlyROCDL_MmaOpGFX1250_WMMA : FlyROCL_MmaOp<"MmaOpGFX1250_WMMA", "gfx1250.wmm
   let genVerifyDecl = 1;
 }
 
+//===----------------------------------------------------------------------===//
+// MmaOp RDNA3 — WMMA wave32 (gfx1100/gfx1150)
+//
+// RDNA 3 / RDNA 3.5 expose a single 16x16x16 WMMA instruction family:
+//   F32 <- F16/F16, BF16/BF16
+//   F16 <- F16/F16
+//   BF16 <- BF16/BF16
+//   I32 <- IU8/IU8, IU4/IU4
+//
+// Operand layout uses the legacy "WMMA256bInsts" convention (lanes 0-15
+// hold all distinct K data; lanes 16-31 are populated by the LLVM AMDGPU
+// codegen with duplicates of the lower half).  M=N=K=16 is the only
+// supported shape; FP8/FP4/scaled/SWMMAC are gfx12+ only and rejected
+// by `verify`.
+//===----------------------------------------------------------------------===//
+
+def FlyROCDL_MmaOpRDNA3_WMMA : FlyROCL_MmaOp<"MmaOpRDNA3_WMMA", "rdna3.wmma", []> {
+  let parameters = (ins
+    "int32_t":$m,
+    "int32_t":$n,
+    "int32_t":$k,
+    "Type":$elemTyA,
+    "Type":$elemTyB,
+    "Type":$elemTyAcc
+  );
+  let assemblyFormat = "`<` custom<MNKDimensionList>($m, $n, $k) `,` `(` $elemTyA `,` $elemTyB `)` `->` $elemTyAcc `>`";
+
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "int32_t":$m, "int32_t":$n, "int32_t":$k, "Type":$elemTyA, "Type":$elemTyB, "Type":$elemTyAcc), [{
+      return $_get(elemTyA.getContext(), m, n, k, elemTyA, elemTyB, elemTyAcc);
+    }]>
+  ];
+  let genVerifyDecl = 1;
+}
+
 #endif // FLYROCDL_MMAATOM

--- a/kernels/rdna3_f16_gemm.py
+++ b/kernels/rdna3_f16_gemm.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""WMMA GEMM kernel for RDNA 3 / 3.5 (gfx1100/gfx1150, wave32).
+
+Atom-based PoC kernel using the FlyDSL Layout API + ``MmaOpRDNA3_WMMAType``.
+
+Differences from the existing :mod:`kernels.rdna_f16_gemm`:
+
+- Goes through ``fly.make_mma_atom`` / ``fly.gemm`` instead of raw
+  ``rocdl.wmma_*`` intrinsics. This exercises the new
+  ``MmaOpRDNA3_WMMAType`` and the corresponding TiledMma layout pipeline.
+- Targets ``gfx115*`` / ``gfx110*`` chips (Strix Point APUs and RDNA 3
+  desktop). RDNA 4 (gfx120x) and gfx1250 use the gfx1250 atom; pick those
+  via :func:`flydsl.expr.rocdl.universal.WMMA_GFX1250` if needed.
+
+Shapes:
+  - M=N=K=16 is one WMMA. The kernel stages multiple WMMAs by tiling the
+    atom over an ``atom_layout`` of shape ``(reg_m, reg_n, reg_k)``.
+  - Block is 32 threads = 1 wave32. The PoC uses a single warp per
+    workgroup; later passes can scale to multi-warp via additional
+    blocks in the X dim.
+
+Computes ``C[M,N] = A[M,K] @ B[N,K]^T``.
+"""
+
+import torch
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+
+
+WMMA_M = 16
+WMMA_N = 16
+WMMA_K = 16
+
+
+def create_rdna3_wmma_gemm_module(
+    M: int,
+    N: int,
+    K: int,
+    *,
+    in_dtype: str = "f16",
+    out_dtype: str = "f32",
+    reg_m: int = 1,
+    reg_n: int = 1,
+    reg_k: int = 1,
+):
+    """Build a single-warp RDNA 3 / 3.5 WMMA GEMM.
+
+    ``reg_m / reg_n / reg_k`` control how many 16x16x16 WMMAs each warp issues
+    along M / N / K. The block tile is therefore
+    ``(WMMA_M*reg_m, WMMA_N*reg_n, WMMA_K*reg_k)`` and the launch grid is
+    ``(M / (WMMA_M*reg_m), N / (WMMA_N*reg_n), 1)``.
+    """
+
+    BLOCK_M = WMMA_M * reg_m
+    BLOCK_N = WMMA_N * reg_n
+    BLOCK_K = WMMA_K * reg_k
+
+    assert M % BLOCK_M == 0, f"M={M} must be divisible by BLOCK_M={BLOCK_M}"
+    assert N % BLOCK_N == 0, f"N={N} must be divisible by BLOCK_N={BLOCK_N}"
+    assert K % BLOCK_K == 0, f"K={K} must be divisible by BLOCK_K={BLOCK_K}"
+
+    if in_dtype == "f16":
+        ab_dtype = fx.Float16
+    elif in_dtype == "bf16":
+        ab_dtype = fx.BFloat16
+    else:
+        raise ValueError(f"unsupported in_dtype={in_dtype} (must be 'f16' or 'bf16')")
+
+    if out_dtype == "f32":
+        acc_dtype = fx.Float32
+    elif out_dtype == "f16" and in_dtype == "f16":
+        acc_dtype = fx.Float16
+    elif out_dtype == "bf16" and in_dtype == "bf16":
+        acc_dtype = fx.BFloat16
+    else:
+        raise ValueError(
+            f"unsupported (in_dtype={in_dtype}, out_dtype={out_dtype}) combination; "
+            "RDNA 3 / 3.5 WMMA supports F32 acc with F16/BF16, and same-precision "
+            "F16 acc with F16, BF16 acc with BF16"
+        )
+
+    THREADS_PER_BLOCK = 32  # one wave32
+
+    @flyc.kernel
+    def gemm_kernel(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+    ):
+        tid = fx.thread_idx.x
+        bid_m = fx.block_idx.x
+        bid_n = fx.block_idx.y
+
+        A = fx.rocdl.make_buffer_tensor(A)
+        B = fx.rocdl.make_buffer_tensor(B)
+        C = fx.rocdl.make_buffer_tensor(C)
+
+        bA_all = fx.zipped_divide(A, (BLOCK_M, BLOCK_K))
+        bB_all = fx.zipped_divide(B, (BLOCK_N, BLOCK_K))
+        bC = fx.zipped_divide(C, (BLOCK_M, BLOCK_N))
+
+        bC = fx.slice(bC, (None, (bid_m, bid_n)))
+
+        # Use the explicit RDNA3 atom factory so the kernel is independent of
+        # the runtime arch (the auto-dispatching `fx.rocdl.WMMA` would also
+        # work on gfx115*/gfx110* but we want the test to pin the type).
+        mma_atom = fx.make_mma_atom(
+            fx.rocdl.WMMA_RDNA3(WMMA_M, WMMA_N, WMMA_K, ab_dtype, acc_dtype)
+        )
+        # Single warp per workgroup; reg_m / reg_n / reg_k atoms within.
+        tiled_mma = fx.make_tiled_mma(
+            mma_atom, fx.make_layout((1, 1, 1), (0, 0, 0))
+        )
+        thr_mma = tiled_mma.thr_slice(tid)
+
+        # Use the universal CDNA3 buffer-copy atom; on gfx115*/gfx110* the
+        # underlying V# flag word is patched for RDNA via
+        # `_get_buffer_flags()` in `flydsl/expr/buffer_ops.py`.
+        copy_bits = ab_dtype.width  # 16 bits for f16/bf16
+        copy_atom = fx.make_copy_atom(
+            fx.rocdl.BufferCopy(copy_bits), ab_dtype
+        )
+        copy_atom_c = fx.make_copy_atom(
+            fx.rocdl.BufferCopy(acc_dtype.width), acc_dtype
+        )
+        tiled_copy_A = fx.make_tiled_copy_A(copy_atom, tiled_mma)
+        tiled_copy_B = fx.make_tiled_copy_B(copy_atom, tiled_mma)
+        tiled_copy_C = fx.make_tiled_copy_C(copy_atom_c, tiled_mma)
+
+        thr_copy_A = tiled_copy_A.get_slice(tid)
+        thr_copy_B = tiled_copy_B.get_slice(tid)
+        thr_copy_C = tiled_copy_C.get_slice(tid)
+
+        copy_dst_C = thr_copy_C.partition_S(bC)
+
+        frag_C = thr_mma.make_fragment_C(bC)
+        copy_frag_C = thr_copy_C.retile(frag_C)
+
+        frag_C.fill(0)
+        for k_tile in fx.range_constexpr(K // BLOCK_K):
+            # Collapse the K-grid mode to one tile per iteration so the source
+            # tile remains rank-2 ((M_in, K_in)/(N_in, K_in)) for partitioning.
+            bA = fx.slice(bA_all, (None, (bid_m, k_tile)))
+            bB = fx.slice(bB_all, (None, (bid_n, k_tile)))
+
+            copy_src_A = thr_copy_A.partition_S(bA)
+            copy_src_B = thr_copy_B.partition_S(bB)
+
+            frag_A = thr_mma.make_fragment_A(bA)
+            frag_B = thr_mma.make_fragment_B(bB)
+            copy_frag_A = thr_copy_A.retile(frag_A)
+            copy_frag_B = thr_copy_B.retile(frag_B)
+
+            fx.copy(copy_atom, copy_src_A, copy_frag_A, pred=None)
+            fx.copy(copy_atom, copy_src_B, copy_frag_B, pred=None)
+            fx.gemm(mma_atom, frag_C, frag_A, frag_B, frag_C)
+
+        fx.copy(copy_atom_c, copy_frag_C, copy_dst_C, pred=None)
+
+    @flyc.jit
+    def launch_gemm(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        grid_m = M // BLOCK_M
+        grid_n = N // BLOCK_N
+        gemm_kernel(A, B, C).launch(
+            grid=(grid_m, grid_n, 1),
+            block=(THREADS_PER_BLOCK, 1, 1),
+            stream=stream,
+        )
+
+    return launch_gemm, BLOCK_M, BLOCK_N, BLOCK_K

--- a/kernels/rdna3_gemm.py
+++ b/kernels/rdna3_gemm.py
@@ -1,23 +1,36 @@
 #!/usr/bin/env python3
-"""Optimized WMMA GEMM kernel for RDNA 3 / 3.5 (gfx1100/gfx1150/gfx1151, wave32).
+"""PoC WMMA GEMM kernel for RDNA 3 / 3.5 (gfx1100/gfx1150/gfx1151, wave32).
 
-Builds on the atom-based path (``MmaOpRDNA3_WMMAType``) and applies the
-standard atom-API optimizations:
+Status: **PoC baseline** — exercises the atom path end-to-end at
+production-shape sizes (≤4096³). This is *not* a rocBLAS replacement.
+Reaches roughly **56% of rocBLAS hgemm at 4096³ on gfx1151** (Strix
+Halo iGPU, ≈30% of WMMA F16 peak). Missing optimizations relative to
+rocBLAS / `kernels.preshuffle_gemm` (CDNA reference):
+
+  * LDS bank-conflict XOR swizzle (estimated +5-10%)
+  * CShuffle epilogue for coalesced C write-back (+5%)
+  * Hot-loop scheduler hints (``fx.rocdl.sched_dsrd / sched_mfma``) (+5-10%)
+  * ``waves_per_eu`` / ``maxnreg`` occupancy tuning
+  * Tail-tile predication for non-aligned shapes
+
+The intent of this kernel is twofold: (a) demonstrate that the
+``MmaOpRDNA3_WMMAType`` atom path lowers correctly through
+``make_tiled_mma`` / ``make_tiled_copy`` for production-shape kernels,
+and (b) provide a starting baseline for follow-up perf work. For peak
+GEMM perf on RDNA 3 / 3.5 today, fall back to PyTorch/rocBLAS hgemm.
+
+Atom-API optimizations already applied here:
 
   * Multi-wave workgroup (2x2 wave layout = 4 wave32 = 128 threads).
   * Per-warp reg_m × reg_n WMMA tile (4x4 = 16 WMMAs per warp per K-step
     by default, giving a 64x64 output tile per warp).
-  * BLOCK = 128 x 128 x 32 (BLOCK_K = 2 x WMMA_K so each iteration issues
-    2 K-tiles' worth of WMMAs per warp).
+  * BLOCK = 128 × 128 × 32 (BLOCK_K = 2 × WMMA_K).
   * LDS staging for A and B with a 2-stage ping-pong buffer: each loop
     iteration writes the next K-tile into one half of LDS while reading
-    the current K-tile from the other half, then swaps. This keeps a
-    single barrier per iteration (instead of two for single-buffered).
+    the current K-tile from the other half, then swaps. Software
+    pipelining hides GMEM latency behind WMMA compute.
 
-Compared to ``kernels.rdna3_f16_gemm`` (single-wave PoC for atom
-validation), this kernel is intended as a production starting point on
-RDNA 3 / 3.5. Subsequent commits add software pipelining (overlapping
-GMEM prefetch with WMMA compute) and bank-conflict swizzle.
+For atom unit-tests at single-warp scope see ``kernels.rdna3_f16_gemm``.
 
 Computes ``C[M, N] = A[M, K] @ B[N, K]^T`` (B is supplied transposed,
 so both A and B are stored row-major contiguous along K).
@@ -44,9 +57,8 @@ def create_rdna3_gemm_module(
     reg_m: int = 4,
     reg_n: int = 4,
     reg_k: int = 2,
-    group_m: int = 1,
 ):
-    """Build an optimized RDNA 3 / 3.5 atom-based WMMA GEMM.
+    """Build the PoC RDNA 3 / 3.5 atom-based WMMA GEMM.
 
     Parameters
     ----------
@@ -58,10 +70,6 @@ def create_rdna3_gemm_module(
     reg_k : int
         Number of WMMA_K-sized K-tiles per workgroup loop iteration. Default 2,
         so BLOCK_K = 32.
-    group_m : int
-        Workgroup swizzle group size along M (Triton-style super-grouping)
-        for L2 locality. Default 1 (no swizzle). Empirically gfx1151 with
-        4 MB L2 doesn't benefit from this at 4096^3 — left as a tunable.
     """
     BLOCK_M = WMMA_M * reg_m * waves_m
     BLOCK_N = WMMA_N * reg_n * waves_n
@@ -93,7 +101,6 @@ def create_rdna3_gemm_module(
     THREADS_PER_BLOCK = NUM_WAVES * 32
     GRID_M = M // BLOCK_M
     GRID_N = N // BLOCK_N
-    EFFECTIVE_GROUP_M = min(group_m, GRID_M)
 
     # GMEM->LDS thread layout. Each thread loads a 128-bit vector
     # (val_per_thr f16 elements). thrs_col threads cover BLOCK_K, thrs_row
@@ -131,18 +138,8 @@ def create_rdna3_gemm_module(
         C: fx.Tensor,
     ):
         tid = fx.thread_idx.x
-        # Workgroup swizzle for L2 locality: visit EFFECTIVE_GROUP_M × GRID_N
-        # tiles in M-fast order, then advance EFFECTIVE_GROUP_M M-tiles.
-        # Triton-style "super-grouping". With EFFECTIVE_GROUP_M == 1 this
-        # degenerates to plain N-major linear scheduling (same correctness,
-        # no L2 reuse benefit).
-        pid = fx.block_idx.x
-        num_pid_in_group = EFFECTIVE_GROUP_M * GRID_N
-        group_id = pid // num_pid_in_group
-        first_pid_m = group_id * EFFECTIVE_GROUP_M
-        pid_in_group = pid % num_pid_in_group
-        bid_m = first_pid_m + (pid_in_group % EFFECTIVE_GROUP_M)
-        bid_n = pid_in_group // EFFECTIVE_GROUP_M
+        bid_m = fx.block_idx.x
+        bid_n = fx.block_idx.y
 
         A = fx.rocdl.make_buffer_tensor(A)
         B = fx.rocdl.make_buffer_tensor(B)
@@ -339,7 +336,7 @@ def create_rdna3_gemm_module(
         stream: fx.Stream = fx.Stream(None),
     ):
         gemm_kernel(A, B, C).launch(
-            grid=(GRID_M * GRID_N, 1, 1),
+            grid=(GRID_M, GRID_N, 1),
             block=(THREADS_PER_BLOCK, 1, 1),
             smem=LDS_BYTES,
             stream=stream,

--- a/kernels/rdna3_gemm.py
+++ b/kernels/rdna3_gemm.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Optimized WMMA GEMM kernel for RDNA 3 / 3.5 (gfx1100/gfx1150/gfx1151, wave32).
+
+Builds on the atom-based path (``MmaOpRDNA3_WMMAType``) and applies the
+standard atom-API optimizations:
+
+  * Multi-wave workgroup (2x2 wave layout = 4 wave32 = 128 threads).
+  * Per-warp reg_m × reg_n WMMA tile (4x4 = 16 WMMAs per warp per K-step
+    by default, giving a 64x64 output tile per warp).
+  * BLOCK = 128 x 128 x 32 (BLOCK_K = 2 x WMMA_K so each iteration issues
+    2 K-tiles' worth of WMMAs per warp).
+  * LDS staging for A and B with a 2-stage ping-pong buffer: each loop
+    iteration writes the next K-tile into one half of LDS while reading
+    the current K-tile from the other half, then swaps. This keeps a
+    single barrier per iteration (instead of two for single-buffered).
+
+Compared to ``kernels.rdna3_f16_gemm`` (single-wave PoC for atom
+validation), this kernel is intended as a production starting point on
+RDNA 3 / 3.5. Subsequent commits add software pipelining (overlapping
+GMEM prefetch with WMMA compute) and bank-conflict swizzle.
+
+Computes ``C[M, N] = A[M, K] @ B[N, K]^T`` (B is supplied transposed,
+so both A and B are stored row-major contiguous along K).
+"""
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+
+
+WMMA_M = 16
+WMMA_N = 16
+WMMA_K = 16
+
+
+def create_rdna3_gemm_module(
+    M: int,
+    N: int,
+    K: int,
+    *,
+    in_dtype: str = "f16",
+    out_dtype: str = "f32",
+    waves_m: int = 2,
+    waves_n: int = 2,
+    reg_m: int = 4,
+    reg_n: int = 4,
+    reg_k: int = 2,
+    group_m: int = 1,
+):
+    """Build an optimized RDNA 3 / 3.5 atom-based WMMA GEMM.
+
+    Parameters
+    ----------
+    waves_m, waves_n : int
+        Wave layout inside one workgroup. Default 2x2 = 4 wave32 = 128 threads.
+    reg_m, reg_n : int
+        Number of 16x16 WMMA atoms each warp issues along M / N per K-step.
+        Default 4x4 = 16 WMMAs/warp/K-step (64x64 per-warp output tile).
+    reg_k : int
+        Number of WMMA_K-sized K-tiles per workgroup loop iteration. Default 2,
+        so BLOCK_K = 32.
+    group_m : int
+        Workgroup swizzle group size along M (Triton-style super-grouping)
+        for L2 locality. Default 1 (no swizzle). Empirically gfx1151 with
+        4 MB L2 doesn't benefit from this at 4096^3 — left as a tunable.
+    """
+    BLOCK_M = WMMA_M * reg_m * waves_m
+    BLOCK_N = WMMA_N * reg_n * waves_n
+    BLOCK_K = WMMA_K * reg_k
+
+    assert M % BLOCK_M == 0, f"M={M} must be divisible by BLOCK_M={BLOCK_M}"
+    assert N % BLOCK_N == 0, f"N={N} must be divisible by BLOCK_N={BLOCK_N}"
+    assert K % BLOCK_K == 0, f"K={K} must be divisible by BLOCK_K={BLOCK_K}"
+
+    if in_dtype == "f16":
+        ab_dtype = fx.Float16
+    elif in_dtype == "bf16":
+        ab_dtype = fx.BFloat16
+    else:
+        raise ValueError(f"unsupported in_dtype={in_dtype}")
+
+    if out_dtype == "f32":
+        acc_dtype = fx.Float32
+    elif out_dtype == "f16" and in_dtype == "f16":
+        acc_dtype = fx.Float16
+    elif out_dtype == "bf16" and in_dtype == "bf16":
+        acc_dtype = fx.BFloat16
+    else:
+        raise ValueError(
+            f"unsupported (in_dtype={in_dtype}, out_dtype={out_dtype}) combination"
+        )
+
+    NUM_WAVES = waves_m * waves_n
+    THREADS_PER_BLOCK = NUM_WAVES * 32
+    GRID_M = M // BLOCK_M
+    GRID_N = N // BLOCK_N
+    EFFECTIVE_GROUP_M = min(group_m, GRID_M)
+
+    # GMEM->LDS thread layout. Each thread loads a 128-bit vector
+    # (val_per_thr f16 elements). thrs_col threads cover BLOCK_K, thrs_row
+    # threads cover (a slice of) BLOCK_M, then the M dim repeats per thread
+    # to fill BLOCK_M.
+    val_per_thr_g2s = 128 // ab_dtype.width  # 8 f16 / 8 bf16 per 128b copy
+    assert BLOCK_K % val_per_thr_g2s == 0, (
+        f"BLOCK_K={BLOCK_K} must be divisible by val_per_thr_g2s={val_per_thr_g2s}"
+    )
+    thrs_col = BLOCK_K // val_per_thr_g2s
+    assert THREADS_PER_BLOCK % thrs_col == 0, (
+        f"THREADS_PER_BLOCK={THREADS_PER_BLOCK} not divisible by thrs_col={thrs_col}"
+    )
+    thrs_row = THREADS_PER_BLOCK // thrs_col
+    assert BLOCK_M % thrs_row == 0 and BLOCK_M >= thrs_row, (
+        f"BLOCK_M={BLOCK_M} must be a positive multiple of thrs_row={thrs_row}; "
+        f"raise reg_m / reg_n / waves_* or lower BLOCK_K (this combo: "
+        f"waves_m={waves_m}, waves_n={waves_n}, reg_m={reg_m}, reg_n={reg_n}, "
+        f"reg_k={reg_k} -> BLOCK_M={BLOCK_M}, threads={THREADS_PER_BLOCK})"
+    )
+    assert BLOCK_N % thrs_row == 0 and BLOCK_N >= thrs_row, (
+        f"BLOCK_N={BLOCK_N} must be a positive multiple of thrs_row={thrs_row}"
+    )
+
+    # LDS shared-memory size: 2 stages × (A tile + B tile) for ping-pong.
+    LDS_STAGES = 2
+    LDS_BYTES = LDS_STAGES * (BLOCK_M + BLOCK_N) * BLOCK_K * (ab_dtype.width // 8)
+    K_ITERS = K // BLOCK_K
+    assert K_ITERS >= 2, "Double-buffered kernel requires K >= 2 * BLOCK_K"
+
+    @flyc.kernel
+    def gemm_kernel(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+    ):
+        tid = fx.thread_idx.x
+        # Workgroup swizzle for L2 locality: visit EFFECTIVE_GROUP_M × GRID_N
+        # tiles in M-fast order, then advance EFFECTIVE_GROUP_M M-tiles.
+        # Triton-style "super-grouping". With EFFECTIVE_GROUP_M == 1 this
+        # degenerates to plain N-major linear scheduling (same correctness,
+        # no L2 reuse benefit).
+        pid = fx.block_idx.x
+        num_pid_in_group = EFFECTIVE_GROUP_M * GRID_N
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * EFFECTIVE_GROUP_M
+        pid_in_group = pid % num_pid_in_group
+        bid_m = first_pid_m + (pid_in_group % EFFECTIVE_GROUP_M)
+        bid_n = pid_in_group // EFFECTIVE_GROUP_M
+
+        A = fx.rocdl.make_buffer_tensor(A)
+        B = fx.rocdl.make_buffer_tensor(B)
+        C = fx.rocdl.make_buffer_tensor(C)
+
+        bA_all = fx.zipped_divide(A, (BLOCK_M, BLOCK_K))
+        bB_all = fx.zipped_divide(B, (BLOCK_N, BLOCK_K))
+        bC = fx.zipped_divide(C, (BLOCK_M, BLOCK_N))
+        bC = fx.slice(bC, (None, (bid_m, bid_n)))
+
+        mma_atom = fx.make_mma_atom(
+            fx.rocdl.WMMA_RDNA3(WMMA_M, WMMA_N, WMMA_K, ab_dtype, acc_dtype)
+        )
+        # Wave layout (waves_m, waves_n, 1) — strides (1, waves_m, 0) pack
+        # warp_id = warp_m + warp_n * waves_m. The number of WMMAs each warp
+        # issues per K-step (reg_m, reg_n, reg_k) is *implicit* from the
+        # ratio  BLOCK_M / (waves_m * WMMA_M)  etc., not passed here.
+        tiled_mma = fx.make_tiled_mma(
+            mma_atom,
+            fx.make_layout((waves_m, waves_n, 1), (1, waves_m, 0)),
+        )
+        thr_mma = tiled_mma.thr_slice(tid)
+
+        # ── LDS allocation (2-stage ping-pong) ────────────────────────
+        # Layout: [sA[stage=0] | sA[stage=1] | sB[stage=0] | sB[stage=1]]
+        # Each tile is row-major to match the row-major GMEM source.
+        smem_base = fx.get_dyn_shared()
+        smem_ab = fx.recast_iter(
+            fx.PointerType.get(
+                ab_dtype.ir_type, fx.AddressSpace.Shared, 128
+            ),
+            smem_base,
+        )
+        # 3D layout: outer axis is the stage (slowest), then row-major K-fast tile.
+        sA = fx.make_view(
+            smem_ab,
+            fx.make_ordered_layout(
+                (BLOCK_M, BLOCK_K, LDS_STAGES), (1, 0, 2)
+            ),
+        )
+        smem_b_ptr = fx.add_offset(
+            smem_ab, LDS_STAGES * BLOCK_M * BLOCK_K
+        )
+        sB = fx.make_view(
+            smem_b_ptr,
+            fx.make_ordered_layout(
+                (BLOCK_N, BLOCK_K, LDS_STAGES), (1, 0, 2)
+            ),
+        )
+
+        # ── Copy atoms ────────────────────────────────────────────────
+        # GMEM->LDS uses 128-bit BufferCopy (vec_8 f16). LDS->register
+        # uses the universal 128-bit copy. Register->GMEM for C uses
+        # acc-dtype-wide BufferCopy.
+        bcopy_128b_ab = fx.make_copy_atom(fx.rocdl.BufferCopy(128), ab_dtype)
+        ucopy_128b_ab = fx.make_copy_atom(fx.UniversalCopy128b(), ab_dtype)
+        copy_atom_c = fx.make_copy_atom(
+            fx.rocdl.BufferCopy(acc_dtype.width), acc_dtype
+        )
+
+        # GMEM -> LDS tiled copies (cooperative across all 128 threads).
+        # thread-value layout: outer (thr_col, thr_row) × inner (1 along M,
+        # val_per_thr along K).  tile is (thrs_row × BLOCK_K) so along M
+        # the layout repeats BLOCK_M / thrs_row times per thread.
+        tiled_copy_g2s_A = fx.make_tiled_copy(
+            bcopy_128b_ab,
+            fx.make_layout(
+                ((thrs_col, thrs_row), (1, val_per_thr_g2s)),
+                ((thrs_row * val_per_thr_g2s, 1), (1, thrs_row)),
+            ),
+            fx.make_tile(thrs_row, BLOCK_K),
+        )
+        tiled_copy_g2s_B = fx.make_tiled_copy(
+            bcopy_128b_ab,
+            fx.make_layout(
+                ((thrs_col, thrs_row), (1, val_per_thr_g2s)),
+                ((thrs_row * val_per_thr_g2s, 1), (1, thrs_row)),
+            ),
+            fx.make_tile(thrs_row, BLOCK_K),
+        )
+        thr_g2s_A = tiled_copy_g2s_A.get_slice(tid)
+        thr_g2s_B = tiled_copy_g2s_B.get_slice(tid)
+
+        # LDS -> register tiled copies (per-warp; derived from tiled_mma).
+        tiled_copy_s2r_A = fx.make_tiled_copy_A(ucopy_128b_ab, tiled_mma)
+        tiled_copy_s2r_B = fx.make_tiled_copy_B(ucopy_128b_ab, tiled_mma)
+        thr_s2r_A = tiled_copy_s2r_A.get_slice(tid)
+        thr_s2r_B = tiled_copy_s2r_B.get_slice(tid)
+
+        # Register -> GMEM for C.
+        tiled_copy_C = fx.make_tiled_copy_C(copy_atom_c, tiled_mma)
+        thr_copy_C = tiled_copy_C.get_slice(tid)
+
+        # Pre-compute per-stage partitions. With LDS stages = 2 the stage
+        # axis is the *outer* dim of sA/sB so slicing [..., 0] / [..., 1] is
+        # constexpr and folds into a static ptr offset.
+        thr_sA_g2s_stage = [
+            thr_g2s_A.partition_D(sA[None, None, s]) for s in range(LDS_STAGES)
+        ]
+        thr_sB_g2s_stage = [
+            thr_g2s_B.partition_D(sB[None, None, s]) for s in range(LDS_STAGES)
+        ]
+        thr_sA_s2r_stage = [
+            thr_s2r_A.partition_S(sA[None, None, s]) for s in range(LDS_STAGES)
+        ]
+        thr_sB_s2r_stage = [
+            thr_s2r_B.partition_S(sB[None, None, s]) for s in range(LDS_STAGES)
+        ]
+
+        copy_dst_C = thr_copy_C.partition_S(bC)
+        frag_C = thr_mma.make_fragment_C(bC)
+        copy_frag_C = thr_copy_C.retile(frag_C)
+        # mma fragments are register-resident; tied to one (any) stage of LDS
+        # for shape inference. They get re-filled from LDS each iter.
+        frag_A = thr_mma.make_fragment_A(sA[None, None, 0])
+        frag_B = thr_mma.make_fragment_B(sB[None, None, 0])
+        s2r_frag_A = thr_s2r_A.retile(frag_A)
+        s2r_frag_B = thr_s2r_B.retile(frag_B)
+
+        frag_C.fill(0)
+
+        # ── Pipeline stage helpers ────────────────────────────────────
+        def issue_g2s(k_tile, stage):
+            """GMEM -> LDS[stage] for A and B at K-tile index k_tile."""
+            bA = fx.slice(bA_all, (None, (bid_m, k_tile)))
+            bB = fx.slice(bB_all, (None, (bid_n, k_tile)))
+            fx.copy(
+                bcopy_128b_ab,
+                thr_g2s_A.partition_S(bA),
+                thr_sA_g2s_stage[stage],
+                pred=None,
+            )
+            fx.copy(
+                bcopy_128b_ab,
+                thr_g2s_B.partition_S(bB),
+                thr_sB_g2s_stage[stage],
+                pred=None,
+            )
+
+        def compute_from_stage(stage):
+            """LDS[stage] -> register -> WMMA accumulate."""
+            fx.copy(ucopy_128b_ab, thr_sA_s2r_stage[stage], s2r_frag_A, pred=None)
+            fx.copy(ucopy_128b_ab, thr_sB_s2r_stage[stage], s2r_frag_B, pred=None)
+            fx.gemm(mma_atom, frag_C, frag_A, frag_B, frag_C)
+
+        # ── Pipeline ──────────────────────────────────────────────────
+        # Prologue: load K-tile 0 into LDS[0].
+        issue_g2s(fx.Int32(0), 0)
+        fx.gpu.barrier()
+
+        # Main loop: K_ITERS - 1 iterations. Each iter k:
+        #   - issues G2S for tile k+1 into LDS[(k+1) & 1]
+        #   - computes from LDS[k & 1] (already populated)
+        #   - barrier so next iter can both compute from LDS[(k+1) & 1] and
+        #     overwrite LDS[k & 1]
+        # We unroll iterations in pairs so the stage index is constexpr.
+        # Outer loop is a runtime SCF loop over (K_ITERS - 1) // 2 pairs to
+        # avoid unrolling 128 K-iterations into the IR for K=4096.
+        full_pairs = (K_ITERS - 1) // 2
+        tail = (K_ITERS - 1) - full_pairs * 2  # 0 or 1 leftover iters
+
+        for pair_idx in range(full_pairs):  # SCF runtime loop over pairs
+            pair_i32 = fx.arith.index_cast(fx.T.i32(), pair_idx)
+            base_k = pair_i32 * fx.Int32(2)
+
+            # Iter even: compute from stage 0, prefetch into stage 1.
+            issue_g2s(base_k + fx.Int32(1), 1)
+            compute_from_stage(0)
+            fx.gpu.barrier()
+
+            # Iter odd: compute from stage 1, prefetch into stage 0.
+            issue_g2s(base_k + fx.Int32(2), 0)
+            compute_from_stage(1)
+            fx.gpu.barrier()
+
+        # Tail prefetch+compute (if K_ITERS - 1 is odd, one more iter).
+        if tail == 1:
+            tail_k = fx.Int32(full_pairs * 2 + 1)
+            issue_g2s(tail_k, 1)
+            compute_from_stage(0)
+            fx.gpu.barrier()
+
+        # Final compute for the last loaded tile (no prefetch needed).
+        last_stage = (K_ITERS - 1) & 1
+        compute_from_stage(last_stage)
+
+        fx.copy(copy_atom_c, copy_frag_C, copy_dst_C, pred=None)
+
+    @flyc.jit
+    def launch_gemm(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        gemm_kernel(A, B, C).launch(
+            grid=(GRID_M * GRID_N, 1, 1),
+            block=(THREADS_PER_BLOCK, 1, 1),
+            smem=LDS_BYTES,
+            stream=stream,
+        )
+
+    return launch_gemm, BLOCK_M, BLOCK_N, BLOCK_K

--- a/lib/Bindings/Python/FlyROCDLExtension.cpp
+++ b/lib/Bindings/Python/FlyROCDLExtension.cpp
@@ -78,6 +78,26 @@ struct PyMmaOpGFX1250_WMMAType : PyConcreteType<PyMmaOpGFX1250_WMMAType> {
   }
 };
 
+struct PyMmaOpRDNA3_WMMAType : PyConcreteType<PyMmaOpRDNA3_WMMAType> {
+  FLYDSL_REGISTER_TYPE_BINDING(MmaOpRDNA3_WMMAType, "MmaOpRDNA3_WMMAType");
+
+  static void bindDerived(ClassTy &c) {
+    c.def_static(
+        "get",
+        [](int32_t m, int32_t n, int32_t k, PyType &elemTyA, PyType &elemTyB, PyType &elemTyAcc,
+           DefaultingPyMlirContext context) {
+          return PyMmaOpRDNA3_WMMAType(
+              context->getRef(),
+              wrap(MmaOpRDNA3_WMMAType::get(m, n, k, unwrap(elemTyA), unwrap(elemTyB),
+                                            unwrap(elemTyAcc))));
+        },
+        "m"_a, "n"_a, "k"_a, "elem_ty_a"_a, "elem_ty_b"_a, "elem_ty_acc"_a, nb::kw_only(),
+        "context"_a = nb::none(),
+        "Create a MmaOpRDNA3_WMMAType for RDNA 3 / 3.5 WMMA (gfx1100/gfx1150). "
+        "Only M=N=K=16 with F16/BF16/IU8/IU4 inputs is accepted.");
+  }
+};
+
 struct PyCopyOpCDNA3BufferCopyType : PyConcreteType<PyCopyOpCDNA3BufferCopyType> {
   FLYDSL_REGISTER_TYPE_BINDING(CopyOpCDNA3BufferCopyType, "CopyOpCDNA3BufferCopyType");
 
@@ -158,6 +178,7 @@ NB_MODULE(_mlirDialectsFlyROCDL, m) {
   ::mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::fly_rocdl::PyMmaOpCDNA3_MFMAType::bind(m);
   ::mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::fly_rocdl::PyMmaOpCDNA4_MFMAScaleType::bind(m);
   ::mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::fly_rocdl::PyMmaOpGFX1250_WMMAType::bind(m);
+  ::mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::fly_rocdl::PyMmaOpRDNA3_WMMAType::bind(m);
   ::mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::fly_rocdl::PyCopyOpCDNA3BufferCopyType::bind(m);
   ::mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::fly_rocdl::PyCopyOpCDNA3BufferCopyLDSType::bind(m);
   ::mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::fly_rocdl::PyCopyOpCDNA3BufferAtomicType::bind(m);

--- a/lib/Dialect/FlyROCDL/CMakeLists.txt
+++ b/lib/Dialect/FlyROCDL/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_dialect_library(MLIRFlyROCDLDialect
   CDNA4/MmaAtom.cpp
   CDNA4/CopyAtom.cpp
   GFX1250/MmaAtom.cpp
+  RDNA3/MmaAtom.cpp
 
   DEPENDS
   MLIRFlyROCDLIncGen

--- a/lib/Dialect/FlyROCDL/RDNA3/MmaAtom.cpp
+++ b/lib/Dialect/FlyROCDL/RDNA3/MmaAtom.cpp
@@ -1,0 +1,554 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 FlyDSL Project Contributors
+//
+// MmaOpRDNA3_WMMAType — wave32 WMMA atom for RDNA 3 / 3.5 (gfx1100/gfx1150).
+//
+// RDNA 3 / 3.5 expose six 16x16x16 V_WMMA opcodes (VOP3P 64-69):
+//   V_WMMA_F32_16X16X16_F16    F16 -> F32
+//   V_WMMA_F32_16X16X16_BF16   BF16 -> F32
+//   V_WMMA_F16_16X16X16_F16    F16 -> F16 (op_sel chooses high/low half)
+//   V_WMMA_BF16_16X16X16_BF16  BF16 -> BF16 (op_sel chooses high/low half)
+//   V_WMMA_I32_16X16X16_IU8    IU8 -> I32  (clamp + signed/unsigned per operand)
+//   V_WMMA_I32_16X16X16_IU4    IU4 -> I32  (clamp + signed/unsigned per operand)
+//
+// The hardware uses the "WMMA256bInsts" convention: lanes 0-15 hold the
+// matrix data; lanes 16-31 are duplicates populated by the LLVM AMDGPU
+// codegen (round-tripped through the LLVM intrinsic interface). At the
+// IR / atom level we use the same lane-group-split logical layout as the
+// gfx1250 K=4 path, with each lane holding K/2 = 8 unique elements.
+// Concretely, lane group 0 (lane/16=0) covers K = 0..7 and lane group 1
+// (lane/16=1) covers K = 8..15. This mirrors what `kernels/rdna_f16_gemm.py`
+// (the existing wave32 raw-intrinsic kernel) constructs by hand.
+//
+// FP8/FP4/scaled/sparse WMMA, K=4 / K=32 / K=64 / K=128 shapes, and the
+// transpose-load atoms are gfx12+ only and rejected by `verify` here.
+
+#include "flydsl/Dialect/Fly/IR/FlyDialect.h"
+#include "flydsl/Dialect/FlyROCDL/IR/Dialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+#include "flydsl/Dialect/Fly/Utils/ThrValLayoutMacro.h.inc"
+
+using namespace mlir;
+using namespace mlir::fly;
+
+namespace rdna3 {
+
+// A/B operand register layout for RDNA 3 / 3.5 WMMA (wave32, M=N=K=16).
+//
+// Reference space is column-major (M, K) with stride (1, M=16). Each lane
+// holds K/2 = 8 unique elements; the duplication of lanes 0-15 into lanes
+// 16-31 required by the hardware is materialised by the LLVM AMDGPU
+// backend at codegen time.
+//
+//   lane_pos = (l%16)*1   // M coord
+//            + (l/16)*128 // K-group offset (8 K elements * stride 16)
+//            + v*16       // K within group (val v -> K=v in group 0,
+//                         //                  val v -> K=v+8 in group 1)
+//
+// shape   = ((16, 2), 8)  -> outer thr is (16,2), val is 8 (flat)
+// stride  = ((1, 128), 16)
+LayoutAttr getThrValLayoutAB(MLIRContext *ctx) {
+  auto getContext = [&]() { return ctx; };
+  return FxLayout(FxShape(FxThr(16, 2), FxVal(8)),
+                  FxStride(FxThr(1, 128), FxVal(16)));
+}
+
+// C/D operand register layout for RDNA 3 / 3.5 WMMA (wave32, M=N=16).
+//
+// The accumulator is always 16x16. Lane l covers N = l%16 (one column).
+// The two lane groups split M into two halves of 8 rows each:
+//   group 0 -> M = 0..7
+//   group 1 -> M = 8..15
+//
+// 32-bit accumulator (f32, i32): 8 VGPRs, one element per VGPR.
+//   M = (l/16)*8 + v
+//
+// 16-bit accumulator (f16, bf16): the LLVM intrinsic returns a 16-wide
+// vector with the OpSel[2] hi/lo bit selecting which half is live; from
+// the FlyDSL atom perspective each lane still holds 8 distinct M
+// coordinates, packed two-per-VGPR (4 VGPRs, sub-element index within VGPR).
+//   M = (l/16)*8 + v*2 + s
+//
+// Reference space is column-major (M, N) with stride (1, M=16).
+LayoutAttr getThrValLayoutCD(MLIRContext *ctx, Type elemTyAcc) {
+  auto getContext = [&]() { return ctx; };
+
+  (void)elemTyAcc;
+  // Keep a single canonical 8-value lane fragment layout for all accumulator
+  // types. The lowering may internally use packed/native forms, but the atom
+  // interface exposes a consistent vec8 fragment to tiled_copy_C.
+  return FxLayout(FxShape(FxThr(16, 2), FxVal(8)),
+                  FxStride(FxThr(16, 8), FxVal(1)));
+}
+
+} // namespace rdna3
+
+namespace mlir::fly_rocdl {
+
+bool MmaOpRDNA3_WMMAType::isStatic() const { return true; }
+
+Value MmaOpRDNA3_WMMAType::rebuildStaticValue(OpBuilder &builder, Location loc,
+                                              Value currentValue) const {
+  if (currentValue && isa<MakeMmaAtomOp>(currentValue.getDefiningOp()))
+    return nullptr;
+  return MakeMmaAtomOp::create(builder, loc, MmaAtomType::get(*this));
+}
+
+Type MmaOpRDNA3_WMMAType::getValTypeA() const { return getElemTyA(); }
+Type MmaOpRDNA3_WMMAType::getValTypeB() const { return getElemTyB(); }
+Type MmaOpRDNA3_WMMAType::getValTypeC() const { return getElemTyAcc(); }
+Type MmaOpRDNA3_WMMAType::getValTypeD() const { return getElemTyAcc(); }
+
+Attribute MmaOpRDNA3_WMMAType::getThrLayout() const {
+  return FxLayout(FxC(32), FxC(1));
+}
+
+Attribute MmaOpRDNA3_WMMAType::getShapeMNK() const {
+  return IntTupleAttr::get(
+      ArrayAttr::get(getContext(), {FxC(getM()), FxC(getN()), FxC(getK())}));
+}
+
+Attribute MmaOpRDNA3_WMMAType::getThrValLayoutA() const {
+  return rdna3::getThrValLayoutAB(getContext());
+}
+
+Attribute MmaOpRDNA3_WMMAType::getThrValLayoutB() const {
+  return rdna3::getThrValLayoutAB(getContext());
+}
+
+Attribute MmaOpRDNA3_WMMAType::getThrValLayoutC() const {
+  return rdna3::getThrValLayoutCD(getContext(), getElemTyAcc());
+}
+
+LogicalResult MmaOpRDNA3_WMMAType::verify(
+    function_ref<InFlightDiagnostic()> emitError, int32_t m, int32_t n,
+    int32_t k, Type elemTyA, Type elemTyB, Type elemTyAcc) {
+  if (m != 16 || n != 16 || k != 16) {
+    return emitError()
+           << "RDNA3 WMMA requires M=N=K=16, got " << m << "x" << n << "x" << k;
+  }
+
+  bool valid = false;
+
+  if (elemTyA.isF16() && elemTyB.isF16() &&
+      (elemTyAcc.isF32() || elemTyAcc.isF16()))
+    valid = true;
+  if (elemTyA.isBF16() && elemTyB.isBF16() &&
+      (elemTyAcc.isF32() || elemTyAcc.isBF16()))
+    valid = true;
+  if (elemTyA.isInteger(8) && elemTyB.isInteger(8) && elemTyAcc.isInteger(32))
+    valid = true;
+  if (elemTyA.isInteger(4) && elemTyB.isInteger(4) && elemTyAcc.isInteger(32))
+    valid = true;
+
+  if (!valid) {
+    return emitError()
+           << "unsupported RDNA3 WMMA configuration: " << m << "x" << n << "x"
+           << k << " with A=" << elemTyA << ", B=" << elemTyB
+           << ", Acc=" << elemTyAcc
+           << " (RDNA 3 / 3.5 supports only F16/BF16/IU8/IU4 K=16; "
+              "FP8/FP4/scaled/sparse require gfx12+)";
+  }
+  return success();
+}
+
+// Vector type each lane holds for A or B operand.
+//
+// RDNA 3 / 3.5 WMMA at K=16:
+//   F16  -> vector<8 x f16>   (8 elements per lane, 4 VGPRs)
+//   BF16 -> vector<8 x bf16>  (same shape)
+//   IU8  -> vector<2 x i32>   (8 i8s packed into 2 dwords per lane)
+//   IU4  -> vector<2 x i32>   (16 i4s packed into 2 dwords per lane = K=16
+//                              elements; M*K/32 = 256/32 = 8 elements * 4 bits
+//                              = 32 bits = 1 dword. But i4 typically uses
+//                              i32 packed. We follow the gfx1250 convention
+//                              of vector<2xi32> for K=16 i4)
+static Type getWmmaABType(MLIRContext *ctx, Type elemTy) {
+  // M*K/wave_size = 16*16/32 = 8 elements per lane.
+  Type i32Ty = IntegerType::get(ctx, 32);
+
+  if (elemTy.isInteger(8)) {
+    // 8 i8 values per lane = 64 bits = vector<2 x i32>.
+    return VectorType::get({2}, i32Ty);
+  }
+  if (elemTy.isInteger(4)) {
+    // 16 i4 values per lane (K=16 fully packed) = 64 bits = vector<2 x i32>.
+    return VectorType::get({2}, i32Ty);
+  }
+  if (elemTy.isF16() || elemTy.isBF16()) {
+    return VectorType::get({8}, elemTy);
+  }
+  return nullptr;
+}
+
+// Vector type the accumulator (C/D) holds per lane.
+//
+// F32 acc: vector<8 x f32>  (8 VGPRs, one f32 per VGPR)
+// I32 acc: vector<8 x i32>
+// F16/BF16 acc: vector<8 x elem> (op_sel selects hi/lo half of each VGPR;
+//   the IR-level vector has 8 elements per lane regardless)
+static int64_t getWmmaAccVecSize(int32_t /*m*/, int32_t /*k*/, Type elemTyAcc) {
+  if (elemTyAcc.isF32() || elemTyAcc.isInteger(32))
+    return 8;
+  if (elemTyAcc.isF16() || elemTyAcc.isBF16())
+    return 8;
+  return 0;
+}
+
+FailureOr<Value> MmaOpRDNA3_WMMAType::emitAtomCallSSA(
+    OpBuilder &builder, Location loc, Type /*resultTy*/, Type /*mmaAtomTyArg*/,
+    Type /*dTyArg*/, Type /*aTyArg*/, Type /*bTyArg*/, Type /*cTyArg*/,
+    Value /*atomVal*/, Value /*d*/, Value a, Value b, Value c) const {
+  Type elemTyA = getElemTyA();
+  Type elemTyB = getElemTyB();
+  Type elemTyAcc = getElemTyAcc();
+  MLIRContext *ctx = builder.getContext();
+
+  Type abTyA = getWmmaABType(ctx, elemTyA);
+  Type abTyB = getWmmaABType(ctx, elemTyB);
+  if (!abTyA || !abTyB)
+    return failure();
+
+  int64_t accVecSize = getWmmaAccVecSize(getM(), getK(), elemTyAcc);
+  if (accVecSize == 0)
+    return failure();
+
+  VectorType accTy = VectorType::get({accVecSize}, elemTyAcc);
+
+  if (a.getType() != abTyA)
+    a = LLVM::BitcastOp::create(builder, loc, abTyA, a);
+  if (b.getType() != abTyB)
+    b = LLVM::BitcastOp::create(builder, loc, abTyB, b);
+  if (c.getType() != accTy)
+    c = LLVM::BitcastOp::create(builder, loc, accTy, c);
+
+  // The bf16 ROCDL ops take `AnyInteger` for A/B (and for C/D when the acc is
+  // bf16), so we must bitcast bfloat vectors to i16 vectors before the call
+  // and back afterwards. The f16 op takes f16 directly so no cast is needed.
+  Type i16Ty = IntegerType::get(ctx, 16);
+
+  auto castToI16Vec = [&](Value v) -> Value {
+    auto vt = cast<VectorType>(v.getType());
+    auto intVt = VectorType::get(vt.getShape(), i16Ty);
+    return LLVM::BitcastOp::create(builder, loc, intVt, v);
+  };
+
+  // RDNA 3 / 3.5 uses `WMMA256bInsts`: the intrinsic selector expects
+  // 16-wide lane operands. FlyDSL's per-lane fragment is 8 elements where
+  // lane-group 0 carries K=0..7 and lane-group 1 carries K=8..15.
+  //
+  // Build a 16-wide lane vector as:
+  //   low  half = lane-local 8 values
+  //   high half = values pulled from the paired lane (lane xor 16)
+  //
+  // `rocdl.ds_bpermute` is 32-bit granularity, so for f16/bf16 we:
+  //   vector<8x{f16|bf16}> -> bitcast vector<4xi32>
+  //   bpermute each dword from lane^16
+  //   bitcast back to vector<8x{f16|bf16}>
+  //   concatenate [self8, pair8] to vector<16x...>
+  auto expandTo16WideWmma256 = [&](Value v) -> Value {
+    auto vt = cast<VectorType>(v.getType());
+    if (vt.getShape().size() != 1 || vt.getShape()[0] != 8)
+      return v;
+    auto wideTy = VectorType::get({16}, vt.getElementType());
+
+    Value pairedHalf = v;
+    if (vt.getElementType().isF16() || vt.getElementType().isBF16()) {
+      auto i32Ty = IntegerType::get(ctx, 32);
+      auto i64Ty = IntegerType::get(ctx, 64);
+      auto packedTy = VectorType::get({4}, i32Ty);
+
+      Value lane = ROCDL::ThreadIdXOp::create(builder, loc, i32Ty).getResult();
+      Value c31 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                           builder.getI32IntegerAttr(31));
+      Value cNeg32 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                              builder.getI32IntegerAttr(-32));
+      Value c16 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                           builder.getI32IntegerAttr(16));
+      Value c2 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                          builder.getI32IntegerAttr(2));
+
+      Value laneInWave = LLVM::AndOp::create(builder, loc, lane, c31);
+      Value waveBase = LLVM::AndOp::create(builder, loc, lane, cNeg32);
+      Value pairedLaneInWave = LLVM::XOrOp::create(builder, loc, laneInWave, c16);
+      Value pairedLane = LLVM::OrOp::create(builder, loc, waveBase, pairedLaneInWave);
+      Value pairedLaneByteAddr = LLVM::ShlOp::create(builder, loc, pairedLane, c2);
+
+      Value packed = LLVM::BitcastOp::create(builder, loc, packedTy, v);
+      Value pairedPacked = LLVM::UndefOp::create(builder, loc, packedTy);
+      for (int i = 0; i < 4; ++i) {
+        Value idx = LLVM::ConstantOp::create(builder, loc, i64Ty,
+                                             builder.getI64IntegerAttr(i));
+        Value laneWord = LLVM::ExtractElementOp::create(builder, loc, packed, idx);
+        Value pairedWord = ROCDL::DsBpermuteOp::create(builder, loc, i32Ty,
+                                                       pairedLaneByteAddr, laneWord)
+                               .getResult();
+        pairedPacked = LLVM::InsertElementOp::create(builder, loc, pairedPacked,
+                                                     pairedWord, idx);
+      }
+      pairedHalf = LLVM::BitcastOp::create(builder, loc, vt, pairedPacked);
+    }
+
+    Value lowHalf = v;
+    Value highHalf = pairedHalf;
+
+    SmallVector<int32_t> concatMask = {0, 1, 2, 3, 4, 5, 6, 7,
+                                       8, 9, 10, 11, 12, 13, 14, 15};
+    return LLVM::ShuffleVectorOp::create(builder, loc, wideTy, lowHalf, highHalf,
+                                         concatMask);
+  };
+
+  // For IU8 / IU4, each lane carries <2xi32> (64 bits). WMMA256b expects
+  // a 128-bit source per operand lane, where the upper half comes from lane^16.
+  auto expandPackedI32To4WideWmma256 = [&](Value v) -> Value {
+    auto vt = dyn_cast<VectorType>(v.getType());
+    if (!vt || vt.getShape().size() != 1 || vt.getShape()[0] != 2 ||
+        !vt.getElementType().isInteger(32))
+      return v;
+
+    auto i32Ty = IntegerType::get(ctx, 32);
+    auto i64Ty = IntegerType::get(ctx, 64);
+    auto wideTy = VectorType::get({4}, i32Ty);
+
+    Value lane = ROCDL::ThreadIdXOp::create(builder, loc, i32Ty).getResult();
+    Value c31 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                         builder.getI32IntegerAttr(31));
+    Value cNeg32 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                            builder.getI32IntegerAttr(-32));
+    Value c16 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                         builder.getI32IntegerAttr(16));
+    Value c2 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                        builder.getI32IntegerAttr(2));
+
+    Value laneInWave = LLVM::AndOp::create(builder, loc, lane, c31);
+    Value waveBase = LLVM::AndOp::create(builder, loc, lane, cNeg32);
+    Value pairedLaneInWave = LLVM::XOrOp::create(builder, loc, laneInWave, c16);
+    Value pairedLane = LLVM::OrOp::create(builder, loc, waveBase, pairedLaneInWave);
+    Value pairedLaneByteAddr = LLVM::ShlOp::create(builder, loc, pairedLane, c2);
+
+    Value pairedHalf = LLVM::UndefOp::create(builder, loc, vt);
+    for (int i = 0; i < 2; ++i) {
+      Value idx = LLVM::ConstantOp::create(builder, loc, i64Ty,
+                                           builder.getI64IntegerAttr(i));
+      Value laneWord = LLVM::ExtractElementOp::create(builder, loc, v, idx);
+      Value pairedWord = ROCDL::DsBpermuteOp::create(builder, loc, i32Ty,
+                                                     pairedLaneByteAddr, laneWord)
+                             .getResult();
+      pairedHalf = LLVM::InsertElementOp::create(builder, loc, pairedHalf,
+                                                 pairedWord, idx);
+    }
+
+    SmallVector<int32_t> concatMask = {0, 1, 2, 3};
+    return LLVM::ShuffleVectorOp::create(builder, loc, wideTy, v, pairedHalf,
+                                         concatMask);
+  };
+
+  auto duplicateTo16WideSimple = [&](Value v) -> Value {
+    auto vt = dyn_cast<VectorType>(v.getType());
+    if (!vt || vt.getShape().size() != 1 || vt.getShape()[0] != 8)
+      return v;
+    auto wideTy = VectorType::get({16}, vt.getElementType());
+    SmallVector<int32_t> mask = {0, 1, 2, 3, 4, 5, 6, 7,
+                                 0, 1, 2, 3, 4, 5, 6, 7};
+    return LLVM::ShuffleVectorOp::create(builder, loc, wideTy, v, v, mask);
+  };
+
+  // Empirically, RDNA3/3.5 `rocdl.wmma.f32.16x16x16.*` returns the per-lane
+  // 8-wide accumulator in a lane-local order different from the default
+  // FlyDSL f32 C-fragment order. Reorder to the fragment convention expected
+  // by `getThrValLayoutCD` / tiled_copy_C.
+  auto reorderAccLaneValues = [&](Value v) -> Value {
+    auto vt = dyn_cast<VectorType>(v.getType());
+    if (!vt || vt.getShape().size() != 1 || vt.getShape()[0] != 8)
+      return v;
+    bool isF32 = vt.getElementType().isF32();
+    bool isI32 = vt.getElementType().isInteger(32);
+    if (!isF32 && !isI32)
+      return v;
+    auto i32Ty = IntegerType::get(ctx, 32);
+    auto i64Ty = IntegerType::get(ctx, 64);
+    auto i32VecTy = VectorType::get({8}, i32Ty);
+
+    // First, apply the observed lane-local reorder from WMMA result encoding.
+    SmallVector<int32_t> laneLocalMask = {0, 4, 1, 5, 2, 6, 3, 7};
+    Value laneLocal = LLVM::ShuffleVectorOp::create(builder, loc, vt, v, v, laneLocalMask);
+
+    // Then fix the cross-lane row bit permutation (bit0 <-> bit3) by pulling
+    // companion values from lane^16 and selecting by lane-group.
+    Value lane = ROCDL::ThreadIdXOp::create(builder, loc, i32Ty).getResult();
+    Value c31 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                         builder.getI32IntegerAttr(31));
+    Value cNeg32 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                            builder.getI32IntegerAttr(-32));
+    Value c16 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                         builder.getI32IntegerAttr(16));
+    Value c2 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                        builder.getI32IntegerAttr(2));
+    Value c0 = LLVM::ConstantOp::create(builder, loc, i32Ty,
+                                        builder.getI32IntegerAttr(0));
+
+    Value laneInWave = LLVM::AndOp::create(builder, loc, lane, c31);
+    Value waveBase = LLVM::AndOp::create(builder, loc, lane, cNeg32);
+    Value pairedLaneInWave = LLVM::XOrOp::create(builder, loc, laneInWave, c16);
+    Value pairedLane = LLVM::OrOp::create(builder, loc, waveBase, pairedLaneInWave);
+    Value pairedLaneByteAddr = LLVM::ShlOp::create(builder, loc, pairedLane, c2);
+
+    Value packed = isF32 ? LLVM::BitcastOp::create(builder, loc, i32VecTy, laneLocal)
+                         : laneLocal;
+    Value pairedPacked = LLVM::UndefOp::create(builder, loc, i32VecTy);
+    for (int i = 0; i < 8; ++i) {
+      Value idx = LLVM::ConstantOp::create(builder, loc, i64Ty,
+                                           builder.getI64IntegerAttr(i));
+      Value laneWord = LLVM::ExtractElementOp::create(builder, loc, packed, idx);
+      Value pairedWord = ROCDL::DsBpermuteOp::create(builder, loc, i32Ty,
+                                                     pairedLaneByteAddr, laneWord)
+                             .getResult();
+      pairedPacked = LLVM::InsertElementOp::create(builder, loc, pairedPacked,
+                                                   pairedWord, idx);
+    }
+    Value pairedLaneLocal = isF32 ? LLVM::BitcastOp::create(builder, loc, vt, pairedPacked)
+                                  : pairedPacked;
+
+    SmallVector<int32_t> maskGroup0 = {0, 8, 2, 10, 4, 12, 6, 14};
+    SmallVector<int32_t> maskGroup1 = {9, 1, 11, 3, 13, 5, 15, 7};
+    Value outGroup0 = LLVM::ShuffleVectorOp::create(builder, loc, vt, laneLocal,
+                                                    pairedLaneLocal, maskGroup0);
+    Value outGroup1 = LLVM::ShuffleVectorOp::create(builder, loc, vt, laneLocal,
+                                                    pairedLaneLocal, maskGroup1);
+
+    Value laneGroupBit = LLVM::AndOp::create(builder, loc, laneInWave, c16);
+    Value isUpperGroup =
+        LLVM::ICmpOp::create(builder, loc, LLVM::ICmpPredicate::ne, laneGroupBit, c0);
+    return LLVM::SelectOp::create(builder, loc, isUpperGroup, outGroup1, outGroup0);
+  };
+
+  // F32 <- F16/F16
+  if (elemTyA.isF16() && elemTyB.isF16() && elemTyAcc.isF32()) {
+    constexpr bool crossLaneA = true;
+    constexpr bool crossLaneB = true;
+    Value aDup = crossLaneA ? expandTo16WideWmma256(a) : duplicateTo16WideSimple(a);
+    Value bDup = crossLaneB ? expandTo16WideWmma256(b) : duplicateTo16WideSimple(b);
+    Value cPacked =
+        reorderAccLaneValues(reorderAccLaneValues(reorderAccLaneValues(c)));
+    Value res = ROCDL::wmma_f32_16x16x16_f16::create(builder, loc, accTy, aDup,
+                                                     bDup, cPacked)
+                    .getResult();
+    return reorderAccLaneValues(res);
+  }
+  // F32 <- BF16/BF16 (op A/B input ty is AnyInteger -> bitcast bf16 to i16)
+  if (elemTyA.isBF16() && elemTyB.isBF16() && elemTyAcc.isF32()) {
+    constexpr bool crossLaneA = true;
+    constexpr bool crossLaneB = true;
+    Value aI = castToI16Vec(crossLaneA ? expandTo16WideWmma256(a)
+                                       : duplicateTo16WideSimple(a));
+    Value bI = castToI16Vec(crossLaneB ? expandTo16WideWmma256(b)
+                                       : duplicateTo16WideSimple(b));
+    Value cPacked =
+        reorderAccLaneValues(reorderAccLaneValues(reorderAccLaneValues(c)));
+    Value res =
+        ROCDL::wmma_f32_16x16x16_bf16::create(builder, loc, accTy, aI, bI, cPacked)
+            .getResult();
+    return reorderAccLaneValues(res);
+  }
+  // F16 <- F16/F16.
+  //
+  // The native f16-acc WMMA variant uses op_sel-packed 16-wide C/D lanes, and
+  // keeping that packed state across loop-carried accumulation in the current
+  // vec8 fragment model is error-prone. For correctness, we use the f32-acc
+  // WMMA path and truncate the final lane-local result to f16.
+  if (elemTyA.isF16() && elemTyB.isF16() && elemTyAcc.isF16()) {
+    Value aDup = expandTo16WideWmma256(a);
+    Value bDup = expandTo16WideWmma256(b);
+    auto accF32Ty = VectorType::get({accVecSize}, builder.getF32Type());
+    Value cF32 = LLVM::FPExtOp::create(builder, loc, accF32Ty, c);
+    Value cPacked =
+        reorderAccLaneValues(reorderAccLaneValues(reorderAccLaneValues(cF32)));
+    Value resF32 = ROCDL::wmma_f32_16x16x16_f16::create(
+                       builder, loc, accF32Ty, aDup, bDup, cPacked)
+                       .getResult();
+    Value resCanonicalF32 = reorderAccLaneValues(resF32);
+    return LLVM::FPTruncOp::create(builder, loc, accTy, resCanonicalF32).getResult();
+  }
+  // BF16 <- BF16/BF16 (op_sel = 0). Op signature is AnyInteger for both A/B
+  // and C/D, so we bitcast to / from i16 vectors and extract low half.
+  if (elemTyA.isBF16() && elemTyB.isBF16() && elemTyAcc.isBF16()) {
+    Value aI = castToI16Vec(expandTo16WideWmma256(a));
+    Value bI = castToI16Vec(expandTo16WideWmma256(b));
+    Value cI = castToI16Vec(expandTo16WideWmma256(c));
+    auto wideIntTy = cast<VectorType>(cI.getType());
+    Value resWideI = ROCDL::wmma_bf16_16x16x16_bf16::create(
+                         builder, loc, wideIntTy, aI, bI, cI, /*opsel=*/false)
+                         .getResult();
+    SmallVector<int32_t> mask = {0, 1, 2, 3, 4, 5, 6, 7};
+    auto narrowIntTy = VectorType::get({8}, i16Ty);
+    Value resI = LLVM::ShuffleVectorOp::create(builder, loc, narrowIntTy,
+                                               resWideI, resWideI, mask);
+    Value res = LLVM::BitcastOp::create(builder, loc, accTy, resI);
+    return res;
+  }
+  // I32 <- IU8 (signA = signB = 0 = unsigned, clamp = 0).
+  // For RDNA 3 / 3.5 WMMA256b, the upper half must come from lane^16.
+  if (elemTyA.isInteger(8) && elemTyB.isInteger(8) && elemTyAcc.isInteger(32)) {
+    Value aWide = expandPackedI32To4WideWmma256(a);
+    Value bWide = expandPackedI32To4WideWmma256(b);
+    Value cPacked =
+        reorderAccLaneValues(reorderAccLaneValues(reorderAccLaneValues(c)));
+    Value res = ROCDL::wmma_i32_16x16x16_iu8::create(
+                    builder, loc, accTy,
+                    /*signA=*/false, aWide, /*signB=*/false, bWide, cPacked,
+                    /*clamp=*/false)
+                    .getResult();
+    return reorderAccLaneValues(res);
+  }
+  // I32 <- IU4. Same WMMA256b lane^16 upper-half rule as IU8.
+  if (elemTyA.isInteger(4) && elemTyB.isInteger(4) && elemTyAcc.isInteger(32)) {
+    Value aWide = expandPackedI32To4WideWmma256(a);
+    Value bWide = expandPackedI32To4WideWmma256(b);
+    Value cPacked =
+        reorderAccLaneValues(reorderAccLaneValues(reorderAccLaneValues(c)));
+    Value res = ROCDL::wmma_i32_16x16x16_iu4::create(
+                    builder, loc, accTy,
+                    /*signA=*/false, aWide, /*signB=*/false, bWide, cPacked,
+                    /*clamp=*/false)
+                    .getResult();
+    return reorderAccLaneValues(res);
+  }
+
+  return failure();
+}
+
+LogicalResult MmaOpRDNA3_WMMAType::emitAtomCall(
+    OpBuilder &builder, Location loc, Type mmaAtomTy, Type /*dMemTy*/,
+    Type /*aMemTy*/, Type /*bMemTy*/, Type /*cMemTy*/, Value atomVal, Value dPtr,
+    Value aPtr, Value bPtr, Value cPtr) const {
+  Type elemTyA = getElemTyA();
+  Type elemTyB = getElemTyB();
+  Type elemTyAcc = getElemTyAcc();
+  MLIRContext *ctx = builder.getContext();
+
+  Type abTyA = getWmmaABType(ctx, elemTyA);
+  Type abTyB = getWmmaABType(ctx, elemTyB);
+  if (!abTyA || !abTyB)
+    return failure();
+
+  int64_t accVecSize = getWmmaAccVecSize(getM(), getK(), elemTyAcc);
+  if (accVecSize == 0)
+    return failure();
+
+  VectorType accTy = VectorType::get({accVecSize}, elemTyAcc);
+
+  Value a = LLVM::LoadOp::create(builder, loc, abTyA, aPtr);
+  Value b = LLVM::LoadOp::create(builder, loc, abTyB, bPtr);
+  Value c = LLVM::LoadOp::create(builder, loc, accTy, cPtr);
+  auto res = emitAtomCallSSA(builder, loc, Type{}, mmaAtomTy, accTy, abTyA,
+                             abTyB, accTy, atomVal, Value{}, a, b, c);
+  if (failed(res))
+    return failure();
+  LLVM::StoreOp::create(builder, loc, *res, dPtr);
+  return success();
+}
+
+} // namespace mlir::fly_rocdl

--- a/lib/Dialect/FlyROCDL/RDNA3/MmaAtom.cpp
+++ b/lib/Dialect/FlyROCDL/RDNA3/MmaAtom.cpp
@@ -11,14 +11,19 @@
 //   V_WMMA_I32_16X16X16_IU8    IU8 -> I32  (clamp + signed/unsigned per operand)
 //   V_WMMA_I32_16X16X16_IU4    IU4 -> I32  (clamp + signed/unsigned per operand)
 //
-// The hardware uses the "WMMA256bInsts" convention: lanes 0-15 hold the
-// matrix data; lanes 16-31 are duplicates populated by the LLVM AMDGPU
-// codegen (round-tripped through the LLVM intrinsic interface). At the
-// IR / atom level we use the same lane-group-split logical layout as the
-// gfx1250 K=4 path, with each lane holding K/2 = 8 unique elements.
-// Concretely, lane group 0 (lane/16=0) covers K = 0..7 and lane group 1
-// (lane/16=1) covers K = 8..15. This mirrors what `kernels/rdna_f16_gemm.py`
-// (the existing wave32 raw-intrinsic kernel) constructs by hand.
+// A/B operand convention. The hardware "WMMA256bInsts" intrinsic expects
+// each lane to hold a 16-K-wide vector for one M (or N) row, with lanes
+// 0-15 and 16-31 holding identical data (replication invariant). Within
+// the FlyDSL atom we keep a compact 8-element-per-lane fragment where
+// lane group 0 (lane/16=0) carries K = 0..7 and lane group 1 (lane/16=1)
+// carries K = 8..15. At lowering time `expandTo16WideWmma256` merges the
+// two K halves into a 16-wide per-lane vector via cross-lane bpermute.
+//
+// C/D operand convention. The hardware writes the per-lane f32 / i32
+// accumulator with M *interleaved* between lane groups, NOT split into
+// contiguous halves. Lane n holds N = n%16 and val v -> M = 2*v + n/16.
+// `getThrValLayoutCD` describes this real layout, so the C-side fragment
+// requires no runtime cross-lane shuffles.
 //
 // FP8/FP4/scaled/sparse WMMA, K=4 / K=32 / K=64 / K=128 shapes, and the
 // transpose-load atoms are gfx12+ only and rejected by `verify` here.
@@ -59,29 +64,28 @@ LayoutAttr getThrValLayoutAB(MLIRContext *ctx) {
 // C/D operand register layout for RDNA 3 / 3.5 WMMA (wave32, M=N=16).
 //
 // The accumulator is always 16x16. Lane l covers N = l%16 (one column).
-// The two lane groups split M into two halves of 8 rows each:
-//   group 0 -> M = 0..7
-//   group 1 -> M = 8..15
+// Empirically validated against gfx1151: the hardware writes the per-lane
+// 8-wide accumulator with M *interleaved* between the two lane groups, not
+// split into contiguous halves:
+//   group 0 (l < 16) -> M = 0, 2, 4, 6, 8, 10, 12, 14   (even rows)
+//   group 1 (l >= 16) -> M = 1, 3, 5, 7, 9, 11, 13, 15  (odd rows)
+// i.e. for f32/i32 acc: lane l, val v -> M = 2*v + (l/16), N = l%16.
 //
-// 32-bit accumulator (f32, i32): 8 VGPRs, one element per VGPR.
-//   M = (l/16)*8 + v
-//
-// 16-bit accumulator (f16, bf16): the LLVM intrinsic returns a 16-wide
-// vector with the OpSel[2] hi/lo bit selecting which half is live; from
-// the FlyDSL atom perspective each lane still holds 8 distinct M
-// coordinates, packed two-per-VGPR (4 VGPRs, sub-element index within VGPR).
-//   M = (l/16)*8 + v*2 + s
+// This matches the AMD gfx11 WMMA hardware natural output ordering. The
+// previous implementation declared a contiguous {M = (l/16)*8 + v} layout
+// and "fixed" the mismatch with cross-lane ds_bpermute swizzles at every
+// WMMA call (~32 ds_bpermute per call). Describing the real layout removes
+// all C-side runtime shuffles.
 //
 // Reference space is column-major (M, N) with stride (1, M=16).
 LayoutAttr getThrValLayoutCD(MLIRContext *ctx, Type elemTyAcc) {
   auto getContext = [&]() { return ctx; };
 
   (void)elemTyAcc;
-  // Keep a single canonical 8-value lane fragment layout for all accumulator
-  // types. The lowering may internally use packed/native forms, but the atom
-  // interface exposes a consistent vec8 fragment to tiled_copy_C.
+  // pos = (l%16)*16 + (l/16)*1 + v*2
+  //     = N*M_stride(=16) + (M = 2v + l/16)*1
   return FxLayout(FxShape(FxThr(16, 2), FxVal(8)),
-                  FxStride(FxThr(16, 8), FxVal(1)));
+                  FxStride(FxThr(16, 1), FxVal(2)));
 }
 
 } // namespace rdna3
@@ -346,112 +350,23 @@ FailureOr<Value> MmaOpRDNA3_WMMAType::emitAtomCallSSA(
                                          concatMask);
   };
 
-  auto duplicateTo16WideSimple = [&](Value v) -> Value {
-    auto vt = dyn_cast<VectorType>(v.getType());
-    if (!vt || vt.getShape().size() != 1 || vt.getShape()[0] != 8)
-      return v;
-    auto wideTy = VectorType::get({16}, vt.getElementType());
-    SmallVector<int32_t> mask = {0, 1, 2, 3, 4, 5, 6, 7,
-                                 0, 1, 2, 3, 4, 5, 6, 7};
-    return LLVM::ShuffleVectorOp::create(builder, loc, wideTy, v, v, mask);
-  };
-
-  // Empirically, RDNA3/3.5 `rocdl.wmma.f32.16x16x16.*` returns the per-lane
-  // 8-wide accumulator in a lane-local order different from the default
-  // FlyDSL f32 C-fragment order. Reorder to the fragment convention expected
-  // by `getThrValLayoutCD` / tiled_copy_C.
-  auto reorderAccLaneValues = [&](Value v) -> Value {
-    auto vt = dyn_cast<VectorType>(v.getType());
-    if (!vt || vt.getShape().size() != 1 || vt.getShape()[0] != 8)
-      return v;
-    bool isF32 = vt.getElementType().isF32();
-    bool isI32 = vt.getElementType().isInteger(32);
-    if (!isF32 && !isI32)
-      return v;
-    auto i32Ty = IntegerType::get(ctx, 32);
-    auto i64Ty = IntegerType::get(ctx, 64);
-    auto i32VecTy = VectorType::get({8}, i32Ty);
-
-    // First, apply the observed lane-local reorder from WMMA result encoding.
-    SmallVector<int32_t> laneLocalMask = {0, 4, 1, 5, 2, 6, 3, 7};
-    Value laneLocal = LLVM::ShuffleVectorOp::create(builder, loc, vt, v, v, laneLocalMask);
-
-    // Then fix the cross-lane row bit permutation (bit0 <-> bit3) by pulling
-    // companion values from lane^16 and selecting by lane-group.
-    Value lane = ROCDL::ThreadIdXOp::create(builder, loc, i32Ty).getResult();
-    Value c31 = LLVM::ConstantOp::create(builder, loc, i32Ty,
-                                         builder.getI32IntegerAttr(31));
-    Value cNeg32 = LLVM::ConstantOp::create(builder, loc, i32Ty,
-                                            builder.getI32IntegerAttr(-32));
-    Value c16 = LLVM::ConstantOp::create(builder, loc, i32Ty,
-                                         builder.getI32IntegerAttr(16));
-    Value c2 = LLVM::ConstantOp::create(builder, loc, i32Ty,
-                                        builder.getI32IntegerAttr(2));
-    Value c0 = LLVM::ConstantOp::create(builder, loc, i32Ty,
-                                        builder.getI32IntegerAttr(0));
-
-    Value laneInWave = LLVM::AndOp::create(builder, loc, lane, c31);
-    Value waveBase = LLVM::AndOp::create(builder, loc, lane, cNeg32);
-    Value pairedLaneInWave = LLVM::XOrOp::create(builder, loc, laneInWave, c16);
-    Value pairedLane = LLVM::OrOp::create(builder, loc, waveBase, pairedLaneInWave);
-    Value pairedLaneByteAddr = LLVM::ShlOp::create(builder, loc, pairedLane, c2);
-
-    Value packed = isF32 ? LLVM::BitcastOp::create(builder, loc, i32VecTy, laneLocal)
-                         : laneLocal;
-    Value pairedPacked = LLVM::UndefOp::create(builder, loc, i32VecTy);
-    for (int i = 0; i < 8; ++i) {
-      Value idx = LLVM::ConstantOp::create(builder, loc, i64Ty,
-                                           builder.getI64IntegerAttr(i));
-      Value laneWord = LLVM::ExtractElementOp::create(builder, loc, packed, idx);
-      Value pairedWord = ROCDL::DsBpermuteOp::create(builder, loc, i32Ty,
-                                                     pairedLaneByteAddr, laneWord)
-                             .getResult();
-      pairedPacked = LLVM::InsertElementOp::create(builder, loc, pairedPacked,
-                                                   pairedWord, idx);
-    }
-    Value pairedLaneLocal = isF32 ? LLVM::BitcastOp::create(builder, loc, vt, pairedPacked)
-                                  : pairedPacked;
-
-    SmallVector<int32_t> maskGroup0 = {0, 8, 2, 10, 4, 12, 6, 14};
-    SmallVector<int32_t> maskGroup1 = {9, 1, 11, 3, 13, 5, 15, 7};
-    Value outGroup0 = LLVM::ShuffleVectorOp::create(builder, loc, vt, laneLocal,
-                                                    pairedLaneLocal, maskGroup0);
-    Value outGroup1 = LLVM::ShuffleVectorOp::create(builder, loc, vt, laneLocal,
-                                                    pairedLaneLocal, maskGroup1);
-
-    Value laneGroupBit = LLVM::AndOp::create(builder, loc, laneInWave, c16);
-    Value isUpperGroup =
-        LLVM::ICmpOp::create(builder, loc, LLVM::ICmpPredicate::ne, laneGroupBit, c0);
-    return LLVM::SelectOp::create(builder, loc, isUpperGroup, outGroup1, outGroup0);
-  };
-
   // F32 <- F16/F16
   if (elemTyA.isF16() && elemTyB.isF16() && elemTyAcc.isF32()) {
-    constexpr bool crossLaneA = true;
-    constexpr bool crossLaneB = true;
-    Value aDup = crossLaneA ? expandTo16WideWmma256(a) : duplicateTo16WideSimple(a);
-    Value bDup = crossLaneB ? expandTo16WideWmma256(b) : duplicateTo16WideSimple(b);
-    Value cPacked =
-        reorderAccLaneValues(reorderAccLaneValues(reorderAccLaneValues(c)));
+    Value aDup = expandTo16WideWmma256(a);
+    Value bDup = expandTo16WideWmma256(b);
     Value res = ROCDL::wmma_f32_16x16x16_f16::create(builder, loc, accTy, aDup,
-                                                     bDup, cPacked)
+                                                     bDup, c)
                     .getResult();
-    return reorderAccLaneValues(res);
+    return res;
   }
   // F32 <- BF16/BF16 (op A/B input ty is AnyInteger -> bitcast bf16 to i16)
   if (elemTyA.isBF16() && elemTyB.isBF16() && elemTyAcc.isF32()) {
-    constexpr bool crossLaneA = true;
-    constexpr bool crossLaneB = true;
-    Value aI = castToI16Vec(crossLaneA ? expandTo16WideWmma256(a)
-                                       : duplicateTo16WideSimple(a));
-    Value bI = castToI16Vec(crossLaneB ? expandTo16WideWmma256(b)
-                                       : duplicateTo16WideSimple(b));
-    Value cPacked =
-        reorderAccLaneValues(reorderAccLaneValues(reorderAccLaneValues(c)));
+    Value aI = castToI16Vec(expandTo16WideWmma256(a));
+    Value bI = castToI16Vec(expandTo16WideWmma256(b));
     Value res =
-        ROCDL::wmma_f32_16x16x16_bf16::create(builder, loc, accTy, aI, bI, cPacked)
+        ROCDL::wmma_f32_16x16x16_bf16::create(builder, loc, accTy, aI, bI, c)
             .getResult();
-    return reorderAccLaneValues(res);
+    return res;
   }
   // F16 <- F16/F16.
   //
@@ -464,57 +379,51 @@ FailureOr<Value> MmaOpRDNA3_WMMAType::emitAtomCallSSA(
     Value bDup = expandTo16WideWmma256(b);
     auto accF32Ty = VectorType::get({accVecSize}, builder.getF32Type());
     Value cF32 = LLVM::FPExtOp::create(builder, loc, accF32Ty, c);
-    Value cPacked =
-        reorderAccLaneValues(reorderAccLaneValues(reorderAccLaneValues(cF32)));
     Value resF32 = ROCDL::wmma_f32_16x16x16_f16::create(
-                       builder, loc, accF32Ty, aDup, bDup, cPacked)
+                       builder, loc, accF32Ty, aDup, bDup, cF32)
                        .getResult();
-    Value resCanonicalF32 = reorderAccLaneValues(resF32);
-    return LLVM::FPTruncOp::create(builder, loc, accTy, resCanonicalF32).getResult();
+    return LLVM::FPTruncOp::create(builder, loc, accTy, resF32).getResult();
   }
-  // BF16 <- BF16/BF16 (op_sel = 0). Op signature is AnyInteger for both A/B
-  // and C/D, so we bitcast to / from i16 vectors and extract low half.
+  // BF16 <- BF16/BF16.
+  //
+  // The native bf16-acc WMMA variant uses op_sel-packed 16-wide C/D lanes,
+  // which conflicts with the FlyDSL vec8 fragment representation. For
+  // correctness and consistency with the f16-acc path, we promote to f32
+  // acc, run the F32_BF16 WMMA, and truncate back to bf16. (BF16 has the
+  // same exponent range as f32, so no value can overflow during the
+  // promote/truncate round-trip.)
   if (elemTyA.isBF16() && elemTyB.isBF16() && elemTyAcc.isBF16()) {
     Value aI = castToI16Vec(expandTo16WideWmma256(a));
     Value bI = castToI16Vec(expandTo16WideWmma256(b));
-    Value cI = castToI16Vec(expandTo16WideWmma256(c));
-    auto wideIntTy = cast<VectorType>(cI.getType());
-    Value resWideI = ROCDL::wmma_bf16_16x16x16_bf16::create(
-                         builder, loc, wideIntTy, aI, bI, cI, /*opsel=*/false)
-                         .getResult();
-    SmallVector<int32_t> mask = {0, 1, 2, 3, 4, 5, 6, 7};
-    auto narrowIntTy = VectorType::get({8}, i16Ty);
-    Value resI = LLVM::ShuffleVectorOp::create(builder, loc, narrowIntTy,
-                                               resWideI, resWideI, mask);
-    Value res = LLVM::BitcastOp::create(builder, loc, accTy, resI);
-    return res;
+    auto accF32Ty = VectorType::get({accVecSize}, builder.getF32Type());
+    Value cF32 = LLVM::FPExtOp::create(builder, loc, accF32Ty, c);
+    Value resF32 =
+        ROCDL::wmma_f32_16x16x16_bf16::create(builder, loc, accF32Ty, aI, bI, cF32)
+            .getResult();
+    return LLVM::FPTruncOp::create(builder, loc, accTy, resF32).getResult();
   }
   // I32 <- IU8 (signA = signB = 0 = unsigned, clamp = 0).
   // For RDNA 3 / 3.5 WMMA256b, the upper half must come from lane^16.
   if (elemTyA.isInteger(8) && elemTyB.isInteger(8) && elemTyAcc.isInteger(32)) {
     Value aWide = expandPackedI32To4WideWmma256(a);
     Value bWide = expandPackedI32To4WideWmma256(b);
-    Value cPacked =
-        reorderAccLaneValues(reorderAccLaneValues(reorderAccLaneValues(c)));
     Value res = ROCDL::wmma_i32_16x16x16_iu8::create(
                     builder, loc, accTy,
-                    /*signA=*/false, aWide, /*signB=*/false, bWide, cPacked,
+                    /*signA=*/false, aWide, /*signB=*/false, bWide, c,
                     /*clamp=*/false)
                     .getResult();
-    return reorderAccLaneValues(res);
+    return res;
   }
   // I32 <- IU4. Same WMMA256b lane^16 upper-half rule as IU8.
   if (elemTyA.isInteger(4) && elemTyB.isInteger(4) && elemTyAcc.isInteger(32)) {
     Value aWide = expandPackedI32To4WideWmma256(a);
     Value bWide = expandPackedI32To4WideWmma256(b);
-    Value cPacked =
-        reorderAccLaneValues(reorderAccLaneValues(reorderAccLaneValues(c)));
     Value res = ROCDL::wmma_i32_16x16x16_iu4::create(
                     builder, loc, accTy,
-                    /*signA=*/false, aWide, /*signB=*/false, bWide, cPacked,
+                    /*signA=*/false, aWide, /*signB=*/false, bWide, c,
                     /*clamp=*/false)
                     .getResult();
-    return reorderAccLaneValues(res);
+    return res;
   }
 
   return failure();

--- a/python/flydsl/compiler/backends/rocm.py
+++ b/python/flydsl/compiler/backends/rocm.py
@@ -33,6 +33,54 @@ class RocmBackend(BaseBackend):
         """Format {key: value, ...} as 'key=value key2=value2' for MLIR pass options."""
         return " ".join(f"{k}={v}" for k, v in opts.items())
 
+    @staticmethod
+    def _resolve_toolkit_path(toolkit_hint: str | None) -> str | None:
+        """Normalize ROCm toolkit layout for gpu-module-to-binary.
+
+        The MLIR pass expects a toolkit root that contains:
+          - <toolkit>/llvm/bin/ld.lld
+          - <toolkit>/amdgcn/bitcode/*.bc
+
+        Some distros install a "flat" layout where both `bin/` and `amdgcn/`
+        live directly under `.../lib/llvm` instead. In that case, we create a
+        user-space shim root under /tmp and symlink:
+          - shim/llvm   -> <flat-root>
+          - shim/amdgcn -> <flat-root>/amdgcn
+        """
+        import hashlib as _hashlib
+        import os as _os
+        import tempfile as _tempfile
+
+        if not toolkit_hint:
+            return None
+
+        toolkit_hint = _os.path.realpath(toolkit_hint)
+        expected_lld = _os.path.join(toolkit_hint, "llvm", "bin", "ld.lld")
+        expected_bitcode = _os.path.join(toolkit_hint, "amdgcn", "bitcode")
+        if _os.path.isfile(expected_lld) and _os.path.isdir(expected_bitcode):
+            return toolkit_hint
+
+        flat_lld = _os.path.join(toolkit_hint, "bin", "ld.lld")
+        flat_amdgcn = _os.path.join(toolkit_hint, "amdgcn")
+        flat_bitcode = _os.path.join(flat_amdgcn, "bitcode")
+        if not (_os.path.isfile(flat_lld) and _os.path.isdir(flat_bitcode)):
+            return None
+
+        digest = _hashlib.sha1(toolkit_hint.encode("utf-8")).hexdigest()[:12]
+        shim_root = _os.path.join(_tempfile.gettempdir(), f"flydsl-rocm-toolkit-{digest}")
+        _os.makedirs(shim_root, exist_ok=True)
+        for name, target in (("llvm", toolkit_hint), ("amdgcn", flat_amdgcn)):
+            link_path = _os.path.join(shim_root, name)
+            if _os.path.islink(link_path):
+                if _os.path.realpath(link_path) == _os.path.realpath(target):
+                    continue
+                _os.unlink(link_path)
+            elif _os.path.exists(link_path):
+                continue
+            _os.symlink(target, link_path)
+
+        return shim_root
+
     def pipeline_fragments(self, *, compile_hints: dict) -> List[str]:
         chip = self.target.arch
         waves_per_eu = compile_hints.get("waves_per_eu")
@@ -45,6 +93,30 @@ class RocmBackend(BaseBackend):
             bin_cli_opts.append(f"--amdgpu-waves-per-eu={waves_per_eu}")
         if maxnreg:
             bin_cli_opts.append(f"--amdgpu-num-vgpr={maxnreg}")
+
+        # ROCm toolkit path for `gpu-module-to-binary` (where lld pulls in
+        # the amdgcn device-libs bitcodes). Order:
+        #   1. FLYDSL_ROCM_TOOLKIT_PATH (explicit override)
+        #   2. ROCM_PATH (standard ROCm env var)
+        #   3. /opt/rocm (default that MLIR uses if neither is set)
+        # On distributions where /opt/rocm only contains the runtime symlink
+        # and the bitcodes live under a versioned subdir like
+        # /opt/rocm/core-7.12/lib/llvm, set FLYDSL_ROCM_TOOLKIT_PATH or
+        # ROCM_PATH to that dir so MLIR finds amdgcn/bitcode/*.bc.
+        import os as _os
+        toolkit_path = self._resolve_toolkit_path(
+            _os.environ.get("FLYDSL_ROCM_TOOLKIT_PATH") or _os.environ.get("ROCM_PATH")
+        )
+        if not toolkit_path:
+            for candidate in (
+                "/opt/rocm/lib/llvm",
+                "/opt/rocm/core-7.12/lib/llvm",
+                "/opt/rocm",
+            ):
+                normalized = self._resolve_toolkit_path(candidate)
+                if normalized:
+                    toolkit_path = normalized
+                    break
 
         rocdl_opts = {
             "O": 2,
@@ -87,7 +159,11 @@ class RocmBackend(BaseBackend):
                 if env.debug.enable_debug_info
                 else []
             ),
-            f'gpu-module-to-binary{{format=fatbin opts="{" ".join(bin_cli_opts)}"}}',
+            (
+                f'gpu-module-to-binary{{format=fatbin opts="{" ".join(bin_cli_opts)}"'
+                + (f" toolkit={toolkit_path}" if toolkit_path else "")
+                + "}"
+            ),
         ]
 
     def gpu_module_targets(self) -> List[str]:

--- a/python/flydsl/expr/rocdl/universal.py
+++ b/python/flydsl/expr/rocdl/universal.py
@@ -2,7 +2,10 @@
 # Copyright (c) 2025 FlyDSL Project Contributors
 
 from ..._mlir import ir
-from ..._mlir._mlir_libs._mlirDialectsFlyROCDL import MmaOpGFX1250_WMMAType
+from ..._mlir._mlir_libs._mlirDialectsFlyROCDL import (
+    MmaOpGFX1250_WMMAType,
+    MmaOpRDNA3_WMMAType,
+)
 from ..._mlir.dialects import arith, fly
 from ..._mlir.dialects._fly_enum_gen import AddressSpace
 from ..._mlir.dialects.fly import AtomicOp, PointerType
@@ -14,6 +17,7 @@ from ..._mlir.dialects.fly_rocdl import (
     TargetAddressSpace,
 )
 from ..._mlir.extras import types as T
+from ...runtime.device import get_rocm_arch
 from ..primitive import (
     get_iter,
     get_layout,
@@ -83,13 +87,52 @@ def MFMA(m, n, k, elem_ty_ab, elem_ty_acc=None):
     return MmaOpCDNA3_MFMAType.get(m, n, k, ty_ab, ty_ab, ty_acc)
 
 
-def WMMA(m, n, k, elem_ty_ab, elem_ty_acc=None):
+def WMMA_GFX1250(m, n, k, elem_ty_ab, elem_ty_acc=None):
+    """Create a GFX1250-class WMMA atom (MI450, K=4/32/64/128, FP8/FP4/scaled OK)."""
     ty_ab = elem_ty_ab.ir_type if hasattr(elem_ty_ab, "ir_type") else elem_ty_ab
     if elem_ty_acc is None:
         ty_acc = ir.F32Type.get()
     else:
         ty_acc = elem_ty_acc.ir_type if hasattr(elem_ty_acc, "ir_type") else elem_ty_acc
     return MmaOpGFX1250_WMMAType.get(m, n, k, ty_ab, ty_ab, ty_acc)
+
+
+def WMMA_RDNA3(m, n, k, elem_ty_ab, elem_ty_acc=None):
+    """Create an RDNA 3 / 3.5 WMMA atom (gfx1100/gfx1150).
+
+    Only M=N=K=16 with F16/BF16/IU8/IU4 input dtypes is supported. FP8/FP4,
+    scaled WMMA, sparse SWMMAC, and K != 16 require gfx12+ and are rejected
+    by the C++ ``verify`` of ``MmaOpRDNA3_WMMAType``.
+    """
+    ty_ab = elem_ty_ab.ir_type if hasattr(elem_ty_ab, "ir_type") else elem_ty_ab
+    if elem_ty_acc is None:
+        ty_acc = ir.F32Type.get()
+    else:
+        ty_acc = elem_ty_acc.ir_type if hasattr(elem_ty_acc, "ir_type") else elem_ty_acc
+    return MmaOpRDNA3_WMMAType.get(m, n, k, ty_ab, ty_ab, ty_acc)
+
+
+def _is_rdna3_arch(arch: str) -> bool:
+    """Return True for arch strings that match RDNA 3 / RDNA 3.5 (gfx110x / gfx115x)."""
+    return arch.startswith("gfx110") or arch.startswith("gfx115")
+
+
+def WMMA(m, n, k, elem_ty_ab, elem_ty_acc=None):
+    """Create a wave32 WMMA atom appropriate for the current GPU arch.
+
+    Dispatches to :func:`WMMA_RDNA3` for gfx110x / gfx115x (RDNA 3 / 3.5,
+    K=16-only intrinsics) and to :func:`WMMA_GFX1250` for gfx12+ MI450-class
+    chips (K=4/32/64/128, FP8/FP4, scaled). Use the explicit ``WMMA_RDNA3`` /
+    ``WMMA_GFX1250`` constructors when a kernel must pin a specific atom
+    regardless of the runtime arch (e.g. tests).
+    """
+    try:
+        arch = str(get_rocm_arch())
+    except Exception:
+        arch = ""
+    if _is_rdna3_arch(arch):
+        return WMMA_RDNA3(m, n, k, elem_ty_ab, elem_ty_acc)
+    return WMMA_GFX1250(m, n, k, elem_ty_ab, elem_ty_acc)
 
 
 def make_buffer_tensor(tensor: Tensor, max_size: bool = True) -> Tensor:

--- a/tests/bench_rdna3_gemm.py
+++ b/tests/bench_rdna3_gemm.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Benchmark the RDNA 3 / 3.5 atom-based GEMM (kernels.rdna3_gemm)
+against a rocBLAS / PyTorch hgemm reference on the same gfx11x device.
+
+Prints TFLOPS, percentage of rocBLAS, and percentage of theoretical
+WMMA peak. On gfx1151 (40 CUs @ 2.9 GHz), the WMMA F16 peak is
+~59 TFLOPS, and rocBLAS hgemm typically reaches ~30 TFLOPS (~50% MFU).
+"""
+
+import argparse
+import os
+import sys
+import time
+
+import torch
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from flydsl.runtime.device import get_rocm_arch
+from kernels.rdna3_gemm import create_rdna3_gemm_module
+
+
+# Per-CU per-GHz F16 WMMA throughput on RDNA 3 / 3.5: ~511 ops/cycle/CU
+# (back-calculated from RX 7900 XTX's 122.6 TFLOPS marketing number /
+# 96 CUs / 2.5 GHz). Same family ⇒ same per-CU rate on gfx115x/gfx110x.
+WMMA_F16_OPS_PER_CU_PER_CYCLE = 511
+
+# Rough chip lookup for theoretical peak hint. Set GHz to your boost clock.
+CHIP_INFO = {
+    "gfx1100": (96, 2.5),  # RX 7900 XTX
+    "gfx1101": (60, 2.5),  # RX 7800 XT
+    "gfx1102": (32, 2.5),  # RX 7600
+    "gfx1150": (32, 2.9),  # Strix Halo desktop fallback
+    "gfx1151": (40, 2.9),  # Strix Halo iGPU (Ryzen AI Max+)
+    "gfx1152": (40, 2.9),  # Strix Halo variant
+}
+
+
+def theoretical_wmma_tflops(arch: str) -> float:
+    cus, ghz = CHIP_INFO.get(arch, (None, None))
+    if cus is None:
+        return 0.0
+    return cus * WMMA_F16_OPS_PER_CU_PER_CYCLE * ghz / 1000.0
+
+
+def bench_one(M, N, K, in_dtype="f16", out_dtype="f32", iters=100, warmup=20, **kw):
+    torch_in = {"f16": torch.float16, "bf16": torch.bfloat16}[in_dtype]
+    torch_out = {"f32": torch.float32, "f16": torch.float16,
+                 "bf16": torch.bfloat16}[out_dtype]
+    A = (torch.randn(M, K, dtype=torch_in, device="cuda") * 0.1)
+    B_T = (torch.randn(N, K, dtype=torch_in, device="cuda") * 0.1)
+
+    # FlyDSL kernel
+    C = torch.zeros(M, N, dtype=torch_out, device="cuda")
+    launch_fn, BM, BN, BK = create_rdna3_gemm_module(
+        M, N, K, in_dtype=in_dtype, out_dtype=out_dtype, **kw
+    )
+    for _ in range(warmup):
+        launch_fn(A, B_T, C, stream=torch.cuda.current_stream())
+    torch.cuda.synchronize()
+    t = time.perf_counter()
+    for _ in range(iters):
+        launch_fn(A, B_T, C, stream=torch.cuda.current_stream())
+    torch.cuda.synchronize()
+    fly_us = (time.perf_counter() - t) / iters * 1e6
+    fly_tflops = 2 * M * N * K / fly_us / 1e6
+
+    # PyTorch / rocBLAS reference (always uses native dtype output, e.g.
+    # f16@f16 -> f16. Same FLOPS budget regardless of out_dtype.)
+    B = B_T.t().contiguous()
+    for _ in range(warmup):
+        C2 = torch.matmul(A, B)
+    torch.cuda.synchronize()
+    t = time.perf_counter()
+    for _ in range(iters):
+        C2 = torch.matmul(A, B)
+    torch.cuda.synchronize()
+    ref_us = (time.perf_counter() - t) / iters * 1e6
+    ref_tflops = 2 * M * N * K / ref_us / 1e6
+
+    # Correctness check
+    Cref = A.float() @ B_T.float().T
+    cos = ((C.float() * Cref).sum() /
+           ((C.float() * C.float()).sum().sqrt() *
+            (Cref * Cref).sum().sqrt())).item()
+
+    return {
+        "M": M, "N": N, "K": K,
+        "BLOCK": (BM, BN, BK),
+        "fly_us": fly_us, "fly_tflops": fly_tflops,
+        "ref_us": ref_us, "ref_tflops": ref_tflops,
+        "cos": cos,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--in-dtype", default="f16", choices=["f16", "bf16"])
+    parser.add_argument("--out-dtype", default="f32",
+                        choices=["f32", "f16", "bf16"])
+    parser.add_argument("--shapes", default="1024,2048,4096",
+                        help="comma-separated square sizes")
+    args = parser.parse_args()
+
+    arch = str(get_rocm_arch())
+    peak = theoretical_wmma_tflops(arch)
+    print(f"GPU arch: {arch}")
+    if peak > 0:
+        print(f"Theoretical WMMA F16 peak: {peak:.1f} TFLOPS")
+    print()
+
+    print(f"{'Shape':<22} {'BLOCK':<14} {'FlyDSL':>10}  {'rocBLAS':>10}  "
+          f"{'%rocBLAS':>9}  {'%peak':>7}  {'cos':>10}")
+    print("-" * 95)
+
+    for s in args.shapes.split(","):
+        M = N = K = int(s)
+        r = bench_one(M, N, K, in_dtype=args.in_dtype, out_dtype=args.out_dtype)
+        pct_ref = 100.0 * r["fly_tflops"] / r["ref_tflops"]
+        pct_peak = 100.0 * r["fly_tflops"] / peak if peak > 0 else 0.0
+        BM, BN, BK = r["BLOCK"]
+        print(f"{M}x{N}x{K:<14}"
+              f"{BM}x{BN}x{BK:<5}"
+              f"  {r['fly_tflops']:6.2f} TF  "
+              f"{r['ref_tflops']:6.2f} TF  "
+              f"{pct_ref:7.1f}%  "
+              f"{pct_peak:5.1f}%  "
+              f"{r['cos']:10.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/test_rdna3_gemm.py
+++ b/tests/kernels/test_rdna3_gemm.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Correctness + perf tests for the optimized RDNA 3 / 3.5 atom-based GEMM
+kernel (``kernels/rdna3_gemm.py``).
+
+Compared to ``test_rdna3_wmma_gemm.py`` (which validates the WMMA atom on
+small single-warp PoC kernels), this file exercises the production-shape
+kernel with multi-wave layout, LDS double-buffer, and software pipelining.
+"""
+
+import logging
+import os
+import sys
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from kernels.rdna3_gemm import create_rdna3_gemm_module
+from tests.test_common import verify_output
+from flydsl.runtime.device import get_rocm_arch
+
+logging.basicConfig(level=logging.INFO)
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA/ROCm not available. Skipping GPU tests.", allow_module_level=True)
+
+ARCH = str(get_rocm_arch())
+
+
+def _requires_rdna3():
+    if not (ARCH.startswith("gfx115") or ARCH.startswith("gfx110")):
+        pytest.skip(f"RDNA 3 / 3.5 GEMM tests require gfx110x or gfx115x, got {ARCH}")
+
+
+# Sizes that exercise the full pipeline (require K >= 2*BLOCK_K=64 for
+# the 2-stage ping-pong; M, N must be divisible by BLOCK_M = BLOCK_N = 128).
+
+
+@pytest.mark.parametrize("dtype", ["f16", "bf16"])
+@pytest.mark.parametrize(
+    "M, N, K",
+    [
+        pytest.param(128, 128, 64, id="128x128x64"),     # minimum (2 K-tiles)
+        pytest.param(128, 128, 256, id="128x128x256"),   # 8 K-tiles
+        pytest.param(256, 256, 256, id="256x256x256"),   # multi-block
+        pytest.param(512, 512, 512, id="512x512x512"),
+        pytest.param(1024, 1024, 1024, id="1024x1024x1024"),
+    ],
+)
+def test_rdna3_gemm_f32_acc(M, N, K, dtype):
+    """Optimized RDNA 3 / 3.5 atom-based GEMM with F32 accumulator."""
+    _requires_rdna3()
+
+    torch.manual_seed(42)
+    torch_dtype = torch.float16 if dtype == "f16" else torch.bfloat16
+
+    A = (torch.randn(M, K, dtype=torch_dtype, device="cuda") * 0.1)
+    B_T = (torch.randn(N, K, dtype=torch_dtype, device="cuda") * 0.1)
+    C = torch.zeros(M, N, dtype=torch.float32, device="cuda")
+
+    launch_fn, _, _, _ = create_rdna3_gemm_module(
+        M, N, K, in_dtype=dtype, out_dtype="f32"
+    )
+    launch_fn(A, B_T, C, stream=torch.cuda.current_stream())
+    torch.cuda.synchronize()
+
+    C_ref = A.float() @ B_T.float().T
+    assert verify_output(C, C_ref, atol=0.05, rtol=0.05)
+
+
+@pytest.mark.parametrize(
+    "M, N, K, dtype",
+    [
+        pytest.param(128, 128, 256, "f16", id="f16_acc-128x128x256"),
+        pytest.param(256, 256, 512, "f16", id="f16_acc-256x256x512"),
+        pytest.param(128, 128, 256, "bf16", id="bf16_acc-128x128x256"),
+        pytest.param(256, 256, 512, "bf16", id="bf16_acc-256x256x512"),
+    ],
+)
+def test_rdna3_gemm_same_precision_acc(M, N, K, dtype):
+    """Same-precision accumulator (f16->f16, bf16->bf16) exercising
+    the f32-internal-acc fallback in MmaOpRDNA3_WMMAType."""
+    _requires_rdna3()
+
+    torch.manual_seed(42)
+    torch_dtype = torch.float16 if dtype == "f16" else torch.bfloat16
+
+    A = (torch.randn(M, K, dtype=torch_dtype, device="cuda") * 0.1)
+    B_T = (torch.randn(N, K, dtype=torch_dtype, device="cuda") * 0.1)
+    C = torch.zeros(M, N, dtype=torch_dtype, device="cuda")
+
+    launch_fn, _, _, _ = create_rdna3_gemm_module(
+        M, N, K, in_dtype=dtype, out_dtype=dtype
+    )
+    launch_fn(A, B_T, C, stream=torch.cuda.current_stream())
+    torch.cuda.synchronize()
+
+    C_ref = (A.float() @ B_T.float().T).to(torch_dtype)
+    # Lower precision: looser bounds.
+    atol = 0.1 if dtype == "f16" else 0.5
+    rtol = 0.1 if dtype == "f16" else 0.1
+    assert verify_output(C, C_ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize(
+    "waves_m, waves_n, reg_m, reg_n, reg_k",
+    [
+        (1, 1, 1, 1, 1),  # 1 wave32, single-WMMA — minimum config
+        (1, 1, 4, 4, 2),  # 1 wave but big reg tile
+        (2, 2, 2, 2, 2),  # 4 waves, modest reg
+        (2, 2, 4, 4, 2),  # default production config
+        (2, 2, 4, 4, 1),  # smaller K tile
+    ],
+)
+def test_rdna3_gemm_wave_reg_configs(waves_m, waves_n, reg_m, reg_n, reg_k):
+    """Sweep wave / register tile knobs to validate the parametrized
+    multi-wave + multi-reg paths."""
+    _requires_rdna3()
+
+    BLOCK_M = 16 * reg_m * waves_m
+    BLOCK_N = 16 * reg_n * waves_n
+    BLOCK_K = 16 * reg_k
+    # Pick the smallest valid problem for this config (need K >= 2*BLOCK_K
+    # for the ping-pong pipeline, and M, N >= BLOCK_M, BLOCK_N).
+    M, N, K = BLOCK_M, BLOCK_N, max(2 * BLOCK_K, 64)
+
+    torch.manual_seed(42)
+    A = (torch.randn(M, K, dtype=torch.float16, device="cuda") * 0.1)
+    B_T = (torch.randn(N, K, dtype=torch.float16, device="cuda") * 0.1)
+    C = torch.zeros(M, N, dtype=torch.float32, device="cuda")
+
+    launch_fn, _, _, _ = create_rdna3_gemm_module(
+        M, N, K, in_dtype="f16", out_dtype="f32",
+        waves_m=waves_m, waves_n=waves_n,
+        reg_m=reg_m, reg_n=reg_n, reg_k=reg_k,
+    )
+    launch_fn(A, B_T, C, stream=torch.cuda.current_stream())
+    torch.cuda.synchronize()
+
+    C_ref = A.float() @ B_T.float().T
+    assert verify_output(C, C_ref, atol=0.05, rtol=0.05)

--- a/tests/kernels/test_rdna3_wmma_gemm.py
+++ b/tests/kernels/test_rdna3_wmma_gemm.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""RDNA 3 / 3.5 WMMA GEMM correctness tests (gfx1100 / gfx1150, wave32).
+
+Exercises the atom-based path through ``MmaOpRDNA3_WMMAType`` introduced
+for the gfx1150 (Strix Point) PoC. RDNA 4 (gfx1201) and gfx1250 keep
+their existing ``MmaOpGFX1250_WMMAType`` path and are not exercised here
+(they have wider K-shapes and FP8 support that this atom does not cover).
+"""
+
+import logging
+import os
+import sys
+
+import pytest
+import torch
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir.ir import Context
+
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from kernels.rdna3_f16_gemm import create_rdna3_wmma_gemm_module
+from tests.test_common import verify_output
+from flydsl.runtime.device import get_rocm_arch
+
+logging.basicConfig(level=logging.INFO)
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA/ROCm not available. Skipping GPU tests.", allow_module_level=True)
+
+ARCH = str(get_rocm_arch())
+
+
+def _requires_rdna3():
+    if not (ARCH.startswith("gfx115") or ARCH.startswith("gfx110")):
+        pytest.skip(f"RDNA3 / 3.5 WMMA tests require gfx110x or gfx115x, got {ARCH}")
+
+
+def _create_rdna3_wmma_iu8_i32_module():
+    """Build a minimal single-tile IU8->I32 RDNA3 WMMA kernel (16x16x16)."""
+    WMMA_M = 16
+    WMMA_N = 16
+    WMMA_K = 16
+    THREADS_PER_BLOCK = 32
+
+    @flyc.kernel
+    def gemm_iu8_i32_kernel(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+    ):
+        tid = fx.thread_idx.x
+
+        A = fx.rocdl.make_buffer_tensor(A)
+        B = fx.rocdl.make_buffer_tensor(B)
+        C = fx.rocdl.make_buffer_tensor(C)
+
+        bA = fx.zipped_divide(A, (WMMA_M, WMMA_K))
+        bB = fx.zipped_divide(B, (WMMA_N, WMMA_K))
+        bC = fx.zipped_divide(C, (WMMA_M, WMMA_N))
+        bA = fx.slice(bA, (None, (0, 0)))
+        bB = fx.slice(bB, (None, (0, 0)))
+        bC = fx.slice(bC, (None, (0, 0)))
+
+        mma_atom = fx.make_mma_atom(
+            fx.rocdl.WMMA_RDNA3(WMMA_M, WMMA_N, WMMA_K, fx.Int8, fx.Int32)
+        )
+        tiled_mma = fx.make_tiled_mma(
+            mma_atom, fx.make_layout((1, 1, 1), (0, 0, 0))
+        )
+        thr_mma = tiled_mma.thr_slice(tid)
+
+        copy_atom_ab = fx.make_copy_atom(
+            fx.rocdl.BufferCopy(fx.Int8.width), fx.Int8
+        )
+        copy_atom_c = fx.make_copy_atom(
+            fx.rocdl.BufferCopy(fx.Int32.width), fx.Int32
+        )
+        tiled_copy_A = fx.make_tiled_copy_A(copy_atom_ab, tiled_mma)
+        tiled_copy_B = fx.make_tiled_copy_B(copy_atom_ab, tiled_mma)
+        tiled_copy_C = fx.make_tiled_copy_C(copy_atom_c, tiled_mma)
+
+        thr_copy_A = tiled_copy_A.get_slice(tid)
+        thr_copy_B = tiled_copy_B.get_slice(tid)
+        thr_copy_C = tiled_copy_C.get_slice(tid)
+
+        copy_src_A = thr_copy_A.partition_S(bA)
+        copy_src_B = thr_copy_B.partition_S(bB)
+        copy_dst_C = thr_copy_C.partition_S(bC)
+
+        frag_A = thr_mma.make_fragment_A(bA)
+        frag_B = thr_mma.make_fragment_B(bB)
+        frag_C = thr_mma.make_fragment_C(bC)
+        copy_frag_A = thr_copy_A.retile(frag_A)
+        copy_frag_B = thr_copy_B.retile(frag_B)
+        copy_frag_C = thr_copy_C.retile(frag_C)
+
+        frag_C.fill(0)
+        fx.copy(copy_atom_ab, copy_src_A, copy_frag_A, pred=None)
+        fx.copy(copy_atom_ab, copy_src_B, copy_frag_B, pred=None)
+        fx.gemm(mma_atom, frag_C, frag_A, frag_B, frag_C)
+        fx.copy(copy_atom_c, copy_frag_C, copy_dst_C, pred=None)
+
+    @flyc.jit
+    def launch_gemm(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        gemm_iu8_i32_kernel(A, B, C).launch(
+            grid=(1, 1, 1),
+            block=(THREADS_PER_BLOCK, 1, 1),
+            stream=stream,
+        )
+
+    return launch_gemm
+
+
+# ── Single-warp WMMA correctness ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "M, N, K",
+    [
+        pytest.param(16, 16, 16, id="16x16x16"),
+        pytest.param(32, 16, 16, id="32x16x16"),
+        pytest.param(16, 32, 16, id="16x32x16"),
+        pytest.param(16, 16, 32, id="16x16x32"),
+        pytest.param(64, 64, 64, id="64x64x64"),
+        pytest.param(128, 128, 128, id="128x128x128"),
+    ],
+)
+@pytest.mark.parametrize("dtype", ["f16", "bf16"])
+def test_rdna3_wmma_f32_acc(M, N, K, dtype):
+    """RDNA 3 / 3.5 WMMA with F32 accumulator, F16 / BF16 inputs."""
+    _requires_rdna3()
+
+    torch.manual_seed(42)
+    torch_dtype = torch.float16 if dtype == "f16" else torch.bfloat16
+
+    A = (torch.randn(M, K, dtype=torch_dtype, device="cuda") * 0.1)
+    B_T = (torch.randn(N, K, dtype=torch_dtype, device="cuda") * 0.1)
+    C = torch.zeros(M, N, dtype=torch.float32, device="cuda")
+
+    launch_fn, _, _, _ = create_rdna3_wmma_gemm_module(
+        M, N, K, in_dtype=dtype, out_dtype="f32"
+    )
+    launch_fn(A, B_T, C, stream=torch.cuda.current_stream())
+    torch.cuda.synchronize()
+
+    C_ref = A.float() @ B_T.float().T
+    assert verify_output(C, C_ref, atol=0.05, rtol=0.05)
+
+
+@pytest.mark.parametrize(
+    "M, N, K",
+    [
+        pytest.param(16, 16, 16, id="16x16x16"),
+        pytest.param(64, 64, 64, id="64x64x64"),
+    ],
+)
+def test_rdna3_wmma_f16_acc(M, N, K):
+    """RDNA 3 / 3.5 WMMA with F16 accumulator (same-precision)."""
+    _requires_rdna3()
+
+    torch.manual_seed(42)
+
+    A = (torch.randn(M, K, dtype=torch.float16, device="cuda") * 0.1)
+    B_T = (torch.randn(N, K, dtype=torch.float16, device="cuda") * 0.1)
+    C = torch.zeros(M, N, dtype=torch.float16, device="cuda")
+
+    launch_fn, _, _, _ = create_rdna3_wmma_gemm_module(
+        M, N, K, in_dtype="f16", out_dtype="f16"
+    )
+    launch_fn(A, B_T, C, stream=torch.cuda.current_stream())
+    torch.cuda.synchronize()
+
+    C_ref = (A.float() @ B_T.float().T).to(torch.float16)
+    assert verify_output(C, C_ref, atol=0.1, rtol=0.1)
+
+
+@pytest.mark.parametrize(
+    "M, N, K",
+    [
+        pytest.param(16, 16, 16, id="16x16x16"),
+    ],
+)
+def test_rdna3_wmma_bf16_acc(M, N, K):
+    """RDNA 3 / 3.5 WMMA with BF16 accumulator (same-precision)."""
+    _requires_rdna3()
+
+    torch.manual_seed(42)
+
+    A = (torch.randn(M, K, dtype=torch.bfloat16, device="cuda") * 0.1)
+    B_T = (torch.randn(N, K, dtype=torch.bfloat16, device="cuda") * 0.1)
+    C = torch.zeros(M, N, dtype=torch.bfloat16, device="cuda")
+
+    launch_fn, _, _, _ = create_rdna3_wmma_gemm_module(
+        M, N, K, in_dtype="bf16", out_dtype="bf16"
+    )
+    launch_fn(A, B_T, C, stream=torch.cuda.current_stream())
+    torch.cuda.synchronize()
+
+    C_ref = (A.float() @ B_T.float().T).to(torch.bfloat16)
+    assert verify_output(C, C_ref, atol=0.1, rtol=0.1)
+
+
+def test_rdna3_wmma_iu8_i32_acc():
+    """RDNA3 WMMA IU8->I32 runtime correctness on a single 16x16x16 tile."""
+    _requires_rdna3()
+
+    torch.manual_seed(42)
+    A = torch.randint(0, 8, (16, 16), dtype=torch.int8, device="cuda")
+    B_T = torch.randint(0, 8, (16, 16), dtype=torch.int8, device="cuda")
+    C = torch.zeros((16, 16), dtype=torch.int32, device="cuda")
+
+    launch_fn = _create_rdna3_wmma_iu8_i32_module()
+    launch_fn(A, B_T, C, stream=torch.cuda.current_stream())
+    torch.cuda.synchronize()
+
+    C_ref = (
+        A.cpu().to(torch.int32) @ B_T.cpu().to(torch.int32).T
+    ).to(device="cuda", dtype=torch.int32)
+    assert torch.equal(C, C_ref)
+
+
+def test_rdna3_wmma_iu4_i32_module_contract():
+    """IU4->I32 should be accepted by the RDNA3 WMMA atom builder.
+
+    Runtime execution is covered by MLIR conversion tests because host-side
+    tensor frameworks do not expose a native int4 tensor dtype.
+    """
+    _requires_rdna3()
+    with Context():
+        mma_ty = fx.rocdl.WMMA_RDNA3(16, 16, 16, fx.Int4, fx.Int32)
+        mma_atom = fx.make_mma_atom(mma_ty)
+        assert mma_atom is not None

--- a/tests/kernels/test_rdna3_wmma_gemm.py
+++ b/tests/kernels/test_rdna3_wmma_gemm.py
@@ -189,10 +189,17 @@ def test_rdna3_wmma_f16_acc(M, N, K):
     "M, N, K",
     [
         pytest.param(16, 16, 16, id="16x16x16"),
+        pytest.param(16, 16, 32, id="16x16x32"),
+        pytest.param(64, 64, 64, id="64x64x64"),
+        pytest.param(128, 128, 128, id="128x128x128"),
     ],
 )
 def test_rdna3_wmma_bf16_acc(M, N, K):
-    """RDNA 3 / 3.5 WMMA with BF16 accumulator (same-precision)."""
+    """RDNA 3 / 3.5 WMMA with BF16 accumulator (same-precision).
+
+    Exercises the multi-K-tile accumulation path for the bf16-acc lowering,
+    which promotes to f32 internally and truncates to bf16 on output.
+    """
     _requires_rdna3()
 
     torch.manual_seed(42)
@@ -209,6 +216,117 @@ def test_rdna3_wmma_bf16_acc(M, N, K):
 
     C_ref = (A.float() @ B_T.float().T).to(torch.bfloat16)
     assert verify_output(C, C_ref, atol=0.1, rtol=0.1)
+
+
+@pytest.mark.parametrize(
+    "M, N, K",
+    [
+        pytest.param(16, 16, 32, id="16x16x32"),
+        pytest.param(128, 128, 128, id="128x128x128"),
+    ],
+)
+def test_rdna3_wmma_f16_acc_multi_k(M, N, K):
+    """f16-acc with multi-K-tile accumulation (stresses the f32 fallback path)."""
+    _requires_rdna3()
+
+    torch.manual_seed(42)
+
+    A = (torch.randn(M, K, dtype=torch.float16, device="cuda") * 0.1)
+    B_T = (torch.randn(N, K, dtype=torch.float16, device="cuda") * 0.1)
+    C = torch.zeros(M, N, dtype=torch.float16, device="cuda")
+
+    launch_fn, _, _, _ = create_rdna3_wmma_gemm_module(
+        M, N, K, in_dtype="f16", out_dtype="f16"
+    )
+    launch_fn(A, B_T, C, stream=torch.cuda.current_stream())
+    torch.cuda.synchronize()
+
+    C_ref = (A.float() @ B_T.float().T).to(torch.float16)
+    assert verify_output(C, C_ref, atol=0.1, rtol=0.1)
+
+
+@pytest.mark.parametrize(
+    "M, N, K",
+    [
+        pytest.param(32, 16, 16, id="32x16x16"),
+        pytest.param(16, 32, 16, id="16x32x16"),
+        pytest.param(64, 64, 64, id="64x64x64"),
+    ],
+)
+def test_rdna3_wmma_iu8_i32_multi_tile(M, N, K):
+    """IU8 -> I32 with multi-tile / multi-K to validate the iu8 lowering at scale."""
+    _requires_rdna3()
+
+    torch.manual_seed(42)
+    A = torch.randint(0, 8, (M, K), dtype=torch.int8, device="cuda")
+    B_T = torch.randint(0, 8, (N, K), dtype=torch.int8, device="cuda")
+    C = torch.zeros((M, N), dtype=torch.int32, device="cuda")
+
+    @flyc.kernel
+    def gemm_iu8_i32_kernel(A: fx.Tensor, B: fx.Tensor, C: fx.Tensor):
+        WMMA_M = 16
+        WMMA_N = 16
+        WMMA_K = 16
+        tid = fx.thread_idx.x
+        bid_m = fx.block_idx.x
+        bid_n = fx.block_idx.y
+
+        A = fx.rocdl.make_buffer_tensor(A)
+        B = fx.rocdl.make_buffer_tensor(B)
+        C = fx.rocdl.make_buffer_tensor(C)
+
+        bA_all = fx.zipped_divide(A, (WMMA_M, WMMA_K))
+        bB_all = fx.zipped_divide(B, (WMMA_N, WMMA_K))
+        bC = fx.zipped_divide(C, (WMMA_M, WMMA_N))
+        bC = fx.slice(bC, (None, (bid_m, bid_n)))
+
+        mma_atom = fx.make_mma_atom(
+            fx.rocdl.WMMA_RDNA3(WMMA_M, WMMA_N, WMMA_K, fx.Int8, fx.Int32)
+        )
+        tiled_mma = fx.make_tiled_mma(mma_atom, fx.make_layout((1, 1, 1), (0, 0, 0)))
+        thr_mma = tiled_mma.thr_slice(tid)
+
+        copy_atom_ab = fx.make_copy_atom(fx.rocdl.BufferCopy(fx.Int8.width), fx.Int8)
+        copy_atom_c = fx.make_copy_atom(fx.rocdl.BufferCopy(fx.Int32.width), fx.Int32)
+        tiled_copy_A = fx.make_tiled_copy_A(copy_atom_ab, tiled_mma)
+        tiled_copy_B = fx.make_tiled_copy_B(copy_atom_ab, tiled_mma)
+        tiled_copy_C = fx.make_tiled_copy_C(copy_atom_c, tiled_mma)
+
+        thr_copy_A = tiled_copy_A.get_slice(tid)
+        thr_copy_B = tiled_copy_B.get_slice(tid)
+        thr_copy_C = tiled_copy_C.get_slice(tid)
+
+        copy_dst_C = thr_copy_C.partition_S(bC)
+        frag_C = thr_mma.make_fragment_C(bC)
+        copy_frag_C = thr_copy_C.retile(frag_C)
+        frag_C.fill(0)
+
+        for k_tile in fx.range_constexpr(K // WMMA_K):
+            bA = fx.slice(bA_all, (None, (bid_m, k_tile)))
+            bB = fx.slice(bB_all, (None, (bid_n, k_tile)))
+            copy_src_A = thr_copy_A.partition_S(bA)
+            copy_src_B = thr_copy_B.partition_S(bB)
+            frag_A = thr_mma.make_fragment_A(bA)
+            frag_B = thr_mma.make_fragment_B(bB)
+            copy_frag_A = thr_copy_A.retile(frag_A)
+            copy_frag_B = thr_copy_B.retile(frag_B)
+            fx.copy(copy_atom_ab, copy_src_A, copy_frag_A, pred=None)
+            fx.copy(copy_atom_ab, copy_src_B, copy_frag_B, pred=None)
+            fx.gemm(mma_atom, frag_C, frag_A, frag_B, frag_C)
+
+        fx.copy(copy_atom_c, copy_frag_C, copy_dst_C, pred=None)
+
+    @flyc.jit
+    def launch(A: fx.Tensor, B: fx.Tensor, C: fx.Tensor,
+               stream: fx.Stream = fx.Stream(None)):
+        gemm_iu8_i32_kernel(A, B, C).launch(
+            grid=(M // 16, N // 16, 1), block=(32, 1, 1), stream=stream,
+        )
+
+    launch(A, B_T, C, stream=torch.cuda.current_stream())
+    torch.cuda.synchronize()
+    C_ref = (A.cpu().to(torch.int32) @ B_T.cpu().to(torch.int32).T).to("cuda")
+    assert torch.equal(C, C_ref)
 
 
 def test_rdna3_wmma_iu8_i32_acc():

--- a/tests/mlir/Conversion/wmma_rdna3.mlir
+++ b/tests/mlir/Conversion/wmma_rdna3.mlir
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 FlyDSL Project Contributors
+// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
+
+// RDNA 3 / 3.5 WMMA atom-call lowering tests.
+// The wave32, M=N=K=16-only WMMA atom from `lib/Dialect/FlyROCDL/RDNA3/MmaAtom.cpp`
+// must lower to the corresponding ROCDL `wmma.*.16x16x16.*` op. Each test
+// covers one of the six supported (A,B,Acc) dtype combinations.
+
+// CHECK-LABEL: @test_rdna3_wmma_f32_f16
+// CHECK-SAME: (%[[D:.*]]: !llvm.ptr<5>, %[[A:.*]]: !llvm.ptr<5>, %[[B:.*]]: !llvm.ptr<5>, %[[C:.*]]: !llvm.ptr<5>)
+func.func @test_rdna3_wmma_f32_f16(
+    %d: !fly.memref<f32, register, 8:1>,
+    %a: !fly.memref<f16, register, 8:1>,
+    %b: !fly.memref<f16, register, 8:1>,
+    %c: !fly.memref<f32, register, 8:1>) {
+  %atom = fly.make_mma_atom : !fly.mma_atom<!fly_rocdl.rdna3.wmma<16x16x16, (f16, f16) -> f32>>
+  // The atom loads <8 x f16> per-lane operands (FlyDSL invariant) and
+  // shufflevector-duplicates them to <16 x f16> for the gfx11 WMMA256b
+  // intrinsic. The accumulator is <8 x f32>.
+  // CHECK: %[[A_VAL:.*]] = llvm.load %[[A]] : !llvm.ptr<5> -> vector<8xf16>
+  // CHECK: %[[B_VAL:.*]] = llvm.load %[[B]] : !llvm.ptr<5> -> vector<8xf16>
+  // CHECK: %[[C_VAL:.*]] = llvm.load %[[C]] : !llvm.ptr<5> -> vector<8xf32>
+  // CHECK: llvm.shufflevector {{.*}} : vector<8xf16>
+// CHECK: rocdl.wmma.f32.16x16x16.f16 {{.*}} : (vector<16xf16>, vector<16xf16>, vector<8xf32>) -> vector<8xf32>
+// CHECK: llvm.store {{.*}}, %[[D]] : vector<8xf32>, !llvm.ptr<5>
+  fly.mma_atom_call(%atom, %d, %a, %b, %c) : (!fly.mma_atom<!fly_rocdl.rdna3.wmma<16x16x16, (f16, f16) -> f32>>, !fly.memref<f32, register, 8:1>, !fly.memref<f16, register, 8:1>, !fly.memref<f16, register, 8:1>, !fly.memref<f32, register, 8:1>) -> ()
+  return
+}
+
+// CHECK-LABEL: @test_rdna3_wmma_f32_bf16
+// CHECK: rocdl.wmma.f32.16x16x16.bf16
+func.func @test_rdna3_wmma_f32_bf16(
+    %d: !fly.memref<f32, register, 8:1>,
+    %a: !fly.memref<bf16, register, 8:1>,
+    %b: !fly.memref<bf16, register, 8:1>,
+    %c: !fly.memref<f32, register, 8:1>) {
+  %atom = fly.make_mma_atom : !fly.mma_atom<!fly_rocdl.rdna3.wmma<16x16x16, (bf16, bf16) -> f32>>
+  fly.mma_atom_call(%atom, %d, %a, %b, %c) : (!fly.mma_atom<!fly_rocdl.rdna3.wmma<16x16x16, (bf16, bf16) -> f32>>, !fly.memref<f32, register, 8:1>, !fly.memref<bf16, register, 8:1>, !fly.memref<bf16, register, 8:1>, !fly.memref<f32, register, 8:1>) -> ()
+  return
+}
+
+// CHECK-LABEL: @test_rdna3_wmma_f16_f16
+// For stable multi-K accumulation semantics, f16-acc lowers through the f32
+// WMMA op and truncates lane-local results back to f16.
+// CHECK: rocdl.wmma.f32.16x16x16.f16
+// CHECK: llvm.fptrunc {{.*}} : vector<8xf32> to vector<8xf16>
+func.func @test_rdna3_wmma_f16_f16(
+    %d: !fly.memref<f16, register, 8:1>,
+    %a: !fly.memref<f16, register, 8:1>,
+    %b: !fly.memref<f16, register, 8:1>,
+    %c: !fly.memref<f16, register, 8:1>) {
+  %atom = fly.make_mma_atom : !fly.mma_atom<!fly_rocdl.rdna3.wmma<16x16x16, (f16, f16) -> f16>>
+  fly.mma_atom_call(%atom, %d, %a, %b, %c) : (!fly.mma_atom<!fly_rocdl.rdna3.wmma<16x16x16, (f16, f16) -> f16>>, !fly.memref<f16, register, 8:1>, !fly.memref<f16, register, 8:1>, !fly.memref<f16, register, 8:1>, !fly.memref<f16, register, 8:1>) -> ()
+  return
+}
+
+// CHECK-LABEL: @test_rdna3_wmma_i32_iu8
+// CHECK: rocdl.wmma.i32.16x16x16.iu8
+func.func @test_rdna3_wmma_i32_iu8(
+    %d: !fly.memref<i32, register, 8:1>,
+    %a: !fly.memref<i8, register, 8:1>,
+    %b: !fly.memref<i8, register, 8:1>,
+    %c: !fly.memref<i32, register, 8:1>) {
+  %atom = fly.make_mma_atom : !fly.mma_atom<!fly_rocdl.rdna3.wmma<16x16x16, (i8, i8) -> i32>>
+  fly.mma_atom_call(%atom, %d, %a, %b, %c) : (!fly.mma_atom<!fly_rocdl.rdna3.wmma<16x16x16, (i8, i8) -> i32>>, !fly.memref<i32, register, 8:1>, !fly.memref<i8, register, 8:1>, !fly.memref<i8, register, 8:1>, !fly.memref<i32, register, 8:1>) -> ()
+  return
+}
+
+// CHECK-LABEL: @test_rdna3_wmma_bf16_bf16
+// CHECK: rocdl.wmma.bf16.16x16x16.bf16
+func.func @test_rdna3_wmma_bf16_bf16(
+    %d: !fly.memref<bf16, register, 8:1>,
+    %a: !fly.memref<bf16, register, 8:1>,
+    %b: !fly.memref<bf16, register, 8:1>,
+    %c: !fly.memref<bf16, register, 8:1>) {
+  %atom = fly.make_mma_atom : !fly.mma_atom<!fly_rocdl.rdna3.wmma<16x16x16, (bf16, bf16) -> bf16>>
+  fly.mma_atom_call(%atom, %d, %a, %b, %c) : (!fly.mma_atom<!fly_rocdl.rdna3.wmma<16x16x16, (bf16, bf16) -> bf16>>, !fly.memref<bf16, register, 8:1>, !fly.memref<bf16, register, 8:1>, !fly.memref<bf16, register, 8:1>, !fly.memref<bf16, register, 8:1>) -> ()
+  return
+}
+
+// CHECK-LABEL: @test_rdna3_wmma_i32_iu4
+// CHECK: rocdl.wmma.i32.16x16x16.iu4
+func.func @test_rdna3_wmma_i32_iu4(
+    %d: !fly.memref<i32, register, 8:1>,
+    %a: !fly.memref<i4, register, 8:1>,
+    %b: !fly.memref<i4, register, 8:1>,
+    %c: !fly.memref<i32, register, 8:1>) {
+  %atom = fly.make_mma_atom : !fly.mma_atom<!fly_rocdl.rdna3.wmma<16x16x16, (i4, i4) -> i32>>
+  fly.mma_atom_call(%atom, %d, %a, %b, %c) : (!fly.mma_atom<!fly_rocdl.rdna3.wmma<16x16x16, (i4, i4) -> i32>>, !fly.memref<i32, register, 8:1>, !fly.memref<i4, register, 8:1>, !fly.memref<i4, register, 8:1>, !fly.memref<i32, register, 8:1>) -> ()
+  return
+}

--- a/tests/mlir/Conversion/wmma_rdna3.mlir
+++ b/tests/mlir/Conversion/wmma_rdna3.mlir
@@ -68,7 +68,11 @@ func.func @test_rdna3_wmma_i32_iu8(
 }
 
 // CHECK-LABEL: @test_rdna3_wmma_bf16_bf16
-// CHECK: rocdl.wmma.bf16.16x16x16.bf16
+// For stable multi-K accumulation semantics, bf16-acc lowers through the f32
+// WMMA op (BF16 has the same exponent range as f32, no overflow risk) and
+// truncates lane-local results back to bf16.
+// CHECK: rocdl.wmma.f32.16x16x16.bf16
+// CHECK: llvm.fptrunc {{.*}} : vector<8xf32> to vector<8xbf16>
 func.func @test_rdna3_wmma_bf16_bf16(
     %d: !fly.memref<bf16, register, 8:1>,
     %a: !fly.memref<bf16, register, 8:1>,


### PR DESCRIPTION
## Motivation

This PR adds initial PoC-level support for AMD RDNA 3 / 3.5 wave32 WMMA on FlyDSL's atom path, validated on gfx1151 (Strix Halo iGPU, Radeon 8060S).

The goals are:

1. Make the `MmaOpRDNA3_WMMAType` atom **functionally and numerically correct** on gfx110x / gfx115x — the previous registration had a C/D layout mismatch with the actual hardware ordering and a suspect bf16-acc lowering, both papered over at runtime by ~28 `ds_bpermute` instructions per WMMA.
2. **Demonstrate the atom path works end-to-end** on production-shape GEMM (≤ 4096³) by adding a multi-wave + LDS double-buffered kernel, so other RDNA 3 / 3.5 kernels can be built on the same primitives.
3. Provide a **rocBLAS-comparison benchmark** so future perf work has a tracked baseline (currently ≈ 56% of rocBLAS hgemm at 4096³).

This is a **PoC baseline, not a competitive flagship kernel**. For peak GEMM perf on RDNA 3 / 3.5 today users should fall back to PyTorch /rocBLAS hgemm. Closing the gap to rocBLAS is left for follow-up PRs (see the *Out of scope* list below).

## Technical Details

### Atom-level fixes (`MmaOpRDNA3_WMMAType`)

Three issues found while reviewing the existing atom registration against the gfx11 ISA + empirically validating on gfx1151 hardware:

- **C/D layout mismatch.** The f32/i32 accumulator's per-lane natural M ordering is *interleaved* between lane groups (lane n, val v → M = 2·v + n/16), not contiguous halves as `getThrValLayoutCD` declared. The mismatch was being papered over by calling `reorderAccLaneValues` four times per WMMA call (3× on the C input as a hand-rolled inverse permutation, 1× on the D output), costing ~32 `ds_bpermute` per call. Updating `getThrValLayoutCD` to match the real layout and dropping the runtime swizzles takes the per-WMMA cross-lane op count from **~28 → 8** (the irreducible A/B expansion for the WMMA256b 16-wide K input).

- **bf16-acc path.** The native bf16-acc WMMA variant uses op_sel-packed 16-wide C/D lanes which conflicted with FlyDSL's vec8 fragment representation. Tests passed because `verify_output` uses cosine-similarity with atol=0.1 and only exercised 16×16×16 — almost certainly silently wrong on larger shapes. Now lowers through the f32 WMMA op + `fptrunc`, matching the f16-acc fallback. (BF16 has the same exponent range as f32, so the promote/truncate round-trip is overflow-safe.)

- **Dead code.** Remove the now-unused `duplicateTo16WideSimple` and `reorderAccLaneValues` helpers (~110 LOC of MmaAtom.cpp).

The MLIR FileCheck test (`tests/mlir/Conversion/wmma_rdna3.mlir`) is updated for the new bf16 → f32 lowering.

### New PoC baseline GEMM kernel — `kernels/rdna3_gemm.py`

A multi-wave atom-based GEMM exercising `MmaOpRDNA3_WMMAType` on production-shape sizes. Reaches **≈ 56% of rocBLAS hgemm at 4096³** on gfx1151 (≈ 30% of WMMA F16 peak). Explicitly framed as a **PoC baseline**, not a peak-perf kernel — the docstring lists the optimizations needed to close the gap to rocBLAS (LDS XOR swizzle, CShuffle epilogue, sched intrinsics, occupancy tuning, tail-tile predication) for follow-up PRs.

Atom-API optimizations applied:

- 2×2 wave layout (4 × wave32 = 128 threads/workgroup), per-warp reg_m × reg_n = 4×4 WMMA tile, BLOCK = 128 × 128 × 32.
- LDS staging for both A and B with a 2-stage ping-pong buffer; LDS layout is row-major (K-fastest) to match the row-major GMEM source, layout-lowering pass handles the reshape into the column-major WMMA fragment convention.
- Software pipelining: each loop iteration prefetches the next K-tile from GMEM into LDS[(k+1)&1] while computing from LDS[k&1], overlapping GMEM latency with WMMA compute.
- Outer loop is a runtime SCF for-op iterating over K-tile *pairs* (so the IR doesn't blow up at K=4096 from unrolling 128 iterations); the pair body unrolls stage 0 and stage 1 explicitly so the LDS-stage index stays constexpr.
- Implementation note: `make_tiled_mma`'s third argument is the K-direction permutation, *not* a per-warp reg-tile knob. reg_m / reg_n / reg_k are implicit from the ratio `BLOCK_M / (waves_m * WMMA_M)`.

### Tests + benchmark infrastructure

- **Atom validation** (`tests/kernels/test_rdna3_wmma_gemm.py`): expanded 17 → 25 cases — bf16-acc multi-K-tile (was only 16×16×16) and multi-block sizes; f16-acc multi-K-tile; iu8 → i32 multi-block (was only single-tile contract test).

- **Production-shape correctness** (`tests/kernels/test_rdna3_gemm.py`, new): 19 tests covering f16/bf16 inputs, f32/f16/bf16 accumulators, multi-block sizes (128³ → 1024³), and a wave / reg-config sweep.

- **rocBLAS-comparison benchmark** (`tests/bench_rdna3_gemm.py`, new): reports TFLOPS, %rocBLAS, and %WMMA-peak. Includes a chip table for back-calculating theoretical peak from per-CU per-cycle WMMA throughput (511 ops/cycle/CU on RDNA 3, derived from RX 7900 XTX's published 122.6 TFLOPS / 96 CUs / 2.5 GHz).
## Test Plan

Validated on gfx1151 (AMD Ryzen AI Max+ 395, Radeon 8060S iGPU, ROCm 7.12).

```bash
# Atom validation (25 tests covering all 6 dtype combos + multi-tile)
python -m pytest tests/kernels/test_rdna3_wmma_gemm.py -v

# Production-shape GEMM correctness (19 tests covering dtypes,
# accumulators, multi-block sizes, and a wave/reg-config sweep)
python -m pytest tests/kernels/test_rdna3_gemm.py -v

# Benchmark 
bash scripts/run_benchmark.sh 
[run_benchmark] GPU arch: gfx1151 (CDNA=false, RDNA4=false)
========================================================================
Benchmarks (logs under /tmp/flydsl_bench)
========================================================================

op                     shape                              dtype            TB/s     TFLOPS
---------------------- ---------------------------------- ---------- ---------- ----------
softmax                32768x8192                         bf16            0.209          -
layernorm              32768x8192                         bf16            0.226          -
rmsnorm                32768x8192                         bf16            0.225          -

========================================================================
Benchmark Summary
========================================================================
Total: 3 tests
Success: 3
Failed: 0
Logs: /tmp/flydsl_bench

All benchmarks passed! 