### PR TITLE
fix: parametrize fp8 4wave gemm test

### DIFF
--- a/tests/kernels/test_fp8_gemm_4wave.py
+++ b/tests/kernels/test_fp8_gemm_4wave.py
@@ -40,6 +40,12 @@ def _run_torch(a, b, scale_a, scale_b, dtype=torch.float32):
     return c.to(dtype)
 
 
+@pytest.mark.parametrize(
+    "M, N, K, tile_m, tile_n",
+    [
+        pytest.param(8192, 8192, 8192, 256, 256, marks=pytest.mark.large_shape, id="8192x8192x8192"),
+    ],
+)
 def test_fp8_gemm_4wave(
     M: int,
     N: int,


### PR DESCRIPTION
## Summary
- Add pytest parametrization for `test_fp8_gemm_4wave` so `M/N/K/tile_m/tile_n` are not treated as missing fixtures during CI collection.
- Mark the default 8192x8192x8192 case as `large_shape`, matching the existing `RUN_TESTS_FULL=1` behavior for full CI.

## Test plan
- `ReadLints` on `tests/kernels/test_fp8_gemm_4wave.py`
- `python3 -m pytest tests/kernels/test_fp8_gemm_4wave.py --collect-only -q`
- `python3 -m pytest tests/kernels/test_fp8_gemm_4wave.py -q -m "not large_shape"`
- `python3 -m pytest tests/kernels/test_fp8_gemm_4wave.py::test_fp8_gemm_4wave -q` (skips locally on gfx942; CI failure was a collection error before the arch skip)


Made with [Cursor](https://cursor.com)