### PR TITLE
[NFC] Rename FlyROCL_* to FlyROCDL_* across ROCDL TableGen refs

### DIFF
--- a/.claude/skills/add-target-atom-op/SKILL.md
+++ b/.claude/skills/add-target-atom-op/SKILL.md
@@ -94,10 +94,10 @@ combinations. In the reference ROCDL backend (`include/flydsl/Dialect/FlyROCDL/I
 are:
 
 ```tablegen
-class FlyROCL_CopyOp         // stateless CopyOp    : MayStatic + CopyOp
-class FlyROCL_StatefulCopyOp // stateful  CopyOp    : CopyOp + Stateful
-class FlyROCL_MmaOp          // stateless MmaOp     : MayStatic + MmaOp
-class FlyROCL_StatefulMmaOp  // stateful  MmaOp     : MmaOp    + Stateful
+class FlyROCDL_CopyOp         // stateless CopyOp    : MayStatic + CopyOp
+class FlyROCDL_StatefulCopyOp // stateful  CopyOp    : CopyOp + Stateful
+class FlyROCDL_MmaOp          // stateless MmaOp     : MayStatic + MmaOp
+class FlyROCDL_StatefulMmaOp  // stateful  MmaOp     : MmaOp    + Stateful
 ```
 
 Mnemonic: **stateful => no `MayStaticTypeInterface`**; the mutable state *is* the dynamic component,
@@ -298,14 +298,14 @@ Concrete instantiation for the reference ROCDL backend:
 ## 3. Recipe: Add a Stateless MmaOp
 
 Examples use the ROCDL backend with a hypothetical `CDNA5_MFMA`. For other backends substitute
-`FlyROCL_MmaOp` → your backend's base class, `CDNA<n>` → your chip family (`SM80`, `SM90`,
+`FlyROCDL_MmaOp` → your backend's base class, `CDNA<n>` → your chip family (`SM80`, `SM90`,
 `X86AVX512`, ...), `ROCDL::mfma_*` → your intrinsic ops (`NVVM::WgmmaMmaAsyncOp`, `vector.contract`,
 ...), `--convert-fly-to-rocdl` → your conversion pass. Everything else is identical.
 
 **Step 1 — TableGen declaration** in `include/flydsl/Dialect/FlyROCDL/IR/MmaAtom.td`:
 
 ```tablegen
-def FlyROCDL_MmaOpCDNA5_MFMA : FlyROCL_MmaOp<"MmaOpCDNA5_MFMA", "cdna5.mfma", []> {
+def FlyROCDL_MmaOpCDNA5_MFMA : FlyROCDL_MmaOp<"MmaOpCDNA5_MFMA", "cdna5.mfma", []> {
   let parameters = (ins "int32_t":$m, "int32_t":$n, "int32_t":$k,
                         "Type":$elemTyA, "Type":$elemTyB, "Type":$elemTyAcc);
   let assemblyFormat = "`<` custom<MNKDimensionList>($m, $n, $k) `,` "
@@ -316,7 +316,7 @@ def FlyROCDL_MmaOpCDNA5_MFMA : FlyROCL_MmaOp<"MmaOpCDNA5_MFMA", "cdna5.mfma", []
 }
 ```
 
-The `FlyROCL_MmaOp` base auto-adds `DeclareTypeInterfaceMethods<Fly_MayStaticTypeInterface>` +
+The `FlyROCDL_MmaOp` base auto-adds `DeclareTypeInterfaceMethods<Fly_MayStaticTypeInterface>` +
 `<Fly_MmaOpTypeInterface>`. `MNKDimensionList` is the shared parser/printer pair
 (`parseMNKDimensionList` / `printMNKDimensionList` in `lib/Dialect/Fly/IR/FlyDialect.cpp`) — reuse
 it.
@@ -391,11 +391,11 @@ concepts with per-call mutable state (AMD buffer descriptors, NVIDIA TMA descrip
 offsets, ...). State always lowers to `!llvm.struct<...>` in rocdl backend, so only the field set
 differs.
 
-**Step 1 — TableGen.** Pick `FlyROCL_StatefulCopyOp` as the base:
+**Step 1 — TableGen.** Pick `FlyROCDL_StatefulCopyOp` as the base:
 
 ```tablegen
 def FlyROCDL_CopyOpCDNA5GlobalCopy
-    : FlyROCL_StatefulCopyOp<"CopyOpCDNA5GlobalCopy", "cdna5.global_copy", []> {
+    : FlyROCDL_StatefulCopyOp<"CopyOpCDNA5GlobalCopy", "cdna5.global_copy", []> {
   let parameters = (ins "int32_t":$bitSize);
   let assemblyFormat = "`<` $bitSize `>`";
 }

--- a/include/flydsl/Dialect/FlyROCDL/IR/CopyAtom.td
+++ b/include/flydsl/Dialect/FlyROCDL/IR/CopyAtom.td
@@ -6,14 +6,14 @@
 
 include "flydsl/Dialect/FlyROCDL/IR/Dialect.td"
 
-def FlyROCDL_CopyOpBufferCopy : FlyROCL_StatefulCopyOp<"CopyOpCDNA3BufferCopy", "cdna3.buffer_copy",[]> {
+def FlyROCDL_CopyOpBufferCopy : FlyROCDL_StatefulCopyOp<"CopyOpCDNA3BufferCopy", "cdna3.buffer_copy",[]> {
   let parameters = (ins
     "int32_t":$bitSize
   );
   let assemblyFormat = "`<` $bitSize `>`";
 }
 
-def FlyROCDL_CopyOpBufferCopyLDS : FlyROCL_StatefulCopyOp<"CopyOpCDNA3BufferCopyLDS", "cdna3.buffer_copy_lds",[]> {
+def FlyROCDL_CopyOpBufferCopyLDS : FlyROCDL_StatefulCopyOp<"CopyOpCDNA3BufferCopyLDS", "cdna3.buffer_copy_lds",[]> {
   let parameters = (ins
     "int32_t":$bitSize
   );
@@ -21,7 +21,7 @@ def FlyROCDL_CopyOpBufferCopyLDS : FlyROCL_StatefulCopyOp<"CopyOpCDNA3BufferCopy
   let genVerifyDecl = 1;
 }
 
-def FlyROCDL_CopyOpBufferAtomic : FlyROCL_StatefulCopyOp<"CopyOpCDNA3BufferAtomic", "cdna3.buffer_atomic",[]> {
+def FlyROCDL_CopyOpBufferAtomic : FlyROCDL_StatefulCopyOp<"CopyOpCDNA3BufferAtomic", "cdna3.buffer_atomic",[]> {
   let parameters = (ins
     "::mlir::fly::AtomicOpAttr":$atomicOp,
     "Type":$valType
@@ -35,7 +35,7 @@ def FlyROCDL_CopyOpBufferAtomic : FlyROCL_StatefulCopyOp<"CopyOpCDNA3BufferAtomi
   ];
 }
 
-def FlyROCDL_CopyOpLdsReadTranspose : FlyROCL_CopyOp<"CopyOpCDNA4LdsReadTranspose", "cdna4.lds_read_trans",[]> {
+def FlyROCDL_CopyOpLdsReadTranspose : FlyROCDL_CopyOp<"CopyOpCDNA4LdsReadTranspose", "cdna4.lds_read_trans",[]> {
   let parameters = (ins
     "int32_t":$transGranularity, "int32_t":$bitSize
   );

--- a/include/flydsl/Dialect/FlyROCDL/IR/Dialect.td
+++ b/include/flydsl/Dialect/FlyROCDL/IR/Dialect.td
@@ -36,7 +36,7 @@ class FlyROCDL_Attr<string attrName, string attrMnemonic, list<Trait> traits = [
   let mnemonic = attrMnemonic;
 }
 
-class FlyROCL_MmaOp<string typeName, string typeMnemonic, list<Trait> traits = []> 
+class FlyROCDL_MmaOp<string typeName, string typeMnemonic, list<Trait> traits = []> 
     : TypeDef<FlyROCDL_Dialect, typeName, !listconcat(traits, [
         DeclareTypeInterfaceMethods<Fly_MayStaticTypeInterface>, 
         DeclareTypeInterfaceMethods<Fly_MmaOpTypeInterface>
@@ -44,7 +44,7 @@ class FlyROCL_MmaOp<string typeName, string typeMnemonic, list<Trait> traits = [
   let mnemonic = typeMnemonic;
 }
 
-class FlyROCL_CopyOp<string typeName, string typeMnemonic, list<Trait> traits = []> 
+class FlyROCDL_CopyOp<string typeName, string typeMnemonic, list<Trait> traits = []> 
     : TypeDef<FlyROCDL_Dialect, typeName, !listconcat(traits, [
         DeclareTypeInterfaceMethods<Fly_MayStaticTypeInterface>, 
         DeclareTypeInterfaceMethods<Fly_CopyOpTypeInterface>
@@ -52,7 +52,7 @@ class FlyROCL_CopyOp<string typeName, string typeMnemonic, list<Trait> traits = 
   let mnemonic = typeMnemonic;
 }
 
-class FlyROCL_StatefulCopyOp<string typeName, string typeMnemonic, list<Trait> traits = []>
+class FlyROCDL_StatefulCopyOp<string typeName, string typeMnemonic, list<Trait> traits = []>
     : TypeDef<FlyROCDL_Dialect, typeName, !listconcat(traits, [
         DeclareTypeInterfaceMethods<Fly_CopyOpTypeInterface>,
         DeclareTypeInterfaceMethods<Fly_StatefulOpTypeInterface>
@@ -63,7 +63,7 @@ class FlyROCL_StatefulCopyOp<string typeName, string typeMnemonic, list<Trait> t
   }];
 }
 
-class FlyROCL_StatefulMmaOp<string typeName, string typeMnemonic, list<Trait> traits = []> 
+class FlyROCDL_StatefulMmaOp<string typeName, string typeMnemonic, list<Trait> traits = []> 
     : TypeDef<FlyROCDL_Dialect, typeName, !listconcat(traits, [
         DeclareTypeInterfaceMethods<Fly_MmaOpTypeInterface>,
         DeclareTypeInterfaceMethods<Fly_StatefulOpTypeInterface>

--- a/include/flydsl/Dialect/FlyROCDL/IR/MmaAtom.td
+++ b/include/flydsl/Dialect/FlyROCDL/IR/MmaAtom.td
@@ -10,7 +10,7 @@ include "flydsl/Dialect/FlyROCDL/IR/Dialect.td"
 // MmaOp CDNA3
 //===----------------------------------------------------------------------===//
 
-def FlyROCDL_MmaOpCDNA3_MFMA : FlyROCL_MmaOp<"MmaOpCDNA3_MFMA", "cdna3.mfma", []> {
+def FlyROCDL_MmaOpCDNA3_MFMA : FlyROCDL_MmaOp<"MmaOpCDNA3_MFMA", "cdna3.mfma", []> {
   let parameters = (ins
     "int32_t":$m,
     "int32_t":$n,
@@ -33,7 +33,7 @@ def FlyROCDL_MmaOpCDNA3_MFMA : FlyROCL_MmaOp<"MmaOpCDNA3_MFMA", "cdna3.mfma", []
 // MmaOp CDNA4
 //===----------------------------------------------------------------------===//
 
-def FlyROCDL_MmaOpCDNA4_MFMAScale : FlyROCL_StatefulMmaOp<"MmaOpCDNA4_MFMAScale", "cdna4.mfma_scale", []> {
+def FlyROCDL_MmaOpCDNA4_MFMAScale : FlyROCDL_StatefulMmaOp<"MmaOpCDNA4_MFMAScale", "cdna4.mfma_scale", []> {
   let parameters = (ins
     "int32_t":$m,
     "int32_t":$n,
@@ -71,7 +71,7 @@ def FlyROCDL_MmaOpCDNA4_MFMAScale : FlyROCL_StatefulMmaOp<"MmaOpCDNA4_MFMAScale"
 // MmaOp GFX1250 — WMMA wave32
 //===----------------------------------------------------------------------===//
 
-def FlyROCDL_MmaOpGFX1250_WMMA : FlyROCL_MmaOp<"MmaOpGFX1250_WMMA", "gfx1250.wmma", []> {
+def FlyROCDL_MmaOpGFX1250_WMMA : FlyROCDL_MmaOp<"MmaOpGFX1250_WMMA", "gfx1250.wmma", []> {
   let parameters = (ins
     "int32_t":$m,
     "int32_t":$n,


### PR DESCRIPTION
This is a naming-only refactor to remove FlyROCL/FlyROCDL inconsistency.
## Motivation
The ROCDL TableGen helper class prefix was `FlyROCL_*`, which is inconsistent with the dialect name `FlyROCDL`.  
This mismatch is easy to misread and can cause confusion during development.
## Technical Details
- Renamed the following helper classes to use the `FlyROCDL_*` prefix:
  - `FlyROCL_MmaOp` -> `FlyROCDL_MmaOp`
  - `FlyROCL_CopyOp` -> `FlyROCDL_CopyOp`
  - `FlyROCL_StatefulCopyOp` -> `FlyROCDL_StatefulCopyOp`
  - `FlyROCL_StatefulMmaOp` -> `FlyROCDL_StatefulMmaOp`
- Updated all in-repo references accordingly (TableGen files and in-repo skill documentation).
- No semantic or behavioral changes were introduced.
## Test Plan
- Run a global search to verify old naming is fully removed:
  - `rg "FlyROCL_"`
## Test Result
- `rg "FlyROCL_"` returns no matches in the repository.
