### PR TITLE
[Bugfix] Include static tensor layouts in JIT cache keys

### DIFF
--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -202,6 +202,21 @@ class TensorAdaptor:
             self._is_layout_dynamic = False
 
     @staticmethod
+    def _static_layout_cache_signature(shape, strides):
+        return (
+            "static_layout",
+            tuple(int(d) for d in shape),
+            tuple(int(s) for s in strides),
+        )
+
+    @staticmethod
+    def _can_share_default_cache_across_shapes(strides):
+        # TensorAdaptor.__init__ uses mark_layout_dynamic(-1, 1). It can only
+        # produce a shape-agnostic memref type when there is one unambiguous
+        # stride-1 dimension. Static-layout fallbacks bake shape/stride into IR.
+        return sum(1 for stride in strides if int(stride) == 1) == 1
+
+    @staticmethod
     def _extract_data_ptr(arg):
         # arg may be a raw torch.Tensor or a TensorAdaptor wrapping one;
         # both can hit the same fast-path CallState because they share
@@ -288,7 +303,10 @@ class TensorAdaptor:
         Matches ``__cache_signature__`` for a default-constructed TensorAdaptor
         (no ``mark_static`` calls).
         """
-        return (tensor.dtype, None, False, tensor.dim())
+        base = (tensor.dtype, None, False, tensor.dim())
+        if TensorAdaptor._can_share_default_cache_across_shapes(tensor.stride()):
+            return base
+        return base + (TensorAdaptor._static_layout_cache_signature(tensor.shape, tensor.stride()),)
 
     def __cache_signature__(self):
         base = (
@@ -297,6 +315,8 @@ class TensorAdaptor:
             self.use_32bit_stride,
             len(self._orig_shape),
         )
+        if not self._is_layout_dynamic:
+            return base + (self._static_layout_cache_signature(self._orig_shape, self._orig_strides),)
         if not self._cached_dims:
             return base
         # Pack only the marked dims as sorted (dim, shape, stride) triples.

--- a/tests/kernels/test_jit_cache_static_layout.py
+++ b/tests/kernels/test_jit_cache_static_layout.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Regression coverage for JIT cache keys with static tensor layouts."""
+
+import pytest
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
+if torch is None or not torch.cuda.is_available():
+    pytest.skip("CUDA/ROCm not available", allow_module_level=True)
+
+
+@flyc.kernel
+def _vec_add_kernel(
+    a: fx.Tensor,
+    b: fx.Tensor,
+    c: fx.Tensor,
+    block_dim: fx.Constexpr[int],
+    vec_width: fx.Constexpr[int],
+):
+    bid = fx.block_idx.x
+    tid = fx.thread_idx.x
+    tile_elems = block_dim * vec_width
+
+    ta = fx.logical_divide(a, fx.make_layout(tile_elems, 1))
+    tb = fx.logical_divide(b, fx.make_layout(tile_elems, 1))
+    tc = fx.logical_divide(c, fx.make_layout(tile_elems, 1))
+
+    ta = fx.slice(ta, (None, bid))
+    tb = fx.slice(tb, (None, bid))
+    tc = fx.slice(tc, (None, bid))
+
+    ta = fx.logical_divide(ta, fx.make_layout(vec_width, 1))
+    tb = fx.logical_divide(tb, fx.make_layout(vec_width, 1))
+    tc = fx.logical_divide(tc, fx.make_layout(vec_width, 1))
+
+    copy_atom = fx.make_copy_atom(fx.UniversalCopy(vec_width * 32), fx.Float32)
+    ra = fx.make_rmem_tensor(vec_width, fx.Float32)
+    rb = fx.make_rmem_tensor(vec_width, fx.Float32)
+    rc = fx.make_rmem_tensor(vec_width, fx.Float32)
+
+    fx.copy_atom_call(copy_atom, fx.slice(ta, (None, tid)), ra)
+    fx.copy_atom_call(copy_atom, fx.slice(tb, (None, tid)), rb)
+    fx.memref_store_vec(fx.arith.addf(fx.memref_load_vec(ra), fx.memref_load_vec(rb)), rc)
+    fx.copy_atom_call(copy_atom, rc, fx.slice(tc, (None, tid)))
+
+
+@flyc.jit
+def _vec_add(
+    a: fx.Tensor,
+    b: fx.Tensor,
+    c: fx.Tensor,
+    n: fx.Int32,
+    block_dim: fx.Constexpr[int],
+    vec_width: fx.Constexpr[int],
+    stream: fx.Stream = fx.Stream(None),
+):
+    tile_elems = block_dim * vec_width
+    grid_x = (n + tile_elems - 1) // tile_elems
+    _vec_add_kernel(a, b, c, block_dim, vec_width).launch(
+        grid=(grid_x, 1, 1),
+        block=(block_dim, 1, 1),
+        stream=stream,
+    )
+
+
+def _run_vec_add(n: int):
+    a = torch.ones(n, 1, dtype=torch.float32, device="cuda")
+    b = torch.ones(n, 1, dtype=torch.float32, device="cuda")
+    c = torch.zeros(n, 1, dtype=torch.float32, device="cuda")
+
+    _vec_add(a, b, c, n, 256, 8, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+    return c, a + b
+
+
+def test_static_layout_tensor_shapes_do_not_reuse_stale_jit_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("FLYDSL_RUNTIME_CACHE_DIR", str(tmp_path))
+
+    first, first_expected = _run_vec_add(512)
+    second, second_expected = _run_vec_add(4096)
+
+    assert torch.allclose(first, first_expected)
+    assert torch.allclose(second, second_expected)

--- a/tests/unit/test_tensor_cache_signature.py
+++ b/tests/unit/test_tensor_cache_signature.py
@@ -6,9 +6,11 @@
 """Tests for TensorAdaptor cache signature and the ``mark_static`` API.
 
 Default cache key is lightweight (dtype + align + 32-bit-stride flag + rank)
-so a single compiled kernel serves calls with different shapes.  When the
-kernel's compiled IR depends on concrete shape values, the affected dims must
-be marked with ``mark_static`` so they participate in the cache key.
+when the tensor can use a layout-dynamic memref, so a single compiled kernel
+serves calls with different shapes. Static-layout memrefs include shape/stride
+in the key because those values are baked into the compiled IR. When a
+layout-dynamic kernel still depends on concrete shape values, the affected dims
+must be marked with ``mark_static`` so they participate in the cache key.
 """
 
 import pytest
@@ -18,7 +20,7 @@ import flydsl.compiler as flyc
 from flydsl.compiler.jit_argument import TensorAdaptor
 
 # -----------------------------------------------------------------------------
-# Default cache behavior: shape NOT in key, kernels reused across shapes
+# Default cache behavior: layout-dynamic tensors share across shapes
 # -----------------------------------------------------------------------------
 
 
@@ -48,10 +50,29 @@ def test_raw_cache_signature_matches_default_dlpack():
     assert raw_sig == dlpack_sig
 
 
+def test_raw_cache_signature_matches_default_dlpack_for_static_layout():
+    t = torch.empty((512, 1), dtype=torch.float32)
+    raw_sig = TensorAdaptor.raw_cache_signature(t)
+    dlpack_sig = flyc.from_dlpack(t).__cache_signature__()
+    assert raw_sig == dlpack_sig
+
+
 def test_raw_cache_signature_shares_across_shapes():
     a = torch.empty((100,), dtype=torch.float32)
     b = torch.empty((999,), dtype=torch.float32)
     assert TensorAdaptor.raw_cache_signature(a) == TensorAdaptor.raw_cache_signature(b)
+
+
+def test_default_cache_signature_differs_for_static_layout_shapes():
+    a = flyc.from_dlpack(torch.empty((512, 1), dtype=torch.float32))
+    b = flyc.from_dlpack(torch.empty((4096, 1), dtype=torch.float32))
+    assert a.__cache_signature__() != b.__cache_signature__()
+
+
+def test_raw_cache_signature_differs_for_static_layout_shapes():
+    a = torch.empty((512, 1), dtype=torch.float32)
+    b = torch.empty((4096, 1), dtype=torch.float32)
+    assert TensorAdaptor.raw_cache_signature(a) != TensorAdaptor.raw_cache_signature(b)
 
 
 def test_raw_cache_signature_differs_by_rank():


### PR DESCRIPTION
## Summary

Fixes #317 by making TensorAdaptor cache keys distinguish tensors that fall back to static-layout memrefs.

`TensorAdaptor` can share a lightweight dtype/rank cache key only when `mark_layout_dynamic(-1, 1)` can produce a shape-agnostic memref. For static-layout fallbacks such as `(N, 1)` tensors with ambiguous stride-1 dimensions, the compiled IR bakes concrete shape/stride values into the memref type. Those shape/stride values now participate in both `__cache_signature__` and `raw_cache_signature`.

## Validation

- Reproduced the issue before the fix with a small `512 -> 4096` vecAdd sequence: the second run reused stale cache and left tail elements as zero.
- `PYTHONPATH=./build-fly/python_packages:. python -m pytest tests/unit/test_tensor_cache_signature.py -q`
- `FLYDSL_RUNTIME_CACHE_DIR=/tmp/flydsl_issue317_pytest_cache HIP_VISIBLE_DEVICES=0 PYTHONPATH=./build-fly/python_packages:. python -m pytest tests/kernels/test_jit_cache_static_layout.py -q -s`
- Original issue repro shape sequence after the fix: `512`, `4096*4096`, `4096*16384` all passed with default runtime cache enabled on MI350X / gfx950.
- `FLYDSL_RUNTIME_ENABLE_CACHE=0` small repro sequence `512`, `4096`, `8192` passed, confirming in-process cache keys also distinguish static layouts.
- `PYTHONPATH=./build-fly/python_packages:. python -m pytest tests/unit/test_jit_cache_key.py tests/unit/test_kernel_known_block_size.py -q`
- `FLYDSL_RUNTIME_CACHE_DIR=/tmp/flydsl_vecadd_existing_cache HIP_VISIBLE_DEVICES=0 PYTHONPATH=./build-fly/python_packages:. python -m pytest tests/kernels/test_vec_add.py::test_benchmark_vector_add -q -s`
- `ruff check python/flydsl/compiler/jit_argument.py tests/unit/test_tensor_cache_signature.py tests/kernels/test_jit_cache_static_layout.py`
- `ruff format --check python/flydsl/compiler/jit_argument.py tests/unit/test_tensor_cache_signature.py tests/kernels/test_jit_cache_static_layout.py`
