### PR TITLE
Cache fix and att trace code match fix

### DIFF
--- a/python/flydsl/compiler/ast_rewriter.py
+++ b/python/flydsl/compiler/ast_rewriter.py
@@ -23,6 +23,25 @@ def _set_lineno(node, n=1):
     return node
 
 
+@contextlib.contextmanager
+def _flydsl_loc(filename, lineno):
+    """Tracing-time context manager: push an MLIR file:line Location so any
+    IR ops created inside this block default to (filename, lineno) instead of
+    the function definition line.  Inserted automatically by `WrapLocations`
+    AST transformer around every user statement.
+
+    No-op outside an active MLIR Context (e.g., if the rewritten function is
+    invoked outside of JIT tracing for some reason).
+    """
+    try:
+        loc = ir.Location.file(filename, lineno, 0)
+    except (RuntimeError, ValueError):
+        yield
+        return
+    with loc:
+        yield
+
+
 def _find_func_in_code_object(co, func_name):
     for c in co.co_consts:
         if type(c) is types.CodeType:
@@ -148,6 +167,7 @@ class ASTRewriter:
         assert isinstance(module.body[0], ast.FunctionDef), f"unexpected ast node {module.body[0]}"
 
         context = types.SimpleNamespace()
+        context.filename = f.__code__.co_filename
         for transformer_ctor in cls.transformers:
             orig_code = ast.unparse(module) if env.debug.ast_diff else None
             func_node = module.body[0]
@@ -1307,3 +1327,136 @@ class CanonicalizeWhile(Transformer):
             node = ast.fix_missing_locations(node)
             assign = ast.fix_missing_locations(assign)
             return [assign, node]
+
+
+@ASTRewriter.register
+class WrapLocations(Transformer):
+    """Wrap every user statement with ``with _flydsl_loc(__file__, lineno):``
+    so MLIR ops emitted during tracing inherit the correct source line.
+
+    Without this pass, all ops that don't pass an explicit ``loc=`` kwarg
+    fall back to the function definition line (via ``FuncLocationTracker``),
+    causing the Pattern-5 hotspot-mapping artifact where everything aggregates
+    to the ``@flyc.kernel`` decorator line in ATT trace output.
+
+    Recurses into bodies of compound statements (``for``, ``while``, ``if``,
+    ``with``, ``try``) so each inner statement also gets its own location.
+    Skips nested ``FunctionDef`` / ``AsyncFunctionDef`` / ``ClassDef`` (they
+    get their own location-tracking machinery if they're traced).
+
+    Gated by ``FLYDSL_DEBUG_ENABLE_DEBUG_INFO`` (the same env var that turns
+    on DWARF emission downstream).  When disabled, this transformer is a
+    no-op so production builds don't pay the AST/tracing overhead.
+    """
+
+    def __init__(self, context, first_lineno):
+        super().__init__(context, first_lineno)
+        # Gate on the same env var as downstream debug-info emission: if
+        # users don't enable debug info, the source mapping won't reach the
+        # ATT trace anyway, so there's no reason to pay the wrapping cost.
+        self._enabled = env.debug.enable_debug_info
+
+    @staticmethod
+    def rewrite_globals():
+        return {"_flydsl_loc": _flydsl_loc}
+
+    def _abs_line(self, node):
+        # During transformer execution, node.lineno is relative to the
+        # function source (1 = first line).  Convert to absolute file line.
+        return self.first_lineno + node.lineno
+
+    def _wrap(self, stmt):
+        if not self._enabled:
+            return stmt
+        if not hasattr(stmt, "lineno") or stmt.lineno is None:
+            return stmt
+        # Don't wrap nested function/class defs — they're either traced
+        # separately or run as plain Python.
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            return stmt
+        # Don't double-wrap if it's already a _flydsl_loc with.
+        if isinstance(stmt, ast.With):
+            for item in stmt.items:
+                ce = item.context_expr
+                if isinstance(ce, ast.Call) and isinstance(ce.func, ast.Name) and ce.func.id == "_flydsl_loc":
+                    return stmt
+        with_stmt = ast.With(
+            items=[
+                ast.withitem(
+                    context_expr=ast.Call(
+                        func=ast.Name("_flydsl_loc", ctx=ast.Load()),
+                        args=[
+                            ast.Constant(self.context.filename),
+                            ast.Constant(self._abs_line(stmt)),
+                        ],
+                        keywords=[],
+                    ),
+                    optional_vars=None,
+                )
+            ],
+            body=[stmt],
+            type_comment=None,
+        )
+        return ast.copy_location(with_stmt, stmt)
+
+    def _wrap_block(self, stmts):
+        # Transform each stmt first (visit recurses into compound bodies),
+        # then wrap with a per-stmt location.
+        out = []
+        for s in stmts:
+            visited = self.visit(s)
+            if isinstance(visited, list):
+                out.extend(self._wrap(x) for x in visited)
+            elif visited is not None:
+                out.append(self._wrap(visited))
+        return out
+
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        if not self._enabled:
+            return node
+        if getattr(node, _ASTREWRITE_MARKER, False):
+            return node
+        node.body = self._wrap_block(node.body)
+        return node
+
+    def visit_AsyncFunctionDef(self, node):
+        return self.visit_FunctionDef(node)
+
+    def visit_For(self, node: ast.For):
+        node.iter = node.iter  # don't recurse into expression nodes
+        node.body = self._wrap_block(node.body)
+        if node.orelse:
+            node.orelse = self._wrap_block(node.orelse)
+        return node
+
+    def visit_AsyncFor(self, node):
+        return self.visit_For(node)
+
+    def visit_While(self, node: ast.While):
+        node.body = self._wrap_block(node.body)
+        if node.orelse:
+            node.orelse = self._wrap_block(node.orelse)
+        return node
+
+    def visit_If(self, node: ast.If):
+        node.body = self._wrap_block(node.body)
+        if node.orelse:
+            node.orelse = self._wrap_block(node.orelse)
+        return node
+
+    def visit_With(self, node: ast.With):
+        node.body = self._wrap_block(node.body)
+        return node
+
+    def visit_AsyncWith(self, node):
+        return self.visit_With(node)
+
+    def visit_Try(self, node: ast.Try):
+        node.body = self._wrap_block(node.body)
+        for handler in node.handlers:
+            handler.body = self._wrap_block(handler.body)
+        if node.orelse:
+            node.orelse = self._wrap_block(node.orelse)
+        if node.finalbody:
+            node.finalbody = self._wrap_block(node.finalbody)
+        return node

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -239,9 +239,13 @@ def _use_external_binary_codegen() -> bool:
 
 def _get_underlying_func(obj):
     if isinstance(obj, KernelFunction):
-        return obj._func
+        # Prefer the pre-AST-rewrite func: its closure / co_names still
+        # reference helper callables, which is what the cache-key dependency
+        # collector needs to walk to detect helper source changes.  Fallback
+        # to `_func` for older KernelFunction instances without the field.
+        return getattr(obj, "_original_func", obj._func)
     if isinstance(obj, JitFunction):
-        return obj.func
+        return getattr(obj, "_original_func", obj.func)
     if isinstance(obj, types.MethodType):
         return obj.__func__
     if isinstance(obj, types.FunctionType):
@@ -1023,6 +1027,22 @@ class CallState:
 
 class JitFunction:
     def __init__(self, func: Callable, compile_hints: Optional[dict] = None):
+        # Same rationale as KernelFunction._original_func: ASTRewriter.transform
+        # mutates `func.__code__` in place, after which the JIT cache walker
+        # (`_get_underlying_func`) can no longer see closure-captured helpers
+        # via the original co_names / co_freevars.  Snapshot the pre-rewrite
+        # func here so the walker can recover those references.
+        import types as _types
+
+        _orig_code = func.__code__
+        self._original_func = _types.FunctionType(
+            _orig_code,
+            func.__globals__,
+            name=func.__name__,
+            argdefs=func.__defaults__,
+            closure=func.__closure__,
+        )
+        self._original_func.__kwdefaults__ = func.__kwdefaults__
         self.func = ASTRewriter.transform(func)
         self.compile_hints = dict(compile_hints) if compile_hints is not None else {}
         self.manager_key = None

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -1043,6 +1043,8 @@ class JitFunction:
             closure=func.__closure__,
         )
         self._original_func.__kwdefaults__ = func.__kwdefaults__
+        self._original_func.__qualname__ = func.__qualname__
+        self._original_func.__module__ = func.__module__
         self.func = ASTRewriter.transform(func)
         self.compile_hints = dict(compile_hints) if compile_hints is not None else {}
         self.manager_key = None

--- a/python/flydsl/compiler/kernel_function.py
+++ b/python/flydsl/compiler/kernel_function.py
@@ -500,6 +500,8 @@ class KernelFunction:
             closure=func.__closure__,
         )
         self._original_func.__kwdefaults__ = func.__kwdefaults__
+        self._original_func.__qualname__ = func.__qualname__
+        self._original_func.__module__ = func.__module__
         self._func = ASTRewriter.transform(func)
         self._some_args = some_args
         self._name = name

--- a/python/flydsl/compiler/kernel_function.py
+++ b/python/flydsl/compiler/kernel_function.py
@@ -483,6 +483,23 @@ class KernelFunction:
     _current: Optional["KernelFunction"] = None
 
     def __init__(self, func: Callable, some_args=None, name: Optional[str] = None, known_block_size=None):
+        # ASTRewriter.transform mutates `func.__code__` in place.  To preserve
+        # the *pre-rewrite* code object (whose co_names / co_freevars still
+        # reference helper callables that the rewriter inlines into IR ops),
+        # build a shallow function wrapper around the original __code__ here,
+        # BEFORE the transform runs.  The JIT-cache dependency collector
+        # uses this to detect changes to closure-captured helpers.
+        import types as _types
+
+        _orig_code = func.__code__
+        self._original_func = _types.FunctionType(
+            _orig_code,
+            func.__globals__,
+            name=func.__name__,
+            argdefs=func.__defaults__,
+            closure=func.__closure__,
+        )
+        self._original_func.__kwdefaults__ = func.__kwdefaults__
         self._func = ASTRewriter.transform(func)
         self._some_args = some_args
         self._name = name


### PR DESCRIPTION
## Motivation

Two independent framework improvements that came out of work on the
paged-attention decode kernel:

1. **JIT cache miss on helper-function changes** — the JIT disk cache walks
   the kernel function's closure / `co_names` to discover dependent helpers
   and hash them into the cache key.  But `ASTRewriter.transform` mutates
   `func.__code__` in-place, so by the time the cache walker runs, the
   helper references it expects to see have been inlined/rewritten and are
   no longer reachable.  Editing a helper does not invalidate the cache →
   stale HSACO is returned → silent staleness during development.

2. **Pattern-5 trace-mapping artifact** — when ATT traces are captured with
   `FLYDSL_DEBUG_ENABLE_DEBUG_INFO=1`, the vast majority of instructions
   (~83% of stall on PA decode) get attributed to the `@flyc.kernel`
   decorator line instead of the user statement that produced them.  This
   makes hotspot analysis very hard: every load / barrier / waitcnt /
   address-arithmetic op shows up on the same line.  The reason is that
   only ops wrapped with `@traced_op` carry a per-call source location;
   everything else falls back to the function-level default loc set by
   `FuncLocationTracker.func_scope()`, which is the function `def` line.

## Technical Details

### 1. Preserve pre-AST-rewrite `func` for the JIT cache walker

`KernelFunction.__init__` now snapshots a shallow `FunctionType` wrapper
around `func.__code__` **before** calling `ASTRewriter.transform` (which
mutates `__code__` in place).  The snapshot, exposed as
`KernelFunction._original_func`, preserves the original `co_names` /
`co_freevars` so the dependency collector can walk to closure-captured
helpers and hash their source.

`jit_function._get_underlying_func` now prefers `_original_func` and falls
back to `_func` for backwards compatibility:

```python
def _get_underlying_func(obj):
    if isinstance(obj, KernelFunction):
        # Prefer the pre-AST-rewrite func: its closure / co_names still
        # reference helper callables, which is what the cache-key dependency
        # collector needs to walk to detect helper source changes.
        return getattr(obj, "_original_func", obj._func)
    ...
```

Net result: editing a helper called from a `@flyc.kernel` function now
properly invalidates the JIT disk cache.

### 2. `WrapLocations` AST transformer

New AST pass at the end of the rewriter pipeline that wraps every user
statement with `with _flydsl_loc(__file__, lineno):`.  `_flydsl_loc` is a
context manager that pushes an `ir.Location.file(...)` onto the MLIR
location stack for the duration of the statement.  Any IR op created
inside the statement that does not pass an explicit `loc=` kwarg
inherits this per-statement location instead of falling back to the
function-level default.

Recurses into the bodies of compound statements (`for`, `while`, `if`,
`with`, `try`) so each inner statement also gets its own loc.  Skips
nested `FunctionDef` / `AsyncFunctionDef` / `ClassDef` (they have their
own tracing entry points).  Avoids double-wrapping if a statement is
already a `with _flydsl_loc(...)`.

Gated on `env.debug.enable_debug_info` (the existing
`FLYDSL_DEBUG_ENABLE_DEBUG_INFO` env var that also turns on DWARF
emission downstream): when the env var is unset, the pass is a no-op so
production tracing pays zero AST / closure-overhead cost.  Composes
correctly with the existing `@traced_op` decorator — when that decorator
pushes its own `_caller_location`, the inner loc shadows the outer
per-stmt loc as expected.

Measured impact on a PA decode trace (`pa_decode_ps_kernel_0`, 804
instructions, 99% source-mapped):
- Distinct source lines: **31 → 109** (3.5× more granularity)
- Top source line aggregation: **83% → 23%** (decorator-line artifact
  disappears, top spot becomes an actual user-code line)
- Runtime kernel performance: **unchanged** (loc only affects IR
  metadata, not generated ASM)

## Test Plan

- Existing FlyDSL test suite (`pytest tests/`) — no regressions expected;
  both changes are additive or invisible when `enable_debug_info=0`.
- Manual: edit a helper called from a `@flyc.kernel` and confirm the JIT
  cache hash changes (i.e., the HSACO is recompiled).
- Manual: capture an ATT trace with
  `FLYDSL_DEBUG_ENABLE_DEBUG_INFO=1` and confirm `code.json` shows
  per-statement source mapping (no longer dominated by the
  `@flyc.kernel` decorator line).

## Test Result

- `python -m pytest tests/kernels/test_pa.py -v -m "not large_shape"` —
  passes
- `python tests/kernels/test_pa_decode_flydsl.py --perf` — kernel
  runtime unchanged with and without `FLYDSL_DEBUG_ENABLE_DEBUG_INFO=1`
  (3025-3050 µs across runs, within noise band)
- ATT trace before/after:
  - before: 31 distinct source lines, line 2076 (`@flyc.kernel`
    decorator) at 83% of stall
  - after: 109 distinct source lines, top line is a real user-code
    LDS read at 23% of stall

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
