### PR TITLE
ci: gate multi-gpu tests behind explicit triggers

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -8,8 +8,6 @@ on:
     branches:
       - main
     types: [opened, synchronize, reopened, labeled]
-  issue_comment:
-    types: [created]
   workflow_dispatch:
 
 permissions:
@@ -32,7 +30,6 @@ jobs:
   # Runs on 1-GPU and Navi runners only.
   # ---------------------------------------------------------------------------
   test:
-    if: github.event_name != 'issue_comment'
     strategy:
       matrix:
         runners: [
@@ -190,8 +187,8 @@ jobs:
   # ---------------------------------------------------------------------------
   # Multi-GPU allreduce tests: ONLY for 8-GPU runners.
   # Runs on BOTH linux-flydsl-mi325-8 AND linux-flydsl-mi355-8 independently.
-  # Triggered when PR has label "multi-gpu", PR comment contains "/multi-gpu",
-  # or when workflow is manually dispatched.
+  # Triggered when PR has label "multi-gpu" (added by a maintainer), or when
+  # the workflow is manually dispatched.
   # fail-fast: false ensures both runners always complete even if one fails.
   # ---------------------------------------------------------------------------
   multi-gpu:
@@ -202,9 +199,6 @@ jobs:
       always() && (
         (github.event_name == 'pull_request' &&
          contains(github.event.pull_request.labels.*.name, 'multi-gpu')) ||
-        (github.event_name == 'issue_comment' &&
-         github.event.issue.pull_request != null &&
-         contains(github.event.comment.body, '/multi-gpu')) ||
         github.event_name == 'workflow_dispatch'
       )
     strategy:
@@ -216,33 +210,11 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runners }}
     steps:
-      - name: Resolve checkout ref
-        id: resolve-ref
-        uses: actions/github-script@v7
-        with:
-          script: |
-            if (context.eventName === 'issue_comment') {
-              const prNumber = context.payload.issue.number;
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-              });
-              core.setOutput('repo', pr.head.repo.full_name);
-              core.setOutput('sha', pr.head.sha);
-            } else if (context.eventName === 'pull_request') {
-              core.setOutput('repo', context.payload.pull_request.head.repo.full_name);
-              core.setOutput('sha', context.payload.pull_request.head.sha);
-            } else {
-              core.setOutput('repo', 'ROCm/FlyDSL');
-              core.setOutput('sha', context.sha);
-            }
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          repository: ${{ steps.resolve-ref.outputs.repo }}
-          ref: ${{ steps.resolve-ref.outputs.sha }}
+          repository: ${{ env.GITHUB_REPO_NAME }}
+          ref: ${{ env.GITHUB_COMMIT_SHA }}
           path: flydsl-test
 
       - name: Start CI container

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, labeled]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
 
 permissions:
@@ -29,6 +32,7 @@ jobs:
   # Runs on 1-GPU and Navi runners only.
   # ---------------------------------------------------------------------------
   test:
+    if: github.event_name != 'issue_comment'
     strategy:
       matrix:
         runners: [
@@ -186,12 +190,23 @@ jobs:
   # ---------------------------------------------------------------------------
   # Multi-GPU allreduce tests: ONLY for 8-GPU runners.
   # Runs on BOTH linux-flydsl-mi325-8 AND linux-flydsl-mi355-8 independently.
+  # Triggered when PR has label "multi-gpu", PR comment contains "/multi-gpu",
+  # or when workflow is manually dispatched.
   # fail-fast: false ensures both runners always complete even if one fails.
   # ---------------------------------------------------------------------------
   multi-gpu:
     needs: test
     name: Multi-GPU AllReduce Tests (${{ matrix.runners }})
     timeout-minutes: 120
+    if: |
+      always() && (
+        (github.event_name == 'pull_request' &&
+         contains(github.event.pull_request.labels.*.name, 'multi-gpu')) ||
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request != null &&
+         contains(github.event.comment.body, '/multi-gpu')) ||
+        github.event_name == 'workflow_dispatch'
+      )
     strategy:
       matrix:
         runners: [
@@ -201,11 +216,33 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runners }}
     steps:
+      - name: Resolve checkout ref
+        id: resolve-ref
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'issue_comment') {
+              const prNumber = context.payload.issue.number;
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              core.setOutput('repo', pr.head.repo.full_name);
+              core.setOutput('sha', pr.head.sha);
+            } else if (context.eventName === 'pull_request') {
+              core.setOutput('repo', context.payload.pull_request.head.repo.full_name);
+              core.setOutput('sha', context.payload.pull_request.head.sha);
+            } else {
+              core.setOutput('repo', 'ROCm/FlyDSL');
+              core.setOutput('sha', context.sha);
+            }
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          repository: ${{ env.GITHUB_REPO_NAME }}
-          ref: ${{ env.GITHUB_COMMIT_SHA }}
+          repository: ${{ steps.resolve-ref.outputs.repo }}
+          ref: ${{ steps.resolve-ref.outputs.sha }}
           path: flydsl-test
 
       - name: Start CI container


### PR DESCRIPTION
Run 8-GPU allreduce and shmem tests only when explicitly requested via label/manual dispatch to keep default PR CI fast and predictable.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
