### PR TITLE
docs: recommend PyPI install and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ layout IR with explicit algebra and coordinate mapping, plus a composable loweri
   - Core abstractions: `!fly.int_tuple`, `!fly.layout`, `!fly.coord_tensor`, `!fly.memref`
   - Algebra ops: composition/product/divide/partition + coordinate mapping ops
 - **Embedded MLIR Python runtime** (`_mlir`)
-  - No external `mlir` python wheel is required: MLIR python bindings are built and staged into `build-fly/python_packages/flydsl/_mlir`
+  - No external `mlir` python wheel is required: MLIR python bindings are included with the FlyDSL package/build artifacts
 
 ### Repository layout
 
@@ -53,58 +53,54 @@ FlyDSL/
 
 ### Prerequisites
 
-- **ROCm**: required for GPU execution (tested on ROCm 6.x, 7.x)
-- **Build tools**: `cmake` (≥3.20), C++17 compiler, optionally `ninja`
 - **Python**: Python 3.10+ with `pip`
-- **Python deps**: `nanobind`, `numpy`, `pybind11` (installed by `build_llvm.sh`)
+- **ROCm**: required for GPU execution, tests, and benchmarks (tested on ROCm 6.x, 7.x)
 
-### Step 1: Build LLVM/MLIR
+### Install FlyDSL
 
-If you already have an MLIR build with Python bindings enabled, skip this step.
+For most users, install the published package directly:
+
+```bash
+pip install flydsl
+```
+
+### Verify the install
+
+```bash
+python -c "import flydsl; print('FlyDSL installed')"
+```
+
+### Build from source
+
+Build from source only if you are developing FlyDSL itself or need a custom MLIR/LLVM build.
+
+Prerequisites for source builds:
+
+- **Build tools**: `cmake` (>=3.20), C++17 compiler, optionally `ninja`
+- **Python deps**: `nanobind`, `numpy`, `pybind11` (installed by the build scripts)
 
 ```bash
 # Clone ROCm LLVM and build MLIR (takes ~30min with -j64)
 bash scripts/build_llvm.sh -j64
+
+# Build FlyDSL C++ dialects, compiler passes, and Python bindings
+bash scripts/build.sh -j64
+
+# Install in development mode
+pip install -e .
 ```
 
-Or point to an existing build:
+If you already have an MLIR build with Python bindings enabled, point to it instead:
+
 ```bash
 export MLIR_PATH=/path/to/llvm-project/build-flydsl/mlir_install
-```
-
-### Step 2: Build FlyDSL
-
-```bash
-bash scripts/build.sh -j64
-```
-
-`build.sh` auto-detects `MLIR_PATH` from common locations. Override with:
-```bash
-MLIR_PATH=/path/to/mlir_install bash scripts/build.sh -j64
+MLIR_PATH=$MLIR_PATH bash scripts/build.sh -j64
+pip install -e .
 ```
 
 > **Note**: If `MLIR_PATH` is set in your environment pointing to a wrong LLVM build, `unset MLIR_PATH` first.
 
-After a successful build, you will have:
-- `build-fly/python_packages/flydsl/` — the complete Python package with embedded MLIR bindings
-
-### Step 3: Install (development mode)
-
-```bash
-pip install -e .
-# or equivalently:
-python setup.py develop
-```
-
-This creates an editable install — changes to `python/flydsl/` are immediately reflected.
-
-**Without installing**, you can also set paths manually:
-```bash
-export PYTHONPATH=$(pwd)/build-fly/python_packages:$(pwd):$PYTHONPATH
-export LD_LIBRARY_PATH=$(pwd)/build-fly/python_packages/flydsl/_mlir/_mlir_libs:$LD_LIBRARY_PATH
-```
-
-### Step 4: Run tests
+### Run tests
 
 ```bash
 # Run GEMM correctness tests (fast, ~15s)
@@ -119,11 +115,14 @@ bash scripts/run_benchmark.sh
 ### Quick reference
 
 ```bash
-# Full build from scratch:
+# Install from PyPI:
+pip install flydsl
+
+# Full source build from scratch:
 bash scripts/build_llvm.sh -j64   # one-time: build LLVM/MLIR
 bash scripts/build.sh -j64        # build FlyDSL
-pip install -e .                   # install in dev mode
-bash scripts/run_tests.sh          # verify
+pip install -e .                  # install in dev mode
+bash scripts/run_tests.sh         # verify
 
 # Rebuild after code changes (C++ only):
 bash scripts/build.sh -j64
@@ -138,7 +137,7 @@ bash scripts/build.sh -j64
   - `unset MLIR_PATH` and let `build.sh` auto-detect, or set it to the correct path.
 
 - **`No module named flydsl`**
-  - Run `pip install -e .` or set `PYTHONPATH` as shown above.
+  - Run `pip install flydsl`. For source checkouts, run `pip install -e .` after building.
 
 - **MLIR `.so` load errors**
   - Add MLIR build lib dir to the loader path:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.join(_project_root, "python"))
 project = "FlyDSL"
 copyright = "2024-2026, Advanced Micro Devices, Inc."
 author = "AMD"
-release = "0.1.0"
+release = "0.1.8"
 
 # -- General configuration ---------------------------------------------------
 extensions = [

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,13 +6,37 @@ Prerequisites
 
 - **Python**: 3.10 or later
 - **ROCm**: Required for GPU execution tests and benchmarks (IR-only tests do not need a GPU)
-- **Build tools**: ``cmake`` (≥3.20), a C++17 compiler, and optionally ``ninja``
-- **Python deps**: ``nanobind``, ``numpy``, ``pybind11`` (installed automatically)
 - **Supported GPUs**: AMD MI300X/MI308X (gfx942), AMD MI350 (gfx950)
 - **Supported OS**: Linux with ROCm 6.x or 7.x
 
+Install from PyPI
+-----------------
+
+For most users, install the published package directly:
+
+.. code-block:: bash
+
+   pip install flydsl
+
+Verify that Python can import FlyDSL:
+
+.. code-block:: bash
+
+   python -c "import flydsl; print('FlyDSL installed')"
+
+Build from source
+-----------------
+
+Build from source only if you are developing FlyDSL itself or need a custom
+MLIR/LLVM build.
+
+Additional prerequisites for source builds:
+
+- **Build tools**: ``cmake`` (>=3.20), a C++17 compiler, and optionally ``ninja``
+- **Python deps**: ``nanobind``, ``numpy``, ``pybind11`` (installed automatically)
+
 Step 1: Build LLVM/MLIR
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 
 If you already have an MLIR build with Python bindings enabled, point to it:
 
@@ -28,7 +52,7 @@ Otherwise, use the helper script which clones the ROCm llvm-project and builds M
    export MLIR_PATH=/path/to/llvm-project/build-flydsl/mlir_install
 
 Step 2: Build FlyDSL
----------------------
+~~~~~~~~~~~~~~~~~~~~
 
 Build the Fly C++ dialect, compiler passes, and embedded Python bindings:
 
@@ -51,7 +75,7 @@ After a successful build you will have:
   - ``_mlir/`` -- embedded MLIR Python bindings (no external ``mlir`` wheel required)
 
 Step 3: Install FlyDSL
------------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 For development (editable install):
 
@@ -82,8 +106,8 @@ To build a distributable wheel:
    python setup.py bdist_wheel
    ls dist/
 
-Step 4: Verify Installation
-----------------------------
+Verify Installation
+-------------------
 
 Run the test suite to verify everything works:
 
@@ -107,9 +131,10 @@ Troubleshooting
       cmake --build build-fly --target fly-opt -j$(nproc)
 
 **Python import issues (No module named flydsl)**
-   Ensure you are using the embedded package::
+   Install the published package, or use the source checkout after building::
 
-      export PYTHONPATH=$(pwd)/build-fly/python_packages:$(pwd):$PYTHONPATH
+      pip install flydsl
+      pip install -e .
 
 **MLIR .so load errors**
    Add the MLIR build lib dir to the loader path::

--- a/python/flydsl/__init__.py
+++ b/python/flydsl/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 
 # FFM simulator compatibility shim (no-op outside simulator sessions).
 from ._compat import _maybe_preload_system_comgr  # noqa: E402


### PR DESCRIPTION
## Summary
- Make `pip install flydsl` the primary getting-started path in the README.
- Update the installation guide to present source builds as the contributor/custom LLVM path.
- Bump FlyDSL package and documentation release version to `0.1.8`.

## Test plan
- Not run; documentation and version metadata only.