### PR TITLE
TensorAdaptor: split static / layout-dynamic adaptation paths

### DIFF
--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -216,9 +216,7 @@ class TensorAdaptor:
         """
         candidates = [idx for idx, val in enumerate(strides) if int(val) == 1]
         if not candidates:
-            raise RuntimeError(
-                "tensor has no axis with stride == 1; layout-dynamic memref requires one"
-            )
+            raise RuntimeError("tensor has no axis with stride == 1; layout-dynamic memref requires one")
         return candidates[0]
 
     @staticmethod
@@ -329,11 +327,7 @@ class TensorAdaptor:
         # the backend sees can disagree with the framework view for tensors
         # with zero-size or unit-size axes (DLPack often coerces such strides
         # to 1), so we resolve on the framework strides here.
-        resolved = (
-            self._pick_unit_stride_axis(self._orig_strides)
-            if leading_dim == -1
-            else int(leading_dim)
-        )
+        resolved = self._pick_unit_stride_axis(self._orig_strides) if leading_dim == -1 else int(leading_dim)
         self.tensor_adaptor.mark_layout_dynamic(resolved, divisibility)
         self._dyn_leading_dim = resolved
         self._dynamic_divisibility = int(divisibility)

--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -167,6 +167,7 @@ class TensorAdaptor:
         tensor: torch.Tensor,
         assumed_align: Optional[int] = None,
         use_32bit_stride: bool = False,
+        dynamic_layout: bool = True,
     ):
         # Forward-only interop: DLPack export from torch rejects tensors that
         # still participate in autograd, so detach before crossing into FlyDSL.
@@ -186,29 +187,44 @@ class TensorAdaptor:
         self._orig_dtype = tensor.dtype
         self._orig_shape = tensor.shape
         self._orig_strides = tensor.stride()
-        # Marked-static dims contribute their (shape, stride) to the cache key.
-        self._cached_dims: frozenset = frozenset()
-        # Default to layout-dynamic memref so one compile serves all sizes.
-        # Skipped (falls back to static memref) for tensors without an
-        # unambiguous leading stride-1 dim -- 0-rank, all-non-unit-stride
-        # slices, multi-stride-1 broadcasts -- where C++ markLayoutDynamic
-        # throws RuntimeError or no stride-1 dim is found.
-        try:
-            self.tensor_adaptor.mark_layout_dynamic(-1, 1)
-            self._dyn_leading_dim = next(i for i, s in enumerate(self._orig_strides) if int(s) == 1)
-            self._is_layout_dynamic = True
-        except (RuntimeError, StopIteration):
-            self._dyn_leading_dim = -1
-            self._is_layout_dynamic = False
+        self._dyn_leading_dim = -1
+        self._dynamic_divisibility = 1
+        self._is_layout_dynamic = False
+
+        if dynamic_layout:
+            try:
+                self._mark_layout_dynamic(leading_dim=-1, divisibility=1)
+            except RuntimeError as e:
+                raise RuntimeError(
+                    f"cannot auto-mark layout-dynamic for tensor "
+                    f"shape={tuple(tensor.shape)} strides={tuple(tensor.stride())}: {e}. "
+                    "Use flyc.from_dlpack(t) to wrap as a static memref instead."
+                ) from e
 
     @staticmethod
     def _extract_data_ptr(arg):
-        # arg may be a raw torch.Tensor or a TensorAdaptor wrapping one;
-        # both can hit the same fast-path CallState because they share
-        # raw_cache_signature / __cache_signature__ when defaults match.
         if hasattr(arg, "_tensor_keepalive"):
             return arg._tensor_keepalive.data_ptr()
         return arg.data_ptr()
+
+    @staticmethod
+    def _pick_unit_stride_axis(strides) -> int:
+        """Return the index of the first axis whose stride is one.
+
+        Raises ``RuntimeError`` if no axis qualifies, so callers do not have
+        to handle a None return.
+        """
+        candidates = [idx for idx, val in enumerate(strides) if int(val) == 1]
+        if not candidates:
+            raise RuntimeError(
+                "tensor has no axis with stride == 1; layout-dynamic memref requires one"
+            )
+        return candidates[0]
+
+    @staticmethod
+    def _dynamic_cache_signature(tensor: torch.Tensor, assumed_align: Optional[int], use_32bit_stride: bool):
+        leading_dim = TensorAdaptor._pick_unit_stride_axis(tensor.stride())
+        return (tensor.dtype, assumed_align, use_32bit_stride, "dynamic", tensor.dim(), leading_dim, 1)
 
     @classmethod
     def _reusable_slot_spec(cls, arg):
@@ -220,7 +236,7 @@ class TensorAdaptor:
         Buffer slots use the in-place protocol: ``extract(arg, storage)``
         writes into ``storage`` via ``struct.pack_into``.
         """
-        if not hasattr(arg, "data_ptr"):
+        if not hasattr(arg, "data_ptr") and not isinstance(arg, cls):
             return None
 
         adaptor = arg if isinstance(arg, cls) else cls(arg)
@@ -283,46 +299,45 @@ class TensorAdaptor:
 
     @staticmethod
     def raw_cache_signature(tensor: torch.Tensor):
-        """Lightweight cache sig from a raw tensor, no DLPack overhead.
+        """Cache sig for a raw torch.Tensor without going through DLPack.
 
-        Matches ``__cache_signature__`` for a default-constructed TensorAdaptor
-        (no ``mark_static`` calls).
+        Matches ``TensorAdaptor(tensor).__cache_signature__()`` on the
+        auto-adapt path so fast and slow paths share the same cache slot:
+        dtype/rank/leading-axis only, no shape/stride values. Raises
+        ``RuntimeError`` for tensors that cannot be layout-dynamic (no
+        unit-stride axis); use ``flyc.from_dlpack(t)`` for those.
         """
-        return (tensor.dtype, None, False, tensor.dim())
+        return TensorAdaptor._dynamic_cache_signature(tensor, None, False)
 
     def __cache_signature__(self):
-        base = (
-            self._orig_dtype,
-            self.assumed_align,
-            self.use_32bit_stride,
-            len(self._orig_shape),
+        base = (self._orig_dtype, self.assumed_align, self.use_32bit_stride)
+        if self._is_layout_dynamic:
+            return base + (
+                "dynamic",
+                len(self._orig_shape),
+                self._dyn_leading_dim,
+                self._dynamic_divisibility,
+            )
+        return base + (
+            "static",
+            tuple(int(d) for d in self._orig_shape),
+            tuple(int(s) for s in self._orig_strides),
         )
-        if not self._cached_dims:
-            return base
-        # Pack only the marked dims as sorted (dim, shape, stride) triples.
-        extras = tuple((d, int(self._orig_shape[d]), int(self._orig_strides[d])) for d in sorted(self._cached_dims))
-        return base + (extras,)
 
-    def mark_static(self, dims: Optional[List[int]] = None):
-        """Include the listed dims' shape/stride values in the JIT cache key.
-
-        ``dims=None`` marks every dim.  Call this when the compiled kernel
-        bakes concrete shape values into the generated IR (for example
-        ``num_records`` on a buffer resource derived from the static layout
-        cosize), so that calls with different shapes do not reuse a stale
-        compiled artifact.  Repeated calls accumulate.
-
-        Returns ``self`` for chaining.
-        """
-        rank = len(self._orig_shape)
-        target = range(rank) if dims is None else dims
-        new_dims = set(self._cached_dims)
-        for d in target:
-            d = int(d)
-            if not 0 <= d < rank:
-                raise IndexError(f"dim {d} out of range for rank {rank}")
-            new_dims.add(d)
-        self._cached_dims = frozenset(new_dims)
+    def _mark_layout_dynamic(self, leading_dim: int, divisibility: int):
+        # Always pass a concrete axis index down. The DLPack stride view that
+        # the backend sees can disagree with the framework view for tensors
+        # with zero-size or unit-size axes (DLPack often coerces such strides
+        # to 1), so we resolve on the framework strides here.
+        resolved = (
+            self._pick_unit_stride_axis(self._orig_strides)
+            if leading_dim == -1
+            else int(leading_dim)
+        )
+        self.tensor_adaptor.mark_layout_dynamic(resolved, divisibility)
+        self._dyn_leading_dim = resolved
+        self._dynamic_divisibility = int(divisibility)
+        self._is_layout_dynamic = True
         return self
 
     def mark_layout_dynamic(self, leading_dim: Optional[int] = None, divisibility: int = 1):
@@ -335,14 +350,13 @@ class TensorAdaptor:
         # Fix path: make C++ reset all dynamic flags before re-marking.
         if leading_dim is None:
             leading_dim = -1
-        if getattr(self, "_is_layout_dynamic", False) and leading_dim not in (-1, self._dyn_leading_dim):
+        if self._is_layout_dynamic and leading_dim not in (-1, self._dyn_leading_dim):
             raise NotImplementedError(
                 f"mark_layout_dynamic(leading_dim={leading_dim}) conflicts with "
                 f"auto-detected leading_dim={self._dyn_leading_dim} from __init__.  "
                 "Re-binding leading_dim is not supported yet (see TODO in jit_argument.py)."
             )
-        self.tensor_adaptor.mark_layout_dynamic(leading_dim, divisibility)
-        return self
+        return self._mark_layout_dynamic(leading_dim, divisibility)
 
 
 class PointerAdaptor:
@@ -378,7 +392,7 @@ def from_dlpack(
     assumed_align: Optional[int] = None,
     use_32bit_stride: bool = False,
 ) -> TensorAdaptor:
-    return TensorAdaptor(tensor, assumed_align, use_32bit_stride)
+    return TensorAdaptor(tensor, assumed_align, use_32bit_stride, dynamic_layout=False)
 
 
 def from_c_void_p(

--- a/tests/kernels/test_fp8_gemm_rowscale.py
+++ b/tests/kernels/test_fp8_gemm_rowscale.py
@@ -78,6 +78,7 @@ def _bench_fp8_gemm(
     num_iters: int = 10,
     vs_torch: bool = False,
     b_preshuffled: bool = False,
+    static_weight_scale: bool = True,
 ):
     """Run + verify a single (M, N, K, tile) configuration. Returns TFLOPS."""
     if "gfx95" not in ARCH:
@@ -107,7 +108,10 @@ def _bench_fp8_gemm(
             BLOCK_N=tile_n,
             b_preshuffled=b_preshuffled,
         )
-        print(f"\n[fp8_gemm_8wave] M={M} N={N} K={K} BLOCK_M={tile_m} BLOCK_N={tile_n} preshuffle_b={b_preshuffled}")
+        print(
+            f"\n[fp8_gemm_8wave] M={M} N={N} K={K} BLOCK_M={tile_m} BLOCK_N={tile_n} "
+            f"preshuffle_b={b_preshuffled} static_weight_scale={static_weight_scale}"
+        )
     else:
         launch_fn = compile_fp8_gemm_4w(
             K=K,
@@ -119,16 +123,23 @@ def _bench_fp8_gemm(
         print(
             f"\n[fp8_gemm_4wave] M={M} N={N} K={K} "
             f"BLOCK_M={tile_m} BLOCK_N={tile_n} xcd_remap={not disable_xcd_remap} "
-            f"preshuffle_b={b_preshuffled}"
+            f"preshuffle_b={b_preshuffled} static_weight_scale={static_weight_scale}"
         )
 
     def _args(c, a, b, sa, sb):
+        b_flat = _as_i8(b).contiguous().view(-1)
+        sa_flat = sa.contiguous().view(-1)
+        sb_flat = sb.contiguous().view(-1)
+        if static_weight_scale:
+            b_flat = flyc.from_dlpack(b_flat)
+            sa_flat = flyc.from_dlpack(sa_flat)
+            sb_flat = flyc.from_dlpack(sb_flat)
         return (
             _as_i8(a).contiguous().view(-1),
-            _as_i8(b).contiguous().view(-1),
+            b_flat,
             c.contiguous().view(-1),
-            sa.contiguous().view(-1),
-            sb.contiguous().view(-1),
+            sa_flat,
+            sb_flat,
             M,
             N,
             torch.cuda.current_stream(),
@@ -270,6 +281,12 @@ if __name__ == "__main__":
         default=False,
         help="Use 8-Wave Ping-Pong variant.",
     )
+    parser.add_argument(
+        "--dynamic_weight_scale",
+        action="store_true",
+        default=False,
+        help="Use dynamic tensor arguments for weight and scales instead of static DLPack adaptors.",
+    )
     args = parser.parse_args()
 
     torch.set_default_device("cuda")
@@ -287,6 +304,7 @@ if __name__ == "__main__":
             num_iters=args.num_iters,
             vs_torch=args.vs_torch,
             b_preshuffled=args.preshuffle_b,
+            static_weight_scale=not args.dynamic_weight_scale,
         )
     except pytest.skip.Exception as e:
         print(f"Skipped: {e}")

--- a/tests/unit/test_tensor_cache_signature.py
+++ b/tests/unit/test_tensor_cache_signature.py
@@ -3,12 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
-"""Tests for TensorAdaptor cache signature and the ``mark_static`` API.
+"""Tests for TensorAdaptor cache signatures.
 
-Default cache key is lightweight (dtype + align + 32-bit-stride flag + rank)
-so a single compiled kernel serves calls with different shapes.  When the
-kernel's compiled IR depends on concrete shape values, the affected dims must
-be marked with ``mark_static`` so they participate in the cache key.
+Two adaptation paths produce two distinct cache-key shapes:
+
+* ``flyc.from_dlpack(t)`` returns a *static-layout* TensorAdaptor: shape and
+  stride are baked into the memref type, so every distinct shape ends up
+  with its own compiled kernel. Chain ``.mark_layout_dynamic()`` to switch
+  to a layout-dynamic memref whose key elides shape/stride (one compile
+  serves all shapes).
+
+* Raw ``torch.Tensor`` arguments go through the auto-adapt path
+  (``TensorAdaptor(t)`` with ``dynamic_layout=True``) and behave like
+  ``from_dlpack(t).mark_layout_dynamic()``: layout-dynamic memref, no
+  shape/stride in the cache key.
 """
 
 import pytest
@@ -17,15 +25,18 @@ import torch
 import flydsl.compiler as flyc
 from flydsl.compiler.jit_argument import TensorAdaptor
 
-# -----------------------------------------------------------------------------
-# Default cache behavior: shape NOT in key, kernels reused across shapes
-# -----------------------------------------------------------------------------
+
+def test_dynamic_layout_cache_signature_shares_key_across_shapes():
+    a = flyc.from_dlpack(torch.empty((4, 8), dtype=torch.float32)).mark_layout_dynamic()
+    b = flyc.from_dlpack(torch.empty((100, 200), dtype=torch.float32)).mark_layout_dynamic()
+    assert a.__cache_signature__() == b.__cache_signature__()
 
 
-def test_default_cache_signature_shares_key_across_shapes():
+def test_default_static_cache_signature_differs_by_shape():
+    """``from_dlpack`` defaults to static layout: shape participates in the key."""
     a = flyc.from_dlpack(torch.empty((4, 8), dtype=torch.float32))
     b = flyc.from_dlpack(torch.empty((100, 200), dtype=torch.float32))
-    assert a.__cache_signature__() == b.__cache_signature__()
+    assert a.__cache_signature__() != b.__cache_signature__()
 
 
 def test_default_cache_signature_differs_by_dtype():
@@ -40,15 +51,16 @@ def test_default_cache_signature_differs_by_rank():
     assert a.__cache_signature__() != b.__cache_signature__()
 
 
-def test_raw_cache_signature_matches_default_dlpack():
-    """raw_cache_signature (lightweight path) and default __cache_signature__ agree."""
+def test_raw_cache_signature_matches_auto_adapted_tensor():
+    """Lightweight raw_cache_signature matches the full __cache_signature__ of an auto-adapted (dynamic_layout=True) TensorAdaptor, so fast/slow paths share the same cache slot."""
     t = torch.empty((4, 8), dtype=torch.float32)
     raw_sig = TensorAdaptor.raw_cache_signature(t)
-    dlpack_sig = flyc.from_dlpack(t).__cache_signature__()
-    assert raw_sig == dlpack_sig
+    auto_sig = TensorAdaptor(t).__cache_signature__()
+    assert raw_sig == auto_sig
 
 
 def test_raw_cache_signature_shares_across_shapes():
+    """Raw tensors hit the layout-dynamic memref path; the cache key elides shape/stride so one compile serves all shapes."""
     a = torch.empty((100,), dtype=torch.float32)
     b = torch.empty((999,), dtype=torch.float32)
     assert TensorAdaptor.raw_cache_signature(a) == TensorAdaptor.raw_cache_signature(b)
@@ -60,51 +72,44 @@ def test_raw_cache_signature_differs_by_rank():
     assert TensorAdaptor.raw_cache_signature(a) != TensorAdaptor.raw_cache_signature(b)
 
 
-# -----------------------------------------------------------------------------
-# mark_static: pin shape/stride values into the cache key
-# -----------------------------------------------------------------------------
+def test_pick_unit_stride_axis_returns_first_match():
+    """When several axes carry stride 1 (typical with degenerate axes), the
+    helper returns the lowest qualifying index. Example: shape (4, 1, 8, 1)
+    strides (8, 8, 1, 1) — axes 2 and 3 both qualify, axis 2 is returned.
+    """
+    t = torch.empty((4, 1, 8, 1), dtype=torch.float32)
+    assert TensorAdaptor._pick_unit_stride_axis(t.stride()) == 2
 
 
-def test_mark_static_all_dims_includes_shape_in_key():
-    a = flyc.from_dlpack(torch.empty((4, 8))).mark_static()
-    b = flyc.from_dlpack(torch.empty((4, 8))).mark_static()
-    c = flyc.from_dlpack(torch.empty((100, 200))).mark_static()
-    assert a.__cache_signature__() == b.__cache_signature__()
-    assert a.__cache_signature__() != c.__cache_signature__()
+def test_pick_unit_stride_axis_raises_without_unit_stride():
+    """Strided slices have no axis with stride 1; raise instead of returning None."""
+    sliced = torch.empty((4, 8))[:, ::2]  # strides (8, 2)
+    with pytest.raises(RuntimeError, match="stride == 1"):
+        TensorAdaptor._pick_unit_stride_axis(sliced.stride())
 
 
-def test_mark_static_per_dim_only_marked_dim_in_key():
-    """mark_static(dims=[1]) → dim 1 in key, dim 0 still 'dynamic'."""
-    s0 = flyc.from_dlpack(torch.empty((4, 8))).mark_static(dims=[1])
-    s1 = flyc.from_dlpack(torch.empty((100, 8))).mark_static(dims=[1])  # diff dim 0
-    s2 = flyc.from_dlpack(torch.empty((4, 16))).mark_static(dims=[1])  # diff dim 1
-    assert s0.__cache_signature__() == s1.__cache_signature__(), "dim 0 not in key"
-    assert s0.__cache_signature__() != s2.__cache_signature__(), "dim 1 in key"
+def test_auto_adapt_handles_size_one_degeneracies():
+    """Tensors with several stride-1 axes (size-1 unsqueeze, size-0 axes
+    whose stride PyTorch / DLPack happens to set to 1) must not silently
+    drop into a static memref — they should stay layout-dynamic with the
+    earliest unit-stride axis chosen.
+    """
+    # Fully degenerate (1, 1) tensor: every axis has stride 1; first wins.
+    assert TensorAdaptor(torch.empty((1, 1)))._dyn_leading_dim == 0
+    # (0, 8) is a real production case (size-0 outer axis). PyTorch's
+    # stride view has only axis 1 at stride 1, so that's what we pick.
+    assert TensorAdaptor(torch.empty((0, 8)))._dyn_leading_dim == 1
 
 
-def test_mark_static_returns_self_for_chaining():
-    t = flyc.from_dlpack(torch.empty((4, 8)))
-    assert t.mark_static() is t
-    assert t.mark_static(dims=[0]) is t
-
-
-def test_mark_static_accumulates_dims():
-    """Repeated calls union dim sets."""
-    a = flyc.from_dlpack(torch.empty((4, 8, 16))).mark_static(dims=[0]).mark_static(dims=[2])
-    b = flyc.from_dlpack(torch.empty((4, 8, 16))).mark_static(dims=[0, 2])
-    assert a.__cache_signature__() == b.__cache_signature__()
-
-
-def test_mark_static_out_of_range_raises():
-    t = flyc.from_dlpack(torch.empty((4,)))
-    with pytest.raises(IndexError):
-        t.mark_static(dims=[5])
-    with pytest.raises(IndexError):
-        t.mark_static(dims=[-1])
-
-
-def test_mark_static_default_vs_dynamic_differ_when_only_one_marked():
-    """A marked tensor and a default tensor with the same shape produce different keys."""
-    default = flyc.from_dlpack(torch.empty((4, 8)))
-    marked = flyc.from_dlpack(torch.empty((4, 8))).mark_static()
-    assert default.__cache_signature__() != marked.__cache_signature__()
+def test_auto_adapt_raises_when_no_unit_stride_axis():
+    """If no axis has stride 1 at all (e.g. a strided slice) the tensor
+    cannot be layout-dynamic; raise with an actionable hint instead of
+    silently falling back to a static memref (which would pin shape into
+    the cache key and trigger surprise per-shape recompiles).
+    """
+    base = torch.empty((4, 8), dtype=torch.float32)
+    sliced = base[:, ::2]  # shape (4, 4) strides (8, 2) — no unit stride
+    with pytest.raises(RuntimeError, match="auto-mark layout-dynamic"):
+        TensorAdaptor(sliced)
+    # Explicit escape hatch still works:
+    flyc.from_dlpack(sliced)  # static memref, shape participates in key


### PR DESCRIPTION
Reorganise the DLPack-based JitArgument so that the two adaptation modes have explicit, distinct semantics:

* ``flyc.from_dlpack(t)`` returns a fully *static-layout* TensorAdaptor: the memref type bakes shape and stride, and they participate in the JIT cache key. Distinct shapes therefore get distinct compiled kernels (the safe default when IR depends on concrete shape values). To opt back into one-compile-per-(dtype, rank), chain ``.mark_layout_dynamic()``.

* Raw ``torch.Tensor`` arguments coming through ``JitArgumentRegistry`` go through the auto-adapt path (``TensorAdaptor(t)`` with the internal ``dynamic_layout=True`` default). They get a layout-dynamic memref and a cache key that carries only dtype, rank, leading-axis index and divisibility -- shape/stride do not enter the key, so one compile serves every shape.

Other changes pulled in by the refactor:

* ``_pick_unit_stride_axis`` resolves the unit-stride axis on the framework stride view (``tensor.stride()``) and passes the explicit index down to the C++ adaptor instead of relying on its ``-1`` auto-detect. The C++ side reads strides from the DLPack capsule, which normalises zero-size and unit-size axis strides toward one; the explicit index avoids spurious "multiple unit-stride dims" rejections on tensors like ``torch.empty(0, 8)``.

* If no axis has stride 1 at all (e.g. ``t[:, ::2]``), the auto-adapt path raises with an actionable message pointing at ``flyc.from_dlpack(t)`` as the explicit escape hatch -- no silent fallback to a static memref under a shape-elided key, which on the previous code path led to per-call latent cache hazards.

* ``__cache_signature__`` carries an explicit ``"static"`` / ``"dynamic"`` discriminator to prevent accidental key collisions between the two adaptation modes for tensors that happen to share the rest of the key shape.

* ``mark_static`` and its associated ``_cached_dims`` state are removed. With the new defaults the API is unused and overlapped with ``Constexpr[int]`` kernel parameters, which are the cleaner way to pin shape values that are baked into IR at trace time.

* ``tests/kernels/test_fp8_gemm_rowscale.py`` adapts weight / scale tensors via ``flyc.from_dlpack`` so the benchmark exercises the static path under the new defaults.

Verification:

* ``tests/unit/test_tensor_cache_signature.py``: 11 / 11 pass (new tests cover the static/dynamic split, the unit-stride resolver, size-0 / size-1 degeneracies, and the no-unit-stride raise path).

* Targeted device sweep on gfx942 (mla_decode, vec_add, rmsnorm, softmax, pa, moe_gemm/stage2 decode variants): 18 / 18 pass with a clean JIT cache.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
