### PR TITLE
test(compiler): generalize attach-target link helpers

### DIFF
--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -35,6 +35,7 @@ from .kernel_function import (
     create_gpu_module,
     get_gpu_module_body,
 )
+from .link_utils import _append_link_lib_options_to_attach_targets, _format_link_lib_options
 from .protocol import construct_from_ir_values, get_ir_types
 
 EXTRA_SOURCE_DIRS: List[str] = []
@@ -575,27 +576,6 @@ def _pipeline_fragments_for_mode(backend) -> PipelineConfig:
     )
 
 
-def _format_link_lib_options(link_libs: list) -> str:
-    """Format external bitcode paths for rocdl-attach-target.
-
-    The MLIR pass-pipeline option parser treats whitespace, commas, and braces
-    as structural syntax.  Until FlyDSL grows proper MLIR option escaping here,
-    reject such paths loudly instead of producing a malformed pipeline.
-    """
-    opts = []
-    for lib in link_libs:
-        path = os.fspath(lib)
-        bad_chars = sorted({ch for ch in path if ch.isspace() or ch in ",{}\"'"})
-        if not path or bad_chars:
-            chars = "empty path" if not path else f"unsupported character(s) {bad_chars!r}"
-            raise ValueError(
-                f"Cannot pass external bitcode path {path!r} to rocdl-attach-target: {chars}. "
-                "Use a path without whitespace, commas, braces, or quotes, or add MLIR pass-option escaping."
-            )
-        opts.append(f"l={path}")
-    return " ".join(opts)
-
-
 def _run_pipeline(module: ir.Module, fragments: list, *, verifier: bool, print_after_all: bool) -> None:
     """Parse and run a comma-joined pass pipeline on *module*."""
     pipeline = f"builtin.module({','.join(fragments)})"
@@ -634,21 +614,9 @@ class MlirCompiler:
 
         if link_libs:
             link_opt = _format_link_lib_options(link_libs)
-            new_fragments = []
-            found_rocdl = False
-            for f in fragments:
-                if "rocdl-attach-target" in f:
-                    if f.endswith("}"):
-                        base = f[:-1].rstrip()
-                    else:
-                        base = f.rstrip()
-                    new_fragments.append(f"{base} {link_opt}" + "}")
-                    found_rocdl = True
-                else:
-                    new_fragments.append(f)
-            if not found_rocdl:
-                raise RuntimeError("link_libs specified but no 'rocdl-attach-target' fragment found in pipeline")
-            fragments = new_fragments
+            fragments, found_attach_target = _append_link_lib_options_to_attach_targets(fragments, link_opt)
+            if not found_attach_target:
+                raise RuntimeError("link_libs specified but no attach-target fragment found in pipeline")
 
         from .llvm_options import llvm_options as _llvm_options
 
@@ -1358,9 +1326,9 @@ class JitFunction:
                         self._extern_linkage_keys.add(cache_key)
                         # Switch to explicit Python-side module loading so
                         # post_load_processors can receive hipModule_t handles.
-                        # Also clear targets set at construction: rocdl-attach-target
-                        # is the sole source when link_libs is used; duplicating
-                        # targets causes hipErrorNoBinaryForGpu.
+                        # Also clear targets set at construction: the backend attach-target
+                        # pass is the sole source when link_libs is used; duplicating
+                        # targets can make the runtime pick an object without extern libs.
                         gpu_module.offloadingHandler = ir.Attribute.parse("#fly.explicit_module")
                         if "targets" in gpu_module.operation.attributes:
                             del gpu_module.operation.attributes["targets"]

--- a/python/flydsl/compiler/link_utils.py
+++ b/python/flydsl/compiler/link_utils.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Helpers for backend target-attach pass options."""
+
+import os
+
+
+def _format_link_lib_options(link_libs: list) -> str:
+    """Format external bitcode paths for backend attach-target passes.
+
+    The MLIR pass-pipeline option parser treats whitespace, commas, and braces
+    as structural syntax. Until FlyDSL grows proper MLIR option escaping here,
+    reject such paths loudly instead of producing a malformed pipeline.
+    """
+    opts = []
+    for lib in link_libs:
+        path = os.fspath(lib)
+        bad_chars = sorted({ch for ch in path if ch.isspace() or ch in ",{}\"'"})
+        if not path or bad_chars:
+            chars = "empty path" if not path else f"unsupported character(s) {bad_chars!r}"
+            raise ValueError(
+                f"Cannot pass external bitcode path {path!r} to an attach-target pass: {chars}. "
+                "Use a path without whitespace, commas, braces, or quotes, or add MLIR pass-option escaping."
+            )
+        opts.append(f"l={path}")
+    return " ".join(opts)
+
+
+def _append_link_lib_options_to_attach_targets(fragments: list, link_opt: str):
+    """Append link options to backend attach-target fragments."""
+    new_fragments = []
+    found_attach_target = False
+    for fragment in fragments:
+        stripped = fragment.rstrip()
+        if "-attach-target" not in stripped:
+            new_fragments.append(fragment)
+            continue
+
+        if "{" in stripped:
+            base = stripped[:-1].rstrip() if stripped.endswith("}") else stripped
+            suffix = "}" if stripped.endswith("}") else ""
+            new_fragments.append(f"{base} {link_opt}{suffix}")
+        else:
+            new_fragments.append(f"{stripped}{{{link_opt}}}")
+        found_attach_target = True
+    return new_fragments, found_attach_target

--- a/tests/unit/test_extern_runtime_integration.py
+++ b/tests/unit/test_extern_runtime_integration.py
@@ -6,7 +6,6 @@ import threading
 
 import pytest
 
-from flydsl.compiler.jit_function import _format_link_lib_options
 from flydsl.compiler.jit_executor import _pack_ciface_args
 from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr.extern import ffi
@@ -55,14 +54,6 @@ def test_link_libs_preserve_first_use_order_and_dedupe():
     ctx.add_link_lib("/tmp/b.bc")
 
     assert ctx.link_libs == ["/tmp/b.bc", "/tmp/a.bc"]
-
-
-def test_link_lib_options_reject_pipeline_syntax_chars():
-    assert _format_link_lib_options(["/tmp/mori_shmem.bc"]) == "l=/tmp/mori_shmem.bc"
-
-    for path in ["/tmp/with space.bc", "/tmp/with,comma.bc", "/tmp/with}brace.bc"]:
-        with pytest.raises(ValueError, match="Cannot pass external bitcode path"):
-            _format_link_lib_options([path])
 
 
 def test_ffi_rejects_link_metadata_arguments():

--- a/tests/unit/test_link_utils.py
+++ b/tests/unit/test_link_utils.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Backend attach-target option helpers."""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.l0_backend_agnostic]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_COMPILER_DIR = _REPO_ROOT / "python" / "flydsl" / "compiler"
+
+
+def _load_link_utils(monkeypatch):
+    """Import compiler link helpers without importing JIT-only compiler exports."""
+    for name in list(sys.modules):
+        if name == "flydsl.compiler" or name.startswith("flydsl.compiler.link_utils"):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    compiler_pkg = types.ModuleType("flydsl.compiler")
+    compiler_pkg.__path__ = [str(_COMPILER_DIR)]
+    monkeypatch.setitem(sys.modules, "flydsl.compiler", compiler_pkg)
+    return importlib.import_module("flydsl.compiler.link_utils")
+
+
+def test_link_lib_options_reject_pipeline_syntax_chars(monkeypatch):
+    link_utils = _load_link_utils(monkeypatch)
+
+    assert link_utils._format_link_lib_options(["/tmp/mori_shmem.bc"]) == "l=/tmp/mori_shmem.bc"
+
+    for path in ["/tmp/with space.bc", "/tmp/with,comma.bc", "/tmp/with}brace.bc"]:
+        with pytest.raises(ValueError, match="Cannot pass external bitcode path"):
+            link_utils._format_link_lib_options([path])
+
+
+def test_link_lib_options_attach_to_backend_target_passes(monkeypatch):
+    link_utils = _load_link_utils(monkeypatch)
+
+    fragments, found = link_utils._append_link_lib_options_to_attach_targets(
+        [
+            "gpu.module(convert-gpu-to-widget)",
+            "widget-attach-target{chip=wgt100}",
+            "gpu-module-to-binary{format=fatbin}",
+        ],
+        "l=/tmp/mori_shmem.bc",
+    )
+
+    assert found
+    assert fragments[1] == "widget-attach-target{chip=wgt100 l=/tmp/mori_shmem.bc}"
+
+
+def test_link_lib_options_still_attach_to_rocdl_target_passes(monkeypatch):
+    link_utils = _load_link_utils(monkeypatch)
+
+    fragments, found = link_utils._append_link_lib_options_to_attach_targets(
+        [
+            "gpu.module(convert-gpu-to-rocdl)",
+            "rocdl-attach-target{chip=gfx942}",
+            "gpu-module-to-binary{format=fatbin}",
+        ],
+        "l=/tmp/mori_shmem.bc",
+    )
+
+    assert found
+    assert fragments[1] == "rocdl-attach-target{chip=gfx942 l=/tmp/mori_shmem.bc}"


### PR DESCRIPTION
Summary
This PR generalizes extern bitcode link option handling for backend attach-target passes.

Previously, link_libs injection in jit_function.py was tied specifically to rocdl-attach-target. This patch moves the lightweight option formatting and attach-target fragment update logic into python/flydsl/compiler/link_utils.py, so the compiler path can handle backend attach-target passes generically without importing JIT-only dependencies in unit tests.

Motivation
FlyDSL now has a backend abstraction where non-ROCDL backends may also use an attach-target pass that accepts external bitcode libraries via l=<path>. Keeping this path hard-coded to rocdl-attach-target makes the generic compiler pipeline less reusable and causes backend-specific coupling in shared JIT code.

This PR keeps the existing ROCm behavior intact while making the attach-target handling backend-neutral.

Changes
Move external bitcode link option formatting out of jit_function.py into compiler/link_utils.py.
Generalize link option injection from rocdl-attach-target to backend *-attach-target fragments.
Update the missing-attach error message to avoid ROCm-specific wording.
Move lightweight link option tests into tests/unit/test_link_utils.py so they do not import jit_function.py and pull in JIT-only dependencies.
Keep ROCm coverage by explicitly testing rocdl-attach-target behavior.
Test Plan

```
PYTHONPATH=/home/peter/sw_home/sdk/FlyDSL-generic-attach-target-link-libs/python \
python3 -m pytest --confcutdir=tests/unit tests/unit/test_link_utils.py -q
python3 -m py_compile \
  python/flydsl/compiler/link_utils.py \
  python/flydsl/compiler/jit_function.py
```

Result: 3 passed, py_compile passed.