### PR TITLE
fix(python): avoid eager ROCDL expr imports

### DIFF
--- a/python/flydsl/expr/__init__.py
+++ b/python/flydsl/expr/__init__.py
@@ -10,9 +10,39 @@ from .struct import *
 
 from . import utils as utils
 from . import arith as arith
-from . import buffer_ops as buffer_ops
 from . import gpu as gpu
 from . import math as math
-from . import rocdl as rocdl
 from . import vector as vector
-from .rocdl import tdm_ops as tdm_ops
+
+_OPTIONAL_ROCDL_MODULES = {
+    "buffer_ops": ".buffer_ops",
+    "rocdl": ".rocdl",
+    "tdm_ops": ".rocdl.tdm_ops",
+}
+
+
+def _is_missing_optional_rocdl(exc: ImportError) -> bool:
+    missing_name = getattr(exc, "name", None) or ""
+    message = str(exc).lower()
+    return missing_name.startswith("flydsl._mlir") and "rocdl" in f"{missing_name.lower()} {message}"
+
+
+try:
+    from . import buffer_ops as buffer_ops
+    from . import rocdl as rocdl
+    from .rocdl import tdm_ops as tdm_ops
+except (ImportError, ModuleNotFoundError) as exc:
+    if not _is_missing_optional_rocdl(exc):
+        raise
+
+
+def __getattr__(name: str):
+    module_name = _OPTIONAL_ROCDL_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import importlib
+
+    module = importlib.import_module(module_name, __name__)
+    globals()[name] = module
+    return module

--- a/python/flydsl/expr/gpu.py
+++ b/python/flydsl/expr/gpu.py
@@ -17,10 +17,9 @@ Usage::
 """
 
 from .._mlir import ir
-from .._mlir.dialects import gpu, rocdl, scf
+from .._mlir.dialects import gpu, scf
 from .._mlir.ir import Attribute
 from . import arith as _arith_ext
-from . import rocdl as _rocdl_ext
 from .primitive import get_dyn_shared
 from .struct import Arena
 from .typing import T, Tuple3D
@@ -63,8 +62,16 @@ CLUSTER_BARRIER_ID = -3
 CLUSTER_WAIT_ALL = CLUSTER_BARRIER_ID
 
 
+def _require_rocdl():
+    from .._mlir.dialects import rocdl
+    from . import rocdl as _rocdl_ext
+
+    return rocdl, _rocdl_ext
+
+
 def is_wave_leader():
     """Return true for wave-0 inside the workgroup."""
+    _, _rocdl_ext = _require_rocdl()
     return _arith_ext.cmpi(
         _arith_ext.CmpIPredicate.eq,
         _rocdl_ext.wave_id(),
@@ -74,6 +81,7 @@ def is_wave_leader():
 
 def cluster_signal_once_per_wg():
     """Signal cluster barrier from exactly one wave per workgroup."""
+    rocdl, _ = _require_rocdl()
     if_op = scf.IfOp(is_wave_leader(), [], has_else=False, loc=ir.Location.unknown())
     if len(if_op.regions[0].blocks) == 0:
         if_op.regions[0].blocks.append(*[])
@@ -84,6 +92,7 @@ def cluster_signal_once_per_wg():
 
 def cluster_wait():
     """Wait on the cluster user barrier."""
+    rocdl, _ = _require_rocdl()
     rocdl.s_barrier_wait(CLUSTER_WAIT_ALL)
 
 
@@ -106,6 +115,7 @@ def compute_cluster_position():
     Returns:
         (local_x, local_y) as MLIR index values — position within the cluster.
     """
+    _, _rocdl_ext = _require_rocdl()
     local_x = _arith_ext.index_cast(T.index, _rocdl_ext.cluster_workgroup_id_x())
     local_y = _arith_ext.index_cast(T.index, _rocdl_ext.cluster_workgroup_id_y())
     return local_x, local_y

--- a/tests/unit/test_expr_optional_rocdl.py
+++ b/tests/unit/test_expr_optional_rocdl.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Import-time guardrails for backend-specific expression modules.
+
+These checks run in a **subprocess** so MLIR value-caster registration (process
+global) is not executed twice in the pytest interpreter.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_SUBPROCESS_CHECK = r"""
+import importlib
+import importlib.abc
+import sys
+
+
+class _BlockRocdlDialect(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if fullname == "flydsl._mlir.dialects.rocdl":
+            raise ModuleNotFoundError("simulated missing ROCDL dialect", name=fullname)
+        return None
+
+
+sys.meta_path.insert(0, _BlockRocdlDialect())
+expr = importlib.import_module("flydsl.expr")
+assert expr.Tensor is not None
+assert expr.Int32 is not None
+assert expr.thread_idx is not None
+assert expr.block_idx is not None
+assert expr.gpu.barrier is not None
+assert expr.math is not None
+try:
+    expr.rocdl
+except ModuleNotFoundError as exc:
+    assert exc.name == "flydsl._mlir.dialects.rocdl"
+else:
+    raise AssertionError("expected explicit ROCDL access to require the ROCDL dialect")
+"""
+
+
+def test_expr_import_does_not_require_rocdl_dialect():
+    """The generic expression namespace should import without ROCDL bindings."""
+
+    pkg = _REPO_ROOT / "build-fly" / "python_packages" / "flydsl"
+    if not pkg.is_dir():
+        pytest.skip("build-fly python_packages not found (run scripts/build.sh)")
+
+    env = os.environ.copy()
+    bpkg = str(_REPO_ROOT / "build-fly" / "python_packages")
+    prev = env.get("PYTHONPATH", "")
+    # Load `flydsl` only from the build tree (matches CI). Prepending `repo/python`
+    # can shadow `_mlir` when the build tree is incomplete.
+    env["PYTHONPATH"] = os.pathsep.join([bpkg] + ([prev] if prev else []))
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _SUBPROCESS_CHECK],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            "subprocess import check failed\n" f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+        ) from None


### PR DESCRIPTION
## Summary

- Avoid importing ROCDL-specific expression modules eagerly from `flydsl.expr`.
- Keep generic expression APIs importable when ROCDL Python dialect bindings are not present.
- Lazily import ROCDL-specific helpers only when `fx.rocdl`, `fx.buffer_ops`, or `fx.tdm_ops` are explicitly accessed.

## Motivation

`flydsl.expr` is the generic Python DSL entry point, but it currently imports ROCDL-specific modules at package import time. This makes non-ROCDL or minimal builds fail before users touch any ROCm-specific API.

This change keeps the generic DSL surface usable without ROCDL bindings, while preserving the existing behavior for builds where ROCDL bindings are available.

## Test Plan

```bash
PYTHONPATH=/home/peter/sw_home/sdk/FlyDSL/python:/home/peter/sw_home/sdk/FlyDSL \
  /home/peter/sw_home/sdk/FlyDSL/.venv/bin/python \
  -m pytest tests/unit/test_expr_optional_rocdl.py -q --confcutdir=tests/unit
```
Result:
```1 passed```