### PR TITLE
Report benchmark ratios against main

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -181,7 +181,14 @@ jobs:
       - name: Run benchmarks
         id: benchmarks
         run: |
-          docker exec flydsl_test bash -c "export PYTHONPATH=/tmp/aiter:\${PYTHONPATH:-} && export AITER_REPO=/tmp/aiter && cd /flydsl-test && BENCH_LOG_DIR=/tmp/flydsl_bench_current bash scripts/run_benchmark.sh --output_csv /tmp/bench_current.csv"
+          docker exec flydsl_test bash <<'BASH'
+          set -e -o pipefail
+          export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
+          export AITER_REPO=/tmp/aiter
+          cd /flydsl-test
+          BENCH_LOG_DIR=/tmp/flydsl_bench_current bash scripts/run_benchmark.sh 2>&1 | tee /tmp/bench_current.out
+          python3 scripts/benchmark_output_to_csv.py /tmp/bench_current.out /tmp/bench_current.csv
+          BASH
 
       - name: Run benchmark baselines
         id: bench-baselines
@@ -205,6 +212,7 @@ jobs:
             fi
             worktree="/tmp/flydsl-bench-main-${idx}"
             csv="/tmp/bench_candidate_${idx}.csv"
+            output="/tmp/bench_candidate_${idx}.out"
             log_dir="/tmp/flydsl_bench_${label}"
             echo "Trying benchmark baseline ${label} (${commit})"
 
@@ -214,7 +222,6 @@ jobs:
               continue
             fi
 
-            cp /flydsl-test/scripts/run_benchmark.sh "${worktree}/scripts/run_benchmark.sh"
             (
               set -e -o pipefail
               cd "${worktree}"
@@ -222,7 +229,8 @@ jobs:
               python3 -m pip install -e . --use-pep517 2>&1 | tail -5
               export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
               export AITER_REPO=/tmp/aiter
-              BENCH_LOG_DIR="${log_dir}" bash scripts/run_benchmark.sh --output_csv "${csv}"
+              BENCH_LOG_DIR="${log_dir}" bash scripts/run_benchmark.sh 2>&1 | tee "${output}"
+              python3 /flydsl-test/scripts/benchmark_output_to_csv.py "${output}" "${csv}"
             )
             status=$?
             if [ "${status}" -eq 0 ] && [ -s "${csv}" ]; then

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -179,19 +179,120 @@ jobs:
           fi
 
       - name: Run benchmarks
+        id: benchmarks
         run: |
-          docker exec flydsl_test bash -c "export PYTHONPATH=/tmp/aiter:\${PYTHONPATH:-} && export AITER_REPO=/tmp/aiter && cd /flydsl-test && bash scripts/run_benchmark.sh"
+          docker exec flydsl_test bash -c "export PYTHONPATH=/tmp/aiter:\${PYTHONPATH:-} && export AITER_REPO=/tmp/aiter && cd /flydsl-test && BENCH_LOG_DIR=/tmp/flydsl_bench_current bash scripts/run_benchmark.sh --output_csv /tmp/bench_current.csv"
+
+      - name: Run benchmark baselines
+        id: bench-baselines
+        timeout-minutes: 180
+        continue-on-error: true
+        run: |
+          docker exec flydsl_test bash <<'BASH'
+          set -u
+          cd /flydsl-test
+          rm -rf /tmp/flydsl-bench-main-*
+          rm -f /tmp/bench_main.csv /tmp/bench_prev_main.csv /tmp/bench_main_label /tmp/bench_prev_main_label
+          git worktree prune || true
+          git fetch origin main --depth=8
+
+          found=0
+          idx=0
+          for commit in $(git rev-list --max-count=8 FETCH_HEAD); do
+            label="main"
+            if [ "${idx}" -gt 0 ]; then
+              label="main~${idx}"
+            fi
+            worktree="/tmp/flydsl-bench-main-${idx}"
+            csv="/tmp/bench_candidate_${idx}.csv"
+            log_dir="/tmp/flydsl_bench_${label}"
+            echo "Trying benchmark baseline ${label} (${commit})"
+
+            if ! git worktree add --detach "${worktree}" "${commit}"; then
+              echo "Failed to create worktree for ${label}; trying older main commit."
+              idx=$((idx + 1))
+              continue
+            fi
+
+            cp /flydsl-test/scripts/run_benchmark.sh "${worktree}/scripts/run_benchmark.sh"
+            (
+              set -e -o pipefail
+              cd "${worktree}"
+              export MLIR_PATH=/llvm-project/mlir_install
+              python3 -m pip install -e . --use-pep517 2>&1 | tail -5
+              export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
+              export AITER_REPO=/tmp/aiter
+              BENCH_LOG_DIR="${log_dir}" bash scripts/run_benchmark.sh --output_csv "${csv}"
+            )
+            status=$?
+            if [ "${status}" -eq 0 ] && [ -s "${csv}" ]; then
+              if [ "${found}" -eq 0 ]; then
+                cp "${csv}" /tmp/bench_main.csv
+                echo "${label}" >/tmp/bench_main_label
+              else
+                cp "${csv}" /tmp/bench_prev_main.csv
+                echo "${label}" >/tmp/bench_prev_main_label
+              fi
+              found=$((found + 1))
+              if [ "${found}" -ge 2 ]; then
+                break
+              fi
+            else
+              echo "Benchmark baseline ${label} failed; trying older main commit."
+            fi
+            idx=$((idx + 1))
+          done
+
+          if [ "${found}" -eq 0 ]; then
+            echo "No usable main benchmark baseline found."
+            exit 0
+          fi
+          if [ "${found}" -eq 1 ]; then
+            echo "Only one usable main benchmark baseline found."
+          fi
+          BASH
+
+      - name: Check benchmark performance (current vs main)
+        if: steps.bench-baselines.outcome != 'skipped'
+        timeout-minutes: 5
+        run: |
+          docker exec flydsl_test bash -c "
+            if [ ! -f /tmp/bench_main.csv ]; then
+              echo 'No usable main benchmark baseline found; skipping main comparison.'
+              exit 0
+            fi
+            cd /flydsl-test
+            main_label=\$(cat /tmp/bench_main_label 2>/dev/null || echo main)
+            python3 scripts/compare_benchmark.py /tmp/bench_main.csv /tmp/bench_current.csv \
+              --baseline-label \"\${main_label}\" --current-label current
+          "
+
+      - name: Check benchmark performance (current vs main~1)
+        if: steps.bench-baselines.outcome != 'skipped'
+        timeout-minutes: 5
+        run: |
+          docker exec flydsl_test bash -c "
+            if [ ! -f /tmp/bench_prev_main.csv ]; then
+              echo 'No second usable main benchmark baseline found; skipping previous-main comparison.'
+              exit 0
+            fi
+            cd /flydsl-test
+            prev_main_label=\$(cat /tmp/bench_prev_main_label 2>/dev/null || echo main~1)
+            python3 scripts/compare_benchmark.py /tmp/bench_prev_main.csv /tmp/bench_current.csv \
+              --baseline-label \"\${prev_main_label}\" --current-label current
+          "
 
       - name: Show benchmarks logs
         if: failure()
         run: |
-          docker exec flydsl_test bash -c 'cd /tmp/flydsl_bench && tar czf /tmp/flydsl_bench/logs.tgz *.log 2>/dev/null || echo "no logs"'
-          docker cp flydsl_test:/tmp/flydsl_bench/logs.tgz . || true
-          if [ -f logs.tgz ]; then
-            tar -xzf logs.tgz || true
-            cat *.log || true
+          docker exec flydsl_test bash -c 'cd /tmp && tar czf /tmp/flydsl_bench_logs.tgz flydsl_bench* bench_*.csv 2>/dev/null || echo "no logs"'
+          docker cp flydsl_test:/tmp/flydsl_bench_logs.tgz . || true
+          if [ -f flydsl_bench_logs.tgz ]; then
+            tar -xzf flydsl_bench_logs.tgz || true
+            cat flydsl_bench*/*.log || true
+            cat bench_*.csv || true
           else
-            echo "logs.tgz not found; skipping log extraction"
+            echo "flydsl_bench_logs.tgz not found; skipping log extraction"
           fi
       
       - name: Clean up

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -181,7 +181,7 @@ jobs:
       - name: Run benchmarks
         id: benchmarks
         run: |
-          docker exec flydsl_test bash <<'BASH'
+          docker exec -i flydsl_test bash <<'BASH'
           set -e -o pipefail
           export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
           export AITER_REPO=/tmp/aiter
@@ -195,7 +195,7 @@ jobs:
         timeout-minutes: 180
         continue-on-error: true
         run: |
-          docker exec flydsl_test bash <<'BASH'
+          docker exec -i flydsl_test bash <<'BASH'
           set -u
           cd /flydsl-test
           rm -rf /tmp/flydsl-bench-main-*

--- a/scripts/benchmark_output_to_csv.py
+++ b/scripts/benchmark_output_to_csv.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+"""Convert run_benchmark.sh table output to CSV."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+
+def _is_metric(value: str) -> bool:
+    if value in {"-", "skip"}:
+        return True
+    try:
+        float(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _status(tbps: str, tflops: str) -> str:
+    if tbps == "skip" or tflops == "skip":
+        return "skip"
+    if tbps == "-" and tflops == "-":
+        return "missing"
+    return "ok"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+
+    rows: list[list[str]] = []
+    for line in args.input.read_text(errors="ignore").splitlines():
+        parts = line.split()
+        if len(parts) != 5:
+            continue
+        op, shape, dtype, tbps, tflops = parts
+        if op == "op" or set(op) == {"-"}:
+            continue
+        if not (_is_metric(tbps) and _is_metric(tflops)):
+            continue
+        rows.append([op, shape, dtype, tbps, tflops, _status(tbps, tflops)])
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["op", "shape", "dtype", "tbps", "tflops", "status"])
+        writer.writerows(rows)
+
+    print(f"Wrote {len(rows)} benchmark row(s) to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/compare_benchmark.py
+++ b/scripts/compare_benchmark.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+"""Report performance ratios between two run_benchmark.sh CSV outputs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class BenchmarkRow:
+    op: str
+    shape: str
+    dtype: str
+    metric_name: str
+    metric_value: float | None
+    status: str
+
+
+def _parse_float(value: str) -> float | None:
+    if value in {"", "-", "skip"}:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _read_csv(path: Path) -> dict[tuple[str, str, str], BenchmarkRow]:
+    rows: dict[tuple[str, str, str], BenchmarkRow] = {}
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        required = {"op", "shape", "dtype", "tbps", "tflops", "status"}
+        missing = required.difference(reader.fieldnames or [])
+        if missing:
+            raise SystemExit(f"{path} is missing columns: {', '.join(sorted(missing))}")
+
+        for raw in reader:
+            op = raw["op"]
+            shape = raw["shape"]
+            dtype = raw["dtype"]
+            tflops = _parse_float(raw["tflops"])
+            tbps = _parse_float(raw["tbps"])
+            if tflops is not None:
+                metric_name = "TFLOPS"
+                metric_value = tflops
+            else:
+                metric_name = "TB/s"
+                metric_value = tbps
+            rows[(op, shape, dtype)] = BenchmarkRow(
+                op=op,
+                shape=shape,
+                dtype=dtype,
+                metric_name=metric_name,
+                metric_value=metric_value,
+                status=raw["status"],
+            )
+    return rows
+
+
+def _format_key(key: tuple[str, str, str]) -> str:
+    op, shape, dtype = key
+    return f"{op:>18s} {shape:>34s} {dtype:>8s}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("baseline_csv", type=Path)
+    parser.add_argument("current_csv", type=Path)
+    parser.add_argument("--baseline-label", default="baseline")
+    parser.add_argument("--current-label", default="current")
+    args = parser.parse_args()
+
+    baseline = _read_csv(args.baseline_csv)
+    current = _read_csv(args.current_csv)
+
+    print(f"=== Benchmark: {args.current_label} vs {args.baseline_label} ===")
+
+    compared = 0
+
+    for key in sorted(current.keys() & baseline.keys()):
+        base = baseline[key]
+        curr = current[key]
+        if base.metric_value is None:
+            continue
+
+        if curr.metric_value is None:
+            print(f"  {_format_key(key)}  {args.current_label}=missing  [SKIP]")
+            continue
+        if curr.metric_name != base.metric_name:
+            print(
+                f"  {_format_key(key)}  metric mismatch: "
+                f"{args.baseline_label}={base.metric_name}, "
+                f"{args.current_label}={curr.metric_name}  [SKIP]"
+            )
+            continue
+
+        compared += 1
+        delta = curr.metric_value - base.metric_value
+        delta_pct = (delta / base.metric_value) * 100.0 if base.metric_value else 0.0
+        ratio = curr.metric_value / base.metric_value if base.metric_value else 0.0
+
+        print(
+            f"  {_format_key(key)}  "
+            f"{args.baseline_label}={base.metric_value:9.3f} {base.metric_name:<6s}  "
+            f"{args.current_label}={curr.metric_value:9.3f} {curr.metric_name:<6s}  "
+            f"ratio={ratio:6.3f}x  delta={delta:+9.3f} ({delta_pct:+6.1f}%)"
+        )
+
+    skipped_new = len(set(current) - set(baseline))
+    if skipped_new:
+        print(f"\nSkipped {skipped_new} new current-only benchmark row(s).")
+
+    if compared == 0:
+        print("No comparable benchmark rows found.")
+
+    print("\nBenchmark comparison report completed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compare_benchmark.py
+++ b/scripts/compare_benchmark.py
@@ -116,6 +116,16 @@ def main() -> int:
     if skipped_new:
         print(f"\nSkipped {skipped_new} new current-only benchmark row(s).")
 
+    skipped_missing = 0
+    for key in sorted(set(baseline) - set(current)):
+        base = baseline[key]
+        if base.metric_value is None:
+            continue
+        skipped_missing += 1
+        print(f"  {_format_key(key)}  {args.current_label}=missing row  [SKIP]")
+    if skipped_missing:
+        print(f"\nSkipped {skipped_missing} baseline-only benchmark row(s).")
+
     if compared == 0:
         print("No comparable benchmark rows found.")
 

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -26,6 +26,7 @@ fi
 
 BENCH_LOG_DIR="${BENCH_LOG_DIR:-/tmp/flydsl_bench}"
 mkdir -p "${BENCH_LOG_DIR}"
+BENCH_OUTPUT_CSV="${BENCH_OUTPUT_CSV:-}"
 
 # Auto-select GPU with the most free VRAM (skip if HIP_VISIBLE_DEVICES is already set).
 if [ -z "${HIP_VISIBLE_DEVICES:-}" ] && command -v python3 >/dev/null 2>&1; then
@@ -161,6 +162,7 @@ Usage:
   bash scripts/run_benchmark.sh softmax          # run only softmax
   bash scripts/run_benchmark.sh layernorm moe      # run only selected benchmarks
   bash scripts/run_benchmark.sh --only softmax,moe
+  bash scripts/run_benchmark.sh --output_csv /tmp/bench.csv
   bash scripts/run_benchmark.sh --list
 
 Supported ops:
@@ -211,6 +213,21 @@ _fmt_table_header() {
 _emit_row() {
   op="$1"; shape="$2"; dtype="$3"; tbps="$4"; tflops="$5"
   printf "%-22.22s %-34.34s %-10.10s %10s %10s\n" "${op}" "${shape}" "${dtype}" "${tbps}" "${tflops}"
+  if [ -n "${BENCH_OUTPUT_CSV:-}" ]; then
+    status="ok"
+    if [ "${tbps}" = "skip" ] || [ "${tflops}" = "skip" ]; then
+      status="skip"
+    elif [ "${tbps}" = "-" ] && [ "${tflops}" = "-" ]; then
+      status="missing"
+    fi
+    python3 - "${BENCH_OUTPUT_CSV}" "${op}" "${shape}" "${dtype}" "${tbps}" "${tflops}" "${status}" <<'PY'
+import csv
+import sys
+
+with open(sys.argv[1], "a", newline="") as f:
+    csv.writer(f).writerow(sys.argv[2:])
+PY
+  fi
 }
 
 _normalize_op() {
@@ -306,6 +323,16 @@ if [ "$#" -gt 0 ]; then
           _add_selected_op "$op"
         done
         ;;
+      --output_csv|--output-csv)
+        flag="$1"
+        shift
+        [ "$#" -gt 0 ] || _die "${flag} requires a CSV path"
+        BENCH_OUTPUT_CSV="$1"
+        ;;
+      --output_csv=*|--output-csv=*)
+        BENCH_OUTPUT_CSV="${1#*=}"
+        [ -n "${BENCH_OUTPUT_CSV}" ] || _die "$1 requires a CSV path"
+        ;;
       --*)
         _die "unknown flag '$1'"
         ;;
@@ -319,6 +346,11 @@ if [ "$#" -gt 0 ]; then
     # shellcheck disable=SC2086 # want word-splitting for ops list
     _enable_only_ops ${SELECTED_OPS}
   fi
+fi
+
+if [ -n "${BENCH_OUTPUT_CSV}" ]; then
+  mkdir -p "$(dirname "${BENCH_OUTPUT_CSV}")"
+  printf "op,shape,dtype,tbps,tflops,status\n" >"${BENCH_OUTPUT_CSV}"
 fi
 
 _py_parse_and_emit() {


### PR DESCRIPTION
## Summary
- Add CSV output support to `scripts/run_benchmark.sh` so CI can compare benchmark rows consistently.
- Report current benchmark ratios against the newest usable `main` baseline and the next usable previous-main baseline.
- Skip new current-only benchmark rows and skip unavailable baselines instead of failing performance comparison steps.

## Test plan
- `sh -n scripts/run_benchmark.sh`
- `python3 -m py_compile scripts/compare_benchmark.py`
- Parsed `.github/workflows/flydsl.yaml` with PyYAML


Made with [Cursor](https://cursor.com)