### PR TITLE
[gfx1250] Modernize GEMM kernels to high-level Vector API

### DIFF
--- a/kernels/gemm_fp8fp4_gfx1250.py
+++ b/kernels/gemm_fp8fp4_gfx1250.py
@@ -93,8 +93,7 @@ def compile_mxscale_gemm(
     use_cluster = cluster_m > 1 or cluster_n > 1
     if use_cluster:
         if cluster_m * cluster_n > 16:
-            raise ValueError(
-                f"cluster_m * cluster_n must be <= 16, got {cluster_m}*{cluster_n}")
+            raise ValueError(f"cluster_m * cluster_n must be <= 16, got {cluster_m}*{cluster_n}")
     effective_waves_per_eu = waves_per_eu
     if use_cluster and effective_waves_per_eu is None:
         effective_waves_per_eu = 2
@@ -102,18 +101,16 @@ def compile_mxscale_gemm(
     num_warps = m_warp * n_warp
     block_threads = num_warps * WAVE_SIZE
     if block_threads > 1024:
-        raise ValueError(
-            f"block_threads must be <= 1024, got {block_threads}")
+        raise ValueError(f"block_threads must be <= 1024, got {block_threads}")
 
     if wave_specialized_tdm and num_warps != 4:
-        raise ValueError(
-            f"wave_specialized_tdm requires exactly 4 waves, got {num_warps}")
+        raise ValueError(f"wave_specialized_tdm requires exactly 4 waves, got {num_warps}")
 
     # ── Format-dependent compile-time constants ──
     # A8W4: activation is FP8 (PACK_FACTOR_A=1), weight is FP4 (PACK_FACTOR_B=2)
     if is_a8w4:
-        PACK_FACTOR_A = 1   # FP8 activation
-        PACK_FACTOR_B = 2   # FP4 weight
+        PACK_FACTOR_A = 1  # FP8 activation
+        PACK_FACTOR_B = 2  # FP4 weight
     elif is_fp4:
         PACK_FACTOR_A = 2
         PACK_FACTOR_B = 2
@@ -121,8 +118,8 @@ def compile_mxscale_gemm(
         PACK_FACTOR_A = 1
         PACK_FACTOR_B = 1
 
-    WMMA_N_EFF = 32 if is_fp4 else 16   # N-cols covered per WMMA instruction
-    ACC_VEC_SIZE = 16 if is_fp4 else 8   # accumulator vector width
+    WMMA_N_EFF = 32 if is_fp4 else 16  # N-cols covered per WMMA instruction
+    ACC_VEC_SIZE = 16 if is_fp4 else 8  # accumulator vector width
     DS_LOADS_PER_A_FRAG = 2 if is_fp4 else 4
 
     packed_tile_k_a = tile_k // PACK_FACTOR_A
@@ -138,8 +135,7 @@ def compile_mxscale_gemm(
     if K % split_k != 0:
         raise ValueError(f"K must be divisible by split_k={split_k}, got K={K}")
     if split_k_chunk % tile_k != 0:
-        raise ValueError(
-            f"K/split_k must be divisible by tile_k={tile_k}, got {split_k_chunk}")
+        raise ValueError(f"K/split_k must be divisible by tile_k={tile_k}, got {split_k_chunk}")
     if tile_k % WMMA_K != 0:
         raise ValueError(f"tile_k must be a multiple of {WMMA_K}, got {tile_k}")
     if tile_m % WMMA_M != 0:
@@ -151,8 +147,7 @@ def compile_mxscale_gemm(
     if packed_tile_k_b % 4 != 0:
         raise ValueError(f"packed_tile_k_b must be a multiple of 4, got {packed_tile_k_b}")
     if scale_k_per_tile % 4 != 0:
-        raise ValueError(
-            f"scale_k_per_tile must be a multiple of 4 (tile_k >= 128), got {scale_k_per_tile}")
+        raise ValueError(f"scale_k_per_tile must be a multiple of 4 (tile_k >= 128), got {scale_k_per_tile}")
 
     warp_tile_m = tile_m // m_warp
     warp_tile_n = tile_n // n_warp
@@ -166,9 +161,7 @@ def compile_mxscale_gemm(
 
     num_k_tiles = split_k_chunk // tile_k
     if num_k_tiles < num_buffers:
-        raise ValueError(
-            f"{num_buffers}-stage buffering requires num_k_tiles >= {num_buffers}, "
-            f"got {num_k_tiles}")
+        raise ValueError(f"{num_buffers}-stage buffering requires num_k_tiles >= {num_buffers}, " f"got {num_k_tiles}")
 
     gpu_arch = str(get_hip_arch())
     assert gpu_arch.startswith("gfx1250"), f"Expected gfx1250, got {gpu_arch}"
@@ -182,11 +175,7 @@ def compile_mxscale_gemm(
     b_scale_load_rep = warp_tile_n // WMMA_M if is_fp4 else wmma_n_rep
 
     _b_frag_loads_per_wn = 2 if is_a8w4 else 4
-    _bs_ds_loads = (
-        wmma_n_rep * _b_frag_loads_per_wn
-        + (b_scale_load_rep + 3) // 4
-        + (wmma_m_rep + 3) // 4
-    )
+    _bs_ds_loads = wmma_n_rep * _b_frag_loads_per_wn + (b_scale_load_rep + 3) // 4 + (wmma_m_rep + 3) // 4
 
     lds_a_stride_bytes = packed_tile_k_a + LDS_PAD_A_BYTES
 
@@ -212,8 +201,7 @@ def compile_mxscale_gemm(
     # All pipeline stages share the same intra-stage layout. Keep that layout
     # unchanged and only remap each logical stage to a physical base inside one
     # LDS arena so TDM epilogue can alias the dead prefix of the arena.
-    stage_layout = SmemAllocator(
-        None, arch=gpu_arch, global_sym_name=f"mxscale_{data_format}_layout")
+    stage_layout = SmemAllocator(None, arch=gpu_arch, global_sym_name=f"mxscale_{data_format}_layout")
     stage_a_data_rel_off = stage_layout._align(stage_layout.ptr, 16)
     stage_layout.ptr = stage_a_data_rel_off + lds_a_data_bytes
     stage_b_data_rel_off = stage_layout._align(stage_layout.ptr, 16)
@@ -237,8 +225,8 @@ def compile_mxscale_gemm(
         None,
         arch=gpu_arch,
         global_sym_name=(
-            f"mxscale_{data_format}_{tile_m}x{tile_n}x{tile_k}_"
-            f"{m_warp}x{n_warp}_{num_buffers}buf_arena"),
+            f"mxscale_{data_format}_{tile_m}x{tile_n}x{tile_k}_" f"{m_warp}x{n_warp}_{num_buffers}buf_arena"
+        ),
     )
 
     stage_phys_order = [i for i in range(num_buffers) if i != _last_compute_stage]
@@ -255,18 +243,10 @@ def compile_mxscale_gemm(
         extra=extra,
     )
 
-    stage_a_data_off = [
-        stage_base_off[i] + stage_a_data_rel_off for i in range(num_buffers)
-    ]
-    stage_b_data_off = [
-        stage_base_off[i] + stage_b_data_rel_off for i in range(num_buffers)
-    ]
-    stage_a_scale_off = [
-        stage_base_off[i] + stage_a_scale_rel_off for i in range(num_buffers)
-    ]
-    stage_b_scale_off = [
-        stage_base_off[i] + stage_b_scale_rel_off for i in range(num_buffers)
-    ]
+    stage_a_data_off = [stage_base_off[i] + stage_a_data_rel_off for i in range(num_buffers)]
+    stage_b_data_off = [stage_base_off[i] + stage_b_data_rel_off for i in range(num_buffers)]
+    stage_a_scale_off = [stage_base_off[i] + stage_a_scale_rel_off for i in range(num_buffers)]
+    stage_b_scale_off = [stage_base_off[i] + stage_b_scale_rel_off for i in range(num_buffers)]
 
     if use_tdm_store:
         lds_d_row_stride = warp_tile_n * elem_bytes_d + LDS_PAD_D_BYTES
@@ -286,10 +266,7 @@ def compile_mxscale_gemm(
     # tensor ops per wave per K-stage, while the wave-specialized path issues
     # only one tensor op from each dedicated loader wave.
     TDM_LOADS_PER_STEP = 1 if wave_specialized_tdm else 4
-    tail_plan = [
-        (ls, cs, o * TDM_LOADS_PER_STEP // 2 if o > 0 else o)
-        for ls, cs, o in _base_tail_plan
-    ]
+    tail_plan = [(ls, cs, o * TDM_LOADS_PER_STEP // 2 if o > 0 else o) for ls, cs, o in _base_tail_plan]
 
     # Pre-compute epilogue sub-tile layout (unified for FP4 vec16 and FP8 vec8)
     _sub_tiles = []
@@ -328,9 +305,7 @@ def compile_mxscale_gemm(
         return COMPUTE_SCHEDULE_FP4_COL_BAND
 
     compute_schedule_kind = _pick_compute_schedule_kind()
-    use_fp4_bank_friendly_schedule = (
-        compute_schedule_kind == COMPUTE_SCHEDULE_FP4_COL_BAND
-    )
+    use_fp4_bank_friendly_schedule = compute_schedule_kind == COMPUTE_SCHEDULE_FP4_COL_BAND
 
     if use_fp4_bank_friendly_schedule:
         _bank_half_wm = wmma_m_rep // 2
@@ -379,19 +354,19 @@ def compile_mxscale_gemm(
 
         if const_expr(use_cluster):
             local_x, local_y = gpu.compute_cluster_position()
-            a_mcast_mask, b_mcast_mask = gpu.compute_mcast_masks(
-                local_x, local_y, cluster_m, cluster_n)
+            a_mcast_mask, b_mcast_mask = gpu.compute_mcast_masks(local_x, local_y, cluster_m, cluster_n)
         else:
             a_mcast_mask = 0
             b_mcast_mask = 0
 
-        layout_thr = fx.make_layout(
-            (m_warp, n_warp, 2, 16),
-            (n_warp * WAVE_SIZE, WAVE_SIZE, 16, 1))
+        layout_thr = fx.make_layout((m_warp, n_warp, 2, 16), (n_warp * WAVE_SIZE, WAVE_SIZE, 16, 1))
         thr_coord = idx2crd(tx, layout_thr)
         wave_m_idx, wave_n_idx, lane_kgrp, lane16 = (
-            fx.get(thr_coord, 0), fx.get(thr_coord, 1),
-            fx.get(thr_coord, 2), fx.get(thr_coord, 3))
+            fx.get(thr_coord, 0),
+            fx.get(thr_coord, 1),
+            fx.get(thr_coord, 2),
+            fx.get(thr_coord, 3),
+        )
 
         warp_m_base = wave_m_idx * arith.index(warp_tile_m)
         warp_n_base = wave_n_idx * arith.index(warp_tile_n)
@@ -405,63 +380,74 @@ def compile_mxscale_gemm(
         def make_desc_a(memref, k_base):
             k_packed_off = k_base / arith.index(PACK_FACTOR_A)
             return tdm_ops.make_tensor_descriptor_2d(
-                global_ptr=arg_a, lds_memref=memref,
+                global_ptr=arg_a,
+                lds_memref=memref,
                 global_offset=(blk_m, k_packed_off),
                 tensor_shape=(tile_m, packed_tile_k_a),
                 strides=(K_packed_a, 1),
                 tile_shape=(tile_m, packed_tile_k_a),
                 elem_bytes=1,
-                pad_interval=packed_tile_k_a, pad_amount=LDS_PAD_A_BYTES,
+                pad_interval=packed_tile_k_a,
+                pad_amount=LDS_PAD_A_BYTES,
                 num_warps=tdm_desc_num_warps,
                 workgroup_mask=a_mcast_mask,
-                atomic_barrier_enable=atomic_barrier_enable)
+                atomic_barrier_enable=atomic_barrier_enable,
+            )
 
         def make_desc_b(memref, k_base):
             k_packed_off = k_base / arith.index(PACK_FACTOR_B)
             return tdm_ops.make_tensor_descriptor_2d(
-                global_ptr=arg_b, lds_memref=memref,
-                global_offset=(blk_n / arith.index(16),
-                               k_packed_off * arith.index(16)),
+                global_ptr=arg_b,
+                lds_memref=memref,
+                global_offset=(blk_n / arith.index(16), k_packed_off * arith.index(16)),
                 tensor_shape=(N // 16, K_packed_b * 16),
                 strides=(K_packed_b * 16, 1),
                 tile_shape=(tile_n // 16, packed_tile_k_b * 16),
                 elem_bytes=1,
-                pad_interval=0, pad_amount=0,
+                pad_interval=0,
+                pad_amount=0,
                 num_warps=tdm_desc_num_warps,
                 workgroup_mask=b_mcast_mask,
-                atomic_barrier_enable=atomic_barrier_enable)
+                atomic_barrier_enable=atomic_barrier_enable,
+            )
 
         def make_desc_as(memref, k_base):
             k_scale_off = k_base / arith.index(SCALE_BLOCK)
             outer_off = blk_m / arith.index(wmma_m_rep)
             inner_off = k_scale_off * arith.index(wmma_m_rep)
             return tdm_ops.make_tensor_descriptor_2d(
-                global_ptr=arg_a_scale, lds_memref=memref,
+                global_ptr=arg_a_scale,
+                lds_memref=memref,
                 global_offset=(outer_off, inner_off),
                 tensor_shape=(WMMA_M * m_warp, interleaved_scale_cols_a),
                 strides=(wmma_m_rep * K_scale, 1),
                 tile_shape=(WMMA_M * m_warp, interleaved_scale_cols_a),
                 elem_bytes=1,
-                pad_interval=0, pad_amount=0,
+                pad_interval=0,
+                pad_amount=0,
                 num_warps=tdm_desc_num_warps,
                 workgroup_mask=a_mcast_mask,
-                atomic_barrier_enable=atomic_barrier_enable)
+                atomic_barrier_enable=atomic_barrier_enable,
+            )
 
         def make_desc_bs(memref, k_base):
             k_scale_off = k_base / arith.index(SCALE_BLOCK)
             outer_off = blk_n / arith.index(b_scale_load_rep)
             inner_off = k_scale_off * arith.index(b_scale_load_rep)
             return tdm_ops.make_tensor_descriptor_2d(
-                global_ptr=arg_b_scale, lds_memref=memref,
+                global_ptr=arg_b_scale,
+                lds_memref=memref,
                 global_offset=(outer_off, inner_off),
                 tensor_shape=(WMMA_M * n_warp, interleaved_scale_cols_b),
                 strides=(b_scale_load_rep * K_scale, 1),
                 tile_shape=(WMMA_M * n_warp, interleaved_scale_cols_b),
                 elem_bytes=1,
-                pad_interval=0, pad_amount=0,
+                pad_interval=0,
+                pad_amount=0,
                 num_warps=tdm_desc_num_warps,
                 workgroup_mask=b_mcast_mask,
-                atomic_barrier_enable=atomic_barrier_enable)
+                atomic_barrier_enable=atomic_barrier_enable,
+            )
 
         if const_expr(wave_specialized_tdm):
             tdm_wave_id = rocdl.wave_id()
@@ -487,7 +473,6 @@ def compile_mxscale_gemm(
                 base = row_base + arith.index(wm * WMMA_M * lds_a_stride_bytes) + k_half_off
                 bases.append(base)
             return lds_ptr, bases
-
 
         def load_a_frag(lds_buffer, a_lane_base, ks):
             """Load one A-fragment from LDS.
@@ -533,14 +518,12 @@ def compile_mxscale_gemm(
             bases = []
             if const_expr(is_fp4):
                 for wn_half in range_constexpr(wmma_n_rep * 2):
-                    ngroup_off = _n_group_base * arith.index(_ngroup_stride) \
-                        + arith.index(wn_half * _ngroup_stride)
+                    ngroup_off = _n_group_base * arith.index(_ngroup_stride) + arith.index(wn_half * _ngroup_stride)
                     bases.append(ngroup_off + row_off + k_tile_off)
             else:
                 # FP8 and A8W4: 1 base per wn (16-col WMMA)
                 for wn in range_constexpr(wmma_n_rep):
-                    ngroup_off = _n_group_base * arith.index(_ngroup_stride) \
-                        + arith.index(wn * _ngroup_stride)
+                    ngroup_off = _n_group_base * arith.index(_ngroup_stride) + arith.index(wn * _ngroup_stride)
                     bases.append(ngroup_off + row_off + k_tile_off)
             return lds_ptr, bases
 
@@ -592,8 +575,7 @@ def compile_mxscale_gemm(
                 v23 = v2.shuffle(v3, list(range(8)))
                 return v01.shuffle(v23, list(range(16)))
 
-        def _precompute_scale_lane_bases(lds_ptr, warp_base, reps,
-                                         interleaved_cols):
+        def _precompute_scale_lane_bases(lds_ptr, warp_base, reps, interleaved_cols):
             """Precompute scale lane bases (byte offsets)."""
             warp_lds_row = warp_base / arith.index(reps) + lane16
             base = warp_lds_row * arith.index(interleaved_cols)
@@ -609,8 +591,7 @@ def compile_mxscale_gemm(
         def load_scale_b128(lds_buffer, scale_base, reps, ks=0):
             """Load all wmma_rep scales via ds_load_b128(s) for K-subtile *ks*."""
             ks_byte_off = ks * reps * SCALES_PER_WMMA
-            eff_base = scale_base if ks_byte_off == 0 \
-                else scale_base + arith.index(ks_byte_off)
+            eff_base = scale_base if ks_byte_off == 0 else scale_base + arith.index(ks_byte_off)
             num_loads = (reps + 3) // 4
             vecs = []
             for ld in range_constexpr(num_loads):
@@ -621,12 +602,10 @@ def compile_mxscale_gemm(
                 results.append(vecs[i // 4][i % 4])
             return results
 
-        def load_scale_slice_b128(lds_buffer, scale_base, full_reps,
-                                  rep_start, rep_count, ks=0):
+        def load_scale_slice_b128(lds_buffer, scale_base, full_reps, rep_start, rep_count, ks=0):
             """Load a contiguous slice of packed scale VGPRs for one K-subtile."""
             ks_byte_off = (ks * full_reps + rep_start) * SCALES_PER_WMMA
-            eff_base = scale_base if ks_byte_off == 0 \
-                else scale_base + arith.index(ks_byte_off)
+            eff_base = scale_base if ks_byte_off == 0 else scale_base + arith.index(ks_byte_off)
             num_loads = (rep_count + 3) // 4
             vecs = []
             for ld in range_constexpr(num_loads):
@@ -637,13 +616,10 @@ def compile_mxscale_gemm(
                 results.append(vecs[i // 4][i % 4])
             return results
 
-        def _load_b_and_scales(b_buf, b_bases, bs_buf, bs_bases,
-                               as_buf, as_bases, ks):
+        def _load_b_and_scales(b_buf, b_bases, bs_buf, bs_bases, as_buf, as_bases, ks):
             """Load B frags + all scales for one K-subtile."""
-            b_frags = [load_b_frag(b_buf, b_bases, wn, ks)
-                       for wn in range_constexpr(wmma_n_rep)]
-            b_scales_all = load_scale_b128(bs_buf, bs_bases[0],
-                                           b_scale_load_rep, ks)
+            b_frags = [load_b_frag(b_buf, b_bases, wn, ks) for wn in range_constexpr(wmma_n_rep)]
+            b_scales_all = load_scale_b128(bs_buf, bs_bases[0], b_scale_load_rep, ks)
             a_scales_all = load_scale_b128(as_buf, as_bases[0], wmma_m_rep, ks)
             if const_expr(is_fp4):
                 # FP4 32x16: scaleAType=0 fixed (no op_sel on BScale)
@@ -676,8 +652,11 @@ def compile_mxscale_gemm(
                 # 32x16 WMMA with A/B swap: SRC0=B, SRC1=A
                 accs[idx] = rocdl.wmma_scale_f32_32x16x128_f4(
                     T.vec(16, T.f32),
-                    b_frags[wn], a_frag, accs[idx],
-                    b_scales[wn * 2], a_scales[a_scale_idx],
+                    b_frags[wn],
+                    a_frag,
+                    accs[idx],
+                    b_scales[wn * 2],
+                    a_scales[a_scale_idx],
                     scaleAType=0,
                     scaleBType=a_opsel,
                 )
@@ -691,16 +670,29 @@ def compile_mxscale_gemm(
                     b_opsel = 0
                 accs[idx] = rocdl.wmma_scale_f32_16x16x128_f8f6f4(
                     T.vec(8, T.f32),
-                    b_frags[wn], a_frag, accs[idx],
-                    b_scales[b_scale_idx], a_scales[a_scale_idx],
-                    fmtA=4 if is_a8w4 else 0, fmtB=0,
-                    scaleAType=b_opsel, scaleBType=a_opsel,
+                    b_frags[wn],
+                    a_frag,
+                    accs[idx],
+                    b_scales[b_scale_idx],
+                    a_scales[a_scale_idx],
+                    fmtA=4 if is_a8w4 else 0,
+                    fmtB=0,
+                    scaleAType=b_opsel,
+                    scaleBType=a_opsel,
                 )
 
-        def _a_streaming_compute(accs, a_buf, a_bases, b_frags, b_scales,
-                                 a_scales, ks, emit_filler=None,
-                                 next_bs_info=None,
-                                 mid_compute_callback=None):
+        def _a_streaming_compute(
+            accs,
+            a_buf,
+            a_bases,
+            b_frags,
+            b_scales,
+            a_scales,
+            ks,
+            emit_filler=None,
+            next_bs_info=None,
+            mid_compute_callback=None,
+        ):
             """Half-based A-streaming with zigzag wn ordering.
 
             When *next_bs_info* is provided, the next K-subtile's B+scale
@@ -714,29 +706,21 @@ def compile_mxscale_gemm(
             def _emit_rows(start_wm, a_frags):
                 for frag_i in range_constexpr(len(a_frags)):
                     wm = start_wm + frag_i
-                    is_last = (wm == wmma_m_rep - 1)
+                    is_last = wm == wmma_m_rep - 1
                     if const_expr(is_last and emit_filler is not None):
                         rocdl.sched_barrier(0)
                         emit_filler()
                     for wn_raw in range_constexpr(wmma_n_rep):
                         wn = (wmma_n_rep - 1 - wn_raw) if (wm % 2 == 1) else wn_raw
-                        _emit_wmma(accs, wm, wn, a_frags[frag_i], b_frags,
-                                   a_scales, b_scales)
+                        _emit_wmma(accs, wm, wn, a_frags[frag_i], b_frags, a_scales, b_scales)
 
-            a_frags_front = [load_a_frag(a_buf, a_bases[wm], ks)
-                             for wm in range_constexpr(_front_wm)]
+            a_frags_front = [load_a_frag(a_buf, a_bases[wm], ks) for wm in range_constexpr(_front_wm)]
 
-            _use_partial_drain = (
-                next_bs_info is not None
-                and _front_wm * wmma_n_rep >= 4
-            )
+            _use_partial_drain = next_bs_info is not None and _front_wm * wmma_n_rep >= 4
 
             if const_expr(_use_partial_drain):
-                nb_buf, nb_bases, nbs_buf, nbs_bases, \
-                    nas_buf, nas_bases, n_ks = next_bs_info
-                next_result = _load_b_and_scales(
-                    nb_buf, nb_bases, nbs_buf, nbs_bases,
-                    nas_buf, nas_bases, n_ks)
+                nb_buf, nb_bases, nbs_buf, nbs_bases, nas_buf, nas_bases, n_ks = next_bs_info
+                next_result = _load_b_and_scales(nb_buf, nb_bases, nbs_buf, nbs_bases, nas_buf, nas_bases, n_ks)
                 rocdl.s_wait_dscnt(_bs_ds_loads)
             else:
                 rocdl.s_wait_dscnt(0)
@@ -748,8 +732,7 @@ def compile_mxscale_gemm(
                 mid_compute_callback()
 
             if const_expr(_back_wm > 0):
-                a_frags_back = [load_a_frag(a_buf, a_bases[_front_wm + h], ks)
-                                for h in range_constexpr(_back_wm)]
+                a_frags_back = [load_a_frag(a_buf, a_bases[_front_wm + h], ks) for h in range_constexpr(_back_wm)]
                 _back_drain = _bs_ds_loads if _use_partial_drain else 0
                 rocdl.s_wait_dscnt(_back_drain)
                 _emit_rows(_front_wm, a_frags_back)
@@ -757,60 +740,70 @@ def compile_mxscale_gemm(
             if const_expr(_use_partial_drain):
                 return accs, next_result
             if const_expr(next_bs_info is not None):
-                nb_buf, nb_bases, nbs_buf, nbs_bases, \
-                    nas_buf, nas_bases, n_ks = next_bs_info
-                next_result = _load_b_and_scales(
-                    nb_buf, nb_bases, nbs_buf, nbs_bases,
-                    nas_buf, nas_bases, n_ks)
+                nb_buf, nb_bases, nbs_buf, nbs_bases, nas_buf, nas_bases, n_ks = next_bs_info
+                next_result = _load_b_and_scales(nb_buf, nb_bases, nbs_buf, nbs_bases, nas_buf, nas_bases, n_ks)
                 return accs, next_result
             return accs
 
         # ── Compute on one LDS buffer ──
-        def compute_tile(accs_in, lds_a, lds_b, lds_as, lds_bs,
-                         emit_filler=None, mid_compute_callback=None):
+        def compute_tile(accs_in, lds_a, lds_b, lds_as, lds_bs, emit_filler=None, mid_compute_callback=None):
             current_accs = list(accs_in)
             a_buf, a_bases = _precompute_a_lane_bases(lds_a)
             b_buf, b_bases = _precompute_b_lane_bases(lds_b)
-            as_buf, as_bases = _precompute_scale_lane_bases(
-                lds_as, warp_m_base, wmma_m_rep, interleaved_scale_cols_a)
+            as_buf, as_bases = _precompute_scale_lane_bases(lds_as, warp_m_base, wmma_m_rep, interleaved_scale_cols_a)
             bs_buf, bs_bases = _precompute_scale_lane_bases(
-                lds_bs, warp_n_base, b_scale_load_rep, interleaved_scale_cols_b)
+                lds_bs, warp_n_base, b_scale_load_rep, interleaved_scale_cols_b
+            )
 
             if const_expr(k_wmma_steps == 1):
-                b_frags, b_scales, a_scales = _load_b_and_scales(
-                    b_buf, b_bases, bs_buf, bs_bases, as_buf, as_bases, 0)
+                b_frags, b_scales, a_scales = _load_b_and_scales(b_buf, b_bases, bs_buf, bs_bases, as_buf, as_bases, 0)
                 current_accs = _a_streaming_compute(
-                    current_accs, a_buf, a_bases, b_frags, b_scales,
-                    a_scales, 0, emit_filler=emit_filler,
-                    mid_compute_callback=mid_compute_callback)
+                    current_accs,
+                    a_buf,
+                    a_bases,
+                    b_frags,
+                    b_scales,
+                    a_scales,
+                    0,
+                    emit_filler=emit_filler,
+                    mid_compute_callback=mid_compute_callback,
+                )
             else:
-                prev_b, prev_bs, prev_as = _load_b_and_scales(
-                    b_buf, b_bases, bs_buf, bs_bases, as_buf, as_bases, 0)
+                prev_b, prev_bs, prev_as = _load_b_and_scales(b_buf, b_bases, bs_buf, bs_bases, as_buf, as_bases, 0)
                 for ks in range_constexpr(k_wmma_steps - 1):
                     _mid_cb = mid_compute_callback if ks == 0 else None
-                    current_accs, (prev_b, prev_bs, prev_as) = \
-                        _a_streaming_compute(
-                            current_accs, a_buf, a_bases, prev_b, prev_bs,
-                            prev_as, ks,
-                            next_bs_info=(b_buf, b_bases, bs_buf, bs_bases,
-                                          as_buf, as_bases, ks + 1),
-                            mid_compute_callback=_mid_cb)
+                    current_accs, (prev_b, prev_bs, prev_as) = _a_streaming_compute(
+                        current_accs,
+                        a_buf,
+                        a_bases,
+                        prev_b,
+                        prev_bs,
+                        prev_as,
+                        ks,
+                        next_bs_info=(b_buf, b_bases, bs_buf, bs_bases, as_buf, as_bases, ks + 1),
+                        mid_compute_callback=_mid_cb,
+                    )
                 current_accs = _a_streaming_compute(
-                    current_accs, a_buf, a_bases, prev_b, prev_bs, prev_as,
-                    k_wmma_steps - 1, emit_filler=emit_filler)
+                    current_accs, a_buf, a_bases, prev_b, prev_bs, prev_as, k_wmma_steps - 1, emit_filler=emit_filler
+                )
             return current_accs
 
         def compute_tile_fp4_bank_friendly(
-            accs_in, lds_a, lds_b, lds_as, lds_bs, emit_filler=None,
+            accs_in,
+            lds_a,
+            lds_b,
+            lds_as,
+            lds_bs,
+            emit_filler=None,
             mid_compute_callback=None,
         ):
             current_accs = list(accs_in)
             a_buf, a_bases = _precompute_a_lane_bases(lds_a)
             b_buf, b_bases = _precompute_b_lane_bases(lds_b)
-            as_buf, as_bases = _precompute_scale_lane_bases(
-                lds_as, warp_m_base, wmma_m_rep, interleaved_scale_cols_a)
+            as_buf, as_bases = _precompute_scale_lane_bases(lds_as, warp_m_base, wmma_m_rep, interleaved_scale_cols_a)
             bs_buf, bs_bases = _precompute_scale_lane_bases(
-                lds_bs, warp_n_base, b_scale_load_rep, interleaved_scale_cols_b)
+                lds_bs, warp_n_base, b_scale_load_rep, interleaved_scale_cols_b
+            )
             _b_half_scale_loads = (_bank_half_b_scale_rep + 3) // 4
 
             def _fp4_get_a_scale_and_opsel(a_scales_all, wm_idx):
@@ -819,28 +812,23 @@ def compile_mxscale_gemm(
                 return a_scales_all[wm_idx], 0
 
             def _load_a_group(wm_base, wm_count, ks):
-                return [
-                    load_a_frag(a_buf, a_bases[wm_base + wm_local], ks)
-                    for wm_local in range_constexpr(wm_count)
-                ]
+                return [load_a_frag(a_buf, a_bases[wm_base + wm_local], ks) for wm_local in range_constexpr(wm_count)]
 
             def _load_b_half(wn_base, ks):
                 return [
-                    load_b_frag(b_buf, b_bases, wn_base + wn_local, ks)
-                    for wn_local in range_constexpr(_bank_half_wn)
+                    load_b_frag(b_buf, b_bases, wn_base + wn_local, ks) for wn_local in range_constexpr(_bank_half_wn)
                 ]
 
             def _load_b_half_bundle(wn_base, rep_start, ks):
                 b_frags = _load_b_half(wn_base, ks)
                 b_scales = load_scale_slice_b128(
-                    bs_buf, bs_bases[0],
-                    b_scale_load_rep, rep_start,
-                    _bank_half_b_scale_rep, ks)
+                    bs_buf, bs_bases[0], b_scale_load_rep, rep_start, _bank_half_b_scale_rep, ks
+                )
                 return b_frags, b_scales
 
-            def _emit_group_rows(group_base, wm_base, a_frags, b_frags, a_scales,
-                                 b_scales, row_start, row_count,
-                                 emit_filler_now=False):
+            def _emit_group_rows(
+                group_base, wm_base, a_frags, b_frags, a_scales, b_scales, row_start, row_count, emit_filler_now=False
+            ):
                 if const_expr(emit_filler_now and emit_filler is not None):
                     rocdl.sched_barrier(0)
                     emit_filler()
@@ -848,26 +836,31 @@ def compile_mxscale_gemm(
                     wm_local = row_start + row_offset
                     a_frag = a_frags[wm_local]
                     global_wm = wm_base + wm_local
-                    a_scale, a_opsel = _fp4_get_a_scale_and_opsel(
-                        a_scales, global_wm)
+                    a_scale, a_opsel = _fp4_get_a_scale_and_opsel(a_scales, global_wm)
                     row_base = group_base + wm_local * _bank_half_wn
                     for wn_local in range_constexpr(_bank_half_wn):
                         idx = row_base + wn_local
                         current_accs[idx] = rocdl.wmma_scale_f32_32x16x128_f4(
                             T.vec(16, T.f32),
-                            b_frags[wn_local], a_frag, current_accs[idx],
-                            b_scales[wn_local * 2], a_scale,
+                            b_frags[wn_local],
+                            a_frag,
+                            current_accs[idx],
+                            b_scales[wn_local * 2],
+                            a_scale,
                             scaleAType=0,
                             scaleBType=a_opsel,
                         )
 
-            def _emit_group(group_base, wm_base, a_frags, b_frags, a_scales,
-                            b_scales, emit_filler_now=False):
+            def _emit_group(group_base, wm_base, a_frags, b_frags, a_scales, b_scales, emit_filler_now=False):
                 _emit_group_rows(
-                    group_base, wm_base,
-                    a_frags, b_frags,
-                    a_scales, b_scales,
-                    0, _bank_half_wm,
+                    group_base,
+                    wm_base,
+                    a_frags,
+                    b_frags,
+                    a_scales,
+                    b_scales,
+                    0,
+                    _bank_half_wm,
                     emit_filler_now=emit_filler_now,
                 )
 
@@ -875,8 +868,7 @@ def compile_mxscale_gemm(
 
             for ks in range_constexpr(k_wmma_steps):
                 is_last_ks = ks == k_wmma_steps - 1
-                a_scales_all = load_scale_b128(as_buf, as_bases[0],
-                                               wmma_m_rep, ks)
+                a_scales_all = load_scale_b128(as_buf, as_bases[0], wmma_m_rep, ks)
 
                 a_top_frags = _load_a_group(0, _bank_half_wm, ks)
                 a_bottom_frags = _load_a_group(_bank_half_wm, _bank_half_wm, ks)
@@ -885,7 +877,8 @@ def compile_mxscale_gemm(
                 rocdl.s_wait_dscnt(_bank_half_wm * DS_LOADS_PER_A_FRAG)
 
                 _emit_group(
-                    0, 0,
+                    0,
+                    0,
                     a_top_frags,
                     b_left_frags,
                     a_scales_all,
@@ -896,15 +889,15 @@ def compile_mxscale_gemm(
                     rocdl.sched_barrier(0)
                     mid_compute_callback()
 
-                b_right_frags, b_right_scales = _load_b_half_bundle(
-                    _bank_half_wn, _bank_half_b_scale_rep, ks)
+                b_right_frags, b_right_scales = _load_b_half_bundle(_bank_half_wn, _bank_half_b_scale_rep, ks)
 
                 # Hold only the next B half outstanding while the second
                 # quadrant consumes the current left-half fragments.
                 rocdl.s_wait_dscnt(_bank_half_wn * 4 + _b_half_scale_loads)
 
                 _emit_group(
-                    _bank_group_size, _bank_half_wm,
+                    _bank_group_size,
+                    _bank_half_wm,
                     a_bottom_frags,
                     b_left_frags,
                     a_scales_all,
@@ -912,25 +905,25 @@ def compile_mxscale_gemm(
                 )
 
                 if const_expr(not is_last_ks):
-                    next_left_frags, next_left_scales = _load_b_half_bundle(
-                        0, 0, ks + 1)
+                    next_left_frags, next_left_scales = _load_b_half_bundle(0, 0, ks + 1)
                     # Older right-half loads must be ready before consuming
                     # them, while the next ks left-half preload can remain in
                     # flight under the final two quadrants.
-                    rocdl.s_wait_dscnt(
-                        _bank_half_wn * 4 + _b_half_scale_loads)
+                    rocdl.s_wait_dscnt(_bank_half_wn * 4 + _b_half_scale_loads)
                 else:
                     rocdl.s_wait_dscnt(0)
 
                 _emit_group(
-                    _bank_group_size * 2, 0,
+                    _bank_group_size * 2,
+                    0,
                     a_top_frags,
                     b_right_frags,
                     a_scales_all,
                     b_right_scales,
                 )
                 _emit_group(
-                    _bank_group_size * 3, _bank_half_wm,
+                    _bank_group_size * 3,
+                    _bank_half_wm,
                     a_bottom_frags,
                     b_right_frags,
                     a_scales_all,
@@ -951,8 +944,7 @@ def compile_mxscale_gemm(
 
             for _ks in range_constexpr(k_wmma_steps):
                 if const_expr(_ks == 0):
-                    rocdl.sched_dsrd(wmma_n_rep * _b_loads_per_frag + 2
-                                     + _half_wm * DS_LOADS_PER_A_FRAG)
+                    rocdl.sched_dsrd(wmma_n_rep * _b_loads_per_frag + 2 + _half_wm * DS_LOADS_PER_A_FRAG)
                 else:
                     rocdl.sched_dsrd(_half_wm * DS_LOADS_PER_A_FRAG)
                 rocdl.sched_mfma(_half_wmma)
@@ -972,9 +964,7 @@ def compile_mxscale_gemm(
 
             for _ks in range_constexpr(k_wmma_steps):
                 if const_expr(_ks == 0):
-                    rocdl.sched_dsrd(
-                        _a_all_loads + _a_scale_loads
-                        + _b_half_loads + _b_half_scale_loads)
+                    rocdl.sched_dsrd(_a_all_loads + _a_scale_loads + _b_half_loads + _b_half_scale_loads)
                 else:
                     rocdl.sched_dsrd(_a_all_loads + _a_scale_loads)
                 rocdl.sched_mfma(_group_wmma)
@@ -986,18 +976,26 @@ def compile_mxscale_gemm(
                 rocdl.sched_mfma(_group_wmma)
             rocdl.sched_barrier(0)
 
-        def compute_tile_scheduled(accs_in, lds_a, lds_b, lds_as, lds_bs,
-                                   emit_filler=None,
-                                   mid_compute_callback=None):
+        def compute_tile_scheduled(accs_in, lds_a, lds_b, lds_as, lds_bs, emit_filler=None, mid_compute_callback=None):
             if const_expr(compute_schedule_kind == COMPUTE_SCHEDULE_FP4_COL_BAND):
                 return compute_tile_fp4_bank_friendly(
-                    accs_in, lds_a, lds_b, lds_as, lds_bs,
+                    accs_in,
+                    lds_a,
+                    lds_b,
+                    lds_as,
+                    lds_bs,
                     emit_filler=emit_filler,
-                    mid_compute_callback=mid_compute_callback)
+                    mid_compute_callback=mid_compute_callback,
+                )
             return compute_tile(
-                accs_in, lds_a, lds_b, lds_as, lds_bs,
+                accs_in,
+                lds_a,
+                lds_b,
+                lds_as,
+                lds_bs,
                 emit_filler=emit_filler,
-                mid_compute_callback=mid_compute_callback)
+                mid_compute_callback=mid_compute_callback,
+            )
 
         def hot_loop_scheduler_scheduled():
             if const_expr(compute_schedule_kind == COMPUTE_SCHEDULE_FP4_COL_BAND):
@@ -1019,11 +1017,9 @@ def compile_mxscale_gemm(
             _bf16_out = out_dtype in ("bf16", "f16")
             for acc_idx, vec_base, m_off, wn in _sub_tiles:
                 row = blk_m + warp_m_base + arith.index(m_off) + lane16
-                col_base = (blk_n + warp_n_base + arith.index(wn * WMMA_N)
-                            + lane_kgrp * arith.index(8))
+                col_base = blk_n + warp_n_base + arith.index(wn * WMMA_N) + lane_kgrp * arith.index(8)
                 if const_expr(_bf16_out):
-                    c_off_bytes = (row * n_stride + col_base) \
-                        * arith.index(elem_bytes_d)
+                    c_off_bytes = (row * n_stride + col_base) * arith.index(elem_bytes_d)
                     addrs.append(c_off_bytes)
                 else:
                     for half in range_constexpr(2):
@@ -1033,8 +1029,7 @@ def compile_mxscale_gemm(
             return addrs
 
         _bf16_out = out_dtype in ("bf16", "f16")
-        _out_elem_local = T.bf16 if out_dtype == "bf16" else \
-            (T.f16 if out_dtype == "f16" else None)
+        _out_elem_local = T.bf16 if out_dtype == "bf16" else (T.f16 if out_dtype == "f16" else None)
 
         def epilogue_stores(final_accs, addrs):
             addr_idx = 0
@@ -1042,28 +1037,24 @@ def compile_mxscale_gemm(
                 sub8 = _get_acc_sub8(final_accs, acc_idx, vec_base)
                 if const_expr(_bf16_out):
                     addr_idx += store_acc_vec8_to_buffer(
-                        sub8, c_rsrc, addrs[addr_idx],
-                        out_elem=_out_elem_local, offset_is_bytes=True)
+                        sub8, c_rsrc, addrs[addr_idx], out_elem=_out_elem_local, offset_is_bytes=True
+                    )
                 else:
-                    addr_idx += store_acc_vec8_to_buffer(
-                        sub8, c_rsrc, addrs[addr_idx:addr_idx + 2])
+                    addr_idx += store_acc_vec8_to_buffer(sub8, c_rsrc, addrs[addr_idx : addr_idx + 2])
 
         def epilogue_lds_stores(final_accs, d_buf, d_base):
             for acc_idx, vec_base, m_off, wn in _sub_tiles:
                 sub8 = _get_acc_sub8(final_accs, acc_idx, vec_base)
                 imm = m_off * _lds_d_stride_elems + wn * _n_col_d_elems
-                store_acc_vec8_to_lds(d_buf, d_base, imm, sub8,
-                                      out_elem=_out_elem_local)
+                store_acc_vec8_to_lds(d_buf, d_base, imm, sub8, out_elem=_out_elem_local)
 
         def _atomic_add_acc_vec8_to_buffer(acc_vec8, addr):
             if const_expr(_bf16_out):
                 h_vec = fx.Vector(arith.trunc_f(T.vec(8, _out_elem_local), acc_vec8))
                 for pair in range_constexpr(4):
-                    pair_vec = fx.Vector.from_elements(
-                        [h_vec[pair * 2], h_vec[pair * 2 + 1]])
+                    pair_vec = fx.Vector.from_elements([h_vec[pair * 2], h_vec[pair * 2 + 1]])
                     byte_off = arith.index_cast(T.i32, addr + arith.index(pair * 4))
-                    rocdl.raw_ptr_buffer_atomic_fadd(
-                        pair_vec, c_rsrc, byte_off, zero_i32, zero_i32)
+                    rocdl.raw_ptr_buffer_atomic_fadd(pair_vec, c_rsrc, byte_off, zero_i32, zero_i32)
                 return 1
 
             acc_vec = fx.Vector(acc_vec8)
@@ -1071,10 +1062,8 @@ def compile_mxscale_gemm(
                 base_addr = addr[half] if isinstance(addr, (list, tuple)) else addr
                 for vi in range_constexpr(4):
                     val = acc_vec[half * 4 + vi]
-                    byte_off = arith.index_cast(
-                        T.i32, (base_addr + arith.index(vi)) * arith.index(4))
-                    rocdl.raw_ptr_buffer_atomic_fadd(
-                        val, c_rsrc, byte_off, zero_i32, zero_i32)
+                    byte_off = arith.index_cast(T.i32, (base_addr + arith.index(vi)) * arith.index(4))
+                    rocdl.raw_ptr_buffer_atomic_fadd(val, c_rsrc, byte_off, zero_i32, zero_i32)
             return 2
 
         def epilogue_atomic_adds(final_accs, addrs):
@@ -1082,11 +1071,9 @@ def compile_mxscale_gemm(
             for acc_idx, vec_base, m_off, wn in _sub_tiles:
                 sub8 = _get_acc_sub8(final_accs, acc_idx, vec_base)
                 if const_expr(_bf16_out):
-                    addr_idx += _atomic_add_acc_vec8_to_buffer(
-                        sub8, addrs[addr_idx])
+                    addr_idx += _atomic_add_acc_vec8_to_buffer(sub8, addrs[addr_idx])
                 else:
-                    addr_idx += _atomic_add_acc_vec8_to_buffer(
-                        sub8, addrs[addr_idx:addr_idx + 2])
+                    addr_idx += _atomic_add_acc_vec8_to_buffer(sub8, addrs[addr_idx : addr_idx + 2])
 
         def grouped_accs_to_row_major(accs_grouped):
             row_major = [None] * n_accs
@@ -1110,15 +1097,23 @@ def compile_mxscale_gemm(
             pf_k_packed_a = pf_k / arith.index(PACK_FACTOR_A)
             pf_k_packed_b = pf_k / arith.index(PACK_FACTOR_B)
             tdm_ops.l2_prefetch_tile(
-                arg_a, (blk_m, pf_k_packed_a),
-                (tile_m, packed_tile_k_a), (K_packed_a, 1),
-                elem_bytes=1, thread_id=tx, block_threads=block_threads)
+                arg_a,
+                (blk_m, pf_k_packed_a),
+                (tile_m, packed_tile_k_a),
+                (K_packed_a, 1),
+                elem_bytes=1,
+                thread_id=tx,
+                block_threads=block_threads,
+            )
             tdm_ops.l2_prefetch_tile(
                 arg_b,
                 (blk_n / arith.index(16), pf_k_packed_b * arith.index(16)),
                 (tile_n // 16, packed_tile_k_b * 16),
                 (K_packed_b * 16, 1),
-                elem_bytes=1, thread_id=tx, block_threads=block_threads)
+                elem_bytes=1,
+                thread_id=tx,
+                block_threads=block_threads,
+            )
 
         # ====== Multi-stage pipeline ======
         acc_zero = arith.constant_vector(0.0, T.vec(ACC_VEC_SIZE, T.f32))
@@ -1132,23 +1127,19 @@ def compile_mxscale_gemm(
         arena_base_ptr = arena_alloc.get_base()
 
         stages_a = [
-            SmemPtr(arena_base_ptr, stage_a_data_off[i], elem_ty_lds,
-                    shape=(lds_a_data_f16,))
+            SmemPtr(arena_base_ptr, stage_a_data_off[i], elem_ty_lds, shape=(lds_a_data_f16,))
             for i in range_constexpr(num_buffers)
         ]
         stages_b = [
-            SmemPtr(arena_base_ptr, stage_b_data_off[i], elem_ty_lds,
-                    shape=(lds_b_data_f16,))
+            SmemPtr(arena_base_ptr, stage_b_data_off[i], elem_ty_lds, shape=(lds_b_data_f16,))
             for i in range_constexpr(num_buffers)
         ]
         stages_as = [
-            SmemPtr(arena_base_ptr, stage_a_scale_off[i], elem_ty_lds,
-                    shape=(lds_a_scale_f16,))
+            SmemPtr(arena_base_ptr, stage_a_scale_off[i], elem_ty_lds, shape=(lds_a_scale_f16,))
             for i in range_constexpr(num_buffers)
         ]
         stages_bs = [
-            SmemPtr(arena_base_ptr, stage_b_scale_off[i], elem_ty_lds,
-                    shape=(lds_b_scale_f16,))
+            SmemPtr(arena_base_ptr, stage_b_scale_off[i], elem_ty_lds, shape=(lds_b_scale_f16,))
             for i in range_constexpr(num_buffers)
         ]
 
@@ -1157,38 +1148,28 @@ def compile_mxscale_gemm(
         stages_as_mem = [stages_as[i].get() for i in range_constexpr(num_buffers)]
         stages_bs_mem = [stages_bs[i].get() for i in range_constexpr(num_buffers)]
 
-        stages_a_idx = [extract_lds_base_idx(stages_a[i])
-                        for i in range_constexpr(num_buffers)]
-        stages_b_idx = [extract_lds_base_idx(stages_b[i])
-                        for i in range_constexpr(num_buffers)]
-        stages_as_idx = [extract_lds_base_idx(stages_as[i])
-                         for i in range_constexpr(num_buffers)]
-        stages_bs_idx = [extract_lds_base_idx(stages_bs[i])
-                         for i in range_constexpr(num_buffers)]
+        stages_a_idx = [extract_lds_base_idx(stages_a[i]) for i in range_constexpr(num_buffers)]
+        stages_b_idx = [extract_lds_base_idx(stages_b[i]) for i in range_constexpr(num_buffers)]
+        stages_as_idx = [extract_lds_base_idx(stages_as[i]) for i in range_constexpr(num_buffers)]
+        stages_bs_idx = [extract_lds_base_idx(stages_bs[i]) for i in range_constexpr(num_buffers)]
 
         if const_expr(use_tdm_store):
             d_lds_base_ptr = arena_base_ptr
             d_lds_f16_count = total_d_bytes // 2
-            d_smem = SmemPtr(d_lds_base_ptr, d_output_off, elem_ty_lds,
-                             shape=(d_lds_f16_count,))
+            d_smem = SmemPtr(d_lds_base_ptr, d_output_off, elem_ty_lds, shape=(d_lds_f16_count,))
             d_lds_buffer = get_lds_memref(d_smem)
-            warp_lds_off = (wave_m_idx * arith.index(n_warp) + wave_n_idx) \
-                * arith.index(_warp_d_elems)
-            d_lane_base = (warp_lds_off
-                           + lane16 * arith.index(_lds_d_stride_elems)
-                           + lane_kgrp * arith.index(4 * elem_bytes_d))
+            warp_lds_off = (wave_m_idx * arith.index(n_warp) + wave_n_idx) * arith.index(_warp_d_elems)
+            d_lane_base = (
+                warp_lds_off + lane16 * arith.index(_lds_d_stride_elems) + lane_kgrp * arith.index(4 * elem_bytes_d)
+            )
             wave_id_idx = arith.index_cast(T.index, rocdl.wave_id())
-            d_warp_off_sgpr = wave_id_idx * arith.index(warp_d_bytes) \
-                + arith.index(d_output_off)
-            warp_m_off_sgpr = (wave_id_idx / arith.index(n_warp)) \
-                * arith.index(warp_tile_m)
-            warp_n_off_sgpr = (wave_id_idx % arith.index(n_warp)) \
-                * arith.index(warp_tile_n)
+            d_warp_off_sgpr = wave_id_idx * arith.index(warp_d_bytes) + arith.index(d_output_off)
+            warp_m_off_sgpr = (wave_id_idx / arith.index(n_warp)) * arith.index(warp_tile_m)
+            warp_n_off_sgpr = (wave_id_idx % arith.index(n_warp)) * arith.index(warp_tile_n)
             d_desc = tdm_ops.make_tensor_descriptor_2d(
                 global_ptr=arg_c,
                 lds_memref=d_lds_base_ptr,
-                global_offset=(blk_m + warp_m_off_sgpr,
-                               blk_n + warp_n_off_sgpr),
+                global_offset=(blk_m + warp_m_off_sgpr, blk_n + warp_n_off_sgpr),
                 tensor_shape=(warp_tile_m, warp_tile_n),
                 strides=(N, 1),
                 tile_shape=(warp_tile_m, warp_tile_n),
@@ -1205,8 +1186,7 @@ def compile_mxscale_gemm(
             return fx.Vector(desc.dgroup0)[lane]
 
         def _pack_dg0(pred, lds_addr, addr_lo, addr_hi):
-            return fx.Vector.from_elements(
-                [pred, lds_addr, addr_lo, addr_hi], fx.Int32)
+            return fx.Vector.from_elements([pred, lds_addr, addr_lo, addr_hi], fx.Int32)
 
         # Precompute LDS addresses for TDM descriptor switching
         stages_a_lds_addr = []
@@ -1214,14 +1194,10 @@ def compile_mxscale_gemm(
         stages_as_lds_addr = []
         stages_bs_lds_addr = []
         for i in range_constexpr(num_buffers):
-            stages_a_lds_addr.append(_dg0_lane(
-                make_desc_a(stages_a_mem[i], arith.index(0)), 1))
-            stages_b_lds_addr.append(_dg0_lane(
-                make_desc_b(stages_b_mem[i], arith.index(0)), 1))
-            stages_as_lds_addr.append(_dg0_lane(
-                make_desc_as(stages_as_mem[i], arith.index(0)), 1))
-            stages_bs_lds_addr.append(_dg0_lane(
-                make_desc_bs(stages_bs_mem[i], arith.index(0)), 1))
+            stages_a_lds_addr.append(_dg0_lane(make_desc_a(stages_a_mem[i], arith.index(0)), 1))
+            stages_b_lds_addr.append(_dg0_lane(make_desc_b(stages_b_mem[i], arith.index(0)), 1))
+            stages_as_lds_addr.append(_dg0_lane(make_desc_as(stages_as_mem[i], arith.index(0)), 1))
+            stages_bs_lds_addr.append(_dg0_lane(make_desc_bs(stages_bs_mem[i], arith.index(0)), 1))
 
         desc_a_init = make_desc_a(stages_a_mem[0], split_k_base)
         desc_b_init = make_desc_b(stages_b_mem[0], split_k_base)
@@ -1263,8 +1239,7 @@ def compile_mxscale_gemm(
                 desc_as_init.dgroup1,
                 desc_bs_init.dgroup1,
             )
-            active_adv_i32 = _select_wave_tdm_value(
-                adv_a_i32, adv_b_i32, adv_as_i32, adv_bs_i32)
+            active_adv_i32 = _select_wave_tdm_value(adv_a_i32, adv_b_i32, adv_as_i32, adv_bs_i32)
         else:
             addr_lo_a = _dg0_lane(desc_a_init, 2)
             addr_hi_a = _dg0_lane(desc_a_init, 3)
@@ -1283,36 +1258,30 @@ def compile_mxscale_gemm(
         # Prologue
         if const_expr(wave_specialized_tdm):
             for i in range_constexpr(pre_loaded):
-                dg0 = _pack_dg0(pred_const, active_stage_lds_addr[i],
-                                active_addr_lo, active_addr_hi)
-                tdm_ops.tensor_load_2d(
-                    tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
+                dg0 = _pack_dg0(pred_const, active_stage_lds_addr[i], active_addr_lo, active_addr_hi)
+                tdm_ops.tensor_load_2d(tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
                 active_addr_lo = active_addr_lo + active_adv_i32
         else:
             for i in range_constexpr(pre_loaded):
-                dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[i],
-                                  addr_lo_a, addr_hi_a)
-                dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[i],
-                                  addr_lo_b, addr_hi_b)
-                dg0_as = _pack_dg0(pred_const, stages_as_lds_addr[i],
-                                   addr_lo_as, addr_hi_as)
-                dg0_bs = _pack_dg0(pred_const, stages_bs_lds_addr[i],
-                                   addr_lo_bs, addr_hi_bs)
+                dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[i], addr_lo_a, addr_hi_a)
+                dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[i], addr_lo_b, addr_hi_b)
+                dg0_as = _pack_dg0(pred_const, stages_as_lds_addr[i], addr_lo_as, addr_hi_as)
+                dg0_bs = _pack_dg0(pred_const, stages_bs_lds_addr[i], addr_lo_bs, addr_hi_bs)
 
                 issue_tdm_loads(
                     tdm_ops.TDMDescriptor2D(dg0_a, dgroup1_a),
                     tdm_ops.TDMDescriptor2D(dg0_b, dgroup1_b),
                     tdm_ops.TDMDescriptor2D(dg0_as, dgroup1_as),
                     tdm_ops.TDMDescriptor2D(dg0_bs, dgroup1_bs),
-                    wave_specialized=wave_specialized_tdm)
+                    wave_specialized=wave_specialized_tdm,
+                )
 
                 addr_lo_a = addr_lo_a + adv_a_i32
                 addr_lo_b = addr_lo_b + adv_b_i32
                 addr_lo_as = addr_lo_as + adv_as_i32
                 addr_lo_bs = addr_lo_bs + adv_bs_i32
 
-        pipeline_fence(outstanding=TDM_LOADS_PER_STEP * (num_buffers - 2),
-                       use_cluster=use_cluster)
+        pipeline_fence(outstanding=TDM_LOADS_PER_STEP * (num_buffers - 2), use_cluster=use_cluster)
 
         # Main loop — acc_mixed style: fence at top, TDM_load mid-compute.
         # This overlaps TDM DMA with the remaining WMMA instructions,
@@ -1329,9 +1298,7 @@ def compile_mxscale_gemm(
                     for buf_idx in range_constexpr(num_buffers):
                         load_stage = (buf_idx + num_buffers - 1) % num_buffers
 
-                        pipeline_fence_signal(
-                            outstanding=_fence_outstanding,
-                            use_cluster=use_cluster)
+                        pipeline_fence_signal(outstanding=_fence_outstanding, use_cluster=use_cluster)
                         pipeline_fence_wait(use_cluster=use_cluster)
 
                         addr_box = [cur_addr_lo]
@@ -1339,14 +1306,14 @@ def compile_mxscale_gemm(
                         def _mid_tdm_ws(
                             _ls=load_stage,
                             _ab=addr_box,
-                            _k_off=(split_k_base
-                                    + loop_iter * arith.index(num_buffers * tile_k)
-                                    + arith.index(buf_idx * tile_k)),
+                            _k_off=(
+                                split_k_base
+                                + loop_iter * arith.index(num_buffers * tile_k)
+                                + arith.index(buf_idx * tile_k)
+                            ),
                         ):
-                            dg0 = _pack_dg0(pred_const, active_stage_lds_addr[_ls],
-                                            _ab[0], active_addr_hi)
-                            tdm_ops.tensor_load_2d(
-                                tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
+                            dg0 = _pack_dg0(pred_const, active_stage_lds_addr[_ls], _ab[0], active_addr_hi)
+                            tdm_ops.tensor_load_2d(tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
                             _ab[0] = _ab[0] + active_adv_i32
                             _l2_prefetch(_k_off)
 
@@ -1357,7 +1324,8 @@ def compile_mxscale_gemm(
                             stages_b_idx[buf_idx],
                             stages_as_idx[buf_idx],
                             stages_bs_idx[buf_idx],
-                            mid_compute_callback=_mid_tdm_ws)
+                            mid_compute_callback=_mid_tdm_ws,
+                        )
                         cur_addr_lo = addr_box[0]
                         hot_loop_scheduler_scheduled()
 
@@ -1378,35 +1346,31 @@ def compile_mxscale_gemm(
                     for buf_idx in range_constexpr(num_buffers):
                         load_stage = (buf_idx + num_buffers - 1) % num_buffers
 
-                        pipeline_fence_signal(
-                            outstanding=_fence_outstanding,
-                            use_cluster=use_cluster)
+                        pipeline_fence_signal(outstanding=_fence_outstanding, use_cluster=use_cluster)
                         pipeline_fence_wait(use_cluster=use_cluster)
 
-                        addr_boxes = [[cur_lo_a], [cur_lo_b],
-                                      [cur_lo_as], [cur_lo_bs]]
+                        addr_boxes = [[cur_lo_a], [cur_lo_b], [cur_lo_as], [cur_lo_bs]]
 
                         def _mid_tdm_nws(
                             _ls=load_stage,
                             _ab=addr_boxes,
-                            _k_off=(split_k_base
-                                    + loop_iter * arith.index(num_buffers * tile_k)
-                                    + arith.index(buf_idx * tile_k)),
+                            _k_off=(
+                                split_k_base
+                                + loop_iter * arith.index(num_buffers * tile_k)
+                                + arith.index(buf_idx * tile_k)
+                            ),
                         ):
-                            dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[_ls],
-                                              _ab[0][0], addr_hi_a)
-                            dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[_ls],
-                                              _ab[1][0], addr_hi_b)
-                            dg0_as = _pack_dg0(pred_const, stages_as_lds_addr[_ls],
-                                               _ab[2][0], addr_hi_as)
-                            dg0_bs = _pack_dg0(pred_const, stages_bs_lds_addr[_ls],
-                                               _ab[3][0], addr_hi_bs)
+                            dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[_ls], _ab[0][0], addr_hi_a)
+                            dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[_ls], _ab[1][0], addr_hi_b)
+                            dg0_as = _pack_dg0(pred_const, stages_as_lds_addr[_ls], _ab[2][0], addr_hi_as)
+                            dg0_bs = _pack_dg0(pred_const, stages_bs_lds_addr[_ls], _ab[3][0], addr_hi_bs)
                             issue_tdm_loads(
                                 tdm_ops.TDMDescriptor2D(dg0_a, dgroup1_a),
                                 tdm_ops.TDMDescriptor2D(dg0_b, dgroup1_b),
                                 tdm_ops.TDMDescriptor2D(dg0_as, dgroup1_as),
                                 tdm_ops.TDMDescriptor2D(dg0_bs, dgroup1_bs),
-                                wave_specialized=wave_specialized_tdm)
+                                wave_specialized=wave_specialized_tdm,
+                            )
                             _ab[0][0] = _ab[0][0] + adv_a_i32
                             _ab[1][0] = _ab[1][0] + adv_b_i32
                             _ab[2][0] = _ab[2][0] + adv_as_i32
@@ -1420,15 +1384,15 @@ def compile_mxscale_gemm(
                             stages_b_idx[buf_idx],
                             stages_as_idx[buf_idx],
                             stages_bs_idx[buf_idx],
-                            mid_compute_callback=_mid_tdm_nws)
+                            mid_compute_callback=_mid_tdm_nws,
+                        )
                         cur_lo_a = addr_boxes[0][0]
                         cur_lo_b = addr_boxes[1][0]
                         cur_lo_as = addr_boxes[2][0]
                         cur_lo_bs = addr_boxes[3][0]
                         hot_loop_scheduler_scheduled()
 
-                    results = yield list(accs_in) + \
-                        [cur_lo_a, cur_lo_b, cur_lo_as, cur_lo_bs]
+                    results = yield list(accs_in) + [cur_lo_a, cur_lo_b, cur_lo_as, cur_lo_bs]
 
                 accs = list(results[:n_accs])
                 addr_lo_a = results[n_accs]
@@ -1450,20 +1414,26 @@ def compile_mxscale_gemm(
                 if const_expr(use_tdm_store):
                     accs = compute_tile_scheduled(
                         accs,
-                        stages_a_idx[_compute_stage], stages_b_idx[_compute_stage],
-                        stages_as_idx[_compute_stage], stages_bs_idx[_compute_stage])
+                        stages_a_idx[_compute_stage],
+                        stages_b_idx[_compute_stage],
+                        stages_as_idx[_compute_stage],
+                        stages_bs_idx[_compute_stage],
+                    )
                 else:
+
                     def _emit_epi_addrs():
                         epi_addrs_box[0] = epilogue_prepare_addrs()
 
                     accs = compute_tile_scheduled(
                         accs,
-                        stages_a_idx[_compute_stage], stages_b_idx[_compute_stage],
-                        stages_as_idx[_compute_stage], stages_bs_idx[_compute_stage],
-                        emit_filler=_emit_epi_addrs)
+                        stages_a_idx[_compute_stage],
+                        stages_b_idx[_compute_stage],
+                        stages_as_idx[_compute_stage],
+                        stages_bs_idx[_compute_stage],
+                        emit_filler=_emit_epi_addrs,
+                    )
             else:
-                pipeline_fence_signal(outstanding=_outstanding,
-                                      use_cluster=use_cluster)
+                pipeline_fence_signal(outstanding=_outstanding, use_cluster=use_cluster)
                 pipeline_fence_wait(use_cluster=use_cluster)
 
                 _tail_mid_cb = None
@@ -1473,32 +1443,26 @@ def compile_mxscale_gemm(
                         _tail_addr_box = [active_addr_lo]
 
                         def _tail_mid_ws(_ls=_load_stage, _ab=_tail_addr_box):
-                            dg0 = _pack_dg0(pred_const, active_stage_lds_addr[_ls],
-                                            _ab[0], active_addr_hi)
-                            tdm_ops.tensor_load_2d(
-                                tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
+                            dg0 = _pack_dg0(pred_const, active_stage_lds_addr[_ls], _ab[0], active_addr_hi)
+                            tdm_ops.tensor_load_2d(tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
                             _ab[0] = _ab[0] + active_adv_i32
 
                         _tail_mid_cb = _tail_mid_ws
                     else:
-                        _tail_ab = [[addr_lo_a], [addr_lo_b],
-                                    [addr_lo_as], [addr_lo_bs]]
+                        _tail_ab = [[addr_lo_a], [addr_lo_b], [addr_lo_as], [addr_lo_bs]]
 
                         def _tail_mid_nws(_ls=_load_stage, _ab=_tail_ab):
-                            dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[_ls],
-                                              _ab[0][0], addr_hi_a)
-                            dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[_ls],
-                                              _ab[1][0], addr_hi_b)
-                            dg0_as = _pack_dg0(pred_const, stages_as_lds_addr[_ls],
-                                               _ab[2][0], addr_hi_as)
-                            dg0_bs = _pack_dg0(pred_const, stages_bs_lds_addr[_ls],
-                                               _ab[3][0], addr_hi_bs)
+                            dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[_ls], _ab[0][0], addr_hi_a)
+                            dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[_ls], _ab[1][0], addr_hi_b)
+                            dg0_as = _pack_dg0(pred_const, stages_as_lds_addr[_ls], _ab[2][0], addr_hi_as)
+                            dg0_bs = _pack_dg0(pred_const, stages_bs_lds_addr[_ls], _ab[3][0], addr_hi_bs)
                             issue_tdm_loads(
                                 tdm_ops.TDMDescriptor2D(dg0_a, dgroup1_a),
                                 tdm_ops.TDMDescriptor2D(dg0_b, dgroup1_b),
                                 tdm_ops.TDMDescriptor2D(dg0_as, dgroup1_as),
                                 tdm_ops.TDMDescriptor2D(dg0_bs, dgroup1_bs),
-                                wave_specialized=wave_specialized_tdm)
+                                wave_specialized=wave_specialized_tdm,
+                            )
                             _ab[0][0] = _ab[0][0] + adv_a_i32
                             _ab[1][0] = _ab[1][0] + adv_b_i32
                             _ab[2][0] = _ab[2][0] + adv_as_i32
@@ -1509,9 +1473,12 @@ def compile_mxscale_gemm(
                 rocdl.sched_barrier(0)
                 accs = compute_tile_scheduled(
                     accs,
-                    stages_a_idx[_compute_stage], stages_b_idx[_compute_stage],
-                    stages_as_idx[_compute_stage], stages_bs_idx[_compute_stage],
-                    mid_compute_callback=_tail_mid_cb)
+                    stages_a_idx[_compute_stage],
+                    stages_b_idx[_compute_stage],
+                    stages_as_idx[_compute_stage],
+                    stages_bs_idx[_compute_stage],
+                    mid_compute_callback=_tail_mid_cb,
+                )
 
                 if const_expr(_load_stage is not None):
                     if const_expr(wave_specialized_tdm):
@@ -1543,13 +1510,29 @@ def compile_mxscale_gemm(
             else:
                 epilogue_stores(accs, epi_addrs_box[0])
 
-    cache_tag = (data_format, K, tile_m, tile_n, tile_k, m_warp, n_warp,
-                 num_buffers, compute_schedule_kind,
-                 effective_waves_per_eu, l2_prefetch_distance,
-                 cluster_m, cluster_n, use_tdm_store,
-                 out_dtype, inst_prefetch, wave_specialized_tdm, split_k,
-                 use_scale_opsel, expert_sched_mode,
-                 atomic_barrier_enable)
+    cache_tag = (
+        data_format,
+        K,
+        tile_m,
+        tile_n,
+        tile_k,
+        m_warp,
+        n_warp,
+        num_buffers,
+        compute_schedule_kind,
+        effective_waves_per_eu,
+        l2_prefetch_distance,
+        cluster_m,
+        cluster_n,
+        use_tdm_store,
+        out_dtype,
+        inst_prefetch,
+        wave_specialized_tdm,
+        split_k,
+        use_scale_opsel,
+        expert_sched_mode,
+        atomic_barrier_enable,
+    )
 
     @flyc.jit
     def launch_mxscale_gemm(
@@ -1611,5 +1594,5 @@ def compile_mxfp8_gemm(**kw):
 def compile_a8w4_gemm(**kw):
     return compile_mxscale_gemm(data_format="a8w4", **kw)
 
-__all__ = ["compile_mxscale_gemm", "compile_mxfp4_gemm", "compile_mxfp8_gemm",
-           "compile_a8w4_gemm"]
+
+__all__ = ["compile_mxscale_gemm", "compile_mxfp4_gemm", "compile_mxfp8_gemm", "compile_a8w4_gemm"]

--- a/kernels/gemm_fp8fp4_gfx1250.py
+++ b/kernels/gemm_fp8fp4_gfx1250.py
@@ -1600,9 +1600,16 @@ def compile_mxscale_gemm(
     return launch_mxscale_gemm
 
 
-compile_mxfp4_gemm = lambda **kw: compile_mxscale_gemm(data_format="fp4", **kw)
-compile_mxfp8_gemm = lambda **kw: compile_mxscale_gemm(data_format="fp8", **kw)
-compile_a8w4_gemm = lambda **kw: compile_mxscale_gemm(data_format="a8w4", **kw)
+def compile_mxfp4_gemm(**kw):
+    return compile_mxscale_gemm(data_format="fp4", **kw)
+
+
+def compile_mxfp8_gemm(**kw):
+    return compile_mxscale_gemm(data_format="fp8", **kw)
+
+
+def compile_a8w4_gemm(**kw):
+    return compile_mxscale_gemm(data_format="a8w4", **kw)
 
 __all__ = ["compile_mxscale_gemm", "compile_mxfp4_gemm", "compile_mxfp8_gemm",
            "compile_a8w4_gemm"]

--- a/kernels/gemm_fp8fp4_gfx1250.py
+++ b/kernels/gemm_fp8fp4_gfx1250.py
@@ -9,7 +9,7 @@ import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import arith, buffer_ops, const_expr, gpu, idx2crd, range_constexpr, rocdl, tdm_ops, vector
+from flydsl.expr import arith, buffer_ops, const_expr, gpu, idx2crd, range_constexpr, rocdl, tdm_ops
 from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr, check_smem_capacity
@@ -365,17 +365,8 @@ def compile_mxscale_gemm(
         rocdl.disable_xdl_arb_stall()
 
         if const_expr(inst_prefetch):
-            from flydsl._mlir.dialects import llvm as llvm_dialect
             if rocdl.wave_id() == fx.Int32(0):
-                _prefetch_lines = ["s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 8, 1), 1"]
-                for _pg in range_constexpr(10):
-                    _prefetch_lines.append(
-                        f"s_prefetch_inst_pc_rel {_pg * 4096}, s0, 31")
-                llvm_dialect.inline_asm(
-                    None, [],
-                    "\n".join(_prefetch_lines),
-                    "", has_side_effects=True,
-                )
+                rocdl.s_prefetch_inst_burst(num_pages=10)
 
         tx = gpu.thread_id("x")
         bx = gpu.block_id("x")
@@ -509,19 +500,19 @@ def compile_mxscale_gemm(
             """
             k_byte_off = arith.index(ks * WMMA_K // PACK_FACTOR_A)
             byte_off = a_lane_base + k_byte_off
-            v0 = lds_load_b128_raw(lds_buffer, byte_off)
+            v0 = fx.Vector(lds_load_b128_raw(lds_buffer, byte_off))
             if const_expr(is_fp4):
                 # Interleaved stride=32: +0, +32
-                v1 = lds_load_b128_raw(lds_buffer, byte_off + arith.index(32))
-                return vector.shuffle(v0, v1, list(range(8)))
+                v1 = fx.Vector(lds_load_b128_raw(lds_buffer, byte_off + arith.index(32)))
+                return v0.shuffle(v1, list(range(8)))
             else:
                 # Interleaved stride=32: +0, +32, +64, +96
-                v1 = lds_load_b128_raw(lds_buffer, byte_off + arith.index(32))
-                v2 = lds_load_b128_raw(lds_buffer, byte_off + arith.index(64))
-                v3 = lds_load_b128_raw(lds_buffer, byte_off + arith.index(96))
-                v01 = vector.shuffle(v0, v1, list(range(8)))
-                v23 = vector.shuffle(v2, v3, list(range(8)))
-                return vector.shuffle(v01, v23, list(range(16)))
+                v1 = fx.Vector(lds_load_b128_raw(lds_buffer, byte_off + arith.index(32)))
+                v2 = fx.Vector(lds_load_b128_raw(lds_buffer, byte_off + arith.index(64)))
+                v3 = fx.Vector(lds_load_b128_raw(lds_buffer, byte_off + arith.index(96)))
+                v01 = v0.shuffle(v1, list(range(8)))
+                v23 = v2.shuffle(v3, list(range(8)))
+                return v01.shuffle(v23, list(range(16)))
 
         def _precompute_b_lane_bases(lds_ptr):
             """Precompute per-wn B fragment lane base addresses (byte offsets).
@@ -570,36 +561,36 @@ def compile_mxscale_gemm(
                 _num_tiles = WMMA_K // PACK_FACTOR_B // 16  # 4 tiles total per N-group
                 k_subtile_off = arith.index(ks * _num_tiles * 256)
                 base0 = b_lane_bases[wn * 2] + k_subtile_off
-                v0 = lds_load_b128_raw(lds_buffer, base0)
-                v1 = lds_load_b128_raw(lds_buffer, base0 + arith.index(512))
+                v0 = fx.Vector(lds_load_b128_raw(lds_buffer, base0))
+                v1 = fx.Vector(lds_load_b128_raw(lds_buffer, base0 + arith.index(512)))
                 base1 = b_lane_bases[wn * 2 + 1] + k_subtile_off
-                v2 = lds_load_b128_raw(lds_buffer, base1)
-                v3 = lds_load_b128_raw(lds_buffer, base1 + arith.index(512))
-                v01 = vector.shuffle(v0, v1, list(range(8)))
-                v23 = vector.shuffle(v2, v3, list(range(8)))
-                return vector.shuffle(v01, v23, list(range(16)))
+                v2 = fx.Vector(lds_load_b128_raw(lds_buffer, base1))
+                v3 = fx.Vector(lds_load_b128_raw(lds_buffer, base1 + arith.index(512)))
+                v01 = v0.shuffle(v1, list(range(8)))
+                v23 = v2.shuffle(v3, list(range(8)))
+                return v01.shuffle(v23, list(range(16)))
             elif const_expr(is_a8w4):
                 # A8W4: FP4 weight, 4 tiles per N-group
                 # Interleaved stride=512: kgrp0→tiles 0,2; kgrp1→tiles 1,3
                 _num_tiles = WMMA_K // PACK_FACTOR_B // 16  # 4 tiles total
                 k_subtile_off = arith.index(ks * _num_tiles * 256)
                 base0 = b_lane_bases[wn] + k_subtile_off
-                v0 = lds_load_b128_raw(lds_buffer, base0)
-                v1 = lds_load_b128_raw(lds_buffer, base0 + arith.index(512))
-                return vector.shuffle(v0, v1, list(range(8)))
+                v0 = fx.Vector(lds_load_b128_raw(lds_buffer, base0))
+                v1 = fx.Vector(lds_load_b128_raw(lds_buffer, base0 + arith.index(512)))
+                return v0.shuffle(v1, list(range(8)))
             else:
                 # FP8: 8 tiles per N-group
                 # Interleaved stride=512: kgrp0→tiles 0,2,4,6; kgrp1→tiles 1,3,5,7
                 _num_tiles = WMMA_K // PACK_FACTOR_B // 16  # 8 tiles total
                 k_subtile_off = arith.index(ks * _num_tiles * 256)
                 base0 = b_lane_bases[wn] + k_subtile_off
-                v0 = lds_load_b128_raw(lds_buffer, base0)
-                v1 = lds_load_b128_raw(lds_buffer, base0 + arith.index(512))
-                v2 = lds_load_b128_raw(lds_buffer, base0 + arith.index(1024))
-                v3 = lds_load_b128_raw(lds_buffer, base0 + arith.index(1536))
-                v01 = vector.shuffle(v0, v1, list(range(8)))
-                v23 = vector.shuffle(v2, v3, list(range(8)))
-                return vector.shuffle(v01, v23, list(range(16)))
+                v0 = fx.Vector(lds_load_b128_raw(lds_buffer, base0))
+                v1 = fx.Vector(lds_load_b128_raw(lds_buffer, base0 + arith.index(512)))
+                v2 = fx.Vector(lds_load_b128_raw(lds_buffer, base0 + arith.index(1024)))
+                v3 = fx.Vector(lds_load_b128_raw(lds_buffer, base0 + arith.index(1536)))
+                v01 = v0.shuffle(v1, list(range(8)))
+                v23 = v2.shuffle(v3, list(range(8)))
+                return v01.shuffle(v23, list(range(16)))
 
         def _precompute_scale_lane_bases(lds_ptr, warp_base, reps,
                                          interleaved_cols):
@@ -624,12 +615,10 @@ def compile_mxscale_gemm(
             vecs = []
             for ld in range_constexpr(num_loads):
                 off = eff_base if ld == 0 else eff_base + arith.index(ld * 16)
-                vecs.append(lds_load_b128_raw(lds_buffer, off))
+                vecs.append(fx.Vector(lds_load_b128_raw(lds_buffer, off)))
             results = []
             for i in range_constexpr(reps):
-                vi = vector.extract(vecs[i // 4],
-                                    static_position=[i % 4], dynamic_position=[])
-                results.append(vi)
+                results.append(vecs[i // 4][i % 4])
             return results
 
         def load_scale_slice_b128(lds_buffer, scale_base, full_reps,
@@ -642,12 +631,10 @@ def compile_mxscale_gemm(
             vecs = []
             for ld in range_constexpr(num_loads):
                 off = eff_base if ld == 0 else eff_base + arith.index(ld * 16)
-                vecs.append(lds_load_b128_raw(lds_buffer, off))
+                vecs.append(fx.Vector(lds_load_b128_raw(lds_buffer, off)))
             results = []
             for i in range_constexpr(rep_count):
-                vi = vector.extract(vecs[i // 4],
-                                    static_position=[i % 4], dynamic_position=[])
-                results.append(vi)
+                results.append(vecs[i // 4][i % 4])
             return results
 
         def _load_b_and_scales(b_buf, b_bases, bs_buf, bs_bases,
@@ -1024,7 +1011,8 @@ def compile_mxscale_gemm(
             if const_expr(ACC_VEC_SIZE == 8):
                 return accs[acc_idx]
             indices = [vec_base + i for i in range_constexpr(8)]
-            return vector.shuffle(accs[acc_idx], accs[acc_idx], indices)
+            acc = fx.Vector(accs[acc_idx])
+            return acc.shuffle(acc, indices)
 
         def epilogue_prepare_addrs():
             addrs = []
@@ -1069,27 +1057,20 @@ def compile_mxscale_gemm(
 
         def _atomic_add_acc_vec8_to_buffer(acc_vec8, addr):
             if const_expr(_bf16_out):
-                h_vec = arith.trunc_f(T.vec(8, _out_elem_local), acc_vec8)
-                pair_ty = T.vec(2, _out_elem_local)
+                h_vec = fx.Vector(arith.trunc_f(T.vec(8, _out_elem_local), acc_vec8))
                 for pair in range_constexpr(4):
-                    e0 = vector.extract(
-                        h_vec, static_position=[pair * 2], dynamic_position=[])
-                    e1 = vector.extract(
-                        h_vec, static_position=[pair * 2 + 1], dynamic_position=[])
-                    pair_vec = vector.from_elements(pair_ty, [e0, e1])
+                    pair_vec = fx.Vector.from_elements(
+                        [h_vec[pair * 2], h_vec[pair * 2 + 1]])
                     byte_off = arith.index_cast(T.i32, addr + arith.index(pair * 4))
                     rocdl.raw_ptr_buffer_atomic_fadd(
                         pair_vec, c_rsrc, byte_off, zero_i32, zero_i32)
                 return 1
 
+            acc_vec = fx.Vector(acc_vec8)
             for half in range_constexpr(2):
                 base_addr = addr[half] if isinstance(addr, (list, tuple)) else addr
                 for vi in range_constexpr(4):
-                    val = vector.extract(
-                        acc_vec8,
-                        static_position=[half * 4 + vi],
-                        dynamic_position=[],
-                    )
+                    val = acc_vec[half * 4 + vi]
                     byte_off = arith.index_cast(
                         T.i32, (base_addr + arith.index(vi)) * arith.index(4))
                     rocdl.raw_ptr_buffer_atomic_fadd(
@@ -1219,24 +1200,28 @@ def compile_mxscale_gemm(
                 for_store=True,
             )
 
+        # TDM descriptor lane layout: dgroup0 = [predicate, lds_addr, addr_lo, addr_hi].
+        def _dg0_lane(desc, lane):
+            return fx.Vector(desc.dgroup0)[lane]
+
+        def _pack_dg0(pred, lds_addr, addr_lo, addr_hi):
+            return fx.Vector.from_elements(
+                [pred, lds_addr, addr_lo, addr_hi], fx.Int32)
+
         # Precompute LDS addresses for TDM descriptor switching
         stages_a_lds_addr = []
         stages_b_lds_addr = []
         stages_as_lds_addr = []
         stages_bs_lds_addr = []
         for i in range_constexpr(num_buffers):
-            stages_a_lds_addr.append(vector.extract(
-                make_desc_a(stages_a_mem[i], arith.index(0)).dgroup0,
-                static_position=[1], dynamic_position=[]))
-            stages_b_lds_addr.append(vector.extract(
-                make_desc_b(stages_b_mem[i], arith.index(0)).dgroup0,
-                static_position=[1], dynamic_position=[]))
-            stages_as_lds_addr.append(vector.extract(
-                make_desc_as(stages_as_mem[i], arith.index(0)).dgroup0,
-                static_position=[1], dynamic_position=[]))
-            stages_bs_lds_addr.append(vector.extract(
-                make_desc_bs(stages_bs_mem[i], arith.index(0)).dgroup0,
-                static_position=[1], dynamic_position=[]))
+            stages_a_lds_addr.append(_dg0_lane(
+                make_desc_a(stages_a_mem[i], arith.index(0)), 1))
+            stages_b_lds_addr.append(_dg0_lane(
+                make_desc_b(stages_b_mem[i], arith.index(0)), 1))
+            stages_as_lds_addr.append(_dg0_lane(
+                make_desc_as(stages_as_mem[i], arith.index(0)), 1))
+            stages_bs_lds_addr.append(_dg0_lane(
+                make_desc_bs(stages_bs_mem[i], arith.index(0)), 1))
 
         desc_a_init = make_desc_a(stages_a_mem[0], split_k_base)
         desc_b_init = make_desc_b(stages_b_mem[0], split_k_base)
@@ -1261,16 +1246,16 @@ def compile_mxscale_gemm(
                 for i in range_constexpr(num_buffers)
             ]
             active_addr_lo = _select_wave_tdm_value(
-                vector.extract(desc_a_init.dgroup0, static_position=[2], dynamic_position=[]),
-                vector.extract(desc_b_init.dgroup0, static_position=[2], dynamic_position=[]),
-                vector.extract(desc_as_init.dgroup0, static_position=[2], dynamic_position=[]),
-                vector.extract(desc_bs_init.dgroup0, static_position=[2], dynamic_position=[]),
+                _dg0_lane(desc_a_init, 2),
+                _dg0_lane(desc_b_init, 2),
+                _dg0_lane(desc_as_init, 2),
+                _dg0_lane(desc_bs_init, 2),
             )
             active_addr_hi = _select_wave_tdm_value(
-                vector.extract(desc_a_init.dgroup0, static_position=[3], dynamic_position=[]),
-                vector.extract(desc_b_init.dgroup0, static_position=[3], dynamic_position=[]),
-                vector.extract(desc_as_init.dgroup0, static_position=[3], dynamic_position=[]),
-                vector.extract(desc_bs_init.dgroup0, static_position=[3], dynamic_position=[]),
+                _dg0_lane(desc_a_init, 3),
+                _dg0_lane(desc_b_init, 3),
+                _dg0_lane(desc_as_init, 3),
+                _dg0_lane(desc_bs_init, 3),
             )
             active_dgroup1 = _select_wave_tdm_value(
                 desc_a_init.dgroup1,
@@ -1281,14 +1266,14 @@ def compile_mxscale_gemm(
             active_adv_i32 = _select_wave_tdm_value(
                 adv_a_i32, adv_b_i32, adv_as_i32, adv_bs_i32)
         else:
-            addr_lo_a = vector.extract(desc_a_init.dgroup0, static_position=[2], dynamic_position=[])
-            addr_hi_a = vector.extract(desc_a_init.dgroup0, static_position=[3], dynamic_position=[])
-            addr_lo_b = vector.extract(desc_b_init.dgroup0, static_position=[2], dynamic_position=[])
-            addr_hi_b = vector.extract(desc_b_init.dgroup0, static_position=[3], dynamic_position=[])
-            addr_lo_as = vector.extract(desc_as_init.dgroup0, static_position=[2], dynamic_position=[])
-            addr_hi_as = vector.extract(desc_as_init.dgroup0, static_position=[3], dynamic_position=[])
-            addr_lo_bs = vector.extract(desc_bs_init.dgroup0, static_position=[2], dynamic_position=[])
-            addr_hi_bs = vector.extract(desc_bs_init.dgroup0, static_position=[3], dynamic_position=[])
+            addr_lo_a = _dg0_lane(desc_a_init, 2)
+            addr_hi_a = _dg0_lane(desc_a_init, 3)
+            addr_lo_b = _dg0_lane(desc_b_init, 2)
+            addr_hi_b = _dg0_lane(desc_b_init, 3)
+            addr_lo_as = _dg0_lane(desc_as_init, 2)
+            addr_hi_as = _dg0_lane(desc_as_init, 3)
+            addr_lo_bs = _dg0_lane(desc_bs_init, 2)
+            addr_hi_bs = _dg0_lane(desc_bs_init, 3)
 
             dgroup1_a = desc_a_init.dgroup1
             dgroup1_b = desc_b_init.dgroup1
@@ -1298,22 +1283,21 @@ def compile_mxscale_gemm(
         # Prologue
         if const_expr(wave_specialized_tdm):
             for i in range_constexpr(pre_loaded):
-                dg0 = vector.from_elements(T.vec(4, T.i32), [
-                    pred_const, active_stage_lds_addr[i],
-                    active_addr_lo, active_addr_hi])
+                dg0 = _pack_dg0(pred_const, active_stage_lds_addr[i],
+                                active_addr_lo, active_addr_hi)
                 tdm_ops.tensor_load_2d(
                     tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
                 active_addr_lo = active_addr_lo + active_adv_i32
         else:
             for i in range_constexpr(pre_loaded):
-                dg0_a = vector.from_elements(T.vec(4, T.i32), [
-                    pred_const, stages_a_lds_addr[i], addr_lo_a, addr_hi_a])
-                dg0_b = vector.from_elements(T.vec(4, T.i32), [
-                    pred_const, stages_b_lds_addr[i], addr_lo_b, addr_hi_b])
-                dg0_as = vector.from_elements(T.vec(4, T.i32), [
-                    pred_const, stages_as_lds_addr[i], addr_lo_as, addr_hi_as])
-                dg0_bs = vector.from_elements(T.vec(4, T.i32), [
-                    pred_const, stages_bs_lds_addr[i], addr_lo_bs, addr_hi_bs])
+                dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[i],
+                                  addr_lo_a, addr_hi_a)
+                dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[i],
+                                  addr_lo_b, addr_hi_b)
+                dg0_as = _pack_dg0(pred_const, stages_as_lds_addr[i],
+                                   addr_lo_as, addr_hi_as)
+                dg0_bs = _pack_dg0(pred_const, stages_bs_lds_addr[i],
+                                   addr_lo_bs, addr_hi_bs)
 
                 issue_tdm_loads(
                     tdm_ops.TDMDescriptor2D(dg0_a, dgroup1_a),
@@ -1359,9 +1343,8 @@ def compile_mxscale_gemm(
                                     + loop_iter * arith.index(num_buffers * tile_k)
                                     + arith.index(buf_idx * tile_k)),
                         ):
-                            dg0 = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, active_stage_lds_addr[_ls],
-                                _ab[0], active_addr_hi])
+                            dg0 = _pack_dg0(pred_const, active_stage_lds_addr[_ls],
+                                            _ab[0], active_addr_hi)
                             tdm_ops.tensor_load_2d(
                                 tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
                             _ab[0] = _ab[0] + active_adv_i32
@@ -1410,18 +1393,14 @@ def compile_mxscale_gemm(
                                     + loop_iter * arith.index(num_buffers * tile_k)
                                     + arith.index(buf_idx * tile_k)),
                         ):
-                            dg0_a = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, stages_a_lds_addr[_ls],
-                                _ab[0][0], addr_hi_a])
-                            dg0_b = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, stages_b_lds_addr[_ls],
-                                _ab[1][0], addr_hi_b])
-                            dg0_as = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, stages_as_lds_addr[_ls],
-                                _ab[2][0], addr_hi_as])
-                            dg0_bs = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, stages_bs_lds_addr[_ls],
-                                _ab[3][0], addr_hi_bs])
+                            dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[_ls],
+                                              _ab[0][0], addr_hi_a)
+                            dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[_ls],
+                                              _ab[1][0], addr_hi_b)
+                            dg0_as = _pack_dg0(pred_const, stages_as_lds_addr[_ls],
+                                               _ab[2][0], addr_hi_as)
+                            dg0_bs = _pack_dg0(pred_const, stages_bs_lds_addr[_ls],
+                                               _ab[3][0], addr_hi_bs)
                             issue_tdm_loads(
                                 tdm_ops.TDMDescriptor2D(dg0_a, dgroup1_a),
                                 tdm_ops.TDMDescriptor2D(dg0_b, dgroup1_b),
@@ -1494,9 +1473,8 @@ def compile_mxscale_gemm(
                         _tail_addr_box = [active_addr_lo]
 
                         def _tail_mid_ws(_ls=_load_stage, _ab=_tail_addr_box):
-                            dg0 = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, active_stage_lds_addr[_ls],
-                                _ab[0], active_addr_hi])
+                            dg0 = _pack_dg0(pred_const, active_stage_lds_addr[_ls],
+                                            _ab[0], active_addr_hi)
                             tdm_ops.tensor_load_2d(
                                 tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
                             _ab[0] = _ab[0] + active_adv_i32
@@ -1507,18 +1485,14 @@ def compile_mxscale_gemm(
                                     [addr_lo_as], [addr_lo_bs]]
 
                         def _tail_mid_nws(_ls=_load_stage, _ab=_tail_ab):
-                            dg0_a = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, stages_a_lds_addr[_ls],
-                                _ab[0][0], addr_hi_a])
-                            dg0_b = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, stages_b_lds_addr[_ls],
-                                _ab[1][0], addr_hi_b])
-                            dg0_as = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, stages_as_lds_addr[_ls],
-                                _ab[2][0], addr_hi_as])
-                            dg0_bs = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, stages_bs_lds_addr[_ls],
-                                _ab[3][0], addr_hi_bs])
+                            dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[_ls],
+                                              _ab[0][0], addr_hi_a)
+                            dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[_ls],
+                                              _ab[1][0], addr_hi_b)
+                            dg0_as = _pack_dg0(pred_const, stages_as_lds_addr[_ls],
+                                               _ab[2][0], addr_hi_as)
+                            dg0_bs = _pack_dg0(pred_const, stages_bs_lds_addr[_ls],
+                                               _ab[3][0], addr_hi_bs)
                             issue_tdm_loads(
                                 tdm_ops.TDMDescriptor2D(dg0_a, dgroup1_a),
                                 tdm_ops.TDMDescriptor2D(dg0_b, dgroup1_b),

--- a/kernels/wmma_gemm_gfx1250.py
+++ b/kernels/wmma_gemm_gfx1250.py
@@ -9,7 +9,7 @@ import flydsl.expr as fx
 
 from flydsl._mlir import ir
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl, tdm_ops, vector
+from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl, tdm_ops
 from flydsl.expr.arith import _to_raw as _raw
 from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
@@ -264,6 +264,8 @@ def compile_wmma_gemm_tdm(
         warp_n_base = wave_n_idx * arith.index(warp_tile_n)
 
         elem_ty = _elem_type()
+        from flydsl.expr.typing import Numeric as _Numeric
+        elem_dtype = _Numeric.from_ir_type(elem_ty)
 
         # --- Epilogue setup ---
         m_idx = arith.index_cast(T.index, i32_m.ir_value())
@@ -317,18 +319,14 @@ def compile_wmma_gemm_tdm(
             a_lane_base is precomputed by _precompute_a_lane_bases.
             ks is the K-subtile index (compile-time constant).
             """
-            vec8_ty = ir.VectorType.get([8], elem_ty)
-
             k_byte_off = arith.index(ks * WMMA_K * elem_bytes)
             off0 = a_lane_base + k_byte_off
             off1 = a_lane_base + k_byte_off + arith.index(32)
 
-            raw0 = lds_load_b128_raw(a_lds_base_idx, off0)
-            raw1 = lds_load_b128_raw(a_lds_base_idx, off1)
-            v0 = vector.bitcast(vec8_ty, raw0)
-            v1 = vector.bitcast(vec8_ty, raw1)
+            v0 = fx.Vector(lds_load_b128_raw(a_lds_base_idx, off0)).bitcast(elem_dtype)
+            v1 = fx.Vector(lds_load_b128_raw(a_lds_base_idx, off1)).bitcast(elem_dtype)
 
-            return vector.shuffle(v0, v1, list(range(16)))
+            return v0.shuffle(v1, list(range(16)))
 
         def _precompute_b_lane_bases(lds_base_idx):
             """Precompute per-wn B fragment lane base addresses.
@@ -371,8 +369,8 @@ def compile_wmma_gemm_tdm(
                 k_row_off = (ks * WMMA_K + k_half * 16) * lds_b_stride * elem_bytes
                 elem_off = b_lane_base + arith.index(k_row_off)
                 v = lds_transpose_load_raw(vec8_ty, lds_base_idx, elem_off)
-                results.append(v)
-            return vector.shuffle(results[0], results[1], list(range(16)))
+                results.append(fx.Vector(v))
+            return results[0].shuffle(results[1], list(range(16)))
 
         # --- K-subtile compute (A-streaming pipeline) ---
         def _load_b_frags(b_lds_buffer, b_bases, ks):
@@ -654,23 +652,29 @@ def compile_wmma_gemm_tdm(
                 for_store=True,
             )
 
+        # TDM descriptor lane layout: dgroup0 = [predicate, lds_addr, addr_lo, addr_hi].
+        def _dg0_lane(desc, lane):
+            return fx.Vector(desc.dgroup0)[lane]
+
+        def _pack_dg0(pred, lds_addr, addr_lo, addr_hi):
+            return fx.Vector.from_elements(
+                [pred, lds_addr, addr_lo, addr_hi], fx.Int32)
+
         # --- TDM descriptor addr_lo management (FP4-style) ---
         stages_a_lds_addr = []
         stages_b_lds_addr = []
         for i in range_constexpr(num_buffers):
-            stages_a_lds_addr.append(vector.extract(
-                make_desc_a(stages_a_mem[i], arith.index(0)).dgroup0,
-                static_position=[1], dynamic_position=[]))
-            stages_b_lds_addr.append(vector.extract(
-                make_desc_b(stages_b_mem[i], arith.index(0)).dgroup0,
-                static_position=[1], dynamic_position=[]))
+            stages_a_lds_addr.append(_dg0_lane(
+                make_desc_a(stages_a_mem[i], arith.index(0)), 1))
+            stages_b_lds_addr.append(_dg0_lane(
+                make_desc_b(stages_b_mem[i], arith.index(0)), 1))
 
         desc_a_init = make_desc_a(stages_a_mem[0], arith.index(0))
         desc_b_init = make_desc_b(stages_b_mem[0], arith.index(0))
 
-        adv_a_i32 = arith.constant(tile_k * elem_bytes, type=T.i32)
-        adv_b_i32 = arith.constant(tile_k * N * elem_bytes, type=T.i32)
-        pred_const = arith.constant(1, type=T.i32)
+        adv_a_i32 = fx.Int32(tile_k * elem_bytes)
+        adv_b_i32 = fx.Int32(tile_k * N * elem_bytes)
+        pred_const = fx.Int32(1)
 
         if const_expr(wave_specialized_tdm):
             tdm_wave_id = rocdl.wave_id()
@@ -687,43 +691,40 @@ def compile_wmma_gemm_tdm(
                 for i in range_constexpr(num_buffers)
             ]
             active_addr_lo = _select_wave_tdm_value(
-                vector.extract(desc_a_init.dgroup0, static_position=[2], dynamic_position=[]),
-                vector.extract(desc_b_init.dgroup0, static_position=[2], dynamic_position=[]))
+                _dg0_lane(desc_a_init, 2), _dg0_lane(desc_b_init, 2))
             active_addr_hi = _select_wave_tdm_value(
-                vector.extract(desc_a_init.dgroup0, static_position=[3], dynamic_position=[]),
-                vector.extract(desc_b_init.dgroup0, static_position=[3], dynamic_position=[]))
+                _dg0_lane(desc_a_init, 3), _dg0_lane(desc_b_init, 3))
             active_dgroup1 = _select_wave_tdm_value(
                 desc_a_init.dgroup1, desc_b_init.dgroup1)
             active_adv_i32 = _select_wave_tdm_value(adv_a_i32, adv_b_i32)
         else:
-            addr_lo_a = vector.extract(desc_a_init.dgroup0, static_position=[2], dynamic_position=[])
-            addr_hi_a = vector.extract(desc_a_init.dgroup0, static_position=[3], dynamic_position=[])
-            addr_lo_b = vector.extract(desc_b_init.dgroup0, static_position=[2], dynamic_position=[])
-            addr_hi_b = vector.extract(desc_b_init.dgroup0, static_position=[3], dynamic_position=[])
+            addr_lo_a = _dg0_lane(desc_a_init, 2)
+            addr_hi_a = _dg0_lane(desc_a_init, 3)
+            addr_lo_b = _dg0_lane(desc_b_init, 2)
+            addr_hi_b = _dg0_lane(desc_b_init, 3)
             dgroup1_a = desc_a_init.dgroup1
             dgroup1_b = desc_b_init.dgroup1
 
         # --- Prologue ---
         if const_expr(wave_specialized_tdm):
             for i in range_constexpr(pre_loaded):
-                dg0 = vector.from_elements(T.vec(4, T.i32), [
-                    pred_const, active_stage_lds_addr[i],
-                    active_addr_lo, active_addr_hi])
+                dg0 = _pack_dg0(pred_const, active_stage_lds_addr[i],
+                                active_addr_lo, active_addr_hi)
                 tdm_ops.tensor_load_2d(
                     tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
-                active_addr_lo = arith.addi(active_addr_lo, active_adv_i32)
+                active_addr_lo = (active_addr_lo + active_adv_i32)
         else:
             for i in range_constexpr(pre_loaded):
-                dg0_a = vector.from_elements(T.vec(4, T.i32), [
-                    pred_const, stages_a_lds_addr[i], addr_lo_a, addr_hi_a])
-                dg0_b = vector.from_elements(T.vec(4, T.i32), [
-                    pred_const, stages_b_lds_addr[i], addr_lo_b, addr_hi_b])
+                dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[i],
+                                  addr_lo_a, addr_hi_a)
+                dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[i],
+                                  addr_lo_b, addr_hi_b)
                 issue_tdm_loads(
                     tdm_ops.TDMDescriptor2D(dg0_a, dgroup1_a),
                     tdm_ops.TDMDescriptor2D(dg0_b, dgroup1_b),
                     wave_specialized=wave_specialized_tdm)
-                addr_lo_a = arith.addi(addr_lo_a, adv_a_i32)
-                addr_lo_b = arith.addi(addr_lo_b, adv_b_i32)
+                addr_lo_a = (addr_lo_a + adv_a_i32)
+                addr_lo_b = (addr_lo_b + adv_b_i32)
 
         pipeline_fence(outstanding=TDM_LOADS_PER_STEP * (num_buffers - 2),
                        use_cluster=use_cluster)
@@ -755,12 +756,11 @@ def compile_wmma_gemm_tdm(
                             _k_off=(loop_iter * arith.index(num_buffers * tile_k)
                                     + arith.index(buf_idx * tile_k)),
                         ):
-                            dg0 = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, active_stage_lds_addr[_ls],
-                                _ab[0], active_addr_hi])
+                            dg0 = _pack_dg0(pred_const, active_stage_lds_addr[_ls],
+                                            _ab[0], active_addr_hi)
                             tdm_ops.tensor_load_2d(
                                 tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
-                            _ab[0] = arith.addi(_ab[0], active_adv_i32)
+                            _ab[0] = (_ab[0] + active_adv_i32)
                             _l2_prefetch(_k_off)
 
                         rocdl.sched_barrier(0)
@@ -800,18 +800,16 @@ def compile_wmma_gemm_tdm(
                             _k_off=(loop_iter * arith.index(num_buffers * tile_k)
                                     + arith.index(buf_idx * tile_k)),
                         ):
-                            dg0_a = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, stages_a_lds_addr[_ls],
-                                _ab[0][0], addr_hi_a])
-                            dg0_b = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, stages_b_lds_addr[_ls],
-                                _ab[1][0], addr_hi_b])
+                            dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[_ls],
+                                              _ab[0][0], addr_hi_a)
+                            dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[_ls],
+                                              _ab[1][0], addr_hi_b)
                             issue_tdm_loads(
                                 tdm_ops.TDMDescriptor2D(dg0_a, dgroup1_a),
                                 tdm_ops.TDMDescriptor2D(dg0_b, dgroup1_b),
                                 wave_specialized=wave_specialized_tdm)
-                            _ab[0][0] = arith.addi(_ab[0][0], adv_a_i32)
-                            _ab[1][0] = arith.addi(_ab[1][0], adv_b_i32)
+                            _ab[0][0] = (_ab[0][0] + adv_a_i32)
+                            _ab[1][0] = (_ab[1][0] + adv_b_i32)
                             _l2_prefetch(_k_off)
 
                         rocdl.sched_barrier(0)
@@ -869,30 +867,27 @@ def compile_wmma_gemm_tdm(
                         _tail_addr_box = [active_addr_lo]
 
                         def _tail_mid_ws(_ls=_load_stage, _ab=_tail_addr_box):
-                            dg0 = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, active_stage_lds_addr[_ls],
-                                _ab[0], active_addr_hi])
+                            dg0 = _pack_dg0(pred_const, active_stage_lds_addr[_ls],
+                                            _ab[0], active_addr_hi)
                             tdm_ops.tensor_load_2d(
                                 tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
-                            _ab[0] = arith.addi(_ab[0], active_adv_i32)
+                            _ab[0] = (_ab[0] + active_adv_i32)
 
                         _tail_mid_cb = _tail_mid_ws
                     else:
                         _tail_ab = [[addr_lo_a], [addr_lo_b]]
 
                         def _tail_mid_nws(_ls=_load_stage, _ab=_tail_ab):
-                            dg0_a = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, stages_a_lds_addr[_ls],
-                                _ab[0][0], addr_hi_a])
-                            dg0_b = vector.from_elements(T.vec(4, T.i32), [
-                                pred_const, stages_b_lds_addr[_ls],
-                                _ab[1][0], addr_hi_b])
+                            dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[_ls],
+                                              _ab[0][0], addr_hi_a)
+                            dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[_ls],
+                                              _ab[1][0], addr_hi_b)
                             issue_tdm_loads(
                                 tdm_ops.TDMDescriptor2D(dg0_a, dgroup1_a),
                                 tdm_ops.TDMDescriptor2D(dg0_b, dgroup1_b),
                                 wave_specialized=wave_specialized_tdm)
-                            _ab[0][0] = arith.addi(_ab[0][0], adv_a_i32)
-                            _ab[1][0] = arith.addi(_ab[1][0], adv_b_i32)
+                            _ab[0][0] = (_ab[0][0] + adv_a_i32)
+                            _ab[1][0] = (_ab[1][0] + adv_b_i32)
 
                         _tail_mid_cb = _tail_mid_nws
 

--- a/kernels/wmma_gemm_gfx1250.py
+++ b/kernels/wmma_gemm_gfx1250.py
@@ -6,22 +6,24 @@ with TDM (Tensor Data Mover) hardware async copy for both A and B tiles.
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-
 from flydsl._mlir import ir
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl, tdm_ops
+from flydsl.expr import arith, buffer_ops, const_expr, gpu, idx2crd, range_constexpr, rocdl, tdm_ops
 from flydsl.expr.arith import _to_raw as _raw
 from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr, check_smem_capacity
-
-from flydsl.expr import idx2crd
 from kernels.gemm_common_gfx1250 import (
-    extract_lds_base_idx, get_lds_memref,
+    extract_lds_base_idx,
+    get_lds_memref,
     issue_tdm_loads,
-    lds_load_b128_raw, lds_transpose_load_raw,
-    pipeline_fence, pipeline_fence_signal, pipeline_fence_wait,
-    store_acc_vec8_to_buffer, store_acc_vec8_to_lds,
+    lds_load_b128_raw,
+    lds_transpose_load_raw,
+    pipeline_fence,
+    pipeline_fence_signal,
+    pipeline_fence_wait,
+    store_acc_vec8_to_buffer,
+    store_acc_vec8_to_lds,
 )
 from kernels.pipeline_utils import make_tail_plan, tdm_epilogue_fence_threshold_bytes
 
@@ -95,7 +97,8 @@ def compile_wmma_gemm_tdm(
     if use_cluster:
         if cluster_m * cluster_n > 16:
             raise ValueError(
-                f"cluster_m * cluster_n must be <= 16, got {cluster_m}*{cluster_n}={cluster_m * cluster_n}")
+                f"cluster_m * cluster_n must be <= 16, got {cluster_m}*{cluster_n}={cluster_m * cluster_n}"
+            )
         if cluster_m < 1 or cluster_n < 1:
             raise ValueError(f"cluster dims must be >= 1, got ({cluster_m}, {cluster_n})")
     effective_waves_per_eu = waves_per_eu
@@ -109,8 +112,7 @@ def compile_wmma_gemm_tdm(
     block_threads = num_warps * WAVE_SIZE
 
     if wave_specialized_tdm and num_warps < 2:
-        raise ValueError(
-            f"wave_specialized_tdm requires at least 2 waves, got {num_warps}")
+        raise ValueError(f"wave_specialized_tdm requires at least 2 waves, got {num_warps}")
 
     TDM_LOADS_PER_STEP = 1 if wave_specialized_tdm else 2
 
@@ -136,7 +138,8 @@ def compile_wmma_gemm_tdm(
     if num_k_tiles < num_buffers:
         raise ValueError(
             f"{num_buffers}-stage buffering requires num_k_tiles >= {num_buffers}, "
-            f"got {num_k_tiles} (K={K}, tile_k={tile_k})")
+            f"got {num_k_tiles} (K={K}, tile_k={tile_k})"
+        )
 
     gpu_arch = str(get_hip_arch())
     assert gpu_arch.startswith("gfx1250"), f"Expected gfx1250, got {gpu_arch}"
@@ -172,24 +175,21 @@ def compile_wmma_gemm_tdm(
     stage_bytes = _align_up(stage_layout.ptr, 128)
 
     # Compile-time pipeline parameters
-    pre_loaded = num_buffers - 1        # stages pre-loaded in prologue
+    pre_loaded = num_buffers - 1  # stages pre-loaded in prologue
     loop_iters = (num_k_tiles - pre_loaded) // num_buffers
     _tail_start = loop_iters * num_buffers  # index of first un-computed tile in tail
     extra = num_k_tiles - _tail_start - pre_loaded
     _base_tail_plan = _make_tail_plan(num_buffers, pre_loaded, extra)
     _last_compute_stage = _base_tail_plan[-1][1]
-    tail_plan = [
-        (ls, cs, o * TDM_LOADS_PER_STEP // 2 if o > 0 else o)
-        for ls, cs, o in _base_tail_plan
-    ]
+    tail_plan = [(ls, cs, o * TDM_LOADS_PER_STEP // 2 if o > 0 else o) for ls, cs, o in _base_tail_plan]
 
     stage_pitch_bytes = _align_up(stage_bytes, 1024)
     arena_alloc = SmemAllocator(
         None,
         arch=gpu_arch,
         global_sym_name=(
-            f"wmma_tdm_{in_dtype}_{out_dtype}_{tile_m}x{tile_n}x{tile_k}_"
-            f"{m_warp}x{n_warp}_{num_buffers}buf_arena"),
+            f"wmma_tdm_{in_dtype}_{out_dtype}_{tile_m}x{tile_n}x{tile_k}_" f"{m_warp}x{n_warp}_{num_buffers}buf_arena"
+        ),
     )
     stage_phys_order = [i for i in range(num_buffers) if i != _last_compute_stage]
     stage_phys_order.append(_last_compute_stage)
@@ -205,12 +205,8 @@ def compile_wmma_gemm_tdm(
         extra=extra,
     )
 
-    stage_b_offsets = [
-        stage_base_off[i] + stage_b_rel_off for i in range(num_buffers)
-    ]
-    stage_a_offsets = [
-        stage_base_off[i] + stage_a_rel_off for i in range(num_buffers)
-    ]
+    stage_b_offsets = [stage_base_off[i] + stage_b_rel_off for i in range(num_buffers)]
+    stage_a_offsets = [stage_base_off[i] + stage_a_rel_off for i in range(num_buffers)]
     if use_tdm_store:
         lds_d_row_stride = warp_tile_n * elem_bytes_d + LDS_PAD_D_BYTES
         warp_d_bytes = warp_tile_m * lds_d_row_stride
@@ -246,25 +242,27 @@ def compile_wmma_gemm_tdm(
         # --- Cluster MCAST setup ---
         if const_expr(use_cluster):
             local_x, local_y = gpu.compute_cluster_position()
-            a_mcast_mask, b_mcast_mask = gpu.compute_mcast_masks(
-                local_x, local_y, cluster_m, cluster_n)
+            a_mcast_mask, b_mcast_mask = gpu.compute_mcast_masks(local_x, local_y, cluster_m, cluster_n)
         else:
             a_mcast_mask = 0
             b_mcast_mask = 0
 
         # --- Thread/wave decomposition ---
-        layout_thr = fx.make_layout(
-            (m_warp, n_warp, 2, 16),
-            (n_warp * WAVE_SIZE, WAVE_SIZE, 16, 1))
+        layout_thr = fx.make_layout((m_warp, n_warp, 2, 16), (n_warp * WAVE_SIZE, WAVE_SIZE, 16, 1))
         thr_coord = idx2crd(tx, layout_thr)
         wave_m_idx, wave_n_idx, lane_kgrp, lane16 = (
-            fx.get(thr_coord, 0), fx.get(thr_coord, 1), fx.get(thr_coord, 2), fx.get(thr_coord, 3))
+            fx.get(thr_coord, 0),
+            fx.get(thr_coord, 1),
+            fx.get(thr_coord, 2),
+            fx.get(thr_coord, 3),
+        )
 
         warp_m_base = wave_m_idx * arith.index(warp_tile_m)
         warp_n_base = wave_n_idx * arith.index(warp_tile_n)
 
         elem_ty = _elem_type()
         from flydsl.expr.typing import Numeric as _Numeric
+
         elem_dtype = _Numeric.from_ir_type(elem_ty)
 
         # --- Epilogue setup ---
@@ -276,23 +274,33 @@ def compile_wmma_gemm_tdm(
         # --- TDM async copy helpers (MCAST-aware) ---
         def make_desc_a(lds_a_mem_ref, k_base):
             return tdm_ops.make_tensor_descriptor_2d(
-                global_ptr=arg_a, lds_memref=lds_a_mem_ref,
+                global_ptr=arg_a,
+                lds_memref=lds_a_mem_ref,
                 global_offset=(blk_m, k_base),
-                tensor_shape=(tile_m, tile_k), strides=(K, 1),
-                tile_shape=(tile_m, tile_k), elem_bytes=elem_bytes,
-                pad_interval=tile_k, pad_amount=LDS_PAD_A,
+                tensor_shape=(tile_m, tile_k),
+                strides=(K, 1),
+                tile_shape=(tile_m, tile_k),
+                elem_bytes=elem_bytes,
+                pad_interval=tile_k,
+                pad_amount=LDS_PAD_A,
                 num_warps=num_warps,
-                workgroup_mask=a_mcast_mask)
+                workgroup_mask=a_mcast_mask,
+            )
 
         def make_desc_b(lds_b_mem_ref, k_base):
             return tdm_ops.make_tensor_descriptor_2d(
-                global_ptr=arg_b, lds_memref=lds_b_mem_ref,
+                global_ptr=arg_b,
+                lds_memref=lds_b_mem_ref,
                 global_offset=(k_base, blk_n),
-                tensor_shape=(tile_k, tile_n), strides=(N, 1),
-                tile_shape=(tile_k, tile_n), elem_bytes=elem_bytes,
-                pad_interval=tile_n, pad_amount=LDS_PAD_B,
+                tensor_shape=(tile_k, tile_n),
+                strides=(N, 1),
+                tile_shape=(tile_k, tile_n),
+                elem_bytes=elem_bytes,
+                pad_interval=tile_n,
+                pad_amount=LDS_PAD_B,
                 num_warps=num_warps,
-                workgroup_mask=b_mcast_mask)
+                workgroup_mask=b_mcast_mask,
+            )
 
         # --- LDS load helpers ---
         def _precompute_a_lane_bases(lds_base_idx):
@@ -305,11 +313,7 @@ def compile_wmma_gemm_tdm(
             k_lane_off = lane_kgrp * arith.index(8 * elem_bytes)
             bases = []
             for wm in range_constexpr(wmma_m_rep):
-                a_base = (
-                    row_stride_off
-                    + arith.index(wm * WMMA_M * lds_a_stride * elem_bytes)
-                    + k_lane_off
-                )
+                a_base = row_stride_off + arith.index(wm * WMMA_M * lds_a_stride * elem_bytes) + k_lane_off
                 bases.append(a_base)
             return lds_base_idx, bases
 
@@ -340,18 +344,11 @@ def compile_wmma_gemm_tdm(
             """
             lane8 = lane16 % arith.index(8)
             lane_ngrp = lane16 / arith.index(8)
-            k_lane_off = (
-                (lane_kgrp * arith.index(8) + lane8)
-                * arith.index(lds_b_stride * elem_bytes)
-            )
+            k_lane_off = (lane_kgrp * arith.index(8) + lane8) * arith.index(lds_b_stride * elem_bytes)
             n_lane_off = lane_ngrp * arith.index(8 * elem_bytes)
             bases = []
             for wn in range_constexpr(wmma_n_rep):
-                n_col = (
-                    (warp_n_base + arith.index(wn * WMMA_N))
-                    * arith.index(elem_bytes)
-                    + n_lane_off
-                )
+                n_col = (warp_n_base + arith.index(wn * WMMA_N)) * arith.index(elem_bytes) + n_lane_off
                 b_base = k_lane_off + n_col
                 bases.append(b_base)
             return lds_base_idx, bases
@@ -375,27 +372,28 @@ def compile_wmma_gemm_tdm(
         # --- K-subtile compute (A-streaming pipeline) ---
         def _load_b_frags(b_lds_buffer, b_bases, ks):
             """Load all B fragments for one K-subtile (no wait)."""
-            return [load_wmma_frag_tr(b_lds_buffer, b_bases[wn], ks)
-                    for wn in range_constexpr(wmma_n_rep)]
+            return [load_wmma_frag_tr(b_lds_buffer, b_bases[wn], ks) for wn in range_constexpr(wmma_n_rep)]
 
-        use_half_streaming_schedule = (
-            (wmma_m_rep % 2) == 0 and wmma_m_rep > 1
-        )
+        use_half_streaming_schedule = (wmma_m_rep % 2) == 0 and wmma_m_rep > 1
 
         def _emit_wmma_row(accs, wm, a_frag, b_frags):
             for wn in range_constexpr(wmma_n_rep):
                 idx = wm * wmma_n_rep + wn
                 accs[idx] = wmma_op(
                     T.vec(8, T.f32),
-                    b_frags[wn], a_frag, accs[idx],
-                    signA=False, signB=False, modC=0,
-                    reuseA=False, reuseB=False,
+                    b_frags[wn],
+                    a_frag,
+                    accs[idx],
+                    signA=False,
+                    signB=False,
+                    modC=0,
+                    reuseA=False,
+                    reuseB=False,
                 ).result
 
-        def _a_streaming_compute_per_wm(accs, a_buf, a_bases, b_frags, ks,
-                                        emit_filler=None,
-                                        mid_compute_callback=None,
-                                        next_b_info=None):
+        def _a_streaming_compute_per_wm(
+            accs, a_buf, a_bases, b_frags, ks, emit_filler=None, mid_compute_callback=None, next_b_info=None
+        ):
             """Stream A fragments per-wm group, interleaved with WMMA.
 
             mid_compute_callback: called mid-compute (after first half of wm
@@ -404,7 +402,7 @@ def compile_wmma_gemm_tdm(
             next_b_frags = None
             a_frag = load_wmma_frag(a_buf, a_bases[0], ks)
             for wm in range_constexpr(wmma_m_rep):
-                is_last = (wm == wmma_m_rep - 1)
+                is_last = wm == wmma_m_rep - 1
                 if const_expr(not is_last):
                     a_next = load_wmma_frag(a_buf, a_bases[wm + 1], ks)
                 if const_expr(is_last):
@@ -429,17 +427,15 @@ def compile_wmma_gemm_tdm(
                 return accs, next_b_frags
             return accs
 
-        def _a_streaming_compute_half(accs, a_buf, a_bases, b_frags, ks,
-                                      emit_filler=None,
-                                      mid_compute_callback=None,
-                                      next_b_info=None):
+        def _a_streaming_compute_half(
+            accs, a_buf, a_bases, b_frags, ks, emit_filler=None, mid_compute_callback=None, next_b_info=None
+        ):
             """Half-based A-streaming with mid-compute callback."""
             next_b_frags = None
             half_wm = wmma_m_rep // 2
             half_wait = (half_wm - 1) * DS_LOADS_PER_A_FRAG
 
-            a_frags_h0 = [load_wmma_frag(a_buf, a_bases[wm], ks)
-                          for wm in range_constexpr(half_wm)]
+            a_frags_h0 = [load_wmma_frag(a_buf, a_bases[wm], ks) for wm in range_constexpr(half_wm)]
             rocdl.s_wait_dscnt(half_wait)
 
             if const_expr(mid_compute_callback is not None):
@@ -449,8 +445,7 @@ def compile_wmma_gemm_tdm(
             for wm in range_constexpr(half_wm):
                 _emit_wmma_row(accs, wm, a_frags_h0[wm], b_frags)
 
-            a_frags_h1 = [load_wmma_frag(a_buf, a_bases[half_wm + h], ks)
-                          for h in range_constexpr(half_wm)]
+            a_frags_h1 = [load_wmma_frag(a_buf, a_bases[half_wm + h], ks) for h in range_constexpr(half_wm)]
             rocdl.s_wait_dscnt(half_wait)
             for h in range_constexpr(half_wm):
                 wm = half_wm + h
@@ -465,25 +460,33 @@ def compile_wmma_gemm_tdm(
                 return accs, next_b_frags
             return accs
 
-        def _a_streaming_compute(accs, a_buf, a_bases, b_frags, ks,
-                                 emit_filler=None,
-                                 mid_compute_callback=None,
-                                 next_b_info=None):
+        def _a_streaming_compute(
+            accs, a_buf, a_bases, b_frags, ks, emit_filler=None, mid_compute_callback=None, next_b_info=None
+        ):
             if const_expr(use_half_streaming_schedule):
                 return _a_streaming_compute_half(
-                    accs, a_buf, a_bases, b_frags, ks,
+                    accs,
+                    a_buf,
+                    a_bases,
+                    b_frags,
+                    ks,
                     emit_filler=emit_filler,
                     mid_compute_callback=mid_compute_callback,
-                    next_b_info=next_b_info)
+                    next_b_info=next_b_info,
+                )
             return _a_streaming_compute_per_wm(
-                accs, a_buf, a_bases, b_frags, ks,
+                accs,
+                a_buf,
+                a_bases,
+                b_frags,
+                ks,
                 emit_filler=emit_filler,
                 mid_compute_callback=mid_compute_callback,
-                next_b_info=next_b_info)
+                next_b_info=next_b_info,
+            )
 
         # --- Compute on one LDS buffer (A-streaming K-subtile pipeline) ---
-        def compute_tile(accs_in, lds_a_idx, lds_b_idx,
-                         emit_filler=None, mid_compute_callback=None):
+        def compute_tile(accs_in, lds_a_idx, lds_b_idx, emit_filler=None, mid_compute_callback=None):
             current_accs = list(accs_in)
             a_buf, a_bases = _precompute_a_lane_bases(lds_a_idx)
             b_buf, b_bases = _precompute_b_lane_bases(lds_b_idx)
@@ -491,21 +494,30 @@ def compile_wmma_gemm_tdm(
             if const_expr(k_wmma_steps == 1):
                 b_frags = _load_b_frags(b_buf, b_bases, 0)
                 current_accs = _a_streaming_compute(
-                    current_accs, a_buf, a_bases, b_frags, 0,
+                    current_accs,
+                    a_buf,
+                    a_bases,
+                    b_frags,
+                    0,
                     emit_filler=emit_filler,
-                    mid_compute_callback=mid_compute_callback)
+                    mid_compute_callback=mid_compute_callback,
+                )
             else:
                 prev_b = _load_b_frags(b_buf, b_bases, 0)
                 for ks in range_constexpr(k_wmma_steps - 1):
                     _mid_cb = mid_compute_callback if ks == 0 else None
                     current_accs, prev_b = _a_streaming_compute(
-                        current_accs, a_buf, a_bases, prev_b, ks,
+                        current_accs,
+                        a_buf,
+                        a_bases,
+                        prev_b,
+                        ks,
                         mid_compute_callback=_mid_cb,
-                        next_b_info=(b_buf, b_bases, ks + 1))
+                        next_b_info=(b_buf, b_bases, ks + 1),
+                    )
                 current_accs = _a_streaming_compute(
-                    current_accs, a_buf, a_bases, prev_b,
-                    k_wmma_steps - 1,
-                    emit_filler=emit_filler)
+                    current_accs, a_buf, a_bases, prev_b, k_wmma_steps - 1, emit_filler=emit_filler
+                )
 
             return current_accs
 
@@ -542,8 +554,7 @@ def compile_wmma_gemm_tdm(
             for wm in range_constexpr(wmma_m_rep):
                 for wn in range_constexpr(wmma_n_rep):
                     row = blk_m + warp_m_base + arith.index(wm * WMMA_M) + lane16
-                    col_base = (blk_n + warp_n_base + arith.index(wn * WMMA_N)
-                                + lane_kgrp * arith.index(8))
+                    col_base = blk_n + warp_n_base + arith.index(wn * WMMA_N) + lane_kgrp * arith.index(8)
                     if const_expr(_half_out):
                         c_off_bytes = (row * n_stride + col_base) * arith.index(elem_bytes_d)
                         addrs.append(c_off_bytes)
@@ -562,11 +573,10 @@ def compile_wmma_gemm_tdm(
                     idx = wm * wmma_n_rep + wn
                     if const_expr(_half_out):
                         addr_idx += store_acc_vec8_to_buffer(
-                            final_accs[idx], c_rsrc, addrs[addr_idx],
-                            out_elem=_out_elem, offset_is_bytes=True)
+                            final_accs[idx], c_rsrc, addrs[addr_idx], out_elem=_out_elem, offset_is_bytes=True
+                        )
                     else:
-                        addr_idx += store_acc_vec8_to_buffer(
-                            final_accs[idx], c_rsrc, addrs[addr_idx:addr_idx + 2])
+                        addr_idx += store_acc_vec8_to_buffer(final_accs[idx], c_rsrc, addrs[addr_idx : addr_idx + 2])
 
         def epilogue_lds_stores(final_accs, d_buf, d_base):
             """Write accumulators to D output LDS via lds_store_b128."""
@@ -574,8 +584,7 @@ def compile_wmma_gemm_tdm(
                 for wn in range_constexpr(wmma_n_rep):
                     idx = wm * wmma_n_rep + wn
                     imm = wm * WMMA_M * _lds_d_stride_elems + wn * _n_col_d_elems
-                    store_acc_vec8_to_lds(
-                        d_buf, d_base, imm, final_accs[idx], out_elem=_out_elem)
+                    store_acc_vec8_to_lds(d_buf, d_base, imm, final_accs[idx], out_elem=_out_elem)
 
         _effective_l2_pf = l2_prefetch_distance
         if const_expr(use_cluster and l2_prefetch_distance > 0):
@@ -586,11 +595,23 @@ def compile_wmma_gemm_tdm(
                 return
             pf_k = k_base + arith.index(_effective_l2_pf * tile_k)
             tdm_ops.l2_prefetch_tile(
-                arg_a, (blk_m, pf_k), (tile_m, tile_k), (K, 1),
-                elem_bytes=elem_bytes, thread_id=tx, block_threads=block_threads)
+                arg_a,
+                (blk_m, pf_k),
+                (tile_m, tile_k),
+                (K, 1),
+                elem_bytes=elem_bytes,
+                thread_id=tx,
+                block_threads=block_threads,
+            )
             tdm_ops.l2_prefetch_tile(
-                arg_b, (pf_k, blk_n), (tile_k, tile_n), (N, 1),
-                elem_bytes=elem_bytes, thread_id=tx, block_threads=block_threads)
+                arg_b,
+                (pf_k, blk_n),
+                (tile_k, tile_n),
+                (N, 1),
+                elem_bytes=elem_bytes,
+                thread_id=tx,
+                block_threads=block_threads,
+            )
 
         # ====== Multi-stage pipeline ======
         acc_zero = arith.constant_vector(0.0, T.vec(8, T.f32))
@@ -608,39 +629,31 @@ def compile_wmma_gemm_tdm(
         ]
         stages_a_mem = [stages_a[i].get() for i in range_constexpr(num_buffers)]
         stages_b_mem = [stages_b[i].get() for i in range_constexpr(num_buffers)]
-        stages_a_idx = [extract_lds_base_idx(stages_a[i])
-                        for i in range_constexpr(num_buffers)]
-        stages_b_idx = [extract_lds_base_idx(stages_b[i])
-                        for i in range_constexpr(num_buffers)]
+        stages_a_idx = [extract_lds_base_idx(stages_a[i]) for i in range_constexpr(num_buffers)]
+        stages_b_idx = [extract_lds_base_idx(stages_b[i]) for i in range_constexpr(num_buffers)]
 
         # D output LDS setup for TDM store epilogue
         if const_expr(use_tdm_store):
             d_lds_base_ptr = arena_base_ptr
             d_lds_f16_count = total_d_bytes // elem_bytes
-            d_smem = SmemPtr(d_lds_base_ptr, d_output_off, elem_ty,
-                             shape=(d_lds_f16_count,))
+            d_smem = SmemPtr(d_lds_base_ptr, d_output_off, elem_ty, shape=(d_lds_f16_count,))
             d_lds_buffer = get_lds_memref(d_smem)
 
-            warp_lds_off = (wave_m_idx * arith.index(n_warp) + wave_n_idx) \
-                * arith.index(_warp_d_elems)
-            d_lane_base = (warp_lds_off
-                           + lane16 * arith.index(_lds_d_stride_elems)
-                           + lane_kgrp * arith.index(4 * elem_bytes_d))
+            warp_lds_off = (wave_m_idx * arith.index(n_warp) + wave_n_idx) * arith.index(_warp_d_elems)
+            d_lane_base = (
+                warp_lds_off + lane16 * arith.index(_lds_d_stride_elems) + lane_kgrp * arith.index(4 * elem_bytes_d)
+            )
 
             wave_id_idx = arith.index_cast(T.index, rocdl.wave_id())
-            d_warp_off_sgpr = wave_id_idx * arith.index(warp_d_bytes) \
-                + arith.index(d_output_off)
+            d_warp_off_sgpr = wave_id_idx * arith.index(warp_d_bytes) + arith.index(d_output_off)
 
-            warp_m_off_sgpr = (wave_id_idx / arith.index(n_warp)) \
-                * arith.index(warp_tile_m)
-            warp_n_off_sgpr = (wave_id_idx % arith.index(n_warp)) \
-                * arith.index(warp_tile_n)
+            warp_m_off_sgpr = (wave_id_idx / arith.index(n_warp)) * arith.index(warp_tile_m)
+            warp_n_off_sgpr = (wave_id_idx % arith.index(n_warp)) * arith.index(warp_tile_n)
 
             d_desc = tdm_ops.make_tensor_descriptor_2d(
                 global_ptr=arg_c,
                 lds_memref=d_lds_base_ptr,
-                global_offset=(blk_m + warp_m_off_sgpr,
-                               blk_n + warp_n_off_sgpr),
+                global_offset=(blk_m + warp_m_off_sgpr, blk_n + warp_n_off_sgpr),
                 tensor_shape=(warp_tile_m, warp_tile_n),
                 strides=(N, 1),
                 tile_shape=(warp_tile_m, warp_tile_n),
@@ -657,17 +670,14 @@ def compile_wmma_gemm_tdm(
             return fx.Vector(desc.dgroup0)[lane]
 
         def _pack_dg0(pred, lds_addr, addr_lo, addr_hi):
-            return fx.Vector.from_elements(
-                [pred, lds_addr, addr_lo, addr_hi], fx.Int32)
+            return fx.Vector.from_elements([pred, lds_addr, addr_lo, addr_hi], fx.Int32)
 
         # --- TDM descriptor addr_lo management (FP4-style) ---
         stages_a_lds_addr = []
         stages_b_lds_addr = []
         for i in range_constexpr(num_buffers):
-            stages_a_lds_addr.append(_dg0_lane(
-                make_desc_a(stages_a_mem[i], arith.index(0)), 1))
-            stages_b_lds_addr.append(_dg0_lane(
-                make_desc_b(stages_b_mem[i], arith.index(0)), 1))
+            stages_a_lds_addr.append(_dg0_lane(make_desc_a(stages_a_mem[i], arith.index(0)), 1))
+            stages_b_lds_addr.append(_dg0_lane(make_desc_b(stages_b_mem[i], arith.index(0)), 1))
 
         desc_a_init = make_desc_a(stages_a_mem[0], arith.index(0))
         desc_b_init = make_desc_b(stages_b_mem[0], arith.index(0))
@@ -678,24 +688,17 @@ def compile_wmma_gemm_tdm(
 
         if const_expr(wave_specialized_tdm):
             tdm_wave_id = rocdl.wave_id()
-            tdm_wave_is_a = arith.cmpi(
-                arith.CmpIPredicate.eq, tdm_wave_id,
-                arith.constant(0, type=T.i32))
+            tdm_wave_is_a = arith.cmpi(arith.CmpIPredicate.eq, tdm_wave_id, arith.constant(0, type=T.i32))
 
             def _select_wave_tdm_value(a_value, b_value):
                 return arith.select(tdm_wave_is_a, a_value, b_value)
 
             active_stage_lds_addr = [
-                _select_wave_tdm_value(
-                    stages_a_lds_addr[i], stages_b_lds_addr[i])
-                for i in range_constexpr(num_buffers)
+                _select_wave_tdm_value(stages_a_lds_addr[i], stages_b_lds_addr[i]) for i in range_constexpr(num_buffers)
             ]
-            active_addr_lo = _select_wave_tdm_value(
-                _dg0_lane(desc_a_init, 2), _dg0_lane(desc_b_init, 2))
-            active_addr_hi = _select_wave_tdm_value(
-                _dg0_lane(desc_a_init, 3), _dg0_lane(desc_b_init, 3))
-            active_dgroup1 = _select_wave_tdm_value(
-                desc_a_init.dgroup1, desc_b_init.dgroup1)
+            active_addr_lo = _select_wave_tdm_value(_dg0_lane(desc_a_init, 2), _dg0_lane(desc_b_init, 2))
+            active_addr_hi = _select_wave_tdm_value(_dg0_lane(desc_a_init, 3), _dg0_lane(desc_b_init, 3))
+            active_dgroup1 = _select_wave_tdm_value(desc_a_init.dgroup1, desc_b_init.dgroup1)
             active_adv_i32 = _select_wave_tdm_value(adv_a_i32, adv_b_i32)
         else:
             addr_lo_a = _dg0_lane(desc_a_init, 2)
@@ -708,26 +711,22 @@ def compile_wmma_gemm_tdm(
         # --- Prologue ---
         if const_expr(wave_specialized_tdm):
             for i in range_constexpr(pre_loaded):
-                dg0 = _pack_dg0(pred_const, active_stage_lds_addr[i],
-                                active_addr_lo, active_addr_hi)
-                tdm_ops.tensor_load_2d(
-                    tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
-                active_addr_lo = (active_addr_lo + active_adv_i32)
+                dg0 = _pack_dg0(pred_const, active_stage_lds_addr[i], active_addr_lo, active_addr_hi)
+                tdm_ops.tensor_load_2d(tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
+                active_addr_lo = active_addr_lo + active_adv_i32
         else:
             for i in range_constexpr(pre_loaded):
-                dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[i],
-                                  addr_lo_a, addr_hi_a)
-                dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[i],
-                                  addr_lo_b, addr_hi_b)
+                dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[i], addr_lo_a, addr_hi_a)
+                dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[i], addr_lo_b, addr_hi_b)
                 issue_tdm_loads(
                     tdm_ops.TDMDescriptor2D(dg0_a, dgroup1_a),
                     tdm_ops.TDMDescriptor2D(dg0_b, dgroup1_b),
-                    wave_specialized=wave_specialized_tdm)
-                addr_lo_a = (addr_lo_a + adv_a_i32)
-                addr_lo_b = (addr_lo_b + adv_b_i32)
+                    wave_specialized=wave_specialized_tdm,
+                )
+                addr_lo_a = addr_lo_a + adv_a_i32
+                addr_lo_b = addr_lo_b + adv_b_i32
 
-        pipeline_fence(outstanding=TDM_LOADS_PER_STEP * (num_buffers - 2),
-                       use_cluster=use_cluster)
+        pipeline_fence(outstanding=TDM_LOADS_PER_STEP * (num_buffers - 2), use_cluster=use_cluster)
 
         # --- Main loop (acc_mixed: fence at top, TDM mid-compute) ---
         _fence_outstanding = TDM_LOADS_PER_STEP * (num_buffers - 2)
@@ -743,9 +742,7 @@ def compile_wmma_gemm_tdm(
                     for buf_idx in range_constexpr(num_buffers):
                         load_stage = (buf_idx + num_buffers - 1) % num_buffers
 
-                        pipeline_fence_signal(
-                            outstanding=_fence_outstanding,
-                            use_cluster=use_cluster)
+                        pipeline_fence_signal(outstanding=_fence_outstanding, use_cluster=use_cluster)
                         pipeline_fence_wait(use_cluster=use_cluster)
 
                         addr_box = [cur_addr_lo]
@@ -753,22 +750,17 @@ def compile_wmma_gemm_tdm(
                         def _mid_tdm_ws(
                             _ls=load_stage,
                             _ab=addr_box,
-                            _k_off=(loop_iter * arith.index(num_buffers * tile_k)
-                                    + arith.index(buf_idx * tile_k)),
+                            _k_off=(loop_iter * arith.index(num_buffers * tile_k) + arith.index(buf_idx * tile_k)),
                         ):
-                            dg0 = _pack_dg0(pred_const, active_stage_lds_addr[_ls],
-                                            _ab[0], active_addr_hi)
-                            tdm_ops.tensor_load_2d(
-                                tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
-                            _ab[0] = (_ab[0] + active_adv_i32)
+                            dg0 = _pack_dg0(pred_const, active_stage_lds_addr[_ls], _ab[0], active_addr_hi)
+                            tdm_ops.tensor_load_2d(tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
+                            _ab[0] = _ab[0] + active_adv_i32
                             _l2_prefetch(_k_off)
 
                         rocdl.sched_barrier(0)
                         accs_in = compute_tile(
-                            accs_in,
-                            stages_a_idx[buf_idx],
-                            stages_b_idx[buf_idx],
-                            mid_compute_callback=_mid_tdm_ws)
+                            accs_in, stages_a_idx[buf_idx], stages_b_idx[buf_idx], mid_compute_callback=_mid_tdm_ws
+                        )
                         cur_addr_lo = addr_box[0]
                         hot_loop_scheduler()
 
@@ -787,9 +779,7 @@ def compile_wmma_gemm_tdm(
                     for buf_idx in range_constexpr(num_buffers):
                         load_stage = (buf_idx + num_buffers - 1) % num_buffers
 
-                        pipeline_fence_signal(
-                            outstanding=_fence_outstanding,
-                            use_cluster=use_cluster)
+                        pipeline_fence_signal(outstanding=_fence_outstanding, use_cluster=use_cluster)
                         pipeline_fence_wait(use_cluster=use_cluster)
 
                         addr_boxes = [[cur_lo_a], [cur_lo_b]]
@@ -797,27 +787,23 @@ def compile_wmma_gemm_tdm(
                         def _mid_tdm_nws(
                             _ls=load_stage,
                             _ab=addr_boxes,
-                            _k_off=(loop_iter * arith.index(num_buffers * tile_k)
-                                    + arith.index(buf_idx * tile_k)),
+                            _k_off=(loop_iter * arith.index(num_buffers * tile_k) + arith.index(buf_idx * tile_k)),
                         ):
-                            dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[_ls],
-                                              _ab[0][0], addr_hi_a)
-                            dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[_ls],
-                                              _ab[1][0], addr_hi_b)
+                            dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[_ls], _ab[0][0], addr_hi_a)
+                            dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[_ls], _ab[1][0], addr_hi_b)
                             issue_tdm_loads(
                                 tdm_ops.TDMDescriptor2D(dg0_a, dgroup1_a),
                                 tdm_ops.TDMDescriptor2D(dg0_b, dgroup1_b),
-                                wave_specialized=wave_specialized_tdm)
-                            _ab[0][0] = (_ab[0][0] + adv_a_i32)
-                            _ab[1][0] = (_ab[1][0] + adv_b_i32)
+                                wave_specialized=wave_specialized_tdm,
+                            )
+                            _ab[0][0] = _ab[0][0] + adv_a_i32
+                            _ab[1][0] = _ab[1][0] + adv_b_i32
                             _l2_prefetch(_k_off)
 
                         rocdl.sched_barrier(0)
                         accs_in = compute_tile(
-                            accs_in,
-                            stages_a_idx[buf_idx],
-                            stages_b_idx[buf_idx],
-                            mid_compute_callback=_mid_tdm_nws)
+                            accs_in, stages_a_idx[buf_idx], stages_b_idx[buf_idx], mid_compute_callback=_mid_tdm_nws
+                        )
                         cur_lo_a = addr_boxes[0][0]
                         cur_lo_b = addr_boxes[1][0]
                         hot_loop_scheduler()
@@ -842,22 +828,17 @@ def compile_wmma_gemm_tdm(
                 if const_expr(_tail_had_load):
                     pipeline_fence(outstanding=0, use_cluster=use_cluster)
                 if const_expr(use_tdm_store):
-                    accs = compute_tile(
-                        accs,
-                        stages_a_idx[_compute_stage],
-                        stages_b_idx[_compute_stage])
+                    accs = compute_tile(accs, stages_a_idx[_compute_stage], stages_b_idx[_compute_stage])
                 else:
+
                     def _emit_epi_addrs():
                         epi_addrs_box[0] = epilogue_prepare_addrs()
 
                     accs = compute_tile(
-                        accs,
-                        stages_a_idx[_compute_stage],
-                        stages_b_idx[_compute_stage],
-                        emit_filler=_emit_epi_addrs)
+                        accs, stages_a_idx[_compute_stage], stages_b_idx[_compute_stage], emit_filler=_emit_epi_addrs
+                    )
             else:
-                pipeline_fence_signal(outstanding=_outstanding,
-                                      use_cluster=use_cluster)
+                pipeline_fence_signal(outstanding=_outstanding, use_cluster=use_cluster)
                 pipeline_fence_wait(use_cluster=use_cluster)
 
                 _tail_mid_cb = None
@@ -867,36 +848,31 @@ def compile_wmma_gemm_tdm(
                         _tail_addr_box = [active_addr_lo]
 
                         def _tail_mid_ws(_ls=_load_stage, _ab=_tail_addr_box):
-                            dg0 = _pack_dg0(pred_const, active_stage_lds_addr[_ls],
-                                            _ab[0], active_addr_hi)
-                            tdm_ops.tensor_load_2d(
-                                tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
-                            _ab[0] = (_ab[0] + active_adv_i32)
+                            dg0 = _pack_dg0(pred_const, active_stage_lds_addr[_ls], _ab[0], active_addr_hi)
+                            tdm_ops.tensor_load_2d(tdm_ops.TDMDescriptor2D(dg0, active_dgroup1))
+                            _ab[0] = _ab[0] + active_adv_i32
 
                         _tail_mid_cb = _tail_mid_ws
                     else:
                         _tail_ab = [[addr_lo_a], [addr_lo_b]]
 
                         def _tail_mid_nws(_ls=_load_stage, _ab=_tail_ab):
-                            dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[_ls],
-                                              _ab[0][0], addr_hi_a)
-                            dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[_ls],
-                                              _ab[1][0], addr_hi_b)
+                            dg0_a = _pack_dg0(pred_const, stages_a_lds_addr[_ls], _ab[0][0], addr_hi_a)
+                            dg0_b = _pack_dg0(pred_const, stages_b_lds_addr[_ls], _ab[1][0], addr_hi_b)
                             issue_tdm_loads(
                                 tdm_ops.TDMDescriptor2D(dg0_a, dgroup1_a),
                                 tdm_ops.TDMDescriptor2D(dg0_b, dgroup1_b),
-                                wave_specialized=wave_specialized_tdm)
-                            _ab[0][0] = (_ab[0][0] + adv_a_i32)
-                            _ab[1][0] = (_ab[1][0] + adv_b_i32)
+                                wave_specialized=wave_specialized_tdm,
+                            )
+                            _ab[0][0] = _ab[0][0] + adv_a_i32
+                            _ab[1][0] = _ab[1][0] + adv_b_i32
 
                         _tail_mid_cb = _tail_mid_nws
 
                 rocdl.sched_barrier(0)
                 accs = compute_tile(
-                    accs,
-                    stages_a_idx[_compute_stage],
-                    stages_b_idx[_compute_stage],
-                    mid_compute_callback=_tail_mid_cb)
+                    accs, stages_a_idx[_compute_stage], stages_b_idx[_compute_stage], mid_compute_callback=_tail_mid_cb
+                )
                 hot_loop_scheduler()
 
                 if const_expr(_load_stage is not None):
@@ -919,10 +895,25 @@ def compile_wmma_gemm_tdm(
             rocdl.sched_barrier(0)
             epilogue_stores(accs, epi_addrs_box[0])
 
-    cache_tag = (in_dtype, out_dtype, K, tile_m, tile_n, tile_k, m_warp, n_warp,
-                 num_buffers, effective_waves_per_eu, l2_prefetch_distance,
-                 use_tdm_store, cluster_m, cluster_n,
-                 wave_specialized_tdm, inst_prefetch, expert_sched_mode)
+    cache_tag = (
+        in_dtype,
+        out_dtype,
+        K,
+        tile_m,
+        tile_n,
+        tile_k,
+        m_warp,
+        n_warp,
+        num_buffers,
+        effective_waves_per_eu,
+        l2_prefetch_distance,
+        use_tdm_store,
+        cluster_m,
+        cluster_n,
+        wave_specialized_tdm,
+        inst_prefetch,
+        expert_sched_mode,
+    )
 
     @flyc.jit
     def launch_wmma_gemm_tdm(

--- a/python/flydsl/expr/rocdl/inline_asm.py
+++ b/python/flydsl/expr/rocdl/inline_asm.py
@@ -63,3 +63,25 @@ def cvt_pk_bf16_f32(src_a_f32, src_b_f32):
         "=v,v,v",
         has_side_effects=False,
     )
+
+
+def s_prefetch_inst_burst(num_pages: int = 10, page_bytes: int = 4096):
+    """gfx1250: prefetch ``num_pages`` cache lines of instructions ahead of PC.
+
+    Sets HW_REG_WAVE_MODE bit 8 (allow s_prefetch) then issues
+    ``s_prefetch_inst_pc_rel offset, s0, 31`` for ``offset = 0, page_bytes,
+    2*page_bytes, ...``.  Used by GEMM kernels to warm the I-cache before the
+    main loop starts so the first few iterations don't stall on instruction
+    fetch.
+
+    Wraps the inline-asm sequence so callers do not need to import the raw
+    ``llvm`` dialect.
+    """
+    from ..._mlir.dialects import llvm as _llvm
+
+    lines = ["s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 8, 1), 1"]
+    for pg in range(num_pages):
+        lines.append(f"s_prefetch_inst_pc_rel {pg * page_bytes}, s0, 31")
+    _llvm.inline_asm(
+        None, [], "\n".join(lines), "", has_side_effects=True,
+    )

--- a/python/flydsl/expr/rocdl/inline_asm.py
+++ b/python/flydsl/expr/rocdl/inline_asm.py
@@ -16,7 +16,8 @@ dialect ops for v_cvt_off_f32_i4 and v_cvt_pk_bf16_f32.
 def _to_ir(v):
     """Coerce DSL Numeric to ir.Value if needed."""
     from ..._mlir import ir as _ir
-    if not isinstance(v, _ir.Value) and hasattr(v, 'ir_value'):
+
+    if not isinstance(v, _ir.Value) and hasattr(v, "ir_value"):
         return v.ir_value()
     return v
 
@@ -27,8 +28,8 @@ def cvt_off_f32_i4(src_i32, byte_sel=None):
     With byte_sel=0..3, uses SDWA to select the byte before conversion,
     avoiding an explicit shift.  byte_sel=None uses the plain VOP1 form.
     """
-    from ..._mlir.dialects import llvm as _llvm
     from ..._mlir import ir
+    from ..._mlir.dialects import llvm as _llvm
 
     if byte_sel is not None:
         sel = ["BYTE_0", "BYTE_1", "BYTE_2", "BYTE_3"][int(byte_sel)]
@@ -54,8 +55,9 @@ def cvt_pk_bf16_f32(src_a_f32, src_b_f32):
     Pack two f32 values into 2xbf16 in i32.
     dst[15:0] = bf16(src_a), dst[31:16] = bf16(src_b).
     """
-    from ..._mlir.dialects import llvm as _llvm
     from ..._mlir import ir
+    from ..._mlir.dialects import llvm as _llvm
+
     return _llvm.inline_asm(
         ir.IntegerType.get_signless(32),
         [_to_ir(src_a_f32), _to_ir(src_b_f32)],
@@ -83,5 +85,9 @@ def s_prefetch_inst_burst(num_pages: int = 10, page_bytes: int = 4096):
     for pg in range(num_pages):
         lines.append(f"s_prefetch_inst_pc_rel {pg * page_bytes}, s0, 31")
     _llvm.inline_asm(
-        None, [], "\n".join(lines), "", has_side_effects=True,
+        None,
+        [],
+        "\n".join(lines),
+        "",
+        has_side_effects=True,
     )


### PR DESCRIPTION
## Motivation

This PR migrates gfx1250 GEMM kernels to the supported high-level `Vector` API while keeping ISA byte-identical.

## Technical Details

### New shared helper
- [`python/flydsl/expr/rocdl/inline_asm.py`](python/flydsl/expr/rocdl/inline_asm.py): added `s_prefetch_inst_burst(num_pages, page_bytes)` so kernels no longer import the raw `llvm` dialect just to emit the I-cache warm-up sequence.

### `kernels/gemm_fp8fp4_gfx1250.py`
- Replaced 53 legacy `vector.shuffle` / `vector.extract` / `vector.from_elements` calls with `fx.Vector` methods (`.shuffle()`, `[i]` indexing, `Vector.from_elements([...], fx.Int32)`).
- Introduced local helpers `_dg0_lane(desc, lane)` and `_pack_dg0(pred, lds, lo, hi)` for the repeated TDM dgroup0 pack/unpack.
- Replaced inline `llvm_dialect.inline_asm` prefetch sequence with `rocdl.s_prefetch_inst_burst(num_pages=10)`.

### `kernels/wmma_gemm_gfx1250.py`
- Same treatment: ~22 legacy `vector.X` calls migrated to `fx.Vector` / `Vector.bitcast(elem_dtype)` / `_dg0_lane` / `_pack_dg0`.
- `pred_const` / `adv_a_i32` / `adv_b_i32` switched from raw `arith.constant(..., type=T.i32)` to `fx.Int32(...)`, and the 9 `arith.addi` calls switched to operator `+`.

## Test Plan

```bash
pytest tests/kernels/test_gemm_fp8fp4_gfx1250.py
pytest tests/kernels/test_wmma_gemm_gfx1250.py
```

## Test Result

- All tests passed.
- All numerics bit-equivalent to pre-refactor (cosine 1.000000–1.000001).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
