### PR TITLE
hgemm_spk: add multi-stage lds pipeline

### DIFF
--- a/kernels/hgemm_splitk.py
+++ b/kernels/hgemm_splitk.py
@@ -107,6 +107,7 @@ def compile_hgemm_kernel(
     TILE_M: int = 128,
     TILE_N: int = 128,
     TILE_K: int = 64,
+    STAGES: int = 2,
     SPLIT_K: int = 1,
     BLOCK_M_WARPS: int = 2,
     BLOCK_N_WARPS: int = 2,
@@ -114,10 +115,11 @@ def compile_hgemm_kernel(
     B_TO_LDS: bool = False,
     HAS_BIAS: bool = False,
 ):
-    assert BLOCK_M_WARPS * BLOCK_N_WARPS * BLOCK_K_WARPS <= 8
+    assert BLOCK_M_WARPS * BLOCK_N_WARPS * BLOCK_K_WARPS <= 16
     assert TILE_M * TILE_N * TILE_K <= 256 * 256 * 64
     if (TILE_M == 256) and (TILE_N == 256):
-        assert (TILE_K == 64) and (SPLIT_K == 1)
+        assert (TILE_K == 64) and (SPLIT_K == 1) and (STAGES == 2)
+    assert STAGES >= 2
     N_BLOCKS = n // TILE_N
     assert (N_BLOCKS >= 1) and (n % TILE_N == 0)
     IS_SPLIT_K = SPLIT_K > 1
@@ -143,7 +145,6 @@ def compile_hgemm_kernel(
     WARP_SIZE = 64
     DTYPE_BYTES = 2
     LDG_VEC_SIZE = 8
-    STAGES = 2
 
     # Propagated parameters:
     WMMA_M = WMMA_IMPL.WMMA_M
@@ -156,6 +157,7 @@ def compile_hgemm_kernel(
     WARP_ATOM_N = WMMA_N
     WARP_ATOM_K = WMMA_K * MFMA_PER_WARP_K
     BLOCK_K_LOOPS = ks // BLOCK_K
+    assert BLOCK_K_LOOPS >= STAGES
     WARP_GROUP_K = BLOCK_K_WARPS * WARP_ATOM_K
     WARP_K_STEPS = BLOCK_K // WARP_GROUP_K
     assert (BLOCK_K % WARP_GROUP_K == 0) and (WARP_K_STEPS >= 1)
@@ -177,7 +179,7 @@ def compile_hgemm_kernel(
     BLOCK_NK_SIZE = BLOCK_N * BLOCK_K
     BLOCK_MN_SIZE = BLOCK_M * BLOCK_N
     LDG_A_X_THREADS = BLOCK_K // LDG_VEC_SIZE
-    LDG_B_X_THREADS = BLOCK_K // LDG_VEC_SIZE
+    # LDG_B_X_THREADS = BLOCK_K // LDG_VEC_SIZE
     LDG_C_X_THREADS = BLOCK_N // LDG_VEC_SIZE
     BLOCK_VECS = LDG_VEC_SIZE * BLOCK_THREADS
     LDG_REG_A_COUNT = BLOCK_MK_SIZE // BLOCK_VECS
@@ -199,6 +201,7 @@ def compile_hgemm_kernel(
         smem_b_offset = allocator._align(allocator.ptr, 16)
         allocator.ptr = smem_b_offset + STAGES * BLOCK_N * BLOCK_K * DTYPE_BYTES
         SMEM_USE += STAGES * BLOCK_N * BLOCK_K * DTYPE_BYTES
+        assert ASYNC_COPY
     SMEM_USE_ = max(SMEM_USE, BLOCK_K_WARPS * BLOCK_M * BLOCK_N * DTYPE_BYTES)
     allocator.ptr += SMEM_USE_ - SMEM_USE
     assert SMEM_USE_ <= SMEM_CAPACITY_MAP[GPU_ARCH]
@@ -207,10 +210,11 @@ def compile_hgemm_kernel(
     LDG_REG_A_COUNT_AS = BLOCK_MK_SIZE // LDG_ASYNC_VEC_SIZE // BLOCK_THREADS
     LDG_B_X_THREADS_AS = BLOCK_K // LDG_ASYNC_VEC_SIZE
     LDG_REG_B_COUNT_AS = BLOCK_NK_SIZE // LDG_ASYNC_VEC_SIZE // BLOCK_THREADS
+    LDG_WAIT_COUNT = LDG_REG_B_COUNT_AS + LDG_REG_A_COUNT_AS
+    assert ((STAGES - 2) * LDG_WAIT_COUNT) < 63
 
-    KERNEL_NAME = f"hgemm_{dtype}_{BLOCK_M}x{BLOCK_N}x{BLOCK_K}_W{BLOCK_M_WARPS}x{BLOCK_N_WARPS}x{BLOCK_K_WARPS}_S{STAGES}_BT_BLDS{int(B_TO_LDS)}"
+    KERNEL_NAME = f"hgemm_{dtype}_{BLOCK_M}x{BLOCK_N}x{BLOCK_K}x{STAGES}_SPK{SPLIT_K}_W{BLOCK_M_WARPS}x{BLOCK_N_WARPS}x{BLOCK_K_WARPS}_BLDS{int(B_TO_LDS)}_TN"
     KERNEL_NAME += "_AS0" if not ASYNC_COPY else "_AS1"
-    KERNEL_NAME += f"_SPK{SPLIT_K}"
     if HAS_BIAS:
         KERNEL_NAME += "_BIAS"
 
@@ -271,10 +275,15 @@ def compile_hgemm_kernel(
         ldmatrix_b_n_idx = w_tid % WMMA_N
         ldmatrix_b_k_vec_idx = w_tid // WMMA_N * WMMA_B_FRAG_VALUES * MFMA_PER_WARP_K
         warp_k_slice_base = wid_k * K_SLICE
-        A_FRAGS_LEN = WARP_K_STEPS * WARP_M_STEPS
-        B_FRAGS_LEN = WARP_K_STEPS * WARP_N_STEPS
         C_FRAGS_LEN = WARP_M_STEPS * WARP_N_STEPS
         c_frags = [acc_init] * C_FRAGS_LEN
+
+        def __barrier(vmcnt=0, use_s_barrier=True):
+            if const_expr(use_s_barrier):
+                asm = f"s_waitcnt vmcnt({vmcnt})\n\ts_barrier"
+            else:
+                asm = f"s_waitcnt vmcnt({vmcnt})"
+            llvm.InlineAsmOp(None, [], asm, "", has_side_effects=True)
 
         def get_llvm_ptr(ptr, offset, dtype_bytes, ptr_type=ir.Type.parse("!llvm.ptr<1>")):
             base_ptr = fly.extract_aligned_pointer_as_index(ptr_type, ptr)
@@ -404,38 +413,23 @@ def compile_hgemm_kernel(
                 col_in_bytes = swizzle_xor16(m_local_idx, col_in_bytes, k_blocks16)
                 as_.vec_store((fx.Index(lds_stage), m_local_idx, col_in_bytes // DTYPE_BYTES), vecs[i], LDG_VEC_SIZE)
 
-        def ldg_b(k_offset):
-            vecs = []
-            for i in range_constexpr(LDG_REG_B_COUNT):
-                global_tid = BLOCK_THREADS * i + tid
-                n_local_idx = global_tid // LDG_B_X_THREADS
-                k_local_idx = global_tid % LDG_B_X_THREADS * LDG_VEC_SIZE
-                row_idx = n_offset + fx.Index(n_local_idx)
-                safe_row_idx = arith.select(
-                    arith.cmpi(arith.CmpIPredicate.ult, row_idx, fx.Index(n)),
-                    row_idx,
-                    fx.Index(0),
-                )
-                col_idx = fx.Index(k_offset + k_local_idx)
-                vec = B_.vec_load((safe_row_idx, col_idx), LDG_VEC_SIZE)
-                vecs.append(vec)
-            return vecs
-
-        def sts_b(vecs, lds_stage):
-            for i in range_constexpr(LDG_REG_B_COUNT):
-                global_tid = BLOCK_THREADS * i + tid
-                n_local_idx = global_tid // LDG_B_X_THREADS
-                k_local_idx = global_tid % LDG_B_X_THREADS * LDG_VEC_SIZE
-                col_in_bytes = k_local_idx * DTYPE_BYTES
-                col_in_bytes = swizzle_xor16(n_local_idx, col_in_bytes, k_blocks16)
-                bs_.vec_store((fx.Index(lds_stage), n_local_idx, col_in_bytes // DTYPE_BYTES), vecs[i], LDG_VEC_SIZE)
-
         def get_dma_copy_warp_offset():
             warp_offset = rocdl.readfirstlane(
                 T.i64,
                 arith.index_cast(T.i64, fx.Index(wid) * arith.constant(WARP_SIZE * DMA_BYTES, index=True)),
             )
             return warp_offset
+
+        def buffer_load_lds_inline(rsrc, lds_ptr, global_offset):
+            if const_expr(DMA_BYTES == 16):
+                asm = "s_mov_b32 m0, $0\n\tbuffer_load_dwordx4 $1, $2, 0 offen sc0 lds"
+            elif const_expr(DMA_BYTES == 8):
+                asm = "s_mov_b32 m0, $0\n\tbuffer_load_dwordx2 $1, $2, 0 offen sc0 lds"
+            elif const_expr(DMA_BYTES == 4):
+                asm = "s_mov_b32 m0, $0\n\tbuffer_load_dword $1, $2, 0 offen sc0 lds"
+            else:
+                raise NotImplementedError(f"DMA_BYTES={DMA_BYTES} not supported")
+            llvm.InlineAsmOp(None, [lds_ptr, global_offset, rsrc], asm, "s,v,s", has_side_effects=True)
 
         def ldg_sts_a_async(k_offset, lds_stage):
             for i in range_constexpr(LDG_REG_A_COUNT_AS):
@@ -466,15 +460,7 @@ def compile_hgemm_kernel(
                         static_byte_offset=BLOCK_THREADS * DMA_BYTES,
                     )
                 # dma copy
-                rocdl.raw_ptr_buffer_load_lds(
-                    A_.rsrc,
-                    lds_ptr,
-                    arith.constant(DMA_BYTES, type=T.i32),
-                    global_offset,
-                    arith.constant(0, type=T.i32),
-                    arith.constant(0, type=T.i32),
-                    arith.constant(1, type=T.i32),
-                )
+                buffer_load_lds_inline(A_.rsrc, lds_ptr, global_offset)
 
         def ldg_sts_b_async(k_offset, lds_stage):
             for i in range_constexpr(LDG_REG_B_COUNT_AS):
@@ -505,43 +491,7 @@ def compile_hgemm_kernel(
                         static_byte_offset=BLOCK_THREADS * DMA_BYTES,
                     )
                 # dma copy
-                rocdl.raw_ptr_buffer_load_lds(
-                    B_.rsrc,
-                    lds_ptr,
-                    arith.constant(DMA_BYTES, type=T.i32),
-                    global_offset,
-                    arith.constant(0, type=T.i32),
-                    arith.constant(0, type=T.i32),
-                    arith.constant(1, type=T.i32),
-                )
-
-        def lds_matrix_a(lds_stage):
-            s = fx.Index(lds_stage)
-            a_frags = [0] * (WARP_K_STEPS * WARP_M_STEPS)
-            for ii in range_constexpr(WARP_M_STEPS):
-                warp_atom_m_idx = warp_m_idx + ii * WARP_ATOM_M
-                for kk in range_constexpr(WARP_K_STEPS):
-                    warp_atom_k_idx = warp_k_slice_base + kk * WARP_ATOM_K
-                    row = warp_atom_m_idx + ldmatrix_a_m_idx
-                    col_in_bytes = (warp_atom_k_idx + ldmatrix_a_k_vec_idx) * DTYPE_BYTES
-                    col_in_bytes = swizzle_xor16(row, col_in_bytes, k_blocks16)
-                    vec = as_.vec_load((s, row, col_in_bytes // DTYPE_BYTES), WMMA_A_FRAG_VALUES * MFMA_PER_WARP_K)
-                    a_frags[kk * WARP_M_STEPS + ii] = vec
-            return a_frags
-
-        def lds_matrix_b(lds_stage):
-            s = fx.Index(lds_stage)
-            b_frags = [0] * (WARP_K_STEPS * WARP_N_STEPS)
-            for ii in range_constexpr(WARP_N_STEPS):
-                warp_atom_n_idx = warp_n_idx + ii * WARP_ATOM_N
-                for kk in range_constexpr(WARP_K_STEPS):
-                    warp_atom_k_idx = warp_k_slice_base + kk * WARP_ATOM_K
-                    row = warp_atom_n_idx + ldmatrix_b_n_idx
-                    col_in_bytes = (warp_atom_k_idx + ldmatrix_b_k_vec_idx) * DTYPE_BYTES
-                    col_in_bytes = swizzle_xor16(row, col_in_bytes, k_blocks16)
-                    vec = bs_.vec_load((s, row, col_in_bytes // DTYPE_BYTES), WMMA_B_FRAG_VALUES * MFMA_PER_WARP_K)
-                    b_frags[kk * WARP_N_STEPS + ii] = vec
-            return b_frags
+                buffer_load_lds_inline(B_.rsrc, lds_ptr, global_offset)
 
         def ldg_matrix_b(k_offset):
             vecs = []
@@ -555,14 +505,35 @@ def compile_hgemm_kernel(
                     vecs.append(vec)
             return vecs
 
-        def block_mma_sync(a_frags, b_frags, c_frags):
-            # wmma
+        def ldmatrix_compute_tile_streaming(lds_stage, c_frags, initial_b_frags=None):
+            s = fx.Index(lds_stage)
             c_frags_new = [cx for cx in c_frags]
             for kk in range_constexpr(WARP_K_STEPS):
+                warp_atom_k_idx = warp_k_slice_base + kk * WARP_ATOM_K
+                if const_expr(initial_b_frags is None):
+                    b_frags = [0] * WARP_N_STEPS
+                    for ii in range_constexpr(WARP_N_STEPS):
+                        warp_atom_n_idx = warp_n_idx + ii * WARP_ATOM_N
+                        row = warp_atom_n_idx + ldmatrix_b_n_idx
+                        col_in_bytes = (warp_atom_k_idx + ldmatrix_b_k_vec_idx) * DTYPE_BYTES
+                        col_in_bytes = swizzle_xor16(row, col_in_bytes, k_blocks16)
+                        vec = bs_.vec_load((s, row, col_in_bytes // DTYPE_BYTES), WMMA_B_FRAG_VALUES * MFMA_PER_WARP_K)
+                        b_frags[ii] = vec
+                else:
+                    b_frags = [initial_b_frags[i] for i in range_constexpr(kk * WARP_N_STEPS, (kk + 1) * WARP_N_STEPS)]
+                a_frags = [0] * WARP_M_STEPS
                 for ii in range_constexpr(WARP_M_STEPS):
-                    a_frag = a_frags[kk * WARP_M_STEPS + ii]
+                    warp_atom_m_idx = warp_m_idx + ii * WARP_ATOM_M
+                    row = warp_atom_m_idx + ldmatrix_a_m_idx
+                    col_in_bytes = (warp_atom_k_idx + ldmatrix_a_k_vec_idx) * DTYPE_BYTES
+                    col_in_bytes = swizzle_xor16(row, col_in_bytes, k_blocks16)
+                    vec = as_.vec_load((s, row, col_in_bytes // DTYPE_BYTES), WMMA_A_FRAG_VALUES * MFMA_PER_WARP_K)
+                    a_frags[ii] = vec
+                rocdl.sched_barrier(0)
+                for ii in range_constexpr(WARP_M_STEPS):
+                    a_frag = a_frags[ii]
                     for jj in range_constexpr(WARP_N_STEPS):
-                        b_frag = b_frags[kk * WARP_N_STEPS + jj]
+                        b_frag = b_frags[jj]
                         if const_expr(MFMA_PER_WARP_K == 2):
                             # split a
                             a_i64x2 = vector.bitcast(T.i64x2, a_frag)
@@ -595,118 +566,93 @@ def compile_hgemm_kernel(
 
         if const_expr(B_TO_LDS):
 
-            ldg_sts_a_async(ks_begin, 0)
-            ldg_sts_b_async(ks_begin, 0)
-            gpu.barrier()
-            b_frags_next = lds_matrix_b(0)
+            for s in range_constexpr(STAGES - 1):
+                ldg_sts_b_async(ks_begin + s * BLOCK_K, s)
+                ldg_sts_a_async(ks_begin + s * BLOCK_K, s)
             rocdl.sched_barrier(0)
 
             def hot_loop_scheduler():
-                MFMA_TOTAL = WARP_K_STEPS * WARP_M_STEPS * WARP_N_STEPS * MFMA_PER_WARP_K
-                LDG_REG_A_COUNT_ = LDG_REG_A_COUNT_AS if const_expr(ASYNC_COPY) else LDG_REG_A_COUNT
-                LDG_REG_B_COUNT_ = LDG_REG_B_COUNT_AS if const_expr(ASYNC_COPY) else LDG_REG_B_COUNT
-                mfma_ = OnlineScheduler(MFMA_TOTAL, MFMA_TOTAL)
                 # ================ Ordered ================
-                for i in range_constexpr(WARP_K_STEPS * WARP_M_STEPS):
-                    rocdl.sched_dsrd(1)  # lds_matrix_a current
-                for i in range_constexpr(LDG_REG_A_COUNT_):
-                    rocdl.sched_vmem(1)  # ldg_sts_a_async next
-                    rocdl.sched_mfma(mfma_.consume(2))
-                for i in range_constexpr(LDG_REG_B_COUNT_):
+                for i in range_constexpr(LDG_REG_B_COUNT_AS):
                     rocdl.sched_vmem(1)  # ldg_sts_b_async next
-                    rocdl.sched_mfma(mfma_.consume(2))
-                for i in range_constexpr(mfma_.remaining):
-                    rocdl.sched_mfma(1)
+                for i in range_constexpr(LDG_REG_A_COUNT_AS):
+                    rocdl.sched_vmem(1)  # ldg_sts_a_async next
+                for ki in range_constexpr(WARP_K_STEPS):
+                    for i in range_constexpr(WARP_N_STEPS):
+                        rocdl.sched_dsrd(1)  # lds_matrix_b current
+                    for i in range_constexpr(WARP_M_STEPS):
+                        rocdl.sched_dsrd(1)  # lds_matrix_a current
+                    for i in range_constexpr(WARP_M_STEPS):
+                        rocdl.sched_mfma(WARP_N_STEPS)
+                # ================ Reordered ================
+                rocdl.sched_barrier(0)
+
+            init_state = [ks_begin, arith.constant(0, index=True)] + c_frags
+            for bki, state in range(0, BLOCK_K_LOOPS - (STAGES - 1), 1, init=init_state):
+                k_offset = state[0]
+                current_stage = fx.Index(state[1])
+                c_frags = state[2:]
+                next_stage = (current_stage + 1) % STAGES
+                write_stage = (current_stage + STAGES - 1) % STAGES
+                __barrier((STAGES - 2) * LDG_WAIT_COUNT)
+                ldg_sts_b_async(k_offset + (STAGES - 1) * BLOCK_K, write_stage)
+                ldg_sts_a_async(k_offset + (STAGES - 1) * BLOCK_K, write_stage)
+                c_frags_new = ldmatrix_compute_tile_streaming(current_stage, c_frags)
+                k_offset_next = k_offset + fx.Int32(BLOCK_K)
+                hot_loop_scheduler()
+                results = yield [k_offset_next, next_stage] + c_frags_new
+            current_stage = fx.Index(results[1])
+            c_frags = results[2:]
+            for s in range_constexpr(0, STAGES - 1):
+                __barrier((STAGES - 2 - s) * LDG_WAIT_COUNT)
+                c_frags = ldmatrix_compute_tile_streaming(current_stage, c_frags)
+                current_stage = (current_stage + 1) % STAGES
+
+        else:
+
+            assert STAGES == 2
+            sts_a(ldg_a(ks_begin), 0)
+            b_frags_next = ldg_matrix_b(ks_begin)
+            rocdl.sched_barrier(0)
+            __barrier()
+
+            def hot_loop_scheduler():
+                LDG_REG_A_COUNT_ = LDG_REG_A_COUNT_AS if const_expr(ASYNC_COPY) else LDG_REG_A_COUNT
+                LDG_TOTAL = LDG_REG_A_COUNT_ + WARP_K_STEPS * WARP_N_STEPS
+                # ================ Ordered ================
+                for i in range_constexpr(LDG_TOTAL):
+                    rocdl.sched_vmem(1)
+                for ki in range_constexpr(WARP_K_STEPS):
+                    for i in range_constexpr(WARP_M_STEPS):
+                        rocdl.sched_dsrd(1)
+                    for i in range_constexpr(WARP_M_STEPS):
+                        rocdl.sched_mfma(WARP_N_STEPS)
                 # ================ Reordered ================
                 rocdl.sched_barrier(0)
 
             init_state = [ks_begin, arith.constant(0, index=True)] + c_frags + b_frags_next
-            for bki, state in range(0, BLOCK_K_LOOPS - 1, 1, init=init_state):
-                k_offset = state[0]
-                current_stage = fx.Index(state[1])
-                next_stage = 1 - current_stage
-                c_frags = state[2 : 2 + C_FRAGS_LEN]
-                b_frags = state[2 + C_FRAGS_LEN : 2 + C_FRAGS_LEN + B_FRAGS_LEN]
-                a_frag = lds_matrix_a(current_stage)
-                ldg_sts_a_async(k_offset + BLOCK_K, next_stage)
-                ldg_sts_b_async(k_offset + BLOCK_K, next_stage)
-                c_frags_new = block_mma_sync(a_frag, b_frags, c_frags)
-                hot_loop_scheduler()
-                gpu.barrier()
-                b_frags_next = lds_matrix_b(next_stage)
-                k_offset_next = k_offset + fx.Int32(BLOCK_K)
-                rocdl.sched_barrier(0)
-                results = yield [k_offset_next, next_stage] + c_frags_new + b_frags_next
-            current_stage = fx.Index(results[1])
-            c_frags = results[2 : 2 + C_FRAGS_LEN]
-            b_frags = results[2 + C_FRAGS_LEN : 2 + C_FRAGS_LEN + B_FRAGS_LEN]
-            a_frag = lds_matrix_a(current_stage)
-            c_frags = block_mma_sync(a_frag, b_frags, c_frags)
-
-        else:
-
-            sts_a(ldg_a(ks_begin), 0)
-            gpu.barrier()
-            a_frags = lds_matrix_a(0)
-            b_frags = ldg_matrix_b(ks_begin)
-            rocdl.sched_barrier(0)
-
-            def hot_loop_scheduler():
-                MFMA_TOTAL = WARP_K_STEPS * WARP_M_STEPS * WARP_N_STEPS * MFMA_PER_WARP_K
-                LDG_REG_A_COUNT_ = LDG_REG_A_COUNT_AS if const_expr(ASYNC_COPY) else LDG_REG_A_COUNT
-                LDG_TOTAL = LDG_REG_A_COUNT_ + WARP_K_STEPS * WARP_N_STEPS
-                mfma_ = OnlineScheduler(MFMA_TOTAL, MFMA_TOTAL)
-                ldg_ = OnlineScheduler(LDG_TOTAL, LDG_TOTAL)
-                # ================ Ordered ================
-                # for i in range_constexpr(LDG_REG_A_COUNT_AS or LDG_REG_A_COUNT):
-                #     rocdl.sched_vmem(1) # ldg_sts_a_async next
-                # for i in range_constexpr(WARP_K_STEPS * WARP_N_STEPS):
-                #     rocdl.sched_vmem(1) # ldg_matrix_b next
-                # for i in range_constexpr(WARP_K_STEPS * WARP_M_STEPS * WARP_N_STEPS * MFMA_PER_WARP_K):
-                #     rocdl.sched_mfma(1)
-                # ================ Reordered ================
-                if const_expr(ASYNC_COPY):
-                    AVG_MFMA_COUNT = (MFMA_TOTAL + LDG_TOTAL - 1) // LDG_TOTAL
-                    for i in range_constexpr(LDG_TOTAL):
-                        rocdl.sched_vmem(ldg_.consume(1))
-                        rocdl.sched_mfma(mfma_.consume(AVG_MFMA_COUNT))
-                else:
-                    LDG_STS_TOTAL = LDG_TOTAL + LDG_REG_A_COUNT_
-                    AVG_MFMA_COUNT = (MFMA_TOTAL + LDG_STS_TOTAL - 1) // LDG_STS_TOTAL
-                    for i in range_constexpr(LDG_TOTAL):
-                        rocdl.sched_vmem(ldg_.consume(1))
-                        rocdl.sched_mfma(mfma_.consume(AVG_MFMA_COUNT))
-                    for i in range_constexpr(LDG_REG_A_COUNT_):
-                        rocdl.sched_dswr(1)
-                        rocdl.sched_mfma(mfma_.consume(AVG_MFMA_COUNT))
-                rocdl.sched_barrier(0)
-
-            init_state = [ks_begin, arith.constant(0, index=True)] + c_frags + a_frags + b_frags
             for bki, state in range(1, BLOCK_K_LOOPS, init=init_state):
                 k_offset = state[0]
                 current_stage = fx.Index(state[1])
                 next_stage = 1 - current_stage
                 c_frags = state[2 : 2 + C_FRAGS_LEN]
-                a_frags = state[2 + C_FRAGS_LEN : 2 + C_FRAGS_LEN + A_FRAGS_LEN]
-                b_frags = state[2 + C_FRAGS_LEN + A_FRAGS_LEN : 2 + C_FRAGS_LEN + A_FRAGS_LEN + B_FRAGS_LEN]
+                b_frags = state[2 + C_FRAGS_LEN :]
                 if const_expr(ASYNC_COPY):
                     ldg_sts_a_async(k_offset + BLOCK_K, next_stage)
                 else:
                     a_regs_next = ldg_a(k_offset + BLOCK_K)
                 b_frags_next = ldg_matrix_b(k_offset + BLOCK_K)
-                c_frags = block_mma_sync(a_frags, b_frags, c_frags)
+                c_frags_new = ldmatrix_compute_tile_streaming(current_stage, c_frags, b_frags)
                 if const_expr(not ASYNC_COPY):
                     sts_a(a_regs_next, next_stage)
-                hot_loop_scheduler()
-                gpu.barrier()
-                a_frags_next = lds_matrix_a(next_stage)
                 k_offset = k_offset + fx.Int32(BLOCK_K)
-                rocdl.sched_barrier(0)
-                results = yield [k_offset, next_stage] + c_frags + a_frags_next + b_frags_next
+                hot_loop_scheduler()
+                __barrier()
+                results = yield [k_offset, next_stage] + c_frags_new + b_frags_next
+            current_stage = fx.Index(results[1])
             c_frags = results[2 : 2 + C_FRAGS_LEN]
-            a_frags = results[2 + C_FRAGS_LEN : 2 + C_FRAGS_LEN + A_FRAGS_LEN]
-            b_frags = results[2 + C_FRAGS_LEN + A_FRAGS_LEN : 2 + C_FRAGS_LEN + A_FRAGS_LEN + B_FRAGS_LEN]
-            c_frags = block_mma_sync(a_frags, b_frags, c_frags)
+            b_frags = results[2 + C_FRAGS_LEN :]
+            c_frags = ldmatrix_compute_tile_streaming(current_stage, c_frags, b_frags)
 
         # write to lds
         stmatrix_c_m_vec_idx = w_tid // WMMA_N * WMMA_C_FRAG_VALUES
@@ -809,57 +755,67 @@ def get_default_kwargs(m, n, k):
         "TILE_M": 256,
         "TILE_N": 256,
         "TILE_K": 64,
+        "STAGES": 2,
         "SPLIT_K": 1,
         "BLOCK_M_WARPS": 2,
-        "BLOCK_N_WARPS": 2,
+        "BLOCK_N_WARPS": 4,
         "BLOCK_K_WARPS": 1,
         "B_TO_LDS": True,
     }
     if m == 2048 and n == 2048 and k == 2048:
         kwargs["TILE_M"] = 128
-        kwargs["TILE_N"] = 64
+        kwargs["TILE_N"] = 128
         kwargs["TILE_K"] = 64
+        kwargs["STAGES"] = 4
         kwargs["SPLIT_K"] = 1
+        kwargs["BLOCK_M_WARPS"] = 4
+        kwargs["BLOCK_N_WARPS"] = 4
+        kwargs["BLOCK_K_WARPS"] = 1
     elif m <= 32 and n == 384 and k == 7168:
         kwargs["TILE_M"] = 32
         kwargs["TILE_N"] = 64
-        kwargs["TILE_K"] = 256
-        kwargs["SPLIT_K"] = 14
-        kwargs["BLOCK_M_WARPS"] = 1
+        kwargs["TILE_K"] = 64
+        kwargs["STAGES"] = 5
+        kwargs["SPLIT_K"] = 16
+        kwargs["BLOCK_M_WARPS"] = 2
         kwargs["BLOCK_N_WARPS"] = 2
-        kwargs["BLOCK_K_WARPS"] = 2
+        kwargs["BLOCK_K_WARPS"] = 1
     elif m <= 32 and n == 7168 and k == 2048:
         kwargs["TILE_M"] = 16
         kwargs["TILE_N"] = 64
-        kwargs["TILE_K"] = 256
-        kwargs["SPLIT_K"] = 2
+        kwargs["TILE_K"] = 128
+        kwargs["STAGES"] = 4
+        kwargs["SPLIT_K"] = 1
         kwargs["BLOCK_M_WARPS"] = 1
-        kwargs["BLOCK_N_WARPS"] = 2
-        kwargs["BLOCK_K_WARPS"] = 1
+        kwargs["BLOCK_N_WARPS"] = 1
+        kwargs["BLOCK_K_WARPS"] = 2
     elif m <= 32 and n == 384 and k == 16384:
         kwargs["TILE_M"] = 32
         kwargs["TILE_N"] = 64
         kwargs["TILE_K"] = 256
+        kwargs["STAGES"] = 3
         kwargs["SPLIT_K"] = 16
-        kwargs["BLOCK_M_WARPS"] = 1
-        kwargs["BLOCK_N_WARPS"] = 2
-        kwargs["BLOCK_K_WARPS"] = 2
-    elif m <= 16 and n == 5120 and k == 2880:
-        kwargs["TILE_M"] = 32
-        kwargs["TILE_N"] = 128
-        kwargs["TILE_K"] = 64
-        kwargs["SPLIT_K"] = 9
         kwargs["BLOCK_M_WARPS"] = 1
         kwargs["BLOCK_N_WARPS"] = 4
         kwargs["BLOCK_K_WARPS"] = 1
-    elif m <= 32 and n == 2880 and k == 2048:
-        kwargs["TILE_M"] = 32
+    elif m <= 16 and n == 5120 and k == 2880:
+        kwargs["TILE_M"] = 16
         kwargs["TILE_N"] = 64
-        kwargs["TILE_K"] = 256
-        kwargs["SPLIT_K"] = 4
+        kwargs["TILE_K"] = 64
+        kwargs["STAGES"] = 5
+        kwargs["SPLIT_K"] = 3
         kwargs["BLOCK_M_WARPS"] = 1
         kwargs["BLOCK_N_WARPS"] = 2
-        kwargs["BLOCK_K_WARPS"] = 2
+        kwargs["BLOCK_K_WARPS"] = 1
+    elif m <= 32 and n == 2880 and k == 2048:
+        kwargs["TILE_M"] = 16
+        kwargs["TILE_N"] = 64
+        kwargs["TILE_K"] = 128
+        kwargs["STAGES"] = 5
+        kwargs["SPLIT_K"] = 2
+        kwargs["BLOCK_M_WARPS"] = 1
+        kwargs["BLOCK_N_WARPS"] = 2
+        kwargs["BLOCK_K_WARPS"] = 1
     return kwargs
 
 
@@ -867,6 +823,7 @@ selections = {
     "TILE_M": [16, 32, 48, 64, 96, 128, 256],
     "TILE_N": [64, 128, 256],
     "TILE_K": [64, 128, 256],
+    "STAGES": [2, 3, 4, 5],
     "SPLIT_K": [i for i in range(1, 17)],
     "BLOCK_M_WARPS": [1, 2, 4],
     "BLOCK_N_WARPS": [1, 2, 4],

--- a/kernels/hgemm_splitk.py
+++ b/kernels/hgemm_splitk.py
@@ -134,7 +134,7 @@ def compile_hgemm_kernel(
         WMMA_IMPL = WmmaHalf_m16n16k16(dtype)
         DMA_BYTES = 4
         MFMA_PER_WARP_K = 2
-        ASYNC_COPY = False
+        ASYNC_COPY = True
     else:
         WMMA_IMPL = WmmaHalf_m16n16k32(dtype)
         DMA_BYTES = 16

--- a/tests/kernels/test_hgemm_splitk.py
+++ b/tests/kernels/test_hgemm_splitk.py
@@ -47,28 +47,29 @@ def run_torch_bench(a, b):
 
 params = (
     [
-        (32, 384, 7168, 32, 64, 256, 14, 1, 2, 2),
-        (32, 7168, 2048, 16, 64, 256, 2, 1, 2, 1),
-        (32, 384, 16384, 32, 64, 256, 16, 1, 2, 2),
-        (8, 5120, 2880, 32, 128, 64, 9, 1, 4, 1),
-        (32, 2880, 2048, 32, 64, 256, 4, 1, 2, 2),
+        (2048, 2048, 2048, 128, 128, 64, 4, 1, 4, 4, 1),
+        (32, 384, 7168, 32, 64, 64, 5, 16, 2, 2, 1),
+        (32, 7168, 2048, 16, 64, 128, 4, 1, 1, 1, 2),
+        (32, 384, 16384, 32, 64, 256, 3, 16, 1, 4, 1),
+        (8, 5120, 2880, 16, 64, 64, 5, 3, 1, 2, 1),
+        (32, 2880, 2048, 16, 64, 128, 5, 2, 1, 2, 1),
     ]
     if IS_GFX950
     else [
-        (32, 384, 7168, 16, 64, 128, 14, 1, 2, 1),
-        (4, 384, 7168, 16, 64, 128, 14, 1, 2, 1),
-        (65, 1024, 8192, 48, 64, 128, 8, 1, 2, 1),
-        (8, 5120, 2880, 32, 128, 64, 9, 2, 2, 1),
-        (4096, 4096, 4096, 128, 128, 64, 1, 2, 2, 1),
-        (8192, 8192, 8192, 128, 128, 64, 1, 2, 2, 1),
-        (32, 2880, 2048, 32, 64, 128, 4, 1, 2, 1),
+        (32, 384, 7168, 16, 64, 128, 2, 14, 1, 2, 1),
+        (4, 384, 7168, 16, 64, 128, 2, 14, 1, 2, 1),
+        (65, 1024, 8192, 48, 64, 128, 2, 8, 1, 2, 1),
+        (8, 5120, 2880, 32, 128, 64, 2, 9, 2, 2, 1),
+        (4096, 4096, 4096, 128, 128, 64, 2, 1, 2, 2, 1),
+        (8192, 8192, 8192, 128, 128, 64, 2, 1, 2, 2, 1),
+        (32, 2880, 2048, 32, 64, 128, 2, 4, 1, 2, 1),
     ]
 )
 
 
 @pytest.mark.parametrize("dtype", ["fp16", "bf16"])
 @pytest.mark.parametrize(
-    "m, n, k, TILE_M, TILE_N, TILE_K, SPLIT_K, BLOCK_M_WARPS, BLOCK_N_WARPS, BLOCK_K_WARPS",
+    "m, n, k, TILE_M, TILE_N, TILE_K, STAGES, SPLIT_K, BLOCK_M_WARPS, BLOCK_N_WARPS, BLOCK_K_WARPS",
     params,
 )
 @pytest.mark.parametrize(
@@ -86,6 +87,7 @@ def test_mfma_flyc_splitk_hgemm(
     TILE_M,
     TILE_N,
     TILE_K,
+    STAGES,
     SPLIT_K,
     BLOCK_M_WARPS,
     BLOCK_N_WARPS,
@@ -132,6 +134,7 @@ def test_mfma_flyc_splitk_hgemm(
         "TILE_M": TILE_M,
         "TILE_N": TILE_N,
         "TILE_K": TILE_K,
+        "STAGES": STAGES,
         "SPLIT_K": SPLIT_K,
         "BLOCK_M_WARPS": BLOCK_M_WARPS,
         "BLOCK_N_WARPS": BLOCK_N_WARPS,
@@ -178,6 +181,7 @@ if __name__ == "__main__":
     parser.add_argument("--TILE_M", type=int, default=256)
     parser.add_argument("--TILE_N", type=int, default=256)
     parser.add_argument("--TILE_K", type=int, default=64)
+    parser.add_argument("--STAGES", type=int, default=2)
     parser.add_argument("--SPLIT_K", type=int, default=1)
     parser.add_argument("--BLOCK_M_WARPS", type=int, default=2)
     parser.add_argument("--BLOCK_N_WARPS", type=int, default=2)
@@ -196,6 +200,7 @@ if __name__ == "__main__":
             TILE_M=args.TILE_M,
             TILE_N=args.TILE_N,
             TILE_K=args.TILE_K,
+            STAGES=args.STAGES,
             SPLIT_K=args.SPLIT_K,
             BLOCK_M_WARPS=args.BLOCK_M_WARPS,
             BLOCK_N_WARPS=args.BLOCK_N_WARPS,


### PR DESCRIPTION
## Motivation

Add multi-stage streaming-k policy for mixed split-slice k

LDS-Stage support: 2,3,4,5

### Key-Results  for GFX950:

| mode  | dtype | m    | n    | k     | speedup before | speedup after | delta |
|-------|-------|------|------|-------|----------------|---------------|-------|
| eager | fp16  | 2048 | 2048 | 2048  | N/A            | 1.094         | N/A   |
| eager | bf16  | 2048 | 2048 | 2048  | N/A            | 1.241         | N/A   |
| eager | fp16  | 32   | 384  | 7168  | 1.606          | 1.734         | +0.128 |
| eager | bf16  | 32   | 384  | 7168  | 1.709          | 1.753         | +0.044 |
| eager | fp16  | 32   | 7168 | 2048  | 0.849          | 1.150         | +0.301 |
| eager | bf16  | 32   | 7168 | 2048  | 0.895          | 1.155         | +0.260 |
| eager | fp16  | 32   | 384  | 16384 | 1.240          | 1.604         | +0.364 |
| eager | bf16  | 32   | 384  | 16384 | 1.272          | 1.660         | +0.388 |
| eager | fp16  | 8    | 5120 | 2880  | 1.139          | 1.471         | +0.332 |
| eager | bf16  | 8    | 5120 | 2880  | 1.111          | 1.468         | +0.357 |
| eager | fp16  | 32   | 2880 | 2048  | 1.059          | 1.234         | +0.175 |
| eager | bf16  | 32   | 2880 | 2048  | 1.132          | 1.200         | +0.068 |
| graph | fp16  | 2048 | 2048 | 2048  | N/A            | 1.441         | N/A   |
| graph | bf16  | 2048 | 2048 | 2048  | N/A            | 1.250         | N/A   |
| graph | fp16  | 32   | 384  | 7168  | 2.393          | 1.892         | -0.501 |
| graph | bf16  | 32   | 384  | 7168  | 1.770          | 1.871         | +0.101 |
| graph | fp16  | 32   | 7168 | 2048  | 0.871          | 1.126         | +0.255 |
| graph | bf16  | 32   | 7168 | 2048  | 0.896          | 1.140         | +0.244 |
| graph | fp16  | 32   | 384  | 16384 | 1.470          | 1.703         | +0.233 |
| graph | bf16  | 32   | 384  | 16384 | 1.439          | 1.674         | +0.235 |
| graph | fp16  | 8    | 5120 | 2880  | 1.139          | 1.458         | +0.319 |
| graph | bf16  | 8    | 5120 | 2880  | 1.118          | 1.461         | +0.343 |
| graph | fp16  | 32   | 2880 | 2048  | 1.104          | 1.178         | +0.074 |
| graph | bf16  | 32   | 2880 | 2048  | 1.095          | 1.170         | +0.075 |
