### PR TITLE
fix(python): pass cluster_size only for cluster launches

### DIFF
--- a/python/flydsl/compiler/kernel_function.py
+++ b/python/flydsl/compiler/kernel_function.py
@@ -412,16 +412,21 @@ class KernelLauncher:
                     _to_index_value(cz),
                 )
 
+            launch_kwargs = {
+                "async_dependencies": async_deps,
+                "dynamic_shared_memory_size": smem_val,
+                "loc": launch_loc,
+                "ip": None,
+            }
+            if cluster_size is not None:
+                launch_kwargs["cluster_size"] = cluster_size
+
             gpu.LaunchFuncOp(
                 ["kernels", self._kernel_name],
                 (grid_x, grid_y, grid_z),
                 (block_x, block_y, block_z),
                 kernel_operands,
-                async_dependencies=async_deps,
-                dynamic_shared_memory_size=smem_val,
-                cluster_size=cluster_size,
-                loc=launch_loc,
-                ip=None,
+                **launch_kwargs,
             )
 
 


### PR DESCRIPTION
## Summary
- Avoid passing `cluster_size=None` to `gpu.LaunchFuncOp` for ordinary kernel launches.
- Preserve cluster launch behavior by passing `cluster_size` only when `cluster=` is explicitly provided.
## Motivation
Some MLIR Python bindings do not accept the `cluster_size` keyword when constructing `gpu.LaunchFuncOp`. Ordinary kernel launches should not depend on cluster-launch binding support when no cluster launch was requested.
This keeps regular launches compatible across binding versions while preserving the explicit cluster path.
## Test Plan
This was validated through a downstream minimal JIT launch smoke that failed with:
```text
TypeError: LaunchFuncOp.__init__() got an unexpected keyword argument 'cluster_size'
````
and passed after omitting cluster_size for non-cluster launches.