### PR TITLE
bench: add FlashAttention custom LLVM path

### DIFF
--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -67,6 +67,11 @@ LAYERNORM_SHAPES='
 RMSNORM_SHAPES='
 32768,8192,bf16
 '
+# FlashAttention shapes: "batch,seq_len,num_heads,head_dim,dtype,causal"
+FLASH_ATTN_FUNC_SHAPES="${FLASH_ATTN_FUNC_SHAPES:-'
+1,4096,64,128,bf16,true
+1,8192,64,128,bf16,true
+'}"
 
 # Preshuffle GEMM shapes: "dtype,M,N,K,tile_m,tile_n,tile_k"
 GEMM_SHAPES='
@@ -160,13 +165,13 @@ _usage() {
 Usage:
   bash scripts/run_benchmark.sh                  # run all benchmarks (default)
   bash scripts/run_benchmark.sh softmax          # run only softmax
-  bash scripts/run_benchmark.sh layernorm moe      # run only selected benchmarks
+  bash scripts/run_benchmark.sh layernorm moe    # run only selected benchmarks
   bash scripts/run_benchmark.sh --only softmax,moe
   bash scripts/run_benchmark.sh --output_csv /tmp/bench.csv
   bash scripts/run_benchmark.sh --list
 
 Supported ops:
-  softmax | layernorm | rmsnorm | gemm | moe
+  softmax | layernorm | rmsnorm | flash_attn | gemm | moe
 USAGE
 }
 
@@ -235,15 +240,17 @@ _normalize_op() {
   op="${1:-}"
   case "${op}" in
     layernorm) echo "layernorm" ;;
+    flash|flash_attn|flash-attn|flash_attn_func|fmha) echo "flash_attn" ;;
     *) echo "${op}" ;;
   esac
 }
 
-# Default: run softmax, norms, and GEMM unless user selected a subset.
-# Use positional args or --only to enable others: softmax, layernorm, rmsnorm, gemm, moe
+# Default: run softmax, norms, FlashAttention, GEMM, and MoE unless user selected a subset.
+# Use positional args or --only to enable others: softmax, layernorm, rmsnorm, flash_attn, gemm, moe
 RUN_SOFTMAX=1
 RUN_LAYERNORM=1
 RUN_RMSNORM=1
+RUN_FLASH_ATTN=1
 RUN_PRESHUFFLE_GEMM=1
 RUN_MOE=1
 
@@ -251,6 +258,7 @@ _enable_only_ops() {
   RUN_SOFTMAX=0
   RUN_LAYERNORM=0
   RUN_RMSNORM=0
+  RUN_FLASH_ATTN=0
   RUN_PRESHUFFLE_GEMM=0
   RUN_MOE=0
   for op in "$@"; do
@@ -259,6 +267,7 @@ _enable_only_ops() {
       softmax) RUN_SOFTMAX=1 ;;
       layernorm) RUN_LAYERNORM=1 ;;
       rmsnorm) RUN_RMSNORM=1 ;;
+      flash_attn) RUN_FLASH_ATTN=1 ;;
       gemm) RUN_PRESHUFFLE_GEMM=1 ;;
       moe) RUN_MOE=1 ;;
       "" ) ;;
@@ -295,6 +304,7 @@ if [ "$#" -gt 0 ]; then
         echo "softmax"
         echo "layernorm"
         echo "rmsnorm"
+        echo "flash_attn"
         echo "gemm"
         echo "moe"
         exit 0
@@ -390,6 +400,14 @@ if tbps is None or tflops is None:
     if m:
         tflops = float(m.group(1))
         tbps = float(m.group(2))
+
+# FlashAttention table: "| PASS | maxerr mincos | time_us tflops".
+if tflops is None:
+    m = None
+    for m in re.finditer(r"\|\s+(?:PASS|FAIL|--)\s+\|\s+[0-9.eE+-]+\s+[0-9.]+\s+\|\s+([0-9.]+)\s+([0-9.]+)", txt):
+        pass
+    if m:
+        tflops = float(m.group(2))
 
 # Softmax/Norm-style: "Kernel avg time: X ms" + "Bandwidth: Y GB/s"
 if tbps is None:
@@ -529,6 +547,50 @@ if [ "${RUN_RMSNORM}" -eq 1 ]; then
       _show_fail_log "${log}" "rmsnorm"
     fi
     row="$(_py_parse_and_emit rmsnorm "${M}x${N}" "${dtype}" "${log}")"
+    set -- $row
+    _emit_row "$1" "$2" "$3" "$4" "$5"
+  done
+fi
+
+# FlashAttention / FMHA (CDNA only)
+if [ "${RUN_FLASH_ATTN}" -eq 1 ] && [ "${IS_CDNA}" = "true" ]; then
+  export FLYDSL_FLASH_ATTN_FUNC_ENABLE_DMA="${FLYDSL_FLASH_ATTN_FUNC_ENABLE_DMA:-1}"
+  export FLYDSL_FLASH_ATTN_FUNC_ENABLE_LDS_VEC16="${FLYDSL_FLASH_ATTN_FUNC_ENABLE_LDS_VEC16:-1}"
+
+  for shape in $FLASH_ATTN_FUNC_SHAPES; do
+    [ -z "$shape" ] && continue
+    oldIFS=$IFS
+    IFS=,
+    # shellcheck disable=SC2086 # intentional word-splitting on IFS=,
+    set -- $shape
+    IFS=$oldIFS
+    batch=$1; seq_len=$2; heads=$3; head_dim=$4; dtype=$5; causal=$6
+    causal_flag="--causal"
+    causal_tag="causal"
+    case "${causal}" in
+      0|false|False|FALSE|no|NO|noncausal|non-causal)
+        causal_flag="--no-causal"
+        causal_tag="nocausal"
+        ;;
+    esac
+    log="${BENCH_LOG_DIR}/flash_attn_B${batch}_S${seq_len}_H${heads}_D${head_dim}_${dtype}_${causal_tag}.log"
+    if python3 tests/kernels/test_flash_attn_func.py \
+      --batch "$batch" \
+      --seq_len "$seq_len" \
+      --num_heads "$heads" \
+      --head_dim "$head_dim" \
+      --dtype "$dtype" \
+      "${causal_flag}" \
+      --warmup 10 \
+      --iters 100 >"${log}" 2>&1; then
+      SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+    else
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      echo "flash_attn failed. Log: ${log}" >&2
+      _show_fail_log "${log}" "flash_attn"
+    fi
+    shape_tag="B${batch}S${seq_len}H${heads}D${head_dim}_${causal_tag}"
+    row="$(_py_parse_and_emit flash_attn "${shape_tag}" "${dtype}" "${log}")"
     set -- $row
     _emit_row "$1" "$2" "$3" "$4" "$5"
   done

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -69,8 +69,9 @@ RMSNORM_SHAPES='
 '
 # FlashAttention shapes: "batch,seq_len,num_heads,head_dim,dtype,causal"
 DEFAULT_FLASH_ATTN_FUNC_SHAPES='
-1,4096,64,128,bf16,true
-1,8192,64,128,bf16,true
+32,8192,8,128,bf16,true
+16,8192,16,128,bf16,true
+4,8192,64,128,bf16,true
 '
 FLASH_ATTN_FUNC_SHAPES="${FLASH_ATTN_FUNC_SHAPES:-${DEFAULT_FLASH_ATTN_FUNC_SHAPES}}"
 # MLA decode shapes: "batch,ctx_len" (DeepSeek MLA, fp8 Q/KV, nh=128).
@@ -616,7 +617,7 @@ if [ "${RUN_FLASH_ATTN}" -eq 1 ] && [ "${IS_CDNA}" = "true" ]; then
   done
 fi
 
-# MLA decode (gfx942 path; gfx950 AITER metadata uses folded nh=16 layout)
+# MLA decode
 if [ "${RUN_MLA}" -eq 1 ] && [ "${IS_CDNA}" = "true" ]; then
   for shape in $MLA_DECODE_SHAPES; do
     [ -z "$shape" ] && continue
@@ -627,10 +628,6 @@ if [ "${RUN_MLA}" -eq 1 ] && [ "${IS_CDNA}" = "true" ]; then
     IFS=$oldIFS
     batch=$1; ctx_len=$2
     shape_tag="B${batch}C${ctx_len}"
-    if [ "${GPU_ARCH}" = "gfx950" ]; then
-      _emit_row "mla" "${shape_tag}" "fp8" "skip" "skip"
-      continue
-    fi
     log="${BENCH_LOG_DIR}/mla_decode_B${batch}_C${ctx_len}.log"
     if python3 tests/kernels/test_mla_decode.py \
       --batch "$batch" \

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -68,14 +68,16 @@ RMSNORM_SHAPES='
 32768,8192,bf16
 '
 # FlashAttention shapes: "batch,seq_len,num_heads,head_dim,dtype,causal"
-FLASH_ATTN_FUNC_SHAPES="${FLASH_ATTN_FUNC_SHAPES:-'
+DEFAULT_FLASH_ATTN_FUNC_SHAPES='
 1,4096,64,128,bf16,true
 1,8192,64,128,bf16,true
-'}"
+'
+FLASH_ATTN_FUNC_SHAPES="${FLASH_ATTN_FUNC_SHAPES:-${DEFAULT_FLASH_ATTN_FUNC_SHAPES}}"
 # MLA decode shapes: "batch,ctx_len" (DeepSeek MLA, fp8 Q/KV, nh=128).
-MLA_DECODE_SHAPES="${MLA_DECODE_SHAPES:-'
+DEFAULT_MLA_DECODE_SHAPES='
 32,8192
-'}"
+'
+MLA_DECODE_SHAPES="${MLA_DECODE_SHAPES:-${DEFAULT_MLA_DECODE_SHAPES}}"
 
 # Preshuffle GEMM shapes: "dtype,M,N,K,tile_m,tile_n,tile_k"
 GEMM_SHAPES='

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -72,6 +72,10 @@ FLASH_ATTN_FUNC_SHAPES="${FLASH_ATTN_FUNC_SHAPES:-'
 1,4096,64,128,bf16,true
 1,8192,64,128,bf16,true
 '}"
+# MLA decode shapes: "batch,ctx_len" (DeepSeek MLA, fp8 Q/KV, nh=128).
+MLA_DECODE_SHAPES="${MLA_DECODE_SHAPES:-'
+32,8192
+'}"
 
 # Preshuffle GEMM shapes: "dtype,M,N,K,tile_m,tile_n,tile_k"
 GEMM_SHAPES='
@@ -171,7 +175,7 @@ Usage:
   bash scripts/run_benchmark.sh --list
 
 Supported ops:
-  softmax | layernorm | rmsnorm | flash_attn | gemm | moe
+  softmax | layernorm | rmsnorm | flash_attn | mla | gemm | moe
 USAGE
 }
 
@@ -241,16 +245,18 @@ _normalize_op() {
   case "${op}" in
     layernorm) echo "layernorm" ;;
     flash|flash_attn|flash-attn|flash_attn_func|fmha) echo "flash_attn" ;;
+    mla|mla_decode|mla-decode) echo "mla" ;;
     *) echo "${op}" ;;
   esac
 }
 
-# Default: run softmax, norms, FlashAttention, GEMM, and MoE unless user selected a subset.
-# Use positional args or --only to enable others: softmax, layernorm, rmsnorm, flash_attn, gemm, moe
+# Default: run softmax, norms, attention, GEMM, and MoE unless user selected a subset.
+# Use positional args or --only to enable others: softmax, layernorm, rmsnorm, flash_attn, mla, gemm, moe
 RUN_SOFTMAX=1
 RUN_LAYERNORM=1
 RUN_RMSNORM=1
 RUN_FLASH_ATTN=1
+RUN_MLA=1
 RUN_PRESHUFFLE_GEMM=1
 RUN_MOE=1
 
@@ -259,6 +265,7 @@ _enable_only_ops() {
   RUN_LAYERNORM=0
   RUN_RMSNORM=0
   RUN_FLASH_ATTN=0
+  RUN_MLA=0
   RUN_PRESHUFFLE_GEMM=0
   RUN_MOE=0
   for op in "$@"; do
@@ -268,6 +275,7 @@ _enable_only_ops() {
       layernorm) RUN_LAYERNORM=1 ;;
       rmsnorm) RUN_RMSNORM=1 ;;
       flash_attn) RUN_FLASH_ATTN=1 ;;
+      mla) RUN_MLA=1 ;;
       gemm) RUN_PRESHUFFLE_GEMM=1 ;;
       moe) RUN_MOE=1 ;;
       "" ) ;;
@@ -305,6 +313,7 @@ if [ "$#" -gt 0 ]; then
         echo "layernorm"
         echo "rmsnorm"
         echo "flash_attn"
+        echo "mla"
         echo "gemm"
         echo "moe"
         exit 0
@@ -408,6 +417,15 @@ if tflops is None:
         pass
     if m:
         tflops = float(m.group(2))
+
+# MLA decode: "TFLOPS=...  TB/s=..."
+if tbps is None or tflops is None:
+    m = None
+    for m in re.finditer(r"TFLOPS=([0-9.]+)\s+TB/s=([0-9.]+)", txt):
+        pass
+    if m:
+        tflops = float(m.group(1))
+        tbps = float(m.group(2))
 
 # Softmax/Norm-style: "Kernel avg time: X ms" + "Bandwidth: Y GB/s"
 if tbps is None:
@@ -591,6 +609,37 @@ if [ "${RUN_FLASH_ATTN}" -eq 1 ] && [ "${IS_CDNA}" = "true" ]; then
     fi
     shape_tag="B${batch}S${seq_len}H${heads}D${head_dim}_${causal_tag}"
     row="$(_py_parse_and_emit flash_attn "${shape_tag}" "${dtype}" "${log}")"
+    set -- $row
+    _emit_row "$1" "$2" "$3" "$4" "$5"
+  done
+fi
+
+# MLA decode (gfx942 path; gfx950 AITER metadata uses folded nh=16 layout)
+if [ "${RUN_MLA}" -eq 1 ] && [ "${IS_CDNA}" = "true" ]; then
+  for shape in $MLA_DECODE_SHAPES; do
+    [ -z "$shape" ] && continue
+    oldIFS=$IFS
+    IFS=,
+    # shellcheck disable=SC2086 # intentional word-splitting on IFS=,
+    set -- $shape
+    IFS=$oldIFS
+    batch=$1; ctx_len=$2
+    shape_tag="B${batch}C${ctx_len}"
+    if [ "${GPU_ARCH}" = "gfx950" ]; then
+      _emit_row "mla" "${shape_tag}" "fp8" "skip" "skip"
+      continue
+    fi
+    log="${BENCH_LOG_DIR}/mla_decode_B${batch}_C${ctx_len}.log"
+    if python3 tests/kernels/test_mla_decode.py \
+      --batch "$batch" \
+      --ctx_len "$ctx_len" >"${log}" 2>&1; then
+      SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+    else
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      echo "mla failed. Log: ${log}" >&2
+      _show_fail_log "${log}" "mla"
+    fi
+    row="$(_py_parse_and_emit mla "${shape_tag}" "fp8" "${log}")"
     set -- $row
     _emit_row "$1" "$2" "$3" "$4" "$5"
   done

--- a/tests/kernels/test_flash_attn_func.py
+++ b/tests/kernels/test_flash_attn_func.py
@@ -82,6 +82,12 @@ def _maybe_configure_custom_llvm_tools() -> None:
     if os.getenv("FLYDSL_FLASH_ATTN_FUNC_USE_CUSTOM_LLVM", "1").lower() in ("0", "false", "no", "off"):
         return
     if os.getenv("FLYDSL_COMPILE_LLVM_DIR"):
+        llvm_dir = Path(os.environ["FLYDSL_COMPILE_LLVM_DIR"]).expanduser()
+        if not (llvm_dir / "bin" / "mlir-opt").is_file():
+            raise RuntimeError(
+                f"FLYDSL_COMPILE_LLVM_DIR={llvm_dir} does not contain bin/mlir-opt. "
+                "Set FLYDSL_FLASH_ATTN_FUNC_USE_CUSTOM_LLVM=0 to use bundled LLVM."
+            )
         return
 
     candidates = []
@@ -136,7 +142,10 @@ def _maybe_configure_custom_llvm_tools() -> None:
                 urllib.request.urlretrieve(https_uri, archive_path)
             except Exception as exc:
                 archive_path.unlink(missing_ok=True)
-                print(f"[flash_attn_func] https download failed: {exc}")
+                raise RuntimeError(
+                    f"failed to download custom LLVM tools from {https_uri}: {exc}. "
+                    "Set FLYDSL_FLASH_ATTN_FUNC_USE_CUSTOM_LLVM=0 to use bundled LLVM."
+                ) from exc
 
         if archive_path.is_file():
             try:
@@ -146,16 +155,20 @@ def _maybe_configure_custom_llvm_tools() -> None:
                 with tarfile.open(archive_path, "r:gz") as tar:
                     tar.extractall(extract_dir)
             except Exception as exc:
-                print(f"[flash_attn_func] failed to extract custom LLVM tools: {exc}")
+                raise RuntimeError(
+                    f"failed to extract custom LLVM tools from {archive_path}: {exc}. "
+                    "Set FLYDSL_FLASH_ATTN_FUNC_USE_CUSTOM_LLVM=0 to use bundled LLVM."
+                ) from exc
 
         if (extract_dir / "bin" / "mlir-opt").is_file():
             os.environ["FLYDSL_COMPILE_LLVM_DIR"] = str(extract_dir)
             print(f"[flash_attn_func] using custom LLVM tools: {extract_dir}")
             return
 
-    print(
-        "[flash_attn_func] custom LLVM tools not found; using bundled codegen. "
-        "Set FLYDSL_COMPILE_LLVM_DIR or FLYDSL_FLASH_ATTN_FUNC_USE_CUSTOM_LLVM=0 to silence this."
+    raise RuntimeError(
+        "custom LLVM tools not found or missing bin/mlir-opt. "
+        "Set FLYDSL_COMPILE_LLVM_DIR to an LLVM tools directory, "
+        "or set FLYDSL_FLASH_ATTN_FUNC_USE_CUSTOM_LLVM=0 to use bundled LLVM."
     )
 
 

--- a/tests/kernels/test_flash_attn_func.py
+++ b/tests/kernels/test_flash_attn_func.py
@@ -16,6 +16,7 @@ import shutil
 import sys
 import tarfile
 import urllib.request
+from contextlib import contextmanager
 from pathlib import Path
 
 # Configure logging to show INFO level messages (required for kernel name display)
@@ -172,7 +173,17 @@ def _maybe_configure_custom_llvm_tools() -> None:
     )
 
 
-_maybe_configure_custom_llvm_tools()
+@contextmanager
+def _custom_llvm_tools_env():
+    prev_llvm_dir = os.environ.get("FLYDSL_COMPILE_LLVM_DIR")
+    _maybe_configure_custom_llvm_tools()
+    try:
+        yield
+    finally:
+        if prev_llvm_dir is None:
+            os.environ.pop("FLYDSL_COMPILE_LLVM_DIR", None)
+        else:
+            os.environ["FLYDSL_COMPILE_LLVM_DIR"] = prev_llvm_dir
 
 
 def setup_seed(seed: int) -> None:
@@ -306,14 +317,15 @@ def run_config(
         return results
 
     try:
-        exe = build_flash_attn_func_module(
-            num_heads=num_heads,
-            head_dim=head_dim,
-            causal=causal,
-            dtype_str=dtype_str,
-            waves_per_eu=FLASH_ATTN_FUNC_KERNEL_CONFIG["waves_per_eu"],
-            daz=FLASH_ATTN_FUNC_KERNEL_CONFIG.get("daz", False),
-        )
+        with _custom_llvm_tools_env():
+            exe = build_flash_attn_func_module(
+                num_heads=num_heads,
+                head_dim=head_dim,
+                causal=causal,
+                dtype_str=dtype_str,
+                waves_per_eu=FLASH_ATTN_FUNC_KERNEL_CONFIG["waves_per_eu"],
+                daz=FLASH_ATTN_FUNC_KERNEL_CONFIG.get("daz", False),
+            )
     except Exception as e:
         results["err"] = f"build: {e}"
         import traceback

--- a/tests/kernels/test_flash_attn_func.py
+++ b/tests/kernels/test_flash_attn_func.py
@@ -7,11 +7,16 @@ Tests flash_attn_func against PyTorch SDPA.
 import argparse
 import csv
 import hashlib
+import json
 import logging
 import math
 import os
 import random
+import shutil
+import subprocess
 import sys
+import tarfile
+import urllib.request
 from pathlib import Path
 
 # Configure logging to show INFO level messages (required for kernel name display)
@@ -71,6 +76,98 @@ DEFAULT_CONFIGS = [
     (1, 8192, 8, 128),
     (32, 8192, 8, 128),
 ]
+
+
+def _maybe_configure_custom_llvm_tools() -> None:
+    """Prefer the custom mlir-opt build used for peak FlashAttention perf."""
+    if os.getenv("FLYDSL_FLASH_ATTN_FUNC_USE_CUSTOM_LLVM", "1").lower() in ("0", "false", "no", "off"):
+        return
+    if os.getenv("FLYDSL_COMPILE_LLVM_DIR"):
+        return
+
+    candidates = []
+    for env_name in ("FLYDSL_FLASH_ATTN_FUNC_LLVM_DIR", "FLYDSL_CUSTOM_LLVM_TOOLS_DIR"):
+        raw = os.getenv(env_name)
+        if raw:
+            candidates.append(Path(raw).expanduser())
+
+    archive_name = None
+    extract_dir = None
+    config_path = _repo / "thirdparty" / "custom-llvm-tools.json"
+    if config_path.is_file():
+        try:
+            cfg = json.loads(config_path.read_text())
+            archive_prefix = cfg.get("archive_name", "flydsl-mlir-tools")
+            llvm_ref = cfg.get("llvm_ref", "")
+            if len(llvm_ref) >= 12:
+                archive_stem = f"{archive_prefix}-{llvm_ref[:12]}-manylinux_2_28-x86_64"
+                archive_name = f"{archive_stem}.tar.gz"
+                extract_dir = _repo / "build-fly" / "custom-llvm-tools" / archive_stem
+                candidates.extend(
+                    [
+                        extract_dir,
+                        _repo / ".cache" / "custom-llvm-tools" / archive_stem,
+                    ]
+                )
+        except Exception as exc:
+            print(f"[flash_attn_func] failed to read custom LLVM tool config: {exc}")
+
+    candidates.extend(
+        [
+            _repo / "build-fly" / "custom-llvm-tools",
+            _repo / ".cache" / "custom-llvm-tools",
+        ]
+    )
+
+    for path in candidates:
+        if (path / "bin" / "mlir-opt").is_file():
+            os.environ["FLYDSL_COMPILE_LLVM_DIR"] = str(path)
+            print(f"[flash_attn_func] using custom LLVM tools: {path}")
+            return
+
+    if archive_name and extract_dir:
+        root_dir = extract_dir.parent
+        archive_path = root_dir / archive_name
+        root_dir.mkdir(parents=True, exist_ok=True)
+
+        if not archive_path.is_file():
+            s3_uri = f"s3://framework-whls-devreleases/llvm-tools/gfx942-gfx950/{archive_name}"
+            https_uri = f"https://framework-whls-devreleases.s3.amazonaws.com/llvm-tools/gfx942-gfx950/{archive_name}"
+            print(f"[flash_attn_func] fetching custom LLVM tools: {archive_name}")
+            if shutil.which("aws"):
+                try:
+                    subprocess.run(["aws", "s3", "cp", s3_uri, str(archive_path)], check=True)
+                except Exception as exc:
+                    print(f"[flash_attn_func] aws download failed: {exc}")
+            if not archive_path.is_file():
+                try:
+                    urllib.request.urlretrieve(https_uri, archive_path)
+                except Exception as exc:
+                    archive_path.unlink(missing_ok=True)
+                    print(f"[flash_attn_func] https download failed: {exc}")
+
+        if archive_path.is_file():
+            try:
+                if extract_dir.exists():
+                    shutil.rmtree(extract_dir)
+                extract_dir.mkdir(parents=True, exist_ok=True)
+                with tarfile.open(archive_path, "r:gz") as tar:
+                    tar.extractall(extract_dir)
+            except Exception as exc:
+                print(f"[flash_attn_func] failed to extract custom LLVM tools: {exc}")
+
+        if (extract_dir / "bin" / "mlir-opt").is_file():
+            os.environ["FLYDSL_COMPILE_LLVM_DIR"] = str(extract_dir)
+            print(f"[flash_attn_func] using custom LLVM tools: {extract_dir}")
+            return
+
+    print(
+        "[flash_attn_func] custom LLVM tools not found; using bundled codegen. "
+        "Set FLYDSL_COMPILE_LLVM_DIR or FLYDSL_FLASH_ATTN_FUNC_USE_CUSTOM_LLVM=0 to silence this."
+    )
+
+
+_maybe_configure_custom_llvm_tools()
 
 
 def setup_seed(seed: int) -> None:

--- a/tests/kernels/test_flash_attn_func.py
+++ b/tests/kernels/test_flash_attn_func.py
@@ -13,7 +13,6 @@ import math
 import os
 import random
 import shutil
-import subprocess
 import sys
 import tarfile
 import urllib.request
@@ -131,20 +130,13 @@ def _maybe_configure_custom_llvm_tools() -> None:
         root_dir.mkdir(parents=True, exist_ok=True)
 
         if not archive_path.is_file():
-            s3_uri = f"s3://framework-whls-devreleases/llvm-tools/gfx942-gfx950/{archive_name}"
-            https_uri = f"https://framework-whls-devreleases.s3.amazonaws.com/llvm-tools/gfx942-gfx950/{archive_name}"
+            https_uri = f"https://rocm.frameworks-devreleases.amd.com/llvm-tools/gfx942-gfx950/{archive_name}"
             print(f"[flash_attn_func] fetching custom LLVM tools: {archive_name}")
-            if shutil.which("aws"):
-                try:
-                    subprocess.run(["aws", "s3", "cp", s3_uri, str(archive_path)], check=True)
-                except Exception as exc:
-                    print(f"[flash_attn_func] aws download failed: {exc}")
-            if not archive_path.is_file():
-                try:
-                    urllib.request.urlretrieve(https_uri, archive_path)
-                except Exception as exc:
-                    archive_path.unlink(missing_ok=True)
-                    print(f"[flash_attn_func] https download failed: {exc}")
+            try:
+                urllib.request.urlretrieve(https_uri, archive_path)
+            except Exception as exc:
+                archive_path.unlink(missing_ok=True)
+                print(f"[flash_attn_func] https download failed: {exc}")
 
         if archive_path.is_file():
             try:


### PR DESCRIPTION
## Summary
- Add FlashAttention/FMHA to `scripts/run_benchmark.sh` with default benchmark shapes and CSV parsing.
- Let `tests/kernels/test_flash_attn_func.py` auto-configure or download the custom `mlir-opt` archive used for peak FlashAttention performance.
- Keep `FLYDSL_FLASH_ATTN_FUNC_USE_CUSTOM_LLVM=0` as an escape hatch for bundled LLVM debugging.

## Test plan
- `python3 -m py_compile tests/kernels/test_flash_attn_func.py`
- `sh -n scripts/run_benchmark.sh`
- `bash scripts/run_benchmark.sh --list`

Made with [Cursor](https://cursor.com)