### PR TITLE
release: bump version to 0.1.7 and restore gpt-oss ATOM nightly

### DIFF
--- a/.github/workflows/flydsl-atom-integration.yaml
+++ b/.github/workflows/flydsl-atom-integration.yaml
@@ -44,6 +44,14 @@ jobs:
             accuracy_threshold: 0.92
             runner: linux-flydsl-mi355-8
             env_vars: ""
+          - model_name: gpt-oss-120b
+            model_path: openai/gpt-oss-120b
+            extra_args: --kv_cache_dtype fp8 --gpu-memory-utilization 0.3
+            accuracy_threshold: 0.38
+            runner: linux-flydsl-mi355-1
+            env_vars: |
+              ATOM_GPT_OSS_MODEL=1
+              HSA_NO_SCRATCH_RECLAIM=1
 
     env:
       CONTAINER_NAME: flydsl_atom_${{ strategy.job-index }}

--- a/python/flydsl/__init__.py
+++ b/python/flydsl/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
 # FFM simulator compatibility shim (no-op outside simulator sessions).
 from ._compat import _maybe_preload_system_comgr  # noqa: E402


### PR DESCRIPTION
## Summary
- Bump the FlyDSL package version from 0.1.6 to 0.1.7.
- Restore gpt-oss-120b coverage in the ATOM nightly workflow, matching the aiter environment knobs.

## Test plan
- `python3 -m black --check python/flydsl/__init__.py`
- Verified `python/flydsl/__init__.py` reports `0.1.7`.
- Parsed `.github/workflows/flydsl-atom-integration.yaml` and confirmed the matrix includes `gpt-oss-120b`.