### PR TITLE
Fix/fly opt gpu llvm translations

### DIFF
--- a/tests/unit/test_fly_opt_tooling.py
+++ b/tests/unit/test_fly_opt_tooling.py
@@ -4,8 +4,8 @@
 """fly-opt tool usage guardrails."""
 
 import os
-from pathlib import Path
 import subprocess
+from pathlib import Path
 
 import pytest
 

--- a/tests/unit/test_fly_opt_tooling.py
+++ b/tests/unit/test_fly_opt_tooling.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""fly-opt tool usage guardrails."""
+
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.l0_backend_agnostic]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _fly_opt_path() -> Path:
+    configured = os.environ.get("FLYDSL_FLY_OPT") or os.environ.get("FLY_OPT")
+    candidates = [
+        Path(configured) if configured else None,
+        _REPO_ROOT / "build-fly" / "bin" / "fly-opt",
+    ]
+    for candidate in candidates:
+        if candidate and candidate.is_file():
+            return candidate
+    pytest.skip("fly-opt binary not available; set FLYDSL_FLY_OPT to run this regression")
+
+
+def test_fly_opt_gpu_module_to_binary_has_llvm_translation(tmp_path):
+    """Regression for gpu-module-to-binary failing before target serialization.
+
+    Without GPU-to-LLVMIR translations registered in fly-opt, this real
+    gpu-module-to-binary invocation fails with:
+    "missing LLVMTranslationDialectInterface registration for dialect for op:
+    gpu.module".
+    """
+
+    input_mlir = tmp_path / "kernel.mlir"
+    input_mlir.write_text(
+        """module attributes {gpu.container_module} {
+  gpu.module @kernels [#rocdl.target<chip = "gfx942">] {
+    llvm.func @kernel() attributes {gpu.kernel, rocdl.kernel} {
+      llvm.return
+    }
+  }
+}
+""",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            str(_fly_opt_path()),
+            str(input_mlir),
+            "--pass-pipeline=builtin.module(gpu-module-to-binary{format=llvm})",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert "missing LLVMTranslationDialectInterface registration" not in result.stderr
+    if result.returncode != 0 and "the `AMDGPU` target was not built" in result.stderr:
+        return
+
+    assert result.returncode == 0, result.stderr
+    assert "gpu.binary @kernels" in result.stdout

--- a/tools/fly-opt/CMakeLists.txt
+++ b/tools/fly-opt/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBS
   MLIRRegisterAllExtensions
 
   MLIRMlirOptMain
+  MLIRToLLVMIRTranslationRegistration
 )
 
 add_llvm_tool(fly-opt

--- a/tools/fly-opt/fly-opt.cpp
+++ b/tools/fly-opt/fly-opt.cpp
@@ -9,6 +9,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
+#include "mlir/Target/LLVMIR/Dialect/All.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 
 #include "mlir-c/IR.h"
@@ -37,6 +38,7 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
   mlir::registerAllDialects(registry);
   mlir::registerAllExtensions(registry);
+  mlir::registerAllGPUToLLVMIRTranslations(registry);
   registry.insert<mlir::fly::FlyDialect>();
   FOR_EACH_BACKEND(REGISTER_BACKEND_DIALECTS, FLYDSL_BACKENDS_TUPLE)
 


### PR DESCRIPTION
## Summary

- Add a `fly-opt` regression smoke test that exercises the real `gpu-module-to-binary` path on a minimal `gpu.module`.
- Register GPU-to-LLVMIR translation interfaces in `fly-opt`, matching the requirements of MLIR GPU binary serialization.
- Link `MLIRToLLVMIRTranslationRegistration` so the translation registration symbols are available.

## Motivation

`fly-opt` currently registers MLIR dialects, extensions, and passes, but not the GPU-to-LLVMIR translation interfaces required by `gpu-module-to-binary`.

As a result, running binary codegen through `fly-opt` can fail before target serialization with:

```text
missing LLVMTranslationDialectInterface registration for dialect for op: gpu.module
```

Test Plan
```
FLYDSL_FLY_OPT=/tmp/flydsl-iluvatar-runtime-smoke/bin/fly-opt \
  python3 -m pytest tests/unit/test_fly_opt_tooling.py -q --confcutdir=tests/unit
Result:
```

1 passed
When no fly-opt binary is available, the test skips unless FLYDSL_FLY_OPT or FLY_OPT points to a built binary.
