### PR TITLE
[Runtime][gfx1250] Fix silent fallback in mgpuLaunchClusterKernel: replace broken #ifdef with HIP_VERSION gate

### DIFF
--- a/lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp
+++ b/lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp
@@ -17,7 +17,11 @@
 #include <vector>
 
 #include "hip/hip_runtime.h"
+#include "hip/hip_version.h"
 #include "mlir/ExecutionEngine/CRunnerUtils.h"
+
+// hipDrvLaunchKernelEx + hipLaunchAttributeClusterDimension were added in HIP 7.0 / ROCm 7.0.
+#define FLY_HIP_HAS_CLUSTER_LAUNCH (HIP_VERSION >= 70000000)
 
 #define HIP_REPORT_IF_ERROR(expr)                                                                  \
   [](hipError_t result) {                                                                          \
@@ -68,7 +72,9 @@ extern "C" void mgpuLaunchClusterKernel(hipFunction_t function, intptr_t cluster
                                         intptr_t blockY, intptr_t blockZ, int32_t smem,
                                         hipStream_t stream, void **params, void **extra,
                                         size_t /*paramsCount*/) {
-#ifdef hipLaunchAttributeClusterDimension
+  const bool requestedRealCluster = (clusterX > 1) || (clusterY > 1) || (clusterZ > 1);
+
+#if FLY_HIP_HAS_CLUSTER_LAUNCH
   hipLaunchAttribute attrs[1];
   attrs[0].id = hipLaunchAttributeClusterDimension;
   attrs[0].value.clusterDim.x = static_cast<unsigned>(clusterX);
@@ -91,7 +97,6 @@ extern "C" void mgpuLaunchClusterKernel(hipFunction_t function, intptr_t cluster
   if (err == hipSuccess)
     return;
 
-  const bool requestedRealCluster = (clusterX > 1) || (clusterY > 1) || (clusterZ > 1);
   if (requestedRealCluster) {
     fprintf(stderr,
             "[mgpuLaunchClusterKernel] hipDrvLaunchKernelEx failed (err=%d) "
@@ -103,6 +108,7 @@ extern "C" void mgpuLaunchClusterKernel(hipFunction_t function, intptr_t cluster
     return;
   }
 
+  // cluster=(1,1,1) carries no cluster semantics — plain launch is equivalent.
   fprintf(stderr,
           "[mgpuLaunchClusterKernel] hipDrvLaunchKernelEx failed (err=%d) "
           "for cluster=(1,1,1); falling back to hipModuleLaunchKernel.\n",
@@ -110,15 +116,20 @@ extern "C" void mgpuLaunchClusterKernel(hipFunction_t function, intptr_t cluster
   HIP_REPORT_IF_ERROR(hipModuleLaunchKernel(function, gridX, gridY, gridZ, blockX, blockY, blockZ,
                                             smem, stream, params, extra));
 #else
-  // Cluster launch not supported by this HIP version; ignore cluster dims
-  // and fall back to regular kernel launch.
-  if ((clusterX > 1) || (clusterY > 1) || (clusterZ > 1)) {
+  // HIP < 7.0: no cluster API. Refuse to downgrade silently — kernel relies on
+  // cluster semantics (multicast, cluster_barrier) that a plain launch breaks.
+  if (requestedRealCluster) {
     fprintf(stderr,
             "[mgpuLaunchClusterKernel] cluster=(%ld,%ld,%ld) requested but "
-            "hipLaunchAttributeClusterDimension is not available in this HIP "
-            "version; falling back to hipModuleLaunchKernel.\n",
-            static_cast<long>(clusterX), static_cast<long>(clusterY), static_cast<long>(clusterZ));
+            "FlyDSL was built against HIP %d (need HIP >= 7.0 / ROCm >= 7.0 "
+            "for hipDrvLaunchKernelEx + hipLaunchAttributeClusterDimension). "
+            "Aborting.\n",
+            static_cast<long>(clusterX), static_cast<long>(clusterY), static_cast<long>(clusterZ),
+            HIP_VERSION);
+    HIP_REPORT_IF_ERROR(hipErrorNotSupported);
+    return;
   }
+  // cluster=(1,1,1): plain launch is equivalent.
   HIP_REPORT_IF_ERROR(hipModuleLaunchKernel(function, gridX, gridY, gridZ, blockX, blockY, blockZ,
                                             smem, stream, params, extra));
 #endif


### PR DESCRIPTION
## Motivation

`mgpuLaunchClusterKernel` gates the cluster launch path on `#ifdef hipLaunchAttributeClusterDimension`, but that symbol is an `enum hipLaunchAttributeID` value, not a macro, so `#ifdef` is always false. Every cluster launch silently falls back to `hipModuleLaunchKernel`, dropping cluster semantics (multicast, `cluster_barrier`) on any kernel authored with `cluster_m > 1` or `cluster_n > 1`.

## Technical Details

Replace the broken `#ifdef` with `#if HIP_VERSION >= 70000000`, the version where `hipDrvLaunchKernelEx` + `hipLaunchAttributeClusterDimension` were introduced (see [ROCm/clr CHANGELOG](https://github.com/ROCm/clr/blob/develop/CHANGELOG.md) and [ROCm 7.0.0 release notes](https://rocm.docs.amd.com/en/docs-7.0.0/about/release-notes.html)). On HIP < 7.0 with a real cluster request, report `hipErrorNotSupported` instead of silently downgrading; `cluster=(1,1,1)` still uses the plain launch path. Single-file change in `lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp`.

## Test Plan

Before the fix, any cluster launch printed `[mgpuLaunchClusterKernel] cluster=(...) requested but hipLaunchAttributeClusterDimension is not available in this HIP version; falling back to hipModuleLaunchKernel.` After the fix, the cluster path is actually invoked. Verified with the cluster-multicast unit tests:

```bash
pytest tests/kernels/test_gemm_fp8fp4_gfx1250.py::test_mxfp4_gemm_mcast -v
```

These cover `cluster=(2,2)`, `(1,2)`, `(2,1)`, `(4,4)`, `(2,4)`, `(4,2)`.

## Test Result

Both tests pass on gfx1250 / ROCm 7.x with no fallback warning.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
