### PR TITLE
[Refactor] Migrate kernels from SmemAllocator to SharedAllocator

### DIFF
--- a/kernels/fp8_gemm_4wave.py
+++ b/kernels/fp8_gemm_4wave.py
@@ -19,9 +19,7 @@ Optional B preshuffle uses the same on-disk layout as
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import arith, const_expr, range_constexpr
-from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from kernels.fp8_gemm_utils import (
     G2SLoader,
     Mfma16x16x128,
@@ -98,26 +96,19 @@ def compile_fp8_gemm_4w(
 
     _use_interleaved_block = BLOCK_M == 256 and BLOCK_N == 256
 
-    A_lds_cur0_alloc = SmemAllocator(None, "gfx950", "A_lds_cur_0")
-    A_lds_cur1_alloc = SmemAllocator(None, "gfx950", "A_lds_cur_1")
-    A_lds_next0_alloc = SmemAllocator(None, "gfx950", "A_lds_next_0")
-    A_lds_next1_alloc = SmemAllocator(None, "gfx950", "A_lds_next_1")
-    B_lds_cur0_alloc = SmemAllocator(None, "gfx950", "B_lds_cur_0")
-    B_lds_cur1_alloc = SmemAllocator(None, "gfx950", "B_lds_cur_1")
-    B_lds_next0_alloc = SmemAllocator(None, "gfx950", "B_lds_next_0")
-    B_lds_next1_alloc = SmemAllocator(None, "gfx950", "B_lds_next_1")
-
     a_lds_size = LDS_BLOCK_M * BLOCK_K
     b_lds_size = LDS_BLOCK_N * BLOCK_K
 
-    A_lds_cur0_alloc.ptr = a_lds_size
-    A_lds_cur1_alloc.ptr = a_lds_size
-    A_lds_next0_alloc.ptr = a_lds_size
-    A_lds_next1_alloc.ptr = a_lds_size
-    B_lds_cur0_alloc.ptr = b_lds_size
-    B_lds_cur1_alloc.ptr = b_lds_size
-    B_lds_next0_alloc.ptr = b_lds_size
-    B_lds_next1_alloc.ptr = b_lds_size
+    @fx.struct
+    class SharedStorage:
+        A_lds_cur_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_cur_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        B_lds_cur_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_cur_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
 
     @flyc.kernel
     def kernel_gemm(
@@ -129,15 +120,15 @@ def compile_fp8_gemm_4w(
     ):
         F8_IR_t = fx.Float8E4M3FN.ir_type
 
-        a_cur0 = SmemPtr(A_lds_cur0_alloc.get_base(), 0, F8_IR_t, shape=(a_lds_size,)).get()
-        a_cur1 = SmemPtr(A_lds_cur1_alloc.get_base(), 0, F8_IR_t, shape=(a_lds_size,)).get()
-        a_next0 = SmemPtr(A_lds_next0_alloc.get_base(), 0, F8_IR_t, shape=(a_lds_size,)).get()
-        a_next1 = SmemPtr(A_lds_next1_alloc.get_base(), 0, F8_IR_t, shape=(a_lds_size,)).get()
-
-        b_cur0 = SmemPtr(B_lds_cur0_alloc.get_base(), 0, F8_IR_t, shape=(b_lds_size,)).get()
-        b_cur1 = SmemPtr(B_lds_cur1_alloc.get_base(), 0, F8_IR_t, shape=(b_lds_size,)).get()
-        b_next0 = SmemPtr(B_lds_next0_alloc.get_base(), 0, F8_IR_t, shape=(b_lds_size,)).get()
-        b_next1 = SmemPtr(B_lds_next1_alloc.get_base(), 0, F8_IR_t, shape=(b_lds_size,)).get()
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        a_cur0 = lds.A_lds_cur_0
+        a_cur1 = lds.A_lds_cur_1
+        a_next0 = lds.A_lds_next_0
+        a_next1 = lds.A_lds_next_1
+        b_cur0 = lds.B_lds_cur_0
+        b_cur1 = lds.B_lds_cur_1
+        b_next0 = lds.B_lds_next_0
+        b_next1 = lds.B_lds_next_1
 
         lane_id = fx.thread_idx.x % 64
         wave_id = fx.thread_idx.x // 64
@@ -427,26 +418,6 @@ def compile_fp8_gemm_4w(
         B_scale: fx.Tensor,
         stream: fx.Stream,
     ):
-        from flydsl._mlir import ir
-
-        A_lds_cur0_alloc.finalized = False
-        A_lds_cur1_alloc.finalized = False
-        A_lds_next0_alloc.finalized = False
-        A_lds_next1_alloc.finalized = False
-        B_lds_cur0_alloc.finalized = False
-        B_lds_cur1_alloc.finalized = False
-        B_lds_next0_alloc.finalized = False
-        B_lds_next1_alloc.finalized = False
-        ctx = CompilationContext.get_current()
-        with ir.InsertionPoint(ctx.gpu_module_body):
-            A_lds_cur0_alloc.finalize()
-            A_lds_cur1_alloc.finalize()
-            A_lds_next0_alloc.finalize()
-            A_lds_next1_alloc.finalize()
-            B_lds_cur0_alloc.finalize()
-            B_lds_cur1_alloc.finalize()
-            B_lds_next0_alloc.finalize()
-            B_lds_next1_alloc.finalize()
         grid_x = ((M + BLOCK_M - 1) // BLOCK_M) * N_BLOCKS
         kernel_gemm(
             A,

--- a/kernels/fp8_gemm_8wave.py
+++ b/kernels/fp8_gemm_8wave.py
@@ -9,9 +9,7 @@ Algorithm derived from HipKittens FP8_8wave
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import range_constexpr, rocdl
-from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from kernels.fp8_gemm_utils import (
     G2SLoader,
     Mfma16x16x128,
@@ -45,27 +43,20 @@ def compile_fp8_gemm_8w(*, M: int, N: int, K: int, BLOCK_M: int = 256, BLOCK_N: 
     N_LDS_STEPS_B = LDS_BLOCK_N // 64
     N_LDS_ROUNDS = max(N_LDS_STEPS_A, N_LDS_STEPS_B)
 
-    A_lds_cur0_alloc = SmemAllocator(None, "gfx950", "A_lds_cur_0")
-    A_lds_cur1_alloc = SmemAllocator(None, "gfx950", "A_lds_cur_1")
-    A_lds_next0_alloc = SmemAllocator(None, "gfx950", "A_lds_next_0")
-    A_lds_next1_alloc = SmemAllocator(None, "gfx950", "A_lds_next_1")
-    B_lds_cur0_alloc = SmemAllocator(None, "gfx950", "B_lds_cur_0")
-    B_lds_cur1_alloc = SmemAllocator(None, "gfx950", "B_lds_cur_1")
-    B_lds_next0_alloc = SmemAllocator(None, "gfx950", "B_lds_next_0")
-    B_lds_next1_alloc = SmemAllocator(None, "gfx950", "B_lds_next_1")
-
     # half size
     a_lds_size = LDS_BLOCK_M * BLOCK_K
     b_lds_size = LDS_BLOCK_N * BLOCK_K
 
-    A_lds_cur0_alloc.ptr = a_lds_size
-    A_lds_cur1_alloc.ptr = a_lds_size
-    A_lds_next0_alloc.ptr = a_lds_size
-    A_lds_next1_alloc.ptr = a_lds_size
-    B_lds_cur0_alloc.ptr = b_lds_size
-    B_lds_cur1_alloc.ptr = b_lds_size
-    B_lds_next0_alloc.ptr = b_lds_size
-    B_lds_next1_alloc.ptr = b_lds_size
+    @fx.struct
+    class SharedStorage:
+        A_lds_cur_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_cur_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        B_lds_cur_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_cur_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
 
     @flyc.kernel(known_block_size=[512, 1, 1])
     def kernel_gemm(
@@ -77,15 +68,15 @@ def compile_fp8_gemm_8w(*, M: int, N: int, K: int, BLOCK_M: int = 256, BLOCK_N: 
     ):
         F8_IR_t = fx.Float8E4M3FN.ir_type
 
-        a_cur0 = SmemPtr(A_lds_cur0_alloc.get_base(), 0, F8_IR_t, shape=(a_lds_size,)).get()
-        a_cur1 = SmemPtr(A_lds_cur1_alloc.get_base(), 0, F8_IR_t, shape=(a_lds_size,)).get()
-        a_next0 = SmemPtr(A_lds_next0_alloc.get_base(), 0, F8_IR_t, shape=(a_lds_size,)).get()
-        a_next1 = SmemPtr(A_lds_next1_alloc.get_base(), 0, F8_IR_t, shape=(a_lds_size,)).get()
-
-        b_cur0 = SmemPtr(B_lds_cur0_alloc.get_base(), 0, F8_IR_t, shape=(b_lds_size,)).get()
-        b_cur1 = SmemPtr(B_lds_cur1_alloc.get_base(), 0, F8_IR_t, shape=(b_lds_size,)).get()
-        b_next0 = SmemPtr(B_lds_next0_alloc.get_base(), 0, F8_IR_t, shape=(b_lds_size,)).get()
-        b_next1 = SmemPtr(B_lds_next1_alloc.get_base(), 0, F8_IR_t, shape=(b_lds_size,)).get()
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        a_cur0 = lds.A_lds_cur_0
+        a_cur1 = lds.A_lds_cur_1
+        a_next0 = lds.A_lds_next_0
+        a_next1 = lds.A_lds_next_1
+        b_cur0 = lds.B_lds_cur_0
+        b_cur1 = lds.B_lds_cur_1
+        b_next0 = lds.B_lds_next_0
+        b_next1 = lds.B_lds_next_1
 
         lane_id = fx.thread_idx.x % 64
         wave_id = fx.thread_idx.x // 64
@@ -268,26 +259,6 @@ def compile_fp8_gemm_8w(*, M: int, N: int, K: int, BLOCK_M: int = 256, BLOCK_N: 
         B_scale: fx.Tensor,
         stream: fx.Stream,
     ):
-        from flydsl._mlir import ir
-
-        A_lds_cur0_alloc.finalized = False
-        A_lds_cur1_alloc.finalized = False
-        A_lds_next0_alloc.finalized = False
-        A_lds_next1_alloc.finalized = False
-        B_lds_cur0_alloc.finalized = False
-        B_lds_cur1_alloc.finalized = False
-        B_lds_next0_alloc.finalized = False
-        B_lds_next1_alloc.finalized = False
-        ctx = CompilationContext.get_current()
-        with ir.InsertionPoint(ctx.gpu_module_body):
-            A_lds_cur0_alloc.finalize()
-            A_lds_cur1_alloc.finalize()
-            A_lds_next0_alloc.finalize()
-            A_lds_next1_alloc.finalize()
-            B_lds_cur0_alloc.finalize()
-            B_lds_cur1_alloc.finalize()
-            B_lds_next0_alloc.finalize()
-            B_lds_next1_alloc.finalize()
         grid_x = ((M + BLOCK_M - 1) // BLOCK_M) * N_BLOCKS
         kernel_gemm(
             A,

--- a/kernels/fp8_gemm_utils.py
+++ b/kernels/fp8_gemm_utils.py
@@ -2,10 +2,8 @@
 # Copyright (c) 2025 FlyDSL Project Contributors
 
 import flydsl.expr as fx
-from flydsl._mlir.dialects import arith as arith_dialect
 from flydsl._mlir.dialects import fly as fly_dialect
 from flydsl._mlir.dialects import llvm as _llvm
-from flydsl._mlir.dialects import memref as memref_dialect
 from flydsl._mlir.dialects.fly_rocdl import TargetAddressSpace
 from flydsl.expr import arith, const_expr, range_constexpr
 from flydsl.expr.typing import Vector as Vec
@@ -66,10 +64,10 @@ class G2SLoader:
         self.n_waves = fx.block_dim.x // 64
 
     def _lds_dst_at(self, lds_dst, step):
-        base_idx = memref_dialect.extract_aligned_pointer_as_index(lds_dst)
-        offset_idx = base_idx + fx.Index(self.wave_id * 1024 + step * (self.n_waves * 1024))
-        offset_i64 = arith_dialect.index_cast(fx.T.i64(), offset_idx)
-        lds_ptr = fx.inttoptr(self.LdsPtr_t, offset_i64)
+        step_off = self.wave_id * 1024 + step * (self.n_waves * 1024)
+        base_i32 = fx.Int32(fx.ptrtoint(lds_dst.ptr))
+        sum_i32 = base_i32 + fx.Int32(step_off)
+        lds_ptr = fx.inttoptr(self.LdsPtr_t, sum_i32)
         return fx.make_view(lds_ptr, fx.make_layout(1, 1))
 
     def load(self, lds_dst, k_offset):
@@ -91,10 +89,16 @@ def pack_i32x4_i32x8(lo, hi):
 
 class S2RLoader:
     def __init__(self, wave_idx, n_tiles):
-        self.vec16_t = Vec.make_type(16, fx.Float8E4M3FN)
         self.lane_id = fx.thread_idx.x % 64
         self.wave_idx = wave_idx
         self.n_tiles = n_tiles
+
+    def _vec_load_16xf8(self, lds_src, offset):
+        off_tup = fx.make_int_tuple(offset)
+        ptr_off = fx.add_offset(lds_src.ptr, off_tup)
+        i8_iter = fx.recast_iter(fx.Uint8, ptr_off)
+        view = fx.make_view(i8_iter, fx.make_layout(16, 1))
+        return view.load()
 
     def load(self, lds_src, preshuffled=False):
         frag = []
@@ -108,13 +112,13 @@ class S2RLoader:
                 else:
                     row_swz, col_swz = swizzle_128(row, col)
                     offset = row_swz * 128 + col_swz
-                v = Vec.load(self.vec16_t, lds_src, [fx.Index(offset)])
+                v = self._vec_load_16xf8(lds_src, offset)
                 halves.append(v.bitcast(fx.Int32))
             frag.append(pack_i32x4_i32x8(halves[0], halves[1]))
         return frag
 
     def load_one(self, lds_src, lds_offset):
-        v = Vec.load(self.vec16_t, lds_src, [fx.Index(lds_offset)])
+        v = self._vec_load_16xf8(lds_src, lds_offset)
         return v.bitcast(fx.Int32)
 
 

--- a/kernels/layernorm_kernel.py
+++ b/kernels/layernorm_kernel.py
@@ -15,13 +15,10 @@ import math
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir.ir import InsertionPoint
-from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import arith, const_expr, gpu, range_constexpr
 from flydsl.expr import math as fmath
 from flydsl.expr.vector import ReductionOp, full
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
-from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from kernels.kernels_common import dtype_to_elem_type, get_warp_size
 
 KERNEL_NAME = "layernorm"
@@ -44,12 +41,10 @@ def build_layernorm_module(M: int, N: int, dtype_str: str):
     elem_bits = 32 if dtype_str == "f32" else 16
 
     # ── Shared-memory allocation for block reductions ─────────────────────
-    allocator = SmemAllocator(None, arch=arch)
-    f32_bytes = 4
-    sum_offset = allocator._align(allocator.ptr, 16)
-    allocator.ptr = sum_offset + RED_SLOTS * f32_bytes
-    sumsq_offset = allocator._align(allocator.ptr, 16)
-    allocator.ptr = sumsq_offset + RED_SLOTS * f32_bytes
+    @fx.struct
+    class SharedStorage:
+        s_sum: fx.Array[fx.Float32, RED_SLOTS, 16]
+        s_sumsq: fx.Array[fx.Float32, RED_SLOTS, 16]
 
     # ── GPU kernel ────────────────────────────────────────────────────────
     @flyc.kernel
@@ -66,11 +61,9 @@ def build_layernorm_module(M: int, N: int, dtype_str: str):
         fm_fast = arith.FastMathFlags.fast
         eps_c = EPS
 
-        base_ptr = allocator.get_base()
-        s_sum = SmemPtr(base_ptr, sum_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
-        s_sumsq = SmemPtr(base_ptr, sumsq_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
-        s_sum.get()
-        s_sumsq.get()
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        s_sum = lds.s_sum.view(fx.make_layout(RED_SLOTS, 1))
+        s_sumsq = lds.s_sumsq.view(fx.make_layout(RED_SLOTS, 1))
 
         # ── helpers: wave / block reduction ───────────────────────────────
         def wave_reduce_add(x):
@@ -92,26 +85,26 @@ def build_layernorm_module(M: int, N: int, dtype_str: str):
             w1 = wave_reduce_add(val1)
 
             if lane == 0:
-                SmemPtr.store(s_sum, w0, [wave])
-                SmemPtr.store(s_sumsq, w1, [wave])
+                fx.memref_store(w0, s_sum, wave)
+                fx.memref_store(w1, s_sumsq, wave)
             gpu.barrier()
 
             if wave == 0:
                 in_range = lane < RED_SLOTS
                 lane_safe = in_range.select(lane, 0)
-                v0 = SmemPtr.load(s_sum, [lane_safe])
-                v1 = SmemPtr.load(s_sumsq, [lane_safe])
+                v0 = fx.memref_load(s_sum, lane_safe)
+                v1 = fx.memref_load(s_sumsq, lane_safe)
                 ww0 = in_range.select(v0, 0.0)
                 ww1 = in_range.select(v1, 0.0)
                 ww0 = wave_reduce_add(ww0)
                 ww1 = wave_reduce_add(ww1)
 
                 if lane == 0:
-                    SmemPtr.store(s_sum, ww0, [0])
-                    SmemPtr.store(s_sumsq, ww1, [0])
+                    fx.memref_store(ww0, s_sum, 0)
+                    fx.memref_store(ww1, s_sumsq, 0)
             gpu.barrier()
 
-            return SmemPtr.load(s_sum, [0]), SmemPtr.load(s_sumsq, [0])
+            return fx.memref_load(s_sum, 0), fx.memref_load(s_sumsq, 0)
 
         def compute_mean_rstd(sum_val, sumsq_val):
             inv_n = 1.0 / float(N)
@@ -313,11 +306,6 @@ def build_layernorm_module(M: int, N: int, dtype_str: str):
         m_in: fx.Int32,
         stream: fx.Stream = fx.Stream(None),
     ):
-        allocator.finalized = False
-        ctx = CompilationContext.get_current()
-        with InsertionPoint(ctx.gpu_module_body):
-            allocator.finalize()
-
         launcher = layernorm_kernel(Input, Gamma, Beta, Output)
         launcher.launch(
             grid=(m_in, 1, 1),

--- a/kernels/rmsnorm_kernel.py
+++ b/kernels/rmsnorm_kernel.py
@@ -14,14 +14,11 @@ import math
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir.ir import InsertionPoint
-from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import arith, const_expr, gpu, range_constexpr
 from flydsl.expr import math as fmath
 from flydsl.expr.typing import Vector as Vec
 from flydsl.expr.vector import ReductionOp, full
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
-from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from kernels.kernels_common import dtype_to_elem_type, get_warp_size
 
 KERNEL_NAME = "rmsnorm"
@@ -33,14 +30,13 @@ WARP_SIZE = get_warp_size()
 VEC_WIDTH = 8
 
 
-def _make_reduction_allocator(arch: str, red_slots: int):
-    allocator = SmemAllocator(None, arch=arch)
-    f32_bytes = 4
-    red_offset = allocator._align(allocator.ptr, 16)
-    allocator.ptr = red_offset + red_slots * f32_bytes
-    red2_offset = allocator._align(allocator.ptr, 16)
-    allocator.ptr = red2_offset + red_slots * f32_bytes
-    return allocator, red_offset, red2_offset
+def _make_reduction_storage(red_slots: int):
+    @fx.struct
+    class SharedStorage:
+        s_red: fx.Array[fx.Float32, red_slots, 16]
+        s_red2: fx.Array[fx.Float32, red_slots, 16]
+
+    return SharedStorage
 
 
 def _load_scalar(copy_atom, elem_dtype, divided_tensor, index):
@@ -114,7 +110,7 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
     RED_SLOTS = max(1, (BLOCK_THREADS + WARP_SIZE - 1) // WARP_SIZE)
     elem_bits = 32 if dtype_str == "f32" else 16
 
-    allocator, red_offset, red2_offset = _make_reduction_allocator(arch, RED_SLOTS)
+    SharedStorage = _make_reduction_storage(RED_SLOTS)
 
     @flyc.kernel
     def rmsnorm_kernel(
@@ -131,11 +127,9 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
         eps_c = EPS
         n_float = float(N)
 
-        base_ptr = allocator.get_base()
-        s_red = SmemPtr(base_ptr, red_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
-        s_red2 = SmemPtr(base_ptr, red2_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
-        s_red.get()
-        s_red2.get()
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        s_red = lds.s_red.view(fx.make_layout(RED_SLOTS, 1))
+        s_red2 = lds.s_red2.view(fx.make_layout(RED_SLOTS, 1))
 
         def wave_reduce_add(x):
             w = x
@@ -161,26 +155,26 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
             w1 = wave_reduce_add(val1)
 
             if lane == 0:
-                SmemPtr.store(s_red, w0, [wave])
-                SmemPtr.store(s_red2, w1, [wave])
+                fx.memref_store(w0, s_red, wave)
+                fx.memref_store(w1, s_red2, wave)
             gpu.barrier()
 
             if wave == 0:
                 in_range = lane < RED_SLOTS
                 lane_safe = in_range.select(lane, 0)
-                v0 = SmemPtr.load(s_red, [lane_safe])
-                v1 = SmemPtr.load(s_red2, [lane_safe])
+                v0 = fx.memref_load(s_red, lane_safe)
+                v1 = fx.memref_load(s_red2, lane_safe)
                 ww0 = in_range.select(v0, 0.0)
                 ww1 = in_range.select(v1, 0.0)
                 ww0 = wave_reduce_add(ww0)
                 ww1 = wave_reduce_add(ww1)
 
                 if lane == 0:
-                    SmemPtr.store(s_red, ww0, [0])
-                    SmemPtr.store(s_red2, ww1, [0])
+                    fx.memref_store(ww0, s_red, 0)
+                    fx.memref_store(ww1, s_red2, 0)
             gpu.barrier()
 
-            return SmemPtr.load(s_red, [0]), SmemPtr.load(s_red2, [0])
+            return fx.memref_load(s_red, 0), fx.memref_load(s_red2, 0)
 
         # ==================================================================
         # Fast path: N is a multiple of tile_cols
@@ -293,11 +287,6 @@ def build_rmsnorm_module(M: int, N: int, dtype_str: str):
         m_in: fx.Int32,
         stream: fx.Stream = fx.Stream(None),
     ):
-        allocator.finalized = False
-        ctx = CompilationContext.get_current()
-        with InsertionPoint(ctx.gpu_module_body):
-            allocator.finalize()
-
         launcher = rmsnorm_kernel(Input, Gamma, Gamma, Output)
         launcher.launch(
             grid=(m_in, 1, 1),
@@ -413,7 +402,7 @@ def build_fused_add_rmsnorm_module(M: int, N: int, dtype_str: str):
     RED_SLOTS = max(1, (BLOCK_THREADS + WARP_SIZE - 1) // WARP_SIZE)
     elem_bits = 32 if dtype_str == "f32" else 16
 
-    allocator, red_offset, red2_offset = _make_reduction_allocator(arch, RED_SLOTS)
+    SharedStorage = _make_reduction_storage(RED_SLOTS)
 
     @flyc.kernel
     def fused_add_rmsnorm_kernel(
@@ -431,11 +420,9 @@ def build_fused_add_rmsnorm_module(M: int, N: int, dtype_str: str):
         eps_c = EPS
         n_float = float(N)
 
-        base_ptr = allocator.get_base()
-        s_red = SmemPtr(base_ptr, red_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
-        s_red2 = SmemPtr(base_ptr, red2_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
-        s_red.get()
-        s_red2.get()
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        s_red = lds.s_red.view(fx.make_layout(RED_SLOTS, 1))
+        s_red2 = lds.s_red2.view(fx.make_layout(RED_SLOTS, 1))
 
         def wave_reduce_add(x):
             w = x
@@ -461,26 +448,26 @@ def build_fused_add_rmsnorm_module(M: int, N: int, dtype_str: str):
             w1 = wave_reduce_add(val1)
 
             if lane == 0:
-                SmemPtr.store(s_red, w0, [wave])
-                SmemPtr.store(s_red2, w1, [wave])
+                fx.memref_store(w0, s_red, wave)
+                fx.memref_store(w1, s_red2, wave)
             gpu.barrier()
 
             if wave == 0:
                 in_range = lane < RED_SLOTS
                 lane_safe = in_range.select(lane, 0)
-                v0 = SmemPtr.load(s_red, [lane_safe])
-                v1 = SmemPtr.load(s_red2, [lane_safe])
+                v0 = fx.memref_load(s_red, lane_safe)
+                v1 = fx.memref_load(s_red2, lane_safe)
                 ww0 = in_range.select(v0, 0.0)
                 ww1 = in_range.select(v1, 0.0)
                 ww0 = wave_reduce_add(ww0)
                 ww1 = wave_reduce_add(ww1)
 
                 if lane == 0:
-                    SmemPtr.store(s_red, ww0, [0])
-                    SmemPtr.store(s_red2, ww1, [0])
+                    fx.memref_store(ww0, s_red, 0)
+                    fx.memref_store(ww1, s_red2, 0)
             gpu.barrier()
 
-            return SmemPtr.load(s_red, [0]), SmemPtr.load(s_red2, [0])
+            return fx.memref_load(s_red, 0), fx.memref_load(s_red2, 0)
 
         # ==================================================================
         # Fast path: N is a multiple of tile_cols
@@ -611,11 +598,6 @@ def build_fused_add_rmsnorm_module(M: int, N: int, dtype_str: str):
         m_in: fx.Int32,
         stream: fx.Stream = fx.Stream(None),
     ):
-        allocator.finalized = False
-        ctx = CompilationContext.get_current()
-        with InsertionPoint(ctx.gpu_module_body):
-            allocator.finalize()
-
         launcher = fused_add_rmsnorm_kernel(Input, ResidualIn, Gamma, Output, ResidualOut)
         launcher.launch(
             grid=(m_in, 1, 1),
@@ -653,7 +635,7 @@ def _build_rmsnorm_quant_module(
     elem_bits = 32 if dtype_str == "f32" else 16
     quant_dtype_max = _quant_dtype_max(quant_dtype_str)
 
-    allocator, red_offset, red2_offset = _make_reduction_allocator(arch, RED_SLOTS)
+    SharedStorage = _make_reduction_storage(RED_SLOTS)
 
     @flyc.kernel
     def rmsnorm_quant_kernel(
@@ -677,11 +659,9 @@ def _build_rmsnorm_quant_module(
         c_neg_inf = fx.Float32(float("-inf"))
         c_dtype_max = fx.Float32(quant_dtype_max)
 
-        base_ptr = allocator.get_base()
-        s_red = SmemPtr(base_ptr, red_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
-        s_red2 = SmemPtr(base_ptr, red2_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
-        s_red.get()
-        s_red2.get()
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        s_red = lds.s_red.view(fx.make_layout(RED_SLOTS, 1))
+        s_red2 = lds.s_red2.view(fx.make_layout(RED_SLOTS, 1))
 
         YScale_buf = fx.rocdl.make_buffer_tensor(YScale)
         yscale_div = fx.logical_divide(YScale_buf, fx.make_layout(1, 1))
@@ -719,26 +699,26 @@ def _build_rmsnorm_quant_module(
             w1 = wave_reduce_add(val1)
 
             if lane == 0:
-                SmemPtr.store(s_red, w0, [wave])
-                SmemPtr.store(s_red2, w1, [wave])
+                fx.memref_store(w0, s_red, wave)
+                fx.memref_store(w1, s_red2, wave)
             gpu.barrier()
 
             if wave == 0:
                 in_range = lane < RED_SLOTS
                 lane_safe = in_range.select(lane, 0)
-                v0 = SmemPtr.load(s_red, [lane_safe])
-                v1 = SmemPtr.load(s_red2, [lane_safe])
+                v0 = fx.memref_load(s_red, lane_safe)
+                v1 = fx.memref_load(s_red2, lane_safe)
                 ww0 = in_range.select(v0, c_zero_f)
                 ww1 = in_range.select(v1, c_zero_f)
                 ww0 = wave_reduce_add(ww0)
                 ww1 = wave_reduce_add(ww1)
 
                 if lane == 0:
-                    SmemPtr.store(s_red, ww0, [0])
-                    SmemPtr.store(s_red2, ww1, [0])
+                    fx.memref_store(ww0, s_red, 0)
+                    fx.memref_store(ww1, s_red2, 0)
             gpu.barrier()
 
-            return SmemPtr.load(s_red, [0]), SmemPtr.load(s_red2, [0])
+            return fx.memref_load(s_red, 0), fx.memref_load(s_red2, 0)
 
         def block_reduce_max(val):
             if const_expr(RED_SLOTS == 1):
@@ -749,20 +729,20 @@ def _build_rmsnorm_quant_module(
 
             w = wave_reduce_max(val)
             if lane == 0:
-                SmemPtr.store(s_red, w, [wave])
+                fx.memref_store(w, s_red, wave)
             gpu.barrier()
 
             if wave == 0:
                 in_range = lane < RED_SLOTS
                 lane_safe = in_range.select(lane, 0)
-                v = SmemPtr.load(s_red, [lane_safe])
+                v = fx.memref_load(s_red, lane_safe)
                 ww = in_range.select(v, c_neg_inf)
                 ww = wave_reduce_max(ww)
                 if lane == 0:
-                    SmemPtr.store(s_red, ww, [0])
+                    fx.memref_store(ww, s_red, 0)
             gpu.barrier()
 
-            return SmemPtr.load(s_red, [0])
+            return fx.memref_load(s_red, 0)
 
         # ==================================================================
         # Fast path: N is a multiple of tile_cols
@@ -954,11 +934,6 @@ def _build_rmsnorm_quant_module(
             m_in: fx.Int32,
             stream: fx.Stream = fx.Stream(None),
         ):
-            allocator.finalized = False
-            ctx = CompilationContext.get_current()
-            with InsertionPoint(ctx.gpu_module_body):
-                allocator.finalize()
-
             launcher = rmsnorm_quant_kernel(Input, Gamma, XScale, YScale, Output)
             launcher.launch(
                 grid=(m_in, 1, 1),
@@ -979,11 +954,6 @@ def _build_rmsnorm_quant_module(
             m_in: fx.Int32,
             stream: fx.Stream = fx.Stream(None),
         ):
-            allocator.finalized = False
-            ctx = CompilationContext.get_current()
-            with InsertionPoint(ctx.gpu_module_body):
-                allocator.finalize()
-
             launcher = rmsnorm_quant_kernel(Input, Gamma, Gamma, YScale, Output)
             launcher.launch(
                 grid=(m_in, 1, 1),
@@ -1040,7 +1010,7 @@ def _build_fused_add_rmsnorm_quant_module(
     elem_bits = 32 if dtype_str == "f32" else 16
     quant_dtype_max = _quant_dtype_max(quant_dtype_str)
 
-    allocator, red_offset, red2_offset = _make_reduction_allocator(arch, RED_SLOTS)
+    SharedStorage = _make_reduction_storage(RED_SLOTS)
 
     @flyc.kernel
     def fused_add_rmsnorm_quant_kernel(
@@ -1066,11 +1036,9 @@ def _build_fused_add_rmsnorm_quant_module(
         c_neg_inf = fx.Float32(float("-inf"))
         c_dtype_max = fx.Float32(quant_dtype_max)
 
-        base_ptr = allocator.get_base()
-        s_red = SmemPtr(base_ptr, red_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
-        s_red2 = SmemPtr(base_ptr, red2_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
-        s_red.get()
-        s_red2.get()
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        s_red = lds.s_red.view(fx.make_layout(RED_SLOTS, 1))
+        s_red2 = lds.s_red2.view(fx.make_layout(RED_SLOTS, 1))
 
         YScale_buf = fx.rocdl.make_buffer_tensor(YScale)
         yscale_div = fx.logical_divide(YScale_buf, fx.make_layout(1, 1))
@@ -1108,26 +1076,26 @@ def _build_fused_add_rmsnorm_quant_module(
             w1 = wave_reduce_add(val1)
 
             if lane == 0:
-                SmemPtr.store(s_red, w0, [wave])
-                SmemPtr.store(s_red2, w1, [wave])
+                fx.memref_store(w0, s_red, wave)
+                fx.memref_store(w1, s_red2, wave)
             gpu.barrier()
 
             if wave == 0:
                 in_range = lane < RED_SLOTS
                 lane_safe = in_range.select(lane, 0)
-                v0 = SmemPtr.load(s_red, [lane_safe])
-                v1 = SmemPtr.load(s_red2, [lane_safe])
+                v0 = fx.memref_load(s_red, lane_safe)
+                v1 = fx.memref_load(s_red2, lane_safe)
                 ww0 = in_range.select(v0, c_zero_f)
                 ww1 = in_range.select(v1, c_zero_f)
                 ww0 = wave_reduce_add(ww0)
                 ww1 = wave_reduce_add(ww1)
 
                 if lane == 0:
-                    SmemPtr.store(s_red, ww0, [0])
-                    SmemPtr.store(s_red2, ww1, [0])
+                    fx.memref_store(ww0, s_red, 0)
+                    fx.memref_store(ww1, s_red2, 0)
             gpu.barrier()
 
-            return SmemPtr.load(s_red, [0]), SmemPtr.load(s_red2, [0])
+            return fx.memref_load(s_red, 0), fx.memref_load(s_red2, 0)
 
         def block_reduce_max(val):
             if const_expr(RED_SLOTS == 1):
@@ -1138,20 +1106,20 @@ def _build_fused_add_rmsnorm_quant_module(
 
             w = wave_reduce_max(val)
             if lane == 0:
-                SmemPtr.store(s_red, w, [wave])
+                fx.memref_store(w, s_red, wave)
             gpu.barrier()
 
             if wave == 0:
                 in_range = lane < RED_SLOTS
                 lane_safe = in_range.select(lane, 0)
-                v = SmemPtr.load(s_red, [lane_safe])
+                v = fx.memref_load(s_red, lane_safe)
                 ww = in_range.select(v, c_neg_inf)
                 ww = wave_reduce_max(ww)
                 if lane == 0:
-                    SmemPtr.store(s_red, ww, [0])
+                    fx.memref_store(ww, s_red, 0)
             gpu.barrier()
 
-            return SmemPtr.load(s_red, [0])
+            return fx.memref_load(s_red, 0)
 
         # ==================================================================
         # Fast path: N is a multiple of tile_cols
@@ -1366,11 +1334,6 @@ def _build_fused_add_rmsnorm_quant_module(
             m_in: fx.Int32,
             stream: fx.Stream = fx.Stream(None),
         ):
-            allocator.finalized = False
-            ctx = CompilationContext.get_current()
-            with InsertionPoint(ctx.gpu_module_body):
-                allocator.finalize()
-
             launcher = fused_add_rmsnorm_quant_kernel(Input, ResidualIn, Gamma, XScale, YScale, Output, ResidualOut)
             launcher.launch(
                 grid=(m_in, 1, 1),
@@ -1393,11 +1356,6 @@ def _build_fused_add_rmsnorm_quant_module(
             m_in: fx.Int32,
             stream: fx.Stream = fx.Stream(None),
         ):
-            allocator.finalized = False
-            ctx = CompilationContext.get_current()
-            with InsertionPoint(ctx.gpu_module_body):
-                allocator.finalize()
-
             launcher = fused_add_rmsnorm_quant_kernel(Input, ResidualIn, Gamma, Gamma, YScale, Output, ResidualOut)
             launcher.launch(
                 grid=(m_in, 1, 1),

--- a/kernels/softmax_kernel.py
+++ b/kernels/softmax_kernel.py
@@ -17,13 +17,9 @@ import math
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir.ir import InsertionPoint
-from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import arith, const_expr, gpu, range_constexpr
 from flydsl.expr import math as fmath
 from flydsl.expr.vector import ReductionOp, full
-from flydsl.runtime.device import get_rocm_arch as get_hip_arch
-from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from kernels.kernels_common import dtype_to_elem_type, get_warp_size
 
 KERNEL_NAME = "softmax_kernel"
@@ -34,16 +30,13 @@ VEC_WIDTH = 8
 
 
 def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
-    arch = get_hip_arch()
-
     tile_cols = BLOCK_THREADS * VEC_WIDTH
     RED_SLOTS = max(1, (BLOCK_THREADS + WARP_SIZE - 1) // WARP_SIZE)
     elem_bits = 32 if dtype_str == "f32" else 16
 
-    allocator = SmemAllocator(None, arch=arch)
-    f32_bytes = 4
-    red_offset = allocator._align(allocator.ptr, 16)
-    allocator.ptr = red_offset + RED_SLOTS * f32_bytes
+    @fx.struct
+    class SharedStorage:
+        s_red: fx.Array[fx.Float32, RED_SLOTS, 16]
 
     @flyc.kernel
     def softmax_kernel(
@@ -58,9 +51,8 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
         elem_dtype = dtype_to_elem_type(dtype_str)
         fm_fast = arith.FastMathFlags.fast
 
-        base_ptr = allocator.get_base()
-        s_red = SmemPtr(base_ptr, red_offset, fx.Float32.ir_type, shape=(RED_SLOTS,))
-        s_red.get()
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        s_red = lds.s_red.view(fx.make_layout(RED_SLOTS, 1))
 
         c_zero_f = fx.Float32(0.0)
         c_neg_inf = fx.Float32(float("-inf"))
@@ -89,22 +81,22 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
             w = wave_reduce(val, mode)
 
             if lane == 0:
-                SmemPtr.store(s_red_buffer, w, [wave])
+                fx.memref_store(w, s_red_buffer, wave)
             gpu.barrier()
 
             if wave == 0:
                 in_range = lane < RED_SLOTS
                 lane_safe = in_range.select(lane, 0)
-                v = SmemPtr.load(s_red_buffer, [lane_safe])
+                v = fx.memref_load(s_red_buffer, lane_safe)
                 z = neutral
                 ww = in_range.select(v, z)
                 ww = wave_reduce(ww, mode)
 
                 if lane == 0:
-                    SmemPtr.store(s_red_buffer, ww, [0])
+                    fx.memref_store(ww, s_red_buffer, 0)
             gpu.barrier()
 
-            return SmemPtr.load(s_red_buffer, [0])
+            return fx.memref_load(s_red_buffer, 0)
 
         # ==================================================================
         # Fast path: N is a multiple of tile_cols
@@ -253,11 +245,6 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
         m_in: fx.Int32,
         stream: fx.Stream = fx.Stream(None),
     ):
-        allocator.finalized = False
-        ctx = CompilationContext.get_current()
-        with InsertionPoint(ctx.gpu_module_body):
-            allocator.finalize()
-
         launcher = softmax_kernel(A, C, C, C)
         launcher.launch(
             grid=(m_in, 1, 1),

--- a/kernels/topk_gating_softmax_kernel.py
+++ b/kernels/topk_gating_softmax_kernel.py
@@ -16,13 +16,9 @@ import math
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir import ir
-from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import arith, range_constexpr, vector
 from flydsl.expr.arith import ArithValue
 from flydsl.expr.typing import Int32, T
-from flydsl.runtime.device import get_rocm_arch as get_hip_arch
-from flydsl.utils.smem_allocator import SmemAllocator
 from kernels.kernels_common import dtype_to_elem_type, get_warp_size
 
 KERNEL_NAME = "topk_gating_softmax_kernel"
@@ -73,8 +69,6 @@ def build_topk_gating_softmax_module(
         A @flyc.jit launcher function with signature
         ``(gating, weights, indices, tei, num_tokens, *, stream)``.
     """
-    arch = get_hip_arch()
-
     elem_bits = 32 if dtype_str == "f32" else 16
 
     VPT, THREADS_PER_TOKEN = _pick_layout(num_experts)
@@ -105,7 +99,6 @@ def build_topk_gating_softmax_module(
     ATOMS_PER_THREAD = VPT // ELEMS_PER_ATOM
 
     # No shared memory used — every reduction stays inside a sub-warp lane group.
-    allocator = SmemAllocator(None, arch=arch)
 
     @flyc.kernel
     def topk_gating_softmax_kernel(
@@ -349,11 +342,6 @@ def build_topk_gating_softmax_module(
         num_tokens_in: fx.Int32,
         stream: fx.Stream = fx.Stream(None),
     ):
-        allocator.finalized = False
-        ctx = CompilationContext.get_current()
-        with ir.InsertionPoint(ctx.gpu_module_body):
-            allocator.finalize()
-
         # grid_x = ceil(num_tokens / TOKENS_PER_BLOCK).
         # We use the (n - 1) // tpb + 1 form (valid for n >= 1) since the
         # additive (n + tpb - 1) form was producing the wrong grid count

--- a/python/flydsl/expr/primitive.py
+++ b/python/flydsl/expr/primitive.py
@@ -1046,7 +1046,7 @@ def ptrtoint(ptr, loc=None, ip=None):
 
 @traced_op
 def add_offset(ptr, offset, loc=None, ip=None):
-    if not isinstance(offset, ir.Value):
+    if not _is_int_tuple_value(offset):
         offset = make_int_tuple(offset, loc=loc, ip=ip)
     return fly.add_offset(ptr, offset, loc=loc, ip=ip)
 


### PR DESCRIPTION
Replace the legacy ``SmemAllocator + SmemPtr.get()`` + manual byte-offset pattern with the static, type-safe ``SharedAllocator + @fx.struct SharedStorage`` API across:

  * kernels/fp8_gemm_4wave.py / fp8_gemm_8wave.py / fp8_gemm_utils.py
  * kernels/layernorm_kernel.py
  * kernels/rmsnorm_kernel.py
  * kernels/softmax_kernel.py
  * kernels/topk_gating_softmax_kernel.py (only drops an unused allocator scaffold; this kernel has no shared memory)

In fp8_gemm_utils.py:
  * ``G2SLoader._lds_dst_at`` is rewritten to use ``ptrtoint(lds.ptr) + Int32 add + inttoptr`` instead of ``extract_aligned_pointer_as_index + index_cast + inttoptr``, removing the dependency on the legacy memref interpretation of the LDS region.
  * ``S2RLoader._vec_load_16xf8`` is introduced as a small bridge from the new shared pointer to a 16xf8 vector load via ``recast_iter(Uint8) -> make_view(layout(16,1)) -> view.load()`` - this is what makes the migrated SharedAllocator-backed LDS usable by the previous ``Vec.load(memref, [idx])`` call sites.

Also harden ``add_offset`` in expr/primitive.py to wrap any non ``!fly.int_tuple`` ir.Value offset through ``make_int_tuple`` before forwarding to ``fly.add_offset`` (previously it only wrapped non-Values, silently producing a verification failure when an i32/index was passed).

ISA impact (compared against HEAD, gfx950, COMPILE_ONLY=1):

  * fp8_gemm_4wave / fp8_gemm_8wave: ISA byte-identical on all 8 rowscale configs verified (4 BLOCK x {rowmajor, preshuffle_b}). All 8 corresponding ``tests/kernels/test_fp8_gemm_rowscale.py`` cases pass on GPU.
  * topk_gating_softmax_kernel: ISA byte-identical (this kernel had no shared memory; the removed allocator was dead code).
  * layernorm / rmsnorm / softmax: instruction stream, register usage, and scheduling are byte-identical; the only ISA diff is the ``.amdhsa_group_segment_fixed_size`` metadata field, which shrinks in every config (e.g. softmax 128 -> 16 bytes, layernorm/rmsnorm 128 -> 32 bytes). The new SharedAllocator reserves exactly the bytes declared by SharedStorage instead of the old allocator's over-padded minimum, so this is a strict improvement to LDS occupancy budget with no effect on emitted code.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
