### PR TITLE
test: preserve default ROCm backend behavior

### DIFF
--- a/tests/unit/test_backend_cmake_defaults.py
+++ b/tests/unit/test_backend_cmake_defaults.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""CMake backend default and dependency guardrails."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.l0_backend_agnostic]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_cmake_default_backend_stays_rocdl():
+    text = (_REPO_ROOT / "cmake" / "FlyDSLBackends.cmake").read_text()
+
+    assert 'set(FLYDSL_BACKENDS "rocdl"' in text
+    assert "set_property(CACHE FLYDSL_BACKENDS PROPERTY STRINGS rocdl)" in text
+    assert "set(_FLYDSL_BACKENDS_ALLOWED rocdl)" in text
+
+
+def test_rocm_runtime_is_only_added_for_rocdl_backend():
+    text = (_REPO_ROOT / "lib" / "Runtime" / "CMakeLists.txt").read_text()
+
+    assert 'if("rocdl" IN_LIST FLYDSL_BACKENDS)' in text
+    assert "add_subdirectory(ROCm)" in text
+
+
+def test_backend_descriptors_are_loaded_from_selected_backend_list():
+    text = (_REPO_ROOT / "cmake" / "FlyDSLBackends.cmake").read_text()
+
+    assert "foreach(_backend ${FLYDSL_BACKENDS})" in text
+    assert 'include("${CMAKE_CURRENT_LIST_DIR}/backends/${_backend}.cmake")' in text
+    assert 'set(FLYDSL_BACKENDS_TUPLE "(${_backends_joined})")' in text
+
+
+def test_future_backend_descriptor_is_opt_in(tmp_path):
+    """A future backend should be legal only when explicitly selected."""
+    cmake = shutil.which("cmake")
+    if cmake is None:
+        pytest.skip("cmake not available")
+
+    cmake_dir = tmp_path / "cmake"
+    backend_dir = cmake_dir / "backends"
+    backend_dir.mkdir(parents=True)
+
+    text = (_REPO_ROOT / "cmake" / "FlyDSLBackends.cmake").read_text()
+    text = text.replace(
+        "set_property(CACHE FLYDSL_BACKENDS PROPERTY STRINGS rocdl)",
+        "set_property(CACHE FLYDSL_BACKENDS PROPERTY STRINGS rocdl dummy)",
+    )
+    text = text.replace(
+        "set(_FLYDSL_BACKENDS_ALLOWED rocdl)",
+        "set(_FLYDSL_BACKENDS_ALLOWED rocdl dummy)",
+    )
+    (cmake_dir / "FlyDSLBackends.cmake").write_text(text)
+
+    (backend_dir / "rocdl.cmake").write_text(
+        'set(GUARDRAIL_SELECTED_ROCDL ON CACHE BOOL "" FORCE)\n'
+    )
+    (backend_dir / "dummy.cmake").write_text(
+        'set(GUARDRAIL_SELECTED_DUMMY ON CACHE BOOL "" FORCE)\n'
+    )
+    (tmp_path / "CMakeLists.txt").write_text(
+        "\n".join(
+            [
+                "cmake_minimum_required(VERSION 3.20)",
+                "project(FlyDSLBackendSelectionGuardrail NONE)",
+                'include("${CMAKE_CURRENT_LIST_DIR}/cmake/FlyDSLBackends.cmake")',
+                'if(FLYDSL_BACKENDS STREQUAL "dummy" AND GUARDRAIL_SELECTED_ROCDL)',
+                '  message(FATAL_ERROR "rocdl descriptor was included for dummy-only build")',
+                "endif()",
+                'if(FLYDSL_BACKENDS STREQUAL "rocdl" AND GUARDRAIL_SELECTED_DUMMY)',
+                '  message(FATAL_ERROR "dummy descriptor was included for default build")',
+                "endif()",
+                "",
+            ]
+        )
+    )
+
+    default_build = tmp_path / "build-default"
+    subprocess.run(
+        [cmake, "-S", str(tmp_path), "-B", str(default_build)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    default_cache = (default_build / "CMakeCache.txt").read_text()
+    assert "FLYDSL_BACKENDS:STRING=rocdl" in default_cache
+    assert "GUARDRAIL_SELECTED_ROCDL:BOOL=ON" in default_cache
+    assert "GUARDRAIL_SELECTED_DUMMY" not in default_cache
+
+    dummy_build = tmp_path / "build-dummy"
+    subprocess.run(
+        [cmake, "-S", str(tmp_path), "-B", str(dummy_build), "-DFLYDSL_BACKENDS=dummy"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    dummy_cache = (dummy_build / "CMakeCache.txt").read_text()
+    assert "FLYDSL_BACKENDS:STRING=dummy" in dummy_cache
+    assert "GUARDRAIL_SELECTED_DUMMY:BOOL=ON" in dummy_cache
+    assert "GUARDRAIL_SELECTED_ROCDL" not in dummy_cache

--- a/tests/unit/test_compile_backends.py
+++ b/tests/unit/test_compile_backends.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""compile backend default behavior and registry guardrails."""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.l0_backend_agnostic]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_COMPILER_DIR = _REPO_ROOT / "python" / "flydsl" / "compiler"
+
+
+def _load_backends(monkeypatch):
+    """Import flydsl.compiler.backends without importing JIT-only compiler exports."""
+    for name in list(sys.modules):
+        if name == "flydsl.compiler" or name.startswith("flydsl.compiler.backends"):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    compiler_pkg = types.ModuleType("flydsl.compiler")
+    compiler_pkg.__path__ = [str(_COMPILER_DIR)]
+    monkeypatch.setitem(sys.modules, "flydsl.compiler", compiler_pkg)
+    return importlib.import_module("flydsl.compiler.backends")
+
+
+def test_default_compile_backend_stays_rocm(monkeypatch):
+    backends = _load_backends(monkeypatch)
+    monkeypatch.delenv("FLYDSL_COMPILE_BACKEND", raising=False)
+
+    backend = backends.get_backend(arch="gfx942")
+
+    assert backends.compile_backend_name() == "rocm"
+    assert backend.target.backend == "rocm"
+    assert backend.target.arch == "gfx942"
+
+
+def test_registering_extra_backend_does_not_change_default(monkeypatch):
+    backends = _load_backends(monkeypatch)
+    monkeypatch.delenv("FLYDSL_COMPILE_BACKEND", raising=False)
+
+    class _DummyBackend(backends.BaseBackend):
+        @staticmethod
+        def supports_target(target):
+            return target.backend == "dummy"
+
+        @staticmethod
+        def detect_target():
+            return backends.GPUTarget(backend="dummy", arch="dummy0", warp_size=1)
+
+        @classmethod
+        def make_target(cls, arch):
+            return backends.GPUTarget(backend="dummy", arch=arch or "dummy0", warp_size=1)
+
+        def pipeline_fragments(self, *, compile_hints):
+            return []
+
+        def gpu_module_targets(self):
+            return []
+
+        def native_lib_patterns(self):
+            return []
+
+        def jit_runtime_lib_basenames(self):
+            return []
+
+    backends.register_backend("dummy", _DummyBackend)
+
+    assert backends.compile_backend_name() == "rocm"
+    assert backends.get_backend(arch="gfx942").target.backend == "rocm"
+    assert backends.get_backend("dummy", arch="dummy0").target.backend == "dummy"

--- a/tests/unit/test_device_runtime.py
+++ b/tests/unit/test_device_runtime.py
@@ -29,6 +29,21 @@ class _FakeCudaRuntime(dr.DeviceRuntime):
         return 1
 
 
+def test_default_runtime_kind_stays_rocm(monkeypatch):
+    """Community users that do not opt into another runtime keep the ROCm default."""
+    monkeypatch.delenv("FLYDSL_COMPILE_BACKEND", raising=False)
+    monkeypatch.delenv("FLYDSL_RUNTIME_KIND", raising=False)
+    rt = dr.get_device_runtime()
+    assert rt.kind == "rocm"
+
+
+def test_default_compile_runtime_pairing_does_not_need_env(monkeypatch):
+    monkeypatch.delenv("FLYDSL_COMPILE_BACKEND", raising=False)
+    monkeypatch.delenv("FLYDSL_RUNTIME_KIND", raising=False)
+    dr.ensure_compile_runtime_pairing_from_env("rocm")
+    assert dr._instance is None
+
+
 def test_rocm_runtime_kind_matches_compile_backend(monkeypatch):
     monkeypatch.delenv("FLYDSL_RUNTIME_KIND", raising=False)
     monkeypatch.setenv("FLYDSL_COMPILE_BACKEND", "rocm")


### PR DESCRIPTION
## Summary

This PR adds guardrail tests for FlyDSL’s multi-backend defaults.

The tests ensure that:
- Python compile backend defaults still resolve to `rocm`
- Python device runtime defaults still resolve to `rocm`
- registering an additional Python backend does not change the default backend selection
- CMake defaults still select only the `rocdl` backend
- ROCm runtime wrappers are only included when `rocdl` is selected
- future CMake backend descriptors are included only when explicitly selected

## Motivation

FlyDSL now has infrastructure for multiple hardware backends. As new backend stacks are added, community users who do not opt into those backends should see no behavior change: default imports, backend selection, runtime pairing, tests, and builds should continue to use the existing ROCm/ROCDL path.

This PR makes that invariant explicit without adding any vendor-specific backend. The CMake test uses a temporary `dummy` backend descriptor to verify that future backend descriptors remain opt-in.

## Test plan

```bash
PYTHONPATH="$PWD/python:$PWD" python3 -m pytest \
  tests/unit/test_device_runtime.py \
  tests/unit/test_compile_backends.py \
  tests/unit/test_backend_cmake_defaults.py \
  -v --confcutdir=tests/unit
```
Result: 15 passed.