### PR TITLE
Move custom LLVM tools build to standalone workflow

### DIFF
--- a/.github/workflows/build-custom-llvm-tools.yaml
+++ b/.github/workflows/build-custom-llvm-tools.yaml
@@ -1,0 +1,218 @@
+name: Build Custom LLVM Tools
+
+on:
+  workflow_dispatch:
+    inputs:
+      llvm_ref:
+        description: 'LLVM branch, tag, or commit SHA (leave empty to use custom-llvm-tools.json)'
+        type: string
+        default: ''
+      release_type:
+        description: 'S3 bucket type for upload'
+        type: string
+        default: 'devreleases'
+      upload_s3:
+        description: 'Upload tarball to S3'
+        type: boolean
+        default: true
+
+jobs:
+  build:
+    runs-on: build-only-flydsl
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: flydsl
+
+      - name: Build manylinux Docker image
+        run: |
+          ROCM_VERSION=7.2
+          IMAGE="flydsl/manylinux_2_28:rocm${ROCM_VERSION}"
+          if docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+            echo "Reusing existing image: ${IMAGE}"
+          else
+            docker build \
+              --build-arg ROCM_VERSION="${ROCM_VERSION}" \
+              -t "${IMAGE}" \
+              - < flydsl/.github/workflows/Dockerfile.manylinux_2_28
+          fi
+          echo "MANYLINUX_IMAGE=${IMAGE}" >> $GITHUB_ENV
+
+      - name: Start build container
+        run: |
+          docker run -dt --network=host --user root \
+            -v "${GITHUB_WORKSPACE}/flydsl:/flydsl" \
+            --ipc=host --shm-size 16g \
+            -w /flydsl \
+            --name llvm_build \
+            "${MANYLINUX_IMAGE}"
+          docker exec llvm_build bash -c "python3 -m pip install -q nanobind"
+          docker exec llvm_build bash -c "git config --global --add safe.directory '*'"
+
+      - name: Resolve LLVM ref
+        id: llvm-ref
+        env:
+          LLVM_REF_INPUT: ${{ inputs.llvm_ref }}
+        run: |
+          set -euo pipefail
+          CONFIG="flydsl/thirdparty/custom-llvm-tools.json"
+          LLVM_REMOTE="https://github.com/llvm/llvm-project.git"
+
+          if [ -n "${LLVM_REF_INPUT}" ]; then
+            REF="${LLVM_REF_INPUT}"
+          elif [ -f "${CONFIG}" ]; then
+            REF="$(python3 -c "import json; print(json.load(open('${CONFIG}'))['llvm_ref'])")"
+            LLVM_REMOTE="$(python3 -c "import json; print(json.load(open('${CONFIG}')).get('llvm_remote', '${LLVM_REMOTE}'))")"
+          else
+            REF="$(tr -d '[:space:]' < flydsl/thirdparty/llvm-hash.txt)"
+          fi
+
+          # Resolve branch/tag to commit SHA for stable cache key
+          if [[ "${REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            COMMIT="${REF}"
+          else
+            echo "Resolving ref '${REF}' via ls-remote on ${LLVM_REMOTE} ..."
+            COMMIT="$(git ls-remote "${LLVM_REMOTE}" "${REF}" | head -1 | cut -f1)"
+            if [ -z "${COMMIT}" ]; then
+              echo "::error::Could not resolve LLVM ref '${REF}' from ${LLVM_REMOTE}"
+              exit 1
+            fi
+            echo "Resolved '${REF}' -> ${COMMIT}"
+          fi
+
+          SAFE_REF=$(printf '%s' "${COMMIT}" | sed 's|[^A-Za-z0-9_.-]|-|g')
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "commit=${COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "safe_ref=${SAFE_REF}" >> "$GITHUB_OUTPUT"
+          echo "remote=${LLVM_REMOTE}" >> "$GITHUB_OUTPUT"
+          echo "LLVM ref: ${REF}  commit: ${COMMIT}  remote: ${LLVM_REMOTE}"
+
+      - name: Restore cached MLIR install tarball
+        id: mlir-cache
+        uses: actions/cache@v4
+        with:
+          path: mlir_install.tgz
+          key: mlir-tools-${{ steps.llvm-ref.outputs.safe_ref }}-${{ hashFiles('flydsl/scripts/build_llvm.sh') }}
+
+      - name: Use cached MLIR install tarball
+        if: steps.mlir-cache.outputs.cache-hit == 'true'
+        run: |
+          docker cp mlir_install.tgz llvm_build:/tmp/mlir_install.tgz
+          docker exec llvm_build bash -c "mkdir -p /llvm-project && tar -xzf /tmp/mlir_install.tgz -C /llvm-project"
+
+      - name: Build LLVM
+        if: steps.mlir-cache.outputs.cache-hit != 'true'
+        env:
+          LLVM_REF: ${{ steps.llvm-ref.outputs.ref }}
+          LLVM_REMOTE: ${{ steps.llvm-ref.outputs.remote }}
+        run: |
+          docker exec \
+            -e "LLVM_REF=${LLVM_REF}" \
+            -e "LLVM_REMOTE=${LLVM_REMOTE}" \
+            llvm_build bash -c "cd /flydsl && bash scripts/build_llvm.sh"
+          docker cp llvm_build:/llvm-project/mlir_install.tgz ./mlir_install.tgz || true
+
+      - name: Package LLVM tools
+        env:
+          LLVM_SHA: ${{ steps.llvm-ref.outputs.commit }}
+        run: |
+          set -euo pipefail
+          CONFIG="flydsl/thirdparty/custom-llvm-tools.json"
+          LLVM_SHA_SHORT="${LLVM_SHA:0:12}"
+          if [ -f "${CONFIG}" ]; then
+            ARCHIVE_NAME="$(python3 -c "import json; print(json.load(open('${CONFIG}')).get('archive_name', 'flydsl-mlir-tools'))")"
+          else
+            ARCHIVE_NAME="flydsl-mlir-tools"
+          fi
+          TOOL_ARCHIVE="${ARCHIVE_NAME}-${LLVM_SHA_SHORT}-manylinux_2_28-x86_64.tar.gz"
+          echo "Packaging ${TOOL_ARCHIVE}"
+
+          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          mkdir -p flydsl/dist
+          docker exec llvm_build bash -c "
+            set -euo pipefail
+            test -x /llvm-project/mlir_install/bin/mlir-opt
+            cd /llvm-project/mlir_install
+            strip bin/mlir-opt
+            printf 'llvm_commit=%s\nbuild_date=%s\nbuild_cmd=scripts/build_llvm.sh  # BUILD_SHARED_LIBS=OFF, static mlir-opt\n' \
+              '${LLVM_SHA}' '${BUILD_DATE}' > BUILD_INFO
+            tar -czf /flydsl/dist/${TOOL_ARCHIVE} bin/mlir-opt BUILD_INFO
+            rm -f BUILD_INFO
+          "
+          # Smoke test: version check + gpu-module-to-binary round-trip
+          docker exec llvm_build bash -c "
+            set -euo pipefail
+            rm -rf /tmp/smoke && mkdir -p /tmp/smoke
+            tar -xzf /flydsl/dist/${TOOL_ARCHIVE} -C /tmp/smoke
+            /tmp/smoke/bin/mlir-opt --version
+            cat /tmp/smoke/BUILD_INFO
+
+            # Verify gpu-module-to-binary can produce a gpu.binary (HSACO).
+            cat > /tmp/smoke/test_input.mlir <<'MLIR'
+          module attributes {gpu.container_module} {
+            gpu.module @test_module [#rocdl.target<chip = \"gfx942\">] {
+              llvm.func @test_kernel() attributes {gpu.kernel, rocdl.kernel} {
+                llvm.return
+              }
+            }
+          }
+          MLIR
+            /tmp/smoke/bin/mlir-opt /tmp/smoke/test_input.mlir \
+              --pass-pipeline='builtin.module(gpu-module-to-binary{format=fatbin})' \
+              -o /tmp/smoke/test_output.mlir
+            grep -q 'gpu.binary' /tmp/smoke/test_output.mlir
+            grep -q 'bin = ' /tmp/smoke/test_output.mlir
+            echo 'gpu-module-to-binary smoke test passed'
+          "
+          ls -lh "flydsl/dist/${TOOL_ARCHIVE}"
+          echo "TOOL_ARCHIVE=${TOOL_ARCHIVE}" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: custom-llvm-tools
+          path: flydsl/dist/*-manylinux_2_28-*.tar.gz
+          retention-days: 7
+
+      - name: Configure AWS credentials
+        if: ${{ github.repository_owner == 'ROCm' && inputs.upload_s3 }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::661452401056:role/framework-flydsl-${{ inputs.release_type }}
+
+      - name: Install AWS CLI
+        if: ${{ github.repository_owner == 'ROCm' && inputs.upload_s3 }}
+        run: bash ./flydsl/scripts/install_awscli.sh
+
+      - name: Upload to S3
+        if: ${{ github.repository_owner == 'ROCm' && inputs.upload_s3 }}
+        env:
+          RELEASE_TYPE: ${{ inputs.release_type }}
+        run: |
+          aws s3 cp flydsl/dist/ "s3://framework-whls-${RELEASE_TYPE}/llvm-tools/gfx942-gfx950/" \
+            --recursive --exclude "*" --include "*-manylinux_2_28-*.tar.gz"
+          echo "Uploaded to s3://framework-whls-${RELEASE_TYPE}/llvm-tools/gfx942-gfx950/"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Custom LLVM Tools Build" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Item | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | --- |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| LLVM ref | \`${{ steps.llvm-ref.outputs.ref }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| LLVM commit | \`${{ steps.llvm-ref.outputs.commit }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| LLVM remote | \`${{ steps.llvm-ref.outputs.remote }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Cache | ${{ steps.mlir-cache.outputs.cache-hit == 'true' && 'Hit' || 'Miss (rebuilt)' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Archive | \`${TOOL_ARCHIVE}\` |" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Clean up
+        if: always()
+        run: |
+          docker stop llvm_build || true
+          docker rm llvm_build || true

--- a/.github/workflows/build-whl.yaml
+++ b/.github/workflows/build-whl.yaml
@@ -17,25 +17,16 @@ on:
         type: string
         required: false
         default: ''
-      llvm_ref:
-        description: 'Optional LLVM branch, tag, or full commit SHA for building external mlir tools'
-        type: string
-        required: false
-        default: ''
     outputs:
       wheel_names:
         description: 'Space-separated list of built wheel filenames'
         value: ${{ jobs.build.outputs.wheel_names }}
-      llvm_tool_names:
-        description: 'Space-separated list of built LLVM tool archive filenames'
-        value: ${{ jobs.build.outputs.llvm_tool_names }}
 
 jobs:
   build:
     runs-on: build-only-flydsl
     outputs:
       wheel_names: ${{ steps.collect-wheels.outputs.wheel_names }}
-      llvm_tool_names: ${{ steps.collect-llvm-tools.outputs.llvm_tool_names }}
     permissions:
       id-token: write
       contents: read
@@ -87,51 +78,12 @@ jobs:
           docker exec flydsl_build bash -c "python3 -m pip install -q nanobind"
           docker exec flydsl_build bash -c "git config --global --add safe.directory '*'"
 
-      - name: Resolve LLVM ref for cache key
-        id: llvm-ref
-        env:
-          LLVM_REF_INPUT: ${{ inputs.llvm_ref }}
-        run: |
-          set -euo pipefail
-          CONFIG="flydsl/thirdparty/custom-llvm-tools.json"
-          LLVM_REMOTE="https://github.com/llvm/llvm-project.git"
-
-          # Priority: workflow input > custom-llvm-tools.json > llvm-hash.txt
-          if [ -n "${LLVM_REF_INPUT}" ]; then
-            REF="${LLVM_REF_INPUT}"
-          elif [ -f "${CONFIG}" ]; then
-            REF="$(python3 -c "import json; print(json.load(open('${CONFIG}'))['llvm_ref'])")"
-            LLVM_REMOTE="$(python3 -c "import json; print(json.load(open('${CONFIG}')).get('llvm_remote', '${LLVM_REMOTE}'))")"
-          else
-            REF="$(tr -d '[:space:]' < flydsl/thirdparty/llvm-hash.txt)"
-          fi
-
-          # Resolve branch/tag refs to commit SHA via ls-remote so the cache
-          # key is always a stable content hash, not a moving pointer.
-          if [[ "${REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
-            COMMIT="${REF}"
-          else
-            echo "Resolving ref '${REF}' via ls-remote on ${LLVM_REMOTE} ..."
-            COMMIT="$(git ls-remote "${LLVM_REMOTE}" "${REF}" | head -1 | cut -f1)"
-            if [ -z "${COMMIT}" ]; then
-              echo "::error::Could not resolve LLVM ref '${REF}' from ${LLVM_REMOTE}"
-              exit 1
-            fi
-            echo "Resolved '${REF}' -> ${COMMIT}"
-          fi
-
-          SAFE_REF=$(printf '%s' "${COMMIT}" | sed 's|[^A-Za-z0-9_.-]|-|g')
-          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
-          echo "commit=${COMMIT}" >> "$GITHUB_OUTPUT"
-          echo "safe_ref=${SAFE_REF}" >> "$GITHUB_OUTPUT"
-          echo "LLVM ref: ${REF}  commit: ${COMMIT}"
-
       - name: Restore cached MLIR install tarball
         id: mlir-cache
         uses: actions/cache@v4
         with:
           path: mlir_install.tgz
-          key: mlir-install-manylinux228-${{ steps.llvm-ref.outputs.safe_ref }}-${{ hashFiles('flydsl/scripts/build_llvm.sh', 'flydsl/CMakeLists.txt') }}
+          key: mlir-install-manylinux228-${{ hashFiles('flydsl/thirdparty/llvm-hash.txt', 'flydsl/scripts/build_llvm.sh', 'flydsl/CMakeLists.txt') }}
 
       - name: Use cached MLIR install tarball
         if: steps.mlir-cache.outputs.cache-hit == 'true'
@@ -142,18 +94,8 @@ jobs:
 
       - name: Build LLVM
         if: steps.mlir-cache.outputs.cache-hit != 'true'
-        env:
-          LLVM_REF: ${{ steps.llvm-ref.outputs.ref }}
         run: |
-          CONFIG="flydsl/thirdparty/custom-llvm-tools.json"
-          LLVM_REMOTE=""
-          if [ -f "${CONFIG}" ]; then
-            LLVM_REMOTE="$(python3 -c "import json; print(json.load(open('${CONFIG}')).get('llvm_remote', ''))")"
-          fi
-          docker exec \
-            -e "LLVM_REF=${LLVM_REF}" \
-            ${LLVM_REMOTE:+-e "LLVM_REMOTE=${LLVM_REMOTE}"} \
-            flydsl_build bash -c "cd /flydsl && bash scripts/build_llvm.sh"
+          docker exec flydsl_build bash -c "cd /flydsl && bash scripts/build_llvm.sh"
           docker cp flydsl_build:/llvm-project/mlir_install.tgz ./mlir_install.tgz || true
 
       - name: Build wheels
@@ -177,55 +119,12 @@ jobs:
           echo "Copying fly-opt from ${FLY_OPT_SRC}"
           docker cp "flydsl_build:${FLY_OPT_SRC}" ./dist/fly-opt
 
-      - name: Package external LLVM tools
-        env:
-          LLVM_SHA: ${{ steps.llvm-ref.outputs.commit }}
-        run: |
-          set -euo pipefail
-          CONFIG="flydsl/thirdparty/custom-llvm-tools.json"
-          LLVM_SHA_SHORT="${LLVM_SHA:0:12}"
-          if [ -f "${CONFIG}" ]; then
-            ARCHIVE_NAME="$(python3 -c "import json; print(json.load(open('${CONFIG}')).get('archive_name', 'flydsl-mlir-tools'))")"
-          else
-            ARCHIVE_NAME="flydsl-mlir-tools"
-          fi
-          # Final tarball: {archive_name}-{commit_id_12char}-manylinux_2_28-x86_64.tar.gz
-          TOOL_ARCHIVE="${ARCHIVE_NAME}-${LLVM_SHA_SHORT}-manylinux_2_28-x86_64.tar.gz"
-          echo "Packaging ${TOOL_ARCHIVE}"
-          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          docker exec flydsl_build bash -c "
-            set -euo pipefail
-            test -x /llvm-project/mlir_install/bin/mlir-opt
-            cd /llvm-project/mlir_install
-            strip bin/mlir-opt
-            printf 'llvm_commit=%s\nbuild_date=%s\nbuild_cmd=scripts/build_llvm.sh  # BUILD_SHARED_LIBS=OFF, static mlir-opt\n' \
-              '${LLVM_SHA}' '${BUILD_DATE}' > BUILD_INFO
-            tar -czf /flydsl/dist/${TOOL_ARCHIVE} bin/mlir-opt BUILD_INFO
-            rm -f BUILD_INFO
-          "
-          docker exec flydsl_build bash -c "
-            set -euo pipefail
-            rm -rf /tmp/custom-llvm-tools-smoke
-            mkdir -p /tmp/custom-llvm-tools-smoke
-            tar -xzf /flydsl/dist/${TOOL_ARCHIVE} -C /tmp/custom-llvm-tools-smoke
-            /tmp/custom-llvm-tools-smoke/bin/mlir-opt --version
-            cat /tmp/custom-llvm-tools-smoke/BUILD_INFO
-          "
-          ls -lh "dist/${TOOL_ARCHIVE}"
-
       - name: Collect wheel names
         id: collect-wheels
         run: |
           WHEELS=$(ls dist/*.whl | xargs -n1 basename | tr '\n' ' ')
           echo "wheel_names=${WHEELS}" >> $GITHUB_OUTPUT
           echo "Built wheels: ${WHEELS}"
-
-      - name: Collect LLVM tool archive names
-        id: collect-llvm-tools
-        run: |
-          TOOLS=$(ls dist/*-manylinux_2_28-*.tar.gz 2>/dev/null | xargs -n1 basename | tr '\n' ' ')
-          echo "llvm_tool_names=${TOOLS}" >> $GITHUB_OUTPUT
-          echo "Built LLVM tool archives: ${TOOLS}"
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4
@@ -234,7 +133,6 @@ jobs:
           path: |
             dist/*.whl
             dist/fly-opt
-            dist/*-manylinux_2_28-*.tar.gz
           retention-days: 3
 
       - name: Build summary
@@ -267,14 +165,6 @@ jobs:
         run: |
           aws s3 cp dist/ "s3://framework-whls-${RELEASE_TYPE}/whl-staging/gfx942-gfx950/" \
             --recursive --exclude "*" --include "*.whl"
-
-      - name: Upload LLVM tools to S3 staging
-        if: ${{ github.repository_owner == 'ROCm' && inputs.upload_s3_staging }}
-        env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
-        run: |
-          aws s3 cp dist/ "s3://framework-whls-${RELEASE_TYPE}/llvm-tools-staging/gfx942-gfx950/" \
-            --recursive --exclude "*" --include "*-manylinux_2_28-*.tar.gz"
 
       - name: Clean up
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,6 @@ on:
         description: 'Docker base image for test'
         type: string
         default: "rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.8.0"
-      llvm_ref:
-        description: 'Optional LLVM branch, tag, or full commit SHA for external mlir tools'
-        type: string
-        default: ''
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: true
@@ -30,7 +26,6 @@ jobs:
     uses: ./.github/workflows/build-whl.yaml
     with:
       release_type: ${{ github.event_name == 'schedule' && 'nightlies' || 'devreleases' }}
-      llvm_ref: ${{ inputs.llvm_ref || '' }}
     permissions:
       id-token: write
       contents: read
@@ -53,7 +48,6 @@ jobs:
     with:
       release_type: ${{ github.event_name == 'schedule' && 'nightlies' || 'devreleases' }}
       wheel_names: ${{ needs.build.outputs.wheel_names }}
-      llvm_tool_names: ${{ needs.build.outputs.llvm_tool_names }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -11,12 +11,6 @@ on:
         description: 'Space-separated list of wheel filenames to promote'
         type: string
         required: true
-      llvm_tool_names:
-        description: 'Space-separated list of LLVM tool archive filenames to promote'
-        type: string
-        required: false
-        default: ''
-
 jobs:
   promote:
     runs-on: linux-flydsl-mi325-1
@@ -69,47 +63,6 @@ jobs:
           done
           echo "All wheels promoted successfully"
 
-      - name: Download LLVM tools from staging
-        if: ${{ inputs.llvm_tool_names != '' }}
-        env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
-          LLVM_TOOL_NAMES: ${{ inputs.llvm_tool_names }}
-        run: |
-          STAGING="s3://framework-whls-${RELEASE_TYPE}/llvm-tools-staging/gfx942-gfx950"
-          mkdir -p /tmp/promote-llvm-tools
-          echo "Downloading LLVM tools from ${STAGING}"
-          for TOOL in ${LLVM_TOOL_NAMES}; do
-            echo "Downloading ${TOOL}..."
-            aws s3 cp "${STAGING}/${TOOL}" "/tmp/promote-llvm-tools/${TOOL}"
-          done
-
-      - name: Smoke test LLVM tool archives
-        if: ${{ inputs.llvm_tool_names != '' }}
-        env:
-          LLVM_TOOL_NAMES: ${{ inputs.llvm_tool_names }}
-        run: |
-          set -euo pipefail
-          for TOOL in ${LLVM_TOOL_NAMES}; do
-            WORKDIR="/tmp/promote-llvm-tools-smoke/${TOOL%.tar.gz}"
-            mkdir -p "${WORKDIR}"
-            tar -xzf "/tmp/promote-llvm-tools/${TOOL}" -C "${WORKDIR}"
-            "${WORKDIR}/bin/mlir-opt" --version
-          done
-
-      - name: Upload LLVM tools to release
-        if: ${{ inputs.llvm_tool_names != '' }}
-        env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
-          LLVM_TOOL_NAMES: ${{ inputs.llvm_tool_names }}
-        run: |
-          RELEASE="s3://framework-whls-${RELEASE_TYPE}/llvm-tools/gfx942-gfx950"
-          echo "Uploading LLVM tools to ${RELEASE}"
-          for TOOL in ${LLVM_TOOL_NAMES}; do
-            echo "Uploading ${TOOL}..."
-            aws s3 cp "/tmp/promote-llvm-tools/${TOOL}" "${RELEASE}/${TOOL}"
-          done
-          echo "All LLVM tools promoted successfully"
-
       - name: Promote summary
         if: always()
         env:
@@ -117,6 +70,5 @@ jobs:
           SUMMARY_S3_SOURCE: "s3://framework-whls-${{ inputs.release_type }}/whl-staging/gfx942-gfx950"
           SUMMARY_S3_DEST: "s3://framework-whls-${{ inputs.release_type }}/whl/gfx942-gfx950"
           SUMMARY_WHEEL_NAMES: ${{ inputs.wheel_names }}
-          SUMMARY_LLVM_TOOL_NAMES: ${{ inputs.llvm_tool_names }}
         run: python3 flydsl/scripts/generate_summary.py promote
 

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -30,8 +30,6 @@ jobs:
           path: dist
 
       - name: Start GPU test container
-        env:
-          DOCKER_IMAGE: ${{ inputs.docker_image }}
         run: |
           docker ps -aq -f name=flydsl_test | xargs -r docker stop | xargs -r docker rm || true
 
@@ -50,7 +48,7 @@ jobs:
             --security-opt seccomp=unconfined \
             -w /flydsl \
             --name flydsl_test \
-            "${DOCKER_IMAGE}"
+            ${{ inputs.docker_image }}
 
       - name: Install wheels and dependencies
         id: install
@@ -60,26 +58,6 @@ jobs:
           docker exec flydsl_test bash -c "python3 -m pip install -U 'hypothesis>=6.82.0'"
           docker exec flydsl_test bash -c "mkdir -p /flydsl/build-fly/bin && cp /dist/fly-opt /flydsl/build-fly/bin/fly-opt && chmod +x /flydsl/build-fly/bin/fly-opt"
           docker exec flydsl_test bash -c "git config --global --add safe.directory /flydsl"
-
-      - name: Smoke test external LLVM tools
-        id: external-tools
-        run: |
-          docker exec flydsl_test bash -c '
-            set -euo pipefail
-            TOOL_ARCHIVE=$(ls -1 /dist/*-manylinux_2_28-*.tar.gz 2>/dev/null | head -n1)
-            if [ -z "${TOOL_ARCHIVE}" ]; then
-              echo "No LLVM tool archive found, skipping"
-              exit 0
-            fi
-            rm -rf /opt/custom-llvm-tools
-            mkdir -p /opt/custom-llvm-tools
-            tar -xzf "${TOOL_ARCHIVE}" -C /opt/custom-llvm-tools
-            /opt/custom-llvm-tools/bin/mlir-opt --version
-            cd /flydsl
-            FLYDSL_COMPILE_LLVM_DIR=/opt/custom-llvm-tools \
-            FLYDSL_RUNTIME_ENABLE_CACHE=0 \
-              python3 -m pytest tests/unit/test_compile_hints.py::TestCompileHintsPropagation::test_llvm_options_in_compile_hints -v
-          '
 
       - name: Run tests
         id: tests
@@ -116,7 +94,6 @@ jobs:
         env:
           SUMMARY_RUNNER: ${{ matrix.runners }}
           SUMMARY_INSTALL_OUTCOME: ${{ steps.install.outcome }}
-          SUMMARY_EXTERNAL_TOOLS_OUTCOME: ${{ steps.external-tools.outcome }}
           SUMMARY_TESTS_OUTCOME: ${{ steps.tests.outcome }}
           SUMMARY_BENCHMARKS_OUTCOME: ${{ steps.benchmarks.outcome }}
           SUMMARY_TEST_LOG: /tmp/test_output.log

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -77,7 +77,6 @@ def build_summary(summary: Path) -> None:
 def test_summary(summary: Path) -> None:
     runner = os.environ.get("SUMMARY_RUNNER", "unknown")
     install_outcome = os.environ.get("SUMMARY_INSTALL_OUTCOME", "unknown")
-    external_tools_outcome = os.environ.get("SUMMARY_EXTERNAL_TOOLS_OUTCOME", "unknown")
     tests_outcome = os.environ.get("SUMMARY_TESTS_OUTCOME", "unknown")
     bench_outcome = os.environ.get("SUMMARY_BENCHMARKS_OUTCOME", "unknown")
     test_log = os.environ.get("SUMMARY_TEST_LOG", "/tmp/test_output.log")
@@ -87,7 +86,6 @@ def test_summary(summary: Path) -> None:
     _out(summary)
     _table(summary, ["Step", "Status"], [
         ["Install wheels", f"`{install_outcome}`"],
-        ["Smoke test external LLVM tools", f"`{external_tools_outcome}`"],
         ["Run tests", f"`{tests_outcome}`"],
         ["Run benchmarks", f"`{bench_outcome}`"],
     ])
@@ -160,7 +158,6 @@ def promote_summary(summary: Path) -> None:
     source = os.environ.get("SUMMARY_S3_SOURCE", "unknown")
     dest = os.environ.get("SUMMARY_S3_DEST", "unknown")
     wheel_names = os.environ.get("SUMMARY_WHEEL_NAMES", "").strip()
-    llvm_tool_names = os.environ.get("SUMMARY_LLVM_TOOL_NAMES", "").strip()
 
     _out(summary, "## Promote Summary")
     _out(summary)
@@ -178,23 +175,11 @@ def promote_summary(summary: Path) -> None:
         _out(summary, "```")
         _out(summary)
 
-    if llvm_tool_names:
-        _out(summary, "### Promoted LLVM Tools")
-        _out(summary, "```")
-        for tool in llvm_tool_names.split():
-            _out(summary, f"  {tool}")
-        _out(summary, "```")
-        _out(summary)
-
     domain = DOMAIN_MAP.get(release_type)
     if domain:
         index_url = f"https://{domain}/whl/gfx942-gfx950/"
-        llvm_tools_url = f"https://{domain}/llvm-tools/gfx942-gfx950/"
         _out(summary, "### Wheels Available At")
         _out(summary, f"- {index_url}")
-        if llvm_tool_names:
-            _out(summary, "### LLVM Tools Available At")
-            _out(summary, f"- {llvm_tools_url}")
         _out(summary)
         _out(summary, "### Install")
         _out(summary, "```bash")


### PR DESCRIPTION
## Summary

- Extract LLVM tools packaging from nightly `build-whl.yaml` into a standalone `build-custom-llvm-tools.yaml`
- Only runs on manual `workflow_dispatch` — nightly CI no longer builds LLVM tools
- Reads `thirdparty/custom-llvm-tools.json` for LLVM ref, remote, and archive name
- Revert LLVM tools additions from build-whl, test-whl, promote, ci workflows and generate_summary.py

## Usage

```
GitHub → Actions → "Build Custom LLVM Tools" → Run workflow
  ├─ llvm_ref: leave empty (uses custom-llvm-tools.json) or override
  ├─ release_type: devreleases (default)
  └─ upload_s3: true
```

Produces: `mlir-opt-bin-mha-opt-{commit12}-manylinux_2_28-x86_64.tar.gz`

## Test plan

- [x] No conflicts with main
- [x] Nightly CI (`ci.yaml`) unaffected — no LLVM tools references remain
- [ ] Manual trigger of "Build Custom LLVM Tools" workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)