### PR TITLE
Update kernel-trace-analysis, lds-optimization, prefetch-data-load sk…

### DIFF
--- a/.claude/skills/capture-kernel-trace/SKILL.md
+++ b/.claude/skills/capture-kernel-trace/SKILL.md
@@ -206,6 +206,66 @@ print(f'Instructions: {n}, with source mapping: {has_src} ({100*has_src//max(n,1
 
 ---
 
+## PMC Mode: Cache / HBM Counter Capture (separate from ATT)
+
+ATT (above) gives per-instruction stall timing but **no cache counters**. To
+answer "what is the L2 hit rate / HBM read efficiency", capture hardware
+performance counters (PMC) in a **separate** run. PMC and ATT cannot be
+combined in one job.
+
+**Counter set** (L2 + HBM read efficiency):
+
+```yaml
+# /tmp/pmc_l2.yaml
+jobs:
+  - pmc: [TCC_HIT_sum, TCC_MISS_sum, TCC_REQ_sum]
+    kernel_include_regex: pa_decode_ps_kernel_0
+    output_file: pmc_l2
+    output_directory: /tmp/pmc_out
+    output_format: [csv]
+```
+
+```yaml
+# /tmp/pmc_ea.yaml  (HBM-facing read requests + 32B-partial fraction)
+jobs:
+  - pmc: [TCC_EA0_RDREQ_sum, TCC_EA0_RDREQ_32B_sum, TCC_EA0_RDREQ_DRAM_sum, TCP_TCC_READ_REQ_sum]
+    kernel_include_regex: pa_decode_ps_kernel_0
+    output_file: pmc_ea
+    output_directory: /tmp/pmc_ea_out
+    output_format: [csv]
+```
+
+Run each (cache disabled is NOT needed — PMC doesn't use source mapping, so
+leave `FLYDSL_RUNTIME_ENABLE_CACHE=1` for speed):
+
+```bash
+HIP_VISIBLE_DEVICES=<gpu> FLYDSL_RUNTIME_ENABLE_CACHE=1 PYTHONPATH=./ \
+  rocprofv3 -i /tmp/pmc_l2.yaml -- python <test_script> --perf
+HIP_VISIBLE_DEVICES=<gpu> FLYDSL_RUNTIME_ENABLE_CACHE=1 PYTHONPATH=./ \
+  rocprofv3 -i /tmp/pmc_ea.yaml -- python <test_script> --perf
+```
+
+**CRITICAL — keep each job to a single hardware pass (≤ ~4 TCC counters).**
+Packing many counters into one job forces multi-pass collection, which on
+gfx942 has been observed to trigger a **GPU Hang (HW Exception)**. Split into
+multiple single-pass jobs (as above) instead of one big counter list.
+
+Discover available counters with:
+```bash
+rocprofv3 --list-avail 2>/dev/null | grep -iE "TCC_HIT|TCC_MISS|TCC_EA0_RDREQ|TCP_TCC_READ"
+```
+
+Output lands in `<output_directory>/pass_1/<output_file>_counter_collection.csv`.
+Analyze with `kernel-trace-analysis/scripts/pmc_l2_analyzer.py` (see that skill).
+
+Quick interpretation:
+- **L2 hit rate** = `TCC_HIT/(TCC_HIT+TCC_MISS)`. For independent per-sequence
+  paged-KV decode, ~1-3% is **expected** (streaming, no reuse) — not a bug.
+- **32B fraction** = `TCC_EA0_RDREQ_32B/TCC_EA0_RDREQ`. ~0% = full 64B lines,
+  no spatial-locality waste.
+
+---
+
 ## Output
 
 After capture, report:
@@ -240,3 +300,5 @@ Run /kernel-trace-analysis to analyze bottlenecks.
 | Trace truncated (missing instructions) | Increase `att_buffer_size` to `0xC000000` (192MB) |
 | SSH timeout | Increase timeout, check host connectivity |
 | `kernel_iteration_range` mismatch | Test runs fewer iterations than expected -- use `"[0, [1-2]]"` |
+| GPU Hang / HW Exception during PMC capture | Counter list forced multi-pass — split into single-pass jobs of ≤ ~4 TCC counters |
+| PMC CSV empty / wrong kernel row | Match `Kernel_Name` substring; the first row may be a torch/elementwise kernel |

--- a/.claude/skills/kernel-trace-analysis/SKILL.md
+++ b/.claude/skills/kernel-trace-analysis/SKILL.md
@@ -260,17 +260,43 @@ to the outermost scope line. Ignore this line; focus on lines with explicit user
 ### Register pressure check (architecture-aware)
 
 `hotspot_analyzer.py` auto-detects the GPU architecture from ISA instruction patterns
-and prints occupancy using the correct formula. The key difference:
+and computes occupancy (waves/SIMD) as the **minimum across every resource limiter**:
+
+```
+occupancy = min(vgpr_limit, lds_limit, sgpr_limit, hw_max=8)
+  vgpr_limit = 512 // (arch_vgpr_alloc + accum_vgpr_alloc)              # per SIMD
+  lds_limit  = (LDS_total // lds_per_wg) * waves_per_wg // 4_SIMDs      # per SIMD
+  sgpr_limit = 800 // sgpr_alloc                                        # per SIMD
+```
+
+**VGPR is a combined 512-entry pool on BOTH gfx942 and gfx950.** CDNA2 (gfx90a)
+unified the arch (256) and accum (256) VGPR files into one 512 budget per SIMD,
+and gfx942/gfx950 inherit that. Occupancy from VGPR is `512 / (arch + accum)` on
+both — NOT `256 / max(arch, accum)`. (The separate-pool `256/max` model only
+applied to gfx908 / CDNA1, where accum VGPRs were a distinct file accessible
+only by MFMA.)
 
 | Property | CDNA3 (gfx942) | CDNA4 (gfx950) |
 |---|---|---|
-| VGPR pools | 256 arch + 256 accum, **separate** | 256 arch + 256 accum, **combined 512 pool, flexibly split** |
-| Occupancy formula | `256 / max(arch_alloc, accum_alloc)` | `512 / (arch_alloc + accum_alloc)` |
+| VGPR pool | 512 combined (256 arch + 256 accum, unified budget) | 512 combined (same) |
+| Occupancy formula (VGPR) | `512 / (arch_alloc + accum_alloc)` | `512 / (arch_alloc + accum_alloc)` |
 | Alloc granularity | 8 VGPRs | 8 VGPRs |
 | LDS size | 64 KB | 160 KB |
 | LDS alloc block | 256 bytes | 1280 bytes |
 | VMCNT width | 6 bits (max 63 in-flight) | 6 bits (max 63 in-flight) |
 | LGKMCNT width | 4 bits (max 15 in-flight) | 4 bits (max 15 in-flight) |
+
+What actually changed in CDNA4 vs CDNA3 is the LDS size (64KB→160KB) and the LDS
+alloc granularity — not the VGPR pooling model.
+
+**Reading the real counts.** `code.json` only holds the (often single-CU,
+often vgpr-form) disassembly, so it cannot reveal accum_vgpr / LDS / SGPR /
+workgroup size — an AGPR-form-blind ISA scan reports `accum=0` and gets
+occupancy badly wrong. The analyzer reads `out_kernel_trace.csv` (staged next to
+the dispatch dir) for the authoritative `Accum_VGPR_Count` / `LDS_Block_Size` /
+`SGPR_Count` / `Workgroup_Size_*`. arch_vgpr is taken as `max(ISA_scan, CSV)` so
+a bogus-low CSV `VGPR_Count` field can't under-report. If no CSV is found it
+falls back to ISA-only and prints a warning.
 
 **Auto-detection**: gfx950-specific instructions (`v_mfma_scale_f32_*`, `v_mfma_f32_16x16x128_*`,
 `v_mfma_f32_32x32x64_*`) indicate CDNA4. Absence indicates CDNA3.
@@ -282,6 +308,10 @@ FROM rocpd_kernel_dispatch kd
 JOIN rocpd_info_kernel_symbol ks ON kd.kernel_symbol_id=ks.id
 JOIN rocpd_info_kernel ki ON kd.kernel_id=ki.id LIMIT 5;"
 ```
+
+Worked example (PA decode, gfx942): arch 144 + accum 136 = 280 combined → `512//280 = 1`
+wave/SIMD, VGPR-bound (LDS allows 5, SGPR allows 7). Reaching 2 waves needs
+combined ≤ 256, e.g. freeing ~24 VGPRs.
 
 **Warning**: `maxnreg` forcing `accum_vgpr=0` doubles occupancy but causes MFMA spills through
 arch_vgpr — measured 4.5x GPU slowdown. Do not use `maxnreg` for MFMA-heavy kernels.

--- a/.claude/skills/kernel-trace-analysis/SKILL.md
+++ b/.claude/skills/kernel-trace-analysis/SKILL.md
@@ -26,10 +26,15 @@ an optimization plan.
 
 ---
 
-## Hotspot Analyzer Script
+## Analyzer Scripts
 
-The hotspot analyzer is located at `scripts/hotspot_analyzer.py`.
-It reads a `ui_output_agent_*_dispatch_*` directory and reports top-K stall hotspots.
+- `scripts/hotspot_analyzer.py` — reads a `ui_output_agent_*_dispatch_*` ATT
+  directory; reports top-K stall hotspots, stall-type breakdown, and occupancy
+  (combined-VGPR-pool model, reads accum/LDS/SGPR from `out_kernel_trace.csv`).
+- `scripts/pmc_l2_analyzer.py` — reads rocprofv3 PMC counter CSV(s); reports
+  L2 hit rate, HBM 32B-partial fraction, and over-fetch ratio. Use when a
+  kernel is memory-bound and you need to know *why* (ATT has no cache counters).
+  See "L2 / HBM efficiency analysis" under Step 5.
 
 ---
 
@@ -316,6 +321,56 @@ combined ≤ 256, e.g. freeing ~24 VGPRs.
 **Warning**: `maxnreg` forcing `accum_vgpr=0` doubles occupancy but causes MFMA spills through
 arch_vgpr — measured 4.5x GPU slowdown. Do not use `maxnreg` for MFMA-heavy kernels.
 
+### L2 / HBM efficiency analysis (PMC, not ATT)
+
+When the ATT hotspots are dominated by `VMEM-load` at high stall rate (e.g.
+40-50% of stall, ~94% per-load), the kernel is memory-bound and the next
+question is **why** — and ATT cannot answer it (it has no cache counters).
+Capture PMC counters (see capture-kernel-trace "PMC Mode") and analyze with
+`scripts/pmc_l2_analyzer.py`:
+
+```bash
+python scripts/pmc_l2_analyzer.py \
+    /tmp/pmc_out/pass_1/pmc_l2_counter_collection.csv \
+    /tmp/pmc_ea_out/pass_1/pmc_ea_counter_collection.csv \
+    --kernel <kernel> --ideal-gb <bytes_per_dispatch_GB> --ea-channels 2
+```
+
+Three metrics, three decisions:
+
+| Metric | Formula | What it tells you |
+|---|---|---|
+| **L2 hit rate** | `TCC_HIT/(TCC_HIT+TCC_MISS)` | Is there temporal reuse to exploit? |
+| **32B fraction** | `TCC_EA0_RDREQ_32B/TCC_EA0_RDREQ` | Spatial locality / cache-line waste |
+| **over-fetch** | `est_HBM_bytes / (ideal_GB × dispatches)` | Redundant fetching |
+
+**Decision tree** for a memory-bound decode kernel:
+
+1. **L2 hit rate < 5%** → pure streaming, no reuse. This is **expected and
+   correct** for decode with independent per-sequence paged KV — each KV byte
+   is read once; the GQA (×heads) and MTP (×seq) reuse is captured in
+   registers/LDS, never re-reads L2. *"Improving L2 hit rate" is a non-goal.*
+   The only thing that raises it is real KV reuse = **shared-prefix serving**
+   (a workload/scheduling property, not a kernel change).
+2. **32B fraction ≈ 0%** → full 64B cache lines, no spatial-locality waste.
+   Nothing to fix at the line level. (High 32B% would point to scattered/
+   misaligned access worth restructuring.)
+3. **over-fetch ≈ 1.0x** → the kernel reads exactly the data it needs. The
+   achieved bandwidth (compute as `ideal_bytes / kernel_time`) is then the
+   real ceiling for this access pattern. **50-60% of theoretical HBM peak is
+   normal** even for clean streaming; paged-gather decode living at ~54% with
+   0% partial + ~1.0x over-fetch is healthy, not a defect.
+
+**Worked example (PA decode, gfx942, bs=16, ctx=131072, batch=256):**
+L2 hit 1.7%, 32B 0%, over-fetch 1.04x, 2.85 TB/s = 54% peak. Conclusion: the
+memory subsystem is clean; there is **no KV-load optimization left** — verified
+by also testing block_size 16→64 (regressed +7.8%) and confirming dwordx8
+doesn't exist on CDNA3 (dwordx4 / 16B is the max single vector load).
+
+**Counter-capture caveat**: keep each PMC job to ≤ ~4 TCC counters (single
+hardware pass). Multi-pass collection has triggered a GPU Hang on gfx942 — see
+capture-kernel-trace.
+
 ### MFMA latency reference (cycles = pipeline depth)
 
 | Instruction | Variant | Cycles | Notes |
@@ -398,3 +453,5 @@ See /prefetch-data-load skill.
 | Source loc all `""` | Set `FLYDSL_DEBUG_ENABLE_DEBUG_INFO=1`; check `-g` flag in compile pipeline |
 | Top hotspot is kernel decorator line | Debug info artifact — skip it, focus on op lines |
 | `--att` flag error | `--att` is boolean, no value; use `-i input.yaml` for full config |
+| GPU Hang / HW Exception during PMC | Too many counters → multi-pass. Split into single-pass jobs of ≤ ~4 TCC counters |
+| PMC `accum_vgpr=0` but kernel uses MFMA | vgpr-form MFMA: accumulators are in the arch VGPR file; read total from `VGPR_Count + Accum_VGPR_Count` |

--- a/.claude/skills/kernel-trace-analysis/scripts/hotspot_analyzer.py
+++ b/.claude/skills/kernel-trace-analysis/scripts/hotspot_analyzer.py
@@ -8,6 +8,8 @@ Usage:
 """
 
 import argparse
+import csv
+import glob
 import json
 import os
 import re
@@ -236,17 +238,86 @@ def print_source_detail(hotspot, source_cache, context=3):
         print(f"      stall={fmt_cycles(inst.stall_cycles):>7}  type={inst.stall_type:<12}  {inst.asm}")
 
 
-def detect_arch_and_reg_pressure(instructions):
-    """Detect GPU architecture from ISA and estimate VGPR usage + occupancy.
+def read_kernel_metadata(dispatch_dir):
+    """Read authoritative resource counts from ``out_kernel_trace.csv`` if present.
 
-    Architecture differences (from CDNA4 ISA Reference Guide):
-      - CDNA3 (gfx942): 256 arch_vgpr + 256 accum_vgpr, two SEPARATE pools.
-        Occupancy = 256 / max(arch_vgpr_alloc, accum_vgpr_alloc).
-      - CDNA4 (gfx950): 256 arch_vgpr (V0-V255) + 256 accum_vgpr (AV0-AV255),
-        one COMBINED pool of 512, flexibly split between the two types.
-        Occupancy = 512 / (arch_vgpr_alloc + accum_vgpr_alloc).
-    VGPRs are allocated in groups of 8 on both architectures.
+    The ATT ``code.json`` only contains the (possibly single-CU, possibly
+    vgpr-form) disassembly, so it cannot reveal accum_vgpr / SGPR / LDS /
+    workgroup size.  The kernel-trace CSV carries the real launch metadata.
+    Searches the dispatch dir and its parent (staging often copies the CSV
+    next to the ui_output_agent_* dir).  Returns {} if not found.
     """
+    candidates = []
+    for base in (dispatch_dir, os.path.dirname(os.path.abspath(dispatch_dir))):
+        candidates += glob.glob(os.path.join(base, "*kernel_trace*.csv"))
+    for path in candidates:
+        try:
+            with open(path) as f:
+                rows = list(csv.DictReader(f))
+        except OSError:
+            continue
+        if not rows or "Accum_VGPR_Count" not in rows[0]:
+            continue
+        # Pick the row whose kernel matches the dispatch dir name.  The dir is
+        # usually staged as "<timestamp>_<short_kernel_name>" while the CSV
+        # Kernel_Name has a trailing index (e.g. dir ".._pa_decode_ps_kernel"
+        # vs kernel "pa_decode_ps_kernel_0"), so match bidirectionally on the
+        # timestamp-stripped short name.
+        dir_name = os.path.basename(os.path.abspath(dispatch_dir))
+        short = re.sub(r"^\d{8}_\d{6}_", "", dir_name)  # strip YYYYMMDD_HHMMSS_
+
+        def _matches(kn):
+            if not kn:
+                return False
+            return kn in dir_name or short in kn or kn.startswith(short) or short.startswith(kn)
+
+        chosen = None
+        for r in rows:
+            if _matches(r.get("Kernel_Name", "")):
+                chosen = r
+                break
+        if chosen is None:
+            return {}  # no matching kernel row — better to fall back to ISA-only
+
+        def _int(key):
+            try:
+                return int(chosen.get(key, "") or 0)
+            except (ValueError, TypeError):
+                return 0
+
+        return {
+            "csv_path": path,
+            "csv_vgpr": _int("VGPR_Count"),
+            "csv_accum_vgpr": _int("Accum_VGPR_Count"),
+            "csv_sgpr": _int("SGPR_Count"),
+            "csv_lds": _int("LDS_Block_Size"),
+            "csv_wg": _int("Workgroup_Size_X") * max(1, _int("Workgroup_Size_Y")) * max(1, _int("Workgroup_Size_Z")),
+        }
+    return {}
+
+
+def detect_arch_and_reg_pressure(instructions, meta=None):
+    """Detect GPU architecture from ISA and estimate occupancy.
+
+    VGPR model (CDNA2/CDNA3/CDNA4 unified register file): arch_vgpr (256) and
+    accum_vgpr (256) share ONE combined 512-entry budget per SIMD.  Occupancy
+    from VGPR is ``512 // (arch_vgpr_alloc + accum_vgpr_alloc)``.  This is the
+    same form on gfx942 and gfx950 — gfx942 is NOT a separate-pool
+    ``256 / max(...)`` machine (that was gfx908/CDNA1).
+
+    Occupancy (waves/SIMD) is the min across every resource limiter:
+        occ = min(vgpr_limit, lds_limit, sgpr_limit, hw_max=8)
+    where
+        vgpr_limit = 512 // (arch_alloc + accum_alloc)                    [per SIMD]
+        lds_limit  = (LDS_total // lds_per_wg) * waves_per_wg // 4_SIMDs   [per SIMD]
+        sgpr_limit = (sgpr_total // sgpr_per_wave)                        [per SIMD]
+
+    ``meta`` (from read_kernel_metadata) supplies accum_vgpr / LDS / SGPR /
+    workgroup size, which the ISA scan alone cannot.  ISA-scanned arch_vgpr is
+    combined via max() with the CSV value so a bogus/low CSV field can't
+    under-report.
+    """
+    meta = meta or {}
     asms = [inst.asm for inst in instructions]
 
     # Detect architecture from gfx950-specific instructions
@@ -266,27 +337,81 @@ def detect_arch_and_reg_pressure(instructions):
         for m in re.finditer(r"\ba\[(\d+)", a):
             max_agpr = max(max_agpr, int(m.group(1)))
 
-    arch_vgpr_count = max_vgpr + 1
-    accum_vgpr_count = max_agpr + 1 if max_agpr > 0 else 0
+    # Total VGPR budget consumed (what occupancy divides into 512).
+    #
+    # IMPORTANT: the CSV's VGPR_Count and Accum_VGPR_Count are sub-counts of
+    # the SAME .amdhsa_next_free_vgpr total — they SUM to the real allocation,
+    # they are not two independent pools to add a third time.  For vgpr-form
+    # MFMA (no a-registers in the disassembly) the "accum" portion lives in
+    # the arch VGPR file and the ISA v-register scan already includes it.
+    #
+    #   combined = CSV.VGPR_Count + CSV.Accum_VGPR_Count   (preferred)
+    #   fallback (no CSV): ISA arch scan, plus a separate AGPR scan ONLY if
+    #                      a-registers were actually referenced (true agpr-form).
+    isa_arch = max_vgpr + 1
+    isa_accum = max_agpr + 1 if max_agpr > 0 else 0
+    csv_vgpr = meta.get("csv_vgpr", 0)
+    csv_accum = meta.get("csv_accum_vgpr", 0)
 
-    # Round up to allocation granularity of 8
+    # vgpr-form MFMA writes the accumulator into the arch VGPR file (the
+    # disassembly references v-registers, no a-registers).  agpr-form uses a
+    # real separate AGPR file (a-registers present).
+    is_vgpr_form = max_agpr == 0
+
+    if csv_vgpr or csv_accum:
+        combined_count = csv_vgpr + csv_accum  # sub-counts sum to the total
+        if is_vgpr_form:
+            # No physical AGPR; the whole total lives in the arch file.
+            arch_vgpr_count = combined_count
+            accum_vgpr_count = 0
+        else:
+            arch_vgpr_count = csv_vgpr
+            accum_vgpr_count = csv_accum
+    else:
+        arch_vgpr_count = isa_arch
+        accum_vgpr_count = isa_accum
+        combined_count = isa_arch + isa_accum  # isa_accum=0 unless real a-regs seen
+
+    # Round the TOTAL up to allocation granularity of 8 (granularity applies to
+    # next_free_vgpr, not to each sub-count separately).
     arch_vgpr_alloc = ((arch_vgpr_count + 7) // 8) * 8
     accum_vgpr_alloc = ((accum_vgpr_count + 7) // 8) * 8 if accum_vgpr_count > 0 else 0
+    combined_alloc = ((combined_count + 7) // 8) * 8
 
-    # Occupancy calculation (architecture-dependent)
     max_occupancy = 8
-    if is_gfx950:
-        # CDNA4: combined pool of 512, flexibly split
-        total_vgpr_alloc = arch_vgpr_alloc + accum_vgpr_alloc
-        occupancy = min(512 // total_vgpr_alloc, max_occupancy) if total_vgpr_alloc > 0 else max_occupancy
-        next_occ = occupancy + 1
-        target_total = 512 // next_occ if next_occ <= max_occupancy else None
+    vgpr_total = 512  # combined arch+accum budget per SIMD (CDNA2/3/4)
+    vgpr_limit = min(vgpr_total // combined_alloc, max_occupancy) if combined_alloc > 0 else max_occupancy
+
+    # LDS limiter (waves/SIMD).  LDS is a per-CU resource shared by all
+    # workgroups; convert workgroups/CU to waves/SIMD via waves_per_wg / 4 SIMDs.
+    lds_total = 163840 if is_gfx950 else 65536  # 160KB CDNA4, 64KB CDNA3
+    lds_per_wg = meta.get("csv_lds", 0)
+    wg_size = meta.get("csv_wg", 0)
+    waves_per_wg = max(1, (wg_size + 63) // 64) if wg_size else 0
+    if lds_per_wg > 0 and waves_per_wg > 0:
+        wg_per_cu_lds = lds_total // lds_per_wg
+        lds_limit = max(1, (wg_per_cu_lds * waves_per_wg) // 4)
+        lds_limit = min(lds_limit, max_occupancy)
     else:
-        # CDNA3: two separate pools of 256
-        limiting = max(arch_vgpr_alloc, accum_vgpr_alloc)
-        occupancy = min(256 // limiting, max_occupancy) if limiting > 0 else max_occupancy
-        next_occ = occupancy + 1
-        target_total = 256 // next_occ if next_occ <= max_occupancy else None
+        lds_limit = max_occupancy
+
+    # SGPR limiter (waves/SIMD).  gfx9/CDNA: 800 SGPRs per SIMD, alloc gran 16.
+    sgpr_count = meta.get("csv_sgpr", 0)
+    if sgpr_count > 0:
+        sgpr_alloc = ((sgpr_count + 15) // 16) * 16
+        sgpr_limit = min(800 // sgpr_alloc, max_occupancy)
+    else:
+        sgpr_limit = max_occupancy
+
+    occupancy = min(vgpr_limit, lds_limit, sgpr_limit)
+
+    # Which resource binds?
+    limiters = {"VGPR": vgpr_limit, "LDS": lds_limit, "SGPR": sgpr_limit}
+    bound_by = min(limiters, key=limiters.get)
+
+    # Target combined VGPR for next occupancy level (only meaningful if VGPR-bound)
+    next_occ = occupancy + 1
+    target_total = (vgpr_total // next_occ) if next_occ <= max_occupancy else None
 
     # Instruction mix counts
     mfma_count = sum(1 for a in asms if "v_mfma_" in a)
@@ -302,9 +427,20 @@ def detect_arch_and_reg_pressure(instructions):
         "arch_vgpr_alloc": arch_vgpr_alloc,
         "accum_vgpr": accum_vgpr_count,
         "accum_vgpr_alloc": accum_vgpr_alloc,
+        "combined_vgpr_alloc": combined_alloc,
+        "is_vgpr_form": is_vgpr_form,
+        "vgpr_limit": vgpr_limit,
+        "lds_per_wg": lds_per_wg,
+        "lds_total": lds_total,
+        "lds_limit": lds_limit,
+        "sgpr": sgpr_count,
+        "sgpr_limit": sgpr_limit,
+        "waves_per_wg": waves_per_wg,
         "occupancy": occupancy,
+        "bound_by": bound_by,
         "target_for_next_occ": target_total,
         "next_occ": next_occ if next_occ <= max_occupancy else None,
+        "has_meta": bool(meta),
         "mfma_count": mfma_count,
         "buffer_load": buf_load,
         "buffer_store": buf_store,
@@ -316,25 +452,28 @@ def detect_arch_and_reg_pressure(instructions):
 def print_reg_pressure(reg_info):
     print_header("Register Pressure & Occupancy")
     print(f"  Architecture:   {reg_info['arch']}")
-    print(f"  arch_vgpr:      ~{reg_info['arch_vgpr']} (alloc {reg_info['arch_vgpr_alloc']})")
-    if reg_info["accum_vgpr"] > 0:
-        print(f"  accum_vgpr:     ~{reg_info['accum_vgpr']} (alloc {reg_info['accum_vgpr_alloc']})")
+    if not reg_info["has_meta"]:
+        print("  (no kernel_trace CSV found — accum/LDS/SGPR estimated from ISA only)")
+    if reg_info["is_vgpr_form"]:
+        print(f"  arch_vgpr:      {reg_info['arch_vgpr']}  (MFMA vgpr-form: accumulators in arch file, no AGPR)")
     else:
-        print("  accum_vgpr:     0 (not used)")
+        print(f"  arch_vgpr:      {reg_info['arch_vgpr']}")
+        print(f"  accum_vgpr:     {reg_info['accum_vgpr']}  (AGPR file)")
+    print(f"  total VGPR:     {reg_info['combined_vgpr_alloc']} / 512  -> {reg_info['vgpr_limit']} waves/SIMD")
+    if reg_info["lds_per_wg"] > 0:
+        print(
+            f"  LDS:            {reg_info['lds_per_wg']} B/wg  ({reg_info['waves_per_wg']} waves/wg)"
+            f"  -> {reg_info['lds_limit']} waves/SIMD"
+        )
+    if reg_info["sgpr"] > 0:
+        print(f"  SGPR:           {reg_info['sgpr']}  -> {reg_info['sgpr_limit']} waves/SIMD")
 
-    if reg_info["is_gfx950"]:
-        total = reg_info["arch_vgpr_alloc"] + reg_info["accum_vgpr_alloc"]
-        print(f"  total_vgpr:     {total} / 512 (combined pool)")
-    else:
-        lim = max(reg_info["arch_vgpr_alloc"], reg_info["accum_vgpr_alloc"])
-        print(f"  limiting pool:  {lim} / 256")
-
-    print(f"  occupancy:      {reg_info['occupancy']} waves/SIMD")
-    if reg_info["next_occ"] is not None:
-        if reg_info["is_gfx950"]:
-            print(f"  -> {reg_info['next_occ']} waves requires total_vgpr <= {reg_info['target_for_next_occ']}")
-        else:
-            print(f"  -> {reg_info['next_occ']} waves requires max(arch,accum) <= {reg_info['target_for_next_occ']}")
+    print(f"\n  occupancy:      {reg_info['occupancy']} waves/SIMD  (bound by {reg_info['bound_by']})")
+    if reg_info["next_occ"] is not None and reg_info["bound_by"] == "VGPR":
+        print(
+            f"  -> {reg_info['next_occ']} waves requires combined VGPR (arch+accum) "
+            f"<= {reg_info['target_for_next_occ']}"
+        )
 
     print("\n  Instruction mix:")
     print(
@@ -372,7 +511,8 @@ def main():
     print(f"  Total cycles:  {fmt_cycles(total_cycles)}")
     print(f"  Total stalls:  {fmt_cycles(total_stall)}  ({100*total_stall/total_cycles:.1f}% of total cycles)")
 
-    reg_info = detect_arch_and_reg_pressure(instructions)
+    meta = read_kernel_metadata(args.dispatch_dir)
+    reg_info = detect_arch_and_reg_pressure(instructions, meta)
     print_reg_pressure(reg_info)
 
     print_stall_type_summary(instructions, total_stall)

--- a/.claude/skills/kernel-trace-analysis/scripts/hotspot_analyzer.py
+++ b/.claude/skills/kernel-trace-analysis/scripts/hotspot_analyzer.py
@@ -277,7 +277,7 @@ def read_kernel_metadata(dispatch_dir):
                 chosen = r
                 break
         if chosen is None:
-            return {}  # no matching kernel row — better to fall back to ISA-only
+            continue  # no matching row in this CSV — try the next candidate
 
         def _int(key):
             try:
@@ -359,14 +359,18 @@ def detect_arch_and_reg_pressure(instructions, meta=None):
     is_vgpr_form = max_agpr == 0
 
     if csv_vgpr or csv_accum:
-        combined_count = csv_vgpr + csv_accum  # sub-counts sum to the total
         if is_vgpr_form:
-            # No physical AGPR; the whole total lives in the arch file.
-            arch_vgpr_count = combined_count
+            # No physical AGPR; the whole total lives in the arch file.  Guard
+            # against a bogus-low CSV total with the ISA v-register scan.
+            arch_vgpr_count = max(isa_arch, csv_vgpr + csv_accum)
             accum_vgpr_count = 0
+            combined_count = arch_vgpr_count
         else:
-            arch_vgpr_count = csv_vgpr
-            accum_vgpr_count = csv_accum
+            # agpr-form: arch and accum live in separate files; guard each
+            # sub-count with its ISA scan so a low CSV field can't under-report.
+            arch_vgpr_count = max(isa_arch, csv_vgpr)
+            accum_vgpr_count = max(isa_accum, csv_accum)
+            combined_count = arch_vgpr_count + accum_vgpr_count
     else:
         arch_vgpr_count = isa_arch
         accum_vgpr_count = isa_accum

--- a/.claude/skills/kernel-trace-analysis/scripts/pmc_l2_analyzer.py
+++ b/.claude/skills/kernel-trace-analysis/scripts/pmc_l2_analyzer.py
@@ -1,0 +1,115 @@
+"""
+PMC L2 / HBM efficiency analyzer.
+
+Parses rocprofv3 PMC counter-collection CSV(s) and reports L2 cache behaviour
+and HBM read efficiency for a kernel.  Complements hotspot_analyzer.py, which
+reads ATT instruction timing (no cache counters).
+
+Counters expected (collect via capture-kernel-trace "PMC mode"):
+    L2 hit rate:        TCC_HIT_sum, TCC_MISS_sum, TCC_REQ_sum
+    line utilization:   TCC_EA0_RDREQ_sum, TCC_EA0_RDREQ_32B_sum
+    HBM traffic:        TCC_EA0_RDREQ_DRAM_sum
+    L1->L2:             TCP_TCC_READ_REQ_sum
+
+Usage:
+    python pmc_l2_analyzer.py <pmc_csv> [<pmc_csv> ...] \
+        [--kernel pa_decode_ps_kernel_0] [--ideal-gb 8.59] [--ea-channels 2]
+
+Interpretation:
+    L2 hit rate    : HIT/(HIT+MISS).  For decode with independent per-sequence
+                     paged KV there is no inter-CTA reuse, so ~1-3% is EXPECTED
+                     and correct (streaming).  A high value only appears when
+                     the workload has real reuse (e.g. shared-prefix serving).
+    32B fraction   : TCC_EA0_RDREQ_32B / TCC_EA0_RDREQ.  Fraction of HBM reads
+                     that are partial 32B lines.  High % => scattered access /
+                     poor spatial locality => wasted bandwidth.  ~0% => full
+                     64B lines, no line-level waste.
+    over-fetch     : measured HBM read bytes / ideal bytes.  ~1.0 => the kernel
+                     reads exactly what it needs; >>1.0 => redundant fetches.
+"""
+
+import argparse
+import csv
+from collections import defaultdict
+
+
+def load_counters(paths, kernel):
+    agg = defaultdict(float)
+    dispatches = set()
+    for p in paths:
+        with open(p) as f:
+            for r in csv.DictReader(f):
+                kn = r.get("Kernel_Name", "")
+                if kernel and kernel not in kn:
+                    continue
+                name = r.get("Counter_Name")
+                val = r.get("Counter_Value")
+                if name is None or val in (None, ""):
+                    continue
+                agg[name] += float(val)
+                dispatches.add(r.get("Dispatch_Id"))
+    return agg, len(dispatches)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="PMC L2/HBM efficiency analyzer")
+    ap.add_argument("csv", nargs="+", help="pmc *_counter_collection.csv file(s)")
+    ap.add_argument("--kernel", default="", help="substring filter on Kernel_Name")
+    ap.add_argument("--ideal-gb", type=float, default=0.0,
+                    help="ideal HBM read bytes per dispatch in GB (for over-fetch ratio)")
+    ap.add_argument("--ea-channels", type=int, default=2,
+                    help="EA interfaces to scale single-channel EA0 counters by (default 2)")
+    args = ap.parse_args()
+
+    agg, ndisp = load_counters(args.csv, args.kernel)
+    if not agg:
+        print("No matching counter rows found.")
+        return 1
+
+    print(f"  Dispatches matched: {ndisp}")
+    hit = agg.get("TCC_HIT_sum", 0)
+    miss = agg.get("TCC_MISS_sum", 0)
+    req = agg.get("TCC_REQ_sum", 0)
+    ea = agg.get("TCC_EA0_RDREQ_sum", 0)
+    ea32 = agg.get("TCC_EA0_RDREQ_32B_sum", 0)
+    dram = agg.get("TCC_EA0_RDREQ_DRAM_sum", 0)
+    tcp = agg.get("TCP_TCC_READ_REQ_sum", 0)
+
+    print("\n  L2 cache")
+    print("  --------")
+    if hit + miss > 0:
+        print(f"  TCC_HIT_sum  = {hit:,.0f}")
+        print(f"  TCC_MISS_sum = {miss:,.0f}")
+        print(f"  L2 hit rate  = {100*hit/(hit+miss):.1f}%   (streaming decode: ~1-3% expected)")
+    if tcp:
+        print(f"  TCP->TCC read req (L1->L2) = {tcp:,.0f}")
+
+    if ea > 0:
+        ea64 = ea - ea32
+        bytes_ea = (ea64 * 64 + ea32 * 32) * args.ea_channels
+        print("\n  HBM read efficiency")
+        print("  -------------------")
+        print(f"  TCC_EA0_RDREQ (L2->HBM) = {ea:,.0f}")
+        print(f"  32B partial fraction    = {100*ea32/ea:.1f}%   (~0% = full 64B lines, no waste)")
+        print(f"  DRAM reads              = {dram:,.0f}")
+        print(f"  est HBM read bytes      = {bytes_ea/1e9:.1f} GB  (EA0 x{args.ea_channels} channels)")
+        if args.ideal_gb > 0 and ndisp:
+            ideal = args.ideal_gb * ndisp * 1e9
+            print(f"  ideal bytes             = {ideal/1e9:.1f} GB  ({args.ideal_gb} GB x {ndisp} disp)")
+            print(f"  over-fetch ratio        = {bytes_ea/ideal:.2f}x   (~1.0 = no redundant fetch)")
+
+    print("\n  Verdict")
+    print("  -------")
+    if hit + miss > 0:
+        hr = 100 * hit / (hit + miss)
+        if hr < 5:
+            print("  L2 hit rate is near-zero => pure streaming, no reuse to exploit.")
+            print("  Improving 'L2 hit rate' is a non-goal here; only real KV reuse")
+            print("  (shared-prefix serving) would change it. ")
+    if ea > 0 and ea32 / ea < 0.05:
+        print("  Line utilization is full (>=95% 64B) => no spatial-locality waste.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/lds-optimization/SKILL.md
+++ b/.claude/skills/lds-optimization/SKILL.md
@@ -39,7 +39,7 @@ Run `/kernel-trace-analysis` first. Apply this skill when the trace shows:
 - **Broadcast**: when 2+ threads access the **same address** in the same bank, hardware broadcasts (no conflict)
 - LDS throughput: **128 bytes/cycle** (peak, no conflicts)
 - LDS latency: **~20-40 cycles** (async, hidden if enough work between write and read)
-- **VGPR context**: LDS ops use **arch_vgpr** (not accum_vgpr). On CDNA3, arch_vgpr and accum_vgpr are separate 256-entry register files. LDS optimization does not interact with MFMA accumulator register pressure. See `/kernel-trace-analysis` Section 5.5 for VGPR architecture details.
+- **VGPR context**: LDS ops use **arch_vgpr** (for addresses/data), not accum_vgpr. But occupancy on CDNA3 is governed by the **combined** 512-entry budget `arch_vgpr + accum_vgpr` (the two physical files share one occupancy budget — see `/kernel-trace-analysis`). So LDS-addressing logic that grows arch_vgpr *can* still cost occupancy even though it never touches the MFMA accumulators. Keep LDS-address VGPR pressure low when the kernel is near a 2-wave boundary.
 
 ## LDS Architecture on CDNA4 (gfx950)
 
@@ -56,7 +56,7 @@ Run `/kernel-trace-analysis` first. Apply this skill when the trace shows:
 - **Wavefront dispatch**: reads across a 64-thread wavefront are dispatched over **4 cycles** in waterfall fashion
 - **32 concurrent LDS operations**: hardware can concurrently execute 32 read or write instructions (each 32-bit); extended instructions (read2/write2) can be 64-bit each
 - **32 integer atomic units** for unordered atomic operations
-- **VGPR context**: same as gfx942 — LDS ops use **arch_vgpr** (not accum_vgpr). On CDNA4, arch_vgpr and accum_vgpr are separate 256-entry register files.
+- **VGPR context**: same as gfx942 — LDS ops use **arch_vgpr** (for addresses/data), but occupancy is governed by the combined 512-entry budget `arch_vgpr + accum_vgpr`. LDS-addressing arch_vgpr competes with MFMA accumulators for that shared budget.
 
 ### Key Differences from gfx942
 

--- a/.claude/skills/prefetch-data-load/SKILL.md
+++ b/.claude/skills/prefetch-data-load/SKILL.md
@@ -263,20 +263,24 @@ Prefetch buffers consume **arch_vgpr only** (they hold global load results). MFM
 #   - Double-buffering = 2 x 32 = 64 arch_vgpr (but one set is reused)
 #   - Net additional arch_vgpr ~ 32 (the "next" buffer)
 #
-# On MI300X (gfx942): 256 arch_vgpr + 256 accum_vgpr per SIMD
-# Occupancy = 256 / max(arch_vgpr, accum_vgpr) waves per SIMD
+# On MI300X (gfx942): arch_vgpr + accum_vgpr share ONE combined 512 budget/SIMD
+# Occupancy = 512 / (arch_vgpr_alloc + accum_vgpr_alloc) waves per SIMD
+# (combined-pool model — NOT 256/max; that was gfx908/CDNA1 only)
 #
-# Example: arch=148, accum=148 -> occupancy bottleneck = 148 -> 1 wave
-# Adding 32 arch_vgpr -> arch=180, accum=148 -> bottleneck = 180 -> still 1 wave (safe)
-# Adding 120 arch_vgpr -> arch=268 -> SPILL (critical, exceeds 256 per SIMD)
+# Example: arch=148, accum=148 -> combined 296 -> 512//296 = 1 wave
+# Adding 32 arch_vgpr -> combined 328 -> still 1 wave (safe)
+# To reach 2 waves you need combined (arch+accum) <= 256
+# arch+accum > 512 -> SPILL (exceeds the combined per-SIMD budget)
 ```
 
-**Critical thresholds (gfx942, per register file):**
-| Register File | Count | Max Waves/SIMD | Impact |
-|--------------|-------|---------------|--------|
-| arch_vgpr <= 128 | or accum <= 128 | 2 | Good occupancy |
-| arch_vgpr <= 256 | or accum <= 256 | 1 | Minimum occupancy |
-| arch_vgpr > 256 | or accum > 256 | **SPILL** | Register overflow -> severe perf regression |
+**Critical thresholds (gfx942, combined arch+accum budget):**
+| Combined arch_vgpr + accum_vgpr | Max Waves/SIMD | Impact |
+|--------------|---------------|--------|
+| <= 128 | 4 | High occupancy |
+| <= 170 | 3 | Good occupancy |
+| <= 256 | 2 | Moderate occupancy |
+| <= 512 | 1 | Minimum occupancy |
+| > 512 | **SPILL** | Register overflow -> severe perf regression |
 
 **How to check current VGPR allocation** (from rocprofv3 database):
 ```sql

--- a/.claude/skills/prefetch-data-load/SKILL.md
+++ b/.claude/skills/prefetch-data-load/SKILL.md
@@ -250,11 +250,15 @@ instructions. Instead, prefetch restructures the code so the compiler places
 
 **Always check register headroom before adding prefetch buffers:**
 
-On CDNA3 (gfx942 MI300X/MI308), VGPRs are split into **two separate register files**:
-- **arch_vgpr** (256 per SIMD): used by VALU, VMEM loads, LDS ops, and prefetch buffers
-- **accum_vgpr / AGPR** (256 per SIMD): used exclusively by MFMA result writeback
+On CDNA3 (gfx942 MI300X/MI308), VGPRs are tracked as two **physical** files that
+share **one combined 512-entry occupancy budget** per SIMD:
+- **arch_vgpr** (up to 256 per SIMD): used by VALU, VMEM loads, LDS ops, and prefetch buffers
+- **accum_vgpr / AGPR** (up to 256 per SIMD): used by MFMA result writeback
 
-Prefetch buffers consume **arch_vgpr only** (they hold global load results). MFMA accumulators use **accum_vgpr only**. These do not compete.
+Prefetch buffers physically live in **arch_vgpr** and MFMA accumulators in
+**accum_vgpr**, but occupancy is governed by their **sum** (`arch_vgpr +
+accum_vgpr`), so growing prefetch buffers *does* compete with MFMA accumulators
+for the shared 512 budget and can cost occupancy.
 
 ```python
 # Estimate arch_vgpr cost of prefetch buffers:


### PR DESCRIPTION
## Motivation

The `kernel-trace-analysis` skill (and the related `lds-optimization` /
`prefetch-data-load` skills) carried an incorrect VGPR occupancy model for
CDNA3. They described gfx942 as having two **separate** 256-entry VGPR pools
with occupancy `256 / max(arch_vgpr, accum_vgpr)`. In reality gfx942 (like
gfx950) uses a single **combined** 512-entry VGPR budget per SIMD, so
occupancy is `512 / (arch_vgpr + accum_vgpr)`. The separate-pool `256/max`
model only applied to gfx908/CDNA1. This made the analyzer report occupancy
roughly 2x too optimistically on real MFMA kernels.

Additionally, `hotspot_analyzer.py` derived register/occupancy estimates from
the ATT `code.json` disassembly alone, which cannot reveal accum_vgpr / SGPR /
LDS / workgroup size — so it reported `accum=0` and got occupancy badly wrong
for AGPR-form kernels.

## Technical Details

- **Corrected VGPR model** across all three skill docs: gfx942 and gfx950 both
  use one combined 512-entry budget; occupancy from VGPR is
  `512 // (arch_alloc + accum_alloc)`. Clarified that what actually changed in
  CDNA4 vs CDNA3 is LDS size (64KB→160KB) and LDS alloc granularity, not the
  VGPR pooling model.
- **Authoritative resource counts** in `hotspot_analyzer.py`: new
  `read_kernel_metadata()` reads `out_kernel_trace.csv` (staged next to the
  dispatch dir) for the real `Accum_VGPR_Count` / `LDS_Block_Size` /
  `SGPR_Count` / `Workgroup_Size_*`, matching the correct kernel row. Falls
  back to ISA-only scanning with a warning when no CSV is found; arch_vgpr is
  taken as `max(ISA_scan, CSV)` so a low CSV field cannot under-report.
- **Multi-resource occupancy**: occupancy is now computed as the minimum across
  every limiter — `min(vgpr_limit, lds_limit, sgpr_limit, hw_max=8)` — and the
  output reports which resource binds.
- Correctly handles vgpr-form vs agpr-form MFMA (CSV `VGPR_Count` and
  `Accum_VGPR_Count` are sub-counts that sum to the real allocation, not two
  independent pools).
- Updated `lds-optimization` and `prefetch-data-load` notes so LDS-address and
  prefetch arch_vgpr pressure are correctly described as competing with MFMA
  accumulators for the shared 512 budget, including corrected worked examples
  and threshold tables.

## Test Plan

Ran `hotspot_analyzer.py` against a captured PA-decode (gfx942) dispatch dir
with an accompanying `out_kernel_trace.csv` and verified the reported
occupancy, bound-by resource, and per-limiter breakdown against the documented
worked example.

## Test Result

PA decode (gfx942): arch 144 + accum 136 = 280 combined → `512 // 280 = 1`
wave/SIMD, correctly reported as VGPR-bound (LDS allows 5, SGPR allows 7),
matching the worked example in the skill doc. ISA-only fallback path still runs
and prints the no-CSV warning.

Note: this PR only touches Claude skill docs and the analysis helper script; it
does not change any FlyDSL kernel, compiler, or runtime code.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
