### PR TITLE
[Feat] source_loc: finer ROCprof ATT source mapping for scheduling helpers (#587)

### DIFF
--- a/kernels/flash_attn_func.py
+++ b/kernels/flash_attn_func.py
@@ -73,6 +73,7 @@ def _pointer_store(value: ir.Value, ptr: ir.Value):
     return llvm.StoreOp(_llvm_value(value), _llvm_value(ptr))
 
 
+@fx.source_loc_scope
 def _waitcnt_vm_n(n):
     """Emit s_waitcnt vmcnt(n) only (lgkmcnt=63, expcnt=7)."""
     val = (n & _VMCNT_LO_MASK) | _LGKMCNT_EXPCNT_BASE | (((n >> 4) & _VMCNT_HI_MASK) << _VMCNT_HI_SHIFT)
@@ -294,6 +295,7 @@ def build_flash_attn_func_module_primary(
         def _fmax(a, b):
             return arith.MaxNumFOp(_raw(a), _raw(b), fastmath=fm_fast).result
 
+        @fx.source_loc_scope
         def mfma_acc(a, b, c):
             if const_expr(dtype_str == "bf16"):
                 if const_expr(USE_K16):
@@ -524,6 +526,7 @@ def build_flash_attn_func_module_primary(
             _dma_off = fx.Int32(0)
             _dma_aux = fx.Int32(1)
 
+            @fx.source_loc_scope
             def coop_dma_k(tile_start, buf_id=0):
                 """Load K tile via DMA with XOR-swizzled global fetch."""
                 if const_expr(isinstance(buf_id, int)):
@@ -570,6 +573,7 @@ def build_flash_attn_func_module_primary(
             LANES_PER_V_ROW = HEAD_DIM * 2 // DMA_BYTES
             ROWS_PER_DMA_BATCH_V = DMA_BATCH_BYTES // (HEAD_DIM * 2)
 
+            @fx.source_loc_scope
             def coop_dma_v(tile_start, buf_id=0):
                 """Load V tile via DMA with XOR-swizzled global fetch."""
                 v_lds_byte_base = lds_kv_base_idx + fx.Index((LDS_V_BASE + buf_id * LDS_V_TILE_SIZE) * 2)
@@ -1068,6 +1072,7 @@ def build_flash_attn_func_module_primary(
                 _steps = [(dc, pks) for dc in range(D_CHUNKS) for pks in range(PV_K_STEPS)]
                 TOTAL_PV = len(_steps)
 
+                @fx.source_loc_scope
                 def _read_v_pack(step_idx):
                     dc, pks = _steps[step_idx]
                     if const_expr(USE_HW_TR):

--- a/kernels/flash_attn_func.py
+++ b/kernels/flash_attn_func.py
@@ -283,15 +283,19 @@ def build_flash_attn_func_module_primary(
         def _mfma(mfma_fn, a, b, c):
             return mfma_fn(v16f32_type, [a, b, c])
 
+        @fx.source_loc_scope
         def _fadd(a, b):
             return arith.addf(_raw(a), _raw(b), fastmath=fm_fast)
 
+        @fx.source_loc_scope
         def _fsub(a, b):
             return arith.subf(_raw(a), _raw(b), fastmath=fm_fast)
 
+        @fx.source_loc_scope
         def _fmul(a, b):
             return arith.mulf(_raw(a), _raw(b), fastmath=fm_fast)
 
+        @fx.source_loc_scope
         def _fmax(a, b):
             return arith.MaxNumFOp(_raw(a), _raw(b), fastmath=fm_fast).result
 

--- a/kernels/flash_attn_func.py
+++ b/kernels/flash_attn_func.py
@@ -382,6 +382,7 @@ def build_flash_attn_func_module_primary(
             gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=elem_type)
             return _pointer_load(Vec.make_type(vec_elems, elem_dtype), gep)
 
+        @fx.source_loc_scope
         def _store_global_half(ptr, base_idx, val):
             gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=elem_type)
             _pointer_store(val, gep)

--- a/python/flydsl/expr/__init__.py
+++ b/python/flydsl/expr/__init__.py
@@ -7,6 +7,8 @@ from .primitive import *
 from .gpu import *
 from .derived import *
 from .struct import *
+from .meta import source_loc as source_loc
+from .meta import source_loc_scope as source_loc_scope
 
 from . import utils as utils
 from . import arith as arith

--- a/python/flydsl/expr/gpu.py
+++ b/python/flydsl/expr/gpu.py
@@ -20,7 +20,7 @@ from .._mlir import ir
 from .._mlir.dialects import gpu
 from .._mlir.dialects._fly_enum_gen import AddressSpace
 from ..compiler.protocol import dsl_align_of, dsl_size_of
-from .meta import _caller_location, _pinned_loc
+from .meta import traced_op
 from .numeric import Uint8
 from .primitive import get_dyn_shared, make_ptr
 from .struct import (
@@ -43,16 +43,15 @@ block_dim = Tuple3D(gpu.block_dim)
 grid_dim = Tuple3D(gpu.grid_dim)
 
 
-def barrier(*, loc=None, ip=None, **kwargs):
-    """``gpu.barrier`` that attributes to its call site for ROCprof ATT source mapping.
+@traced_op
+def barrier(*, address_spaces=None, loc=None, ip=None):
+    """``gpu.barrier`` wrapped so ROCprof ATT maps it to its call site.
 
-    Without this, a bare ``gpu.barrier()`` in a kernel body emits with no location and
-    inherits the coarse kernel-default location. ``_pinned_loc()`` lets a ``source_loc``
-    helper scope override it; otherwise the immediate caller line is used.
+    A bare ``gpu.barrier()`` in a kernel body emits with no location and inherits the
+    coarse kernel-default location. ``@traced_op`` resolves ``loc`` (explicit > enclosing
+    ``source_loc`` pin > caller line) and stamps the emitted op via the ambient location.
     """
-    if loc is None:
-        loc = _pinned_loc() or _caller_location(depth=1)
-    return gpu.barrier(loc=loc, ip=ip, **kwargs)
+    return gpu.barrier(address_spaces=address_spaces, loc=loc, ip=ip)
 
 
 _int = int

--- a/python/flydsl/expr/gpu.py
+++ b/python/flydsl/expr/gpu.py
@@ -20,6 +20,7 @@ from .._mlir import ir
 from .._mlir.dialects import gpu
 from .._mlir.dialects._fly_enum_gen import AddressSpace
 from ..compiler.protocol import dsl_align_of, dsl_size_of
+from .meta import _caller_location, _pinned_loc
 from .numeric import Uint8
 from .primitive import get_dyn_shared, make_ptr
 from .struct import (
@@ -41,7 +42,18 @@ block_idx = Tuple3D(gpu.block_id)
 block_dim = Tuple3D(gpu.block_dim)
 grid_dim = Tuple3D(gpu.grid_dim)
 
-barrier = gpu.barrier
+
+def barrier(*, loc=None, ip=None, **kwargs):
+    """``gpu.barrier`` that attributes to its call site for ROCprof ATT source mapping.
+
+    Without this, a bare ``gpu.barrier()`` in a kernel body emits with no location and
+    inherits the coarse kernel-default location. ``_pinned_loc()`` lets a ``source_loc``
+    helper scope override it; otherwise the immediate caller line is used.
+    """
+    if loc is None:
+        loc = _pinned_loc() or _caller_location(depth=1)
+    return gpu.barrier(loc=loc, ip=ip, **kwargs)
+
 
 _int = int
 

--- a/python/flydsl/expr/meta.py
+++ b/python/flydsl/expr/meta.py
@@ -70,25 +70,26 @@ class source_loc:
     ``with source_loc():`` captures the caller once and makes both untraced ODS builders
     (via MLIR's ambient location) and ``traced_op`` leaves (via the pin) resolve to it.
 
-    ``depth`` is the number of helper frames between this ``with`` statement and the user's
-    intended call site (1 when the helper is called directly from kernel code). It is
-    re-entrant: a nested ``source_loc`` is a no-op so the outermost scope wins.
+    Re-entrant: a nested ``source_loc`` is a no-op so the outermost scope wins.
     """
 
-    def __init__(self, depth=1):
+    def __init__(self):
         self._own = _pinned_loc() is None
-        self._loc = _caller_location(depth + 1) if self._own else None
+        # depth 2: hop past __init__ and the helper/wrapper frame to the user call site.
+        self._loc = _caller_location(2) if self._own else None
 
     def __enter__(self):
         if self._own:
-            _scope.cur = self._loc
             self._loc.__enter__()
+            _scope.cur = self._loc
         return self
 
     def __exit__(self, *exc):
         if self._own:
-            self._loc.__exit__(*exc)
-            _scope.cur = None
+            try:
+                self._loc.__exit__(*exc)
+            finally:
+                _scope.cur = None
         return False
 
 
@@ -97,8 +98,8 @@ def source_loc_scope(fn):
 
     Runs the whole helper body inside ``source_loc()`` so every op it emits attributes to
     the helper's call site, without reindenting the body. The ``wrapper`` frame occupies
-    the same stack slot the helper body otherwise would, so the default ``depth=1`` (the
-    helper is called directly from kernel code) is correct here too.
+    the same stack slot the helper body otherwise would, so the captured location resolves
+    to the helper's call site.
     """
 
     @wraps(fn)

--- a/python/flydsl/expr/meta.py
+++ b/python/flydsl/expr/meta.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 FlyDSL Project Contributors
 
 import inspect
+import threading
 from functools import wraps
 
 from .._mlir import ir
@@ -52,12 +53,68 @@ def _caller_location(depth=1):
     return ir.Location.name(label, childLoc=file_loc)
 
 
+_scope = threading.local()
+
+
+def _pinned_loc():
+    """Return the call-site Location pinned by an enclosing ``source_loc`` scope, or None."""
+    return getattr(_scope, "cur", None)
+
+
+class source_loc:
+    """Pin the user call-site location for every op emitted inside the ``with`` block.
+
+    A kernel helper that emits device ops is itself one (or more) Python frames above the
+    user's scheduling line, so ``traced_op``'s ``_caller_location(depth=1)`` would attribute
+    those ops to the helper body instead of the call site. Wrapping the helper body in
+    ``with source_loc():`` captures the caller once and makes both untraced ODS builders
+    (via MLIR's ambient location) and ``traced_op`` leaves (via the pin) resolve to it.
+
+    ``depth`` is the number of helper frames between this ``with`` statement and the user's
+    intended call site (1 when the helper is called directly from kernel code). It is
+    re-entrant: a nested ``source_loc`` is a no-op so the outermost scope wins.
+    """
+
+    def __init__(self, depth=1):
+        self._own = _pinned_loc() is None
+        self._loc = _caller_location(depth + 1) if self._own else None
+
+    def __enter__(self):
+        if self._own:
+            _scope.cur = self._loc
+            self._loc.__enter__()
+        return self
+
+    def __exit__(self, *exc):
+        if self._own:
+            self._loc.__exit__(*exc)
+            _scope.cur = None
+        return False
+
+
+def source_loc_scope(fn):
+    """Decorator form of :class:`source_loc` for a kernel helper.
+
+    Runs the whole helper body inside ``source_loc()`` so every op it emits attributes to
+    the helper's call site, without reindenting the body. The ``wrapper`` frame occupies
+    the same stack slot the helper body otherwise would, so the default ``depth=1`` (the
+    helper is called directly from kernel code) is correct here too.
+    """
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        with source_loc():
+            return fn(*args, **kwargs)
+
+    return wrapper
+
+
 def traced_op(op):
     @wraps(op)
     def wrapper(*args, **kwargs):
         loc = kwargs.pop("loc", None)
         if loc is None:
-            loc = _caller_location(depth=1)
+            loc = _pinned_loc() or _caller_location(depth=1)
         args, kwargs = _flatten_args(args, kwargs)
         with loc:
             return op(*args, **kwargs)

--- a/python/flydsl/expr/rocdl/__init__.py
+++ b/python/flydsl/expr/rocdl/__init__.py
@@ -15,7 +15,7 @@ This module provides access to ROCm-specific GPU operations including:
 """
 
 from ..._mlir.dialects.rocdl import *  # noqa: F401,F403
-from ..meta import traced_op
+from ..meta import _caller_location, _pinned_loc, traced_op
 from . import cdna4 as cdna4
 
 # Keep references to ODS-generated builders so we can wrap them without losing access.
@@ -31,6 +31,9 @@ _ods_cluster_load_async_to_lds_b64 = cluster_load_async_to_lds_b64
 _ods_cluster_load_async_to_lds_b128 = cluster_load_async_to_lds_b128
 _ods_s_wait_asynccnt = s_wait_asynccnt
 _ods_readfirstlane = readfirstlane
+_ods_s_waitcnt = s_waitcnt
+_ods_sched_barrier = sched_barrier
+_ods_sched_group_barrier = sched_group_barrier
 _ods_mfma_f32_32x32x8f16 = globals().get("mfma_f32_32x32x8f16", None)
 _ods_mfma_f32_32x32x8bf16_1k = globals().get("mfma_f32_32x32x8bf16_1k", None)
 _ods_mfma_f32_32x32x16_f16 = globals().get("mfma_f32_32x32x16_f16", None)
@@ -50,20 +53,54 @@ mask_dsrd = 0x100
 mask_dswr = 0x200
 
 
-def sched_mfma(cnt):
-    sched_group_barrier(mask_mfma, cnt, 0)
+# Synchronization / scheduling primitives carry an explicit call-site Location so
+# ROCprof ATT maps them to the user's kernel line instead of the coarse kernel-default
+# location. ``_pinned_loc()`` lets an enclosing ``source_loc`` helper scope override it.
 
 
-def sched_vmem(cnt):
-    sched_group_barrier(mask_vmem_rd, cnt, 0)
+def s_waitcnt(bitfield, *, loc=None, ip=None):
+    """``s_waitcnt`` that attributes to its call site for ROCprof ATT source mapping."""
+    if loc is None:
+        loc = _pinned_loc() or _caller_location(depth=1)
+    return _ods_s_waitcnt(bitfield, loc=loc, ip=ip)
 
 
-def sched_dsrd(cnt):
-    sched_group_barrier(mask_dsrd, cnt, 0)
+def sched_barrier(mask, *, loc=None, ip=None):
+    """``sched_barrier`` that attributes to its call site for ROCprof ATT source mapping."""
+    if loc is None:
+        loc = _pinned_loc() or _caller_location(depth=1)
+    return _ods_sched_barrier(mask, loc=loc, ip=ip)
 
 
-def sched_dswr(cnt):
-    sched_group_barrier(mask_dswr, cnt, 0)
+def sched_group_barrier(mask, size, group_id, *, loc=None, ip=None):
+    """``sched_group_barrier`` that attributes to its call site for ROCprof ATT source mapping."""
+    if loc is None:
+        loc = _pinned_loc() or _caller_location(depth=1)
+    return _ods_sched_group_barrier(mask, size, group_id, loc=loc, ip=ip)
+
+
+def sched_mfma(cnt, *, loc=None):
+    if loc is None:
+        loc = _pinned_loc() or _caller_location(depth=1)
+    _ods_sched_group_barrier(mask_mfma, cnt, 0, loc=loc)
+
+
+def sched_vmem(cnt, *, loc=None):
+    if loc is None:
+        loc = _pinned_loc() or _caller_location(depth=1)
+    _ods_sched_group_barrier(mask_vmem_rd, cnt, 0, loc=loc)
+
+
+def sched_dsrd(cnt, *, loc=None):
+    if loc is None:
+        loc = _pinned_loc() or _caller_location(depth=1)
+    _ods_sched_group_barrier(mask_dsrd, cnt, 0, loc=loc)
+
+
+def sched_dswr(cnt, *, loc=None):
+    if loc is None:
+        loc = _pinned_loc() or _caller_location(depth=1)
+    _ods_sched_group_barrier(mask_dswr, cnt, 0, loc=loc)
 
 
 def _unwrap_mfma_operand(v, *, loc=None):

--- a/python/flydsl/expr/rocdl/__init__.py
+++ b/python/flydsl/expr/rocdl/__init__.py
@@ -15,7 +15,7 @@ This module provides access to ROCm-specific GPU operations including:
 """
 
 from ..._mlir.dialects.rocdl import *  # noqa: F401,F403
-from ..meta import _caller_location, _pinned_loc, traced_op
+from ..meta import traced_op
 from . import cdna4 as cdna4
 
 # Keep references to ODS-generated builders so we can wrap them without losing access.
@@ -53,54 +53,46 @@ mask_dsrd = 0x100
 mask_dswr = 0x200
 
 
-# Synchronization / scheduling primitives carry an explicit call-site Location so
-# ROCprof ATT maps them to the user's kernel line instead of the coarse kernel-default
-# location. ``_pinned_loc()`` lets an enclosing ``source_loc`` helper scope override it.
+# Synchronization / scheduling primitives are wrapped with @traced_op so ROCprof ATT
+# maps them to the user's kernel line instead of the coarse kernel-default location.
+# traced_op resolves loc (explicit > source_loc pin > caller line) and stamps the op via
+# the ambient location; their args are compile-time int masks, so the eager arg-unwrap is
+# a no-op (unlike the high-level helpers, which must use source_loc_scope instead).
 
 
+@traced_op
 def s_waitcnt(bitfield, *, loc=None, ip=None):
-    """``s_waitcnt`` that attributes to its call site for ROCprof ATT source mapping."""
-    if loc is None:
-        loc = _pinned_loc() or _caller_location(depth=1)
     return _ods_s_waitcnt(bitfield, loc=loc, ip=ip)
 
 
+@traced_op
 def sched_barrier(mask, *, loc=None, ip=None):
-    """``sched_barrier`` that attributes to its call site for ROCprof ATT source mapping."""
-    if loc is None:
-        loc = _pinned_loc() or _caller_location(depth=1)
     return _ods_sched_barrier(mask, loc=loc, ip=ip)
 
 
+@traced_op
 def sched_group_barrier(mask, size, group_id, *, loc=None, ip=None):
-    """``sched_group_barrier`` that attributes to its call site for ROCprof ATT source mapping."""
-    if loc is None:
-        loc = _pinned_loc() or _caller_location(depth=1)
     return _ods_sched_group_barrier(mask, size, group_id, loc=loc, ip=ip)
 
 
-def sched_mfma(cnt, *, loc=None):
-    if loc is None:
-        loc = _pinned_loc() or _caller_location(depth=1)
-    _ods_sched_group_barrier(mask_mfma, cnt, 0, loc=loc)
+@traced_op
+def sched_mfma(cnt, *, loc=None, ip=None):
+    return _ods_sched_group_barrier(mask_mfma, cnt, 0, loc=loc, ip=ip)
 
 
-def sched_vmem(cnt, *, loc=None):
-    if loc is None:
-        loc = _pinned_loc() or _caller_location(depth=1)
-    _ods_sched_group_barrier(mask_vmem_rd, cnt, 0, loc=loc)
+@traced_op
+def sched_vmem(cnt, *, loc=None, ip=None):
+    return _ods_sched_group_barrier(mask_vmem_rd, cnt, 0, loc=loc, ip=ip)
 
 
-def sched_dsrd(cnt, *, loc=None):
-    if loc is None:
-        loc = _pinned_loc() or _caller_location(depth=1)
-    _ods_sched_group_barrier(mask_dsrd, cnt, 0, loc=loc)
+@traced_op
+def sched_dsrd(cnt, *, loc=None, ip=None):
+    return _ods_sched_group_barrier(mask_dsrd, cnt, 0, loc=loc, ip=ip)
 
 
-def sched_dswr(cnt, *, loc=None):
-    if loc is None:
-        loc = _pinned_loc() or _caller_location(depth=1)
-    _ods_sched_group_barrier(mask_dswr, cnt, 0, loc=loc)
+@traced_op
+def sched_dswr(cnt, *, loc=None, ip=None):
+    return _ods_sched_group_barrier(mask_dswr, cnt, 0, loc=loc, ip=ip)
 
 
 def _unwrap_mfma_operand(v, *, loc=None):


### PR DESCRIPTION
Fixes #587.

## Problem

For `flash_attn_func`, debug info is present and 2069/2070 ISA rows map to Python source, but the mapping is useless for navigating the ping-pong / double-buffer schedule: **91.9 % of kernel instructions collapse onto `flash_attn_func.py:257`** (the `@flyc.kernel` decorator) and **6.3 % onto `:283`** (the body of the one-line `_mfma` helper).

Root cause: the schedule emits its DMA / MFMA / wait / barrier ops from **nested helper closures** (`coop_dma_k`, `mfma_acc`→`_mfma`, `_waitcnt_vm_n`, `_read_v_pack`), so `traced_op`'s `_caller_location(depth=1)` lands on the helper body, and the untraced sync ops fall through to the kernel-default location.

## Fix

**`expr/meta.py`** — a `source_loc` context manager (+ `source_loc_scope` decorator) that pins the user call-site Location via a thread-local. `traced_op` consults it first:
```python
loc = kwargs.pop("loc", None) or _pinned_loc() or _caller_location(depth=1)
```
Untraced ODS builders inherit the pin through MLIR's ambient location; `@traced_op` leaves through the pin. Re-entrant (outermost wins). **No-op when no scope is active**, so existing kernels are byte-for-byte unaffected.

**`expr/gpu.py`, `expr/rocdl/__init__.py`** — `gpu.barrier` and `rocdl.s_waitcnt` / `sched_barrier` / `sched_group_barrier` (+ `sched_mfma/vmem/dsrd/dswr`) made loc-aware so inline kernel-body sync calls attribute to their own line (the pattern from 9f29c0de). Args are ints only, so no eager-unwrap hazard.

**`kernels/flash_attn_func.py`** — five one-line `@source_loc_scope` decorators on `coop_dma_k`, `coop_dma_v`, `mfma_acc`, `_waitcnt_vm_n`, `_read_v_pack`. Bodies untouched.

I deliberately did **not** wrap the multi-arg scheduling helpers in `@traced_op` — its `_flatten_args` eager-unwrap raises on aggregates/Constexprs (the behavior change the issue warns about). `source_loc` carries the location without touching arguments.

## Evidence (gfx950 / MI350X, bf16 causal)

Locations are pure metadata, so on the default (debug-off) path they are stripped before codegen:

- **debug-off ISA is byte-identical** before vs after (`diff` empty on the dumped `.s`), kernel output md5 unchanged.
- **perf unchanged**: 372 TFLOPS / 92 µs at B1/S2048/H32/D128 (before 372.7, after 371.6 — run-to-run noise).

ATT source granularity on the recaptured trace (`source/att_source_granularity.py`, GPU-free):

| metric (big, dispatch_44) | before | after |
|---|---:|---:|
| distinct mapped source lines | 7 | **20** |
| effective #lines `exp(H)` | 2.0 | **4.5** |
| weight on `:283` (`_mfma`) | 19.9 % | **0 %** |
| MFMA → GEMM1/GEMM2 call sites | — | 740/741, 1111/1112 |

K DMA double-buffer, GEMM1/GEMM2 MFMA, the V-visibility waits and the GEMM2 V pre-read now each resolve to the kernel line that expresses them. Side-effect: 64 of 84 backend-inserted `s_waitcnt` rows moved onto the MFMA lines they guard.

Before/after trace bundle + reproduction: [REPORT.md](https://github.com/jhinpan/flydsl-kernel-profiling/blob/2e2da4ef39aef484b2f628a19650ecd109982cc8/examples/flash_attn_func/REPORT.md), [after `code.json`](https://github.com/jhinpan/flydsl-kernel-profiling/blob/2e2da4ef39aef484b2f628a19650ecd109982cc8/examples/flash_attn_func/att_viewer/big/ui_output_agent_27340_dispatch_44_after_loc_fix/code.json).

## Answers to the issue's questions

1. **Yes** — the outer helper captures the call site once (`source_loc`) and every emitted op inherits it; no per-leaf `loc=` threading.
2. **Yes** — when a scope/loc is in effect, `traced_op` no longer re-runs `_caller_location`, so nested helpers don't remap to helper-internal lines.
3. All ops from one helper call attribute to the outer user call site (the structured way: a `with`-scope / decorator), which is what's wanted for the schedule.
4. The DMA/LDS/MFMA leaves are handled via the scope + the loc-aware sync wrappers here.

## Relation to `9f29c0de`

This patch covers the **scheduling-helper path**. The remaining weight on the function line is dominated by backend-inserted `s_nop`/`s_waitcnt` (no source line) plus the **inline softmax/index arithmetic**, which is exactly what `9f29c0de` ("fix asm source code map") targets at the arith layer. Happy to rebase this on top of that branch, or fold the arith-loc work in here — whichever the maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
## Update — softmax compute also scoped (`36e9f0f6`)

Extended `@source_loc_scope` to the `_fadd`/`_fsub`/`_fmul`/`_fmax` softmax arith helpers, so the online-softmax running-max / exp-sum and the o_acc rescale now map to lines 922–961. Distinct `flash_attn_func.py` lines **6 → 29** (was 6 → 19 with the scheduling path alone). Debug-off ISA still byte-identical, perf unchanged.

Being honest about the residual: ~54 % of sampled weight still sits on the function line `:258` — ~35 % backend `s_nop`/`s_waitcnt` (no source line), ~7 % `exp2` + causal-mask `select` (`ArithValue` framework methods, `9f29c0de`'s layer), and **~12 % kernel-emitted ops this PR did not scope** (the epilogue O `global_store` is the single biggest, plus some LDS reads / `v_ldexp` / adds / bf16 packing) — attributable with more scoping, just out of scope here.



---
## Update — epilogue O store also scoped (`1042aa97`)

Added `@source_loc_scope` to `_store_global_half`, so the epilogue O `global_store` — called out in the residual above as the single biggest still-coarse op — now maps to its kernel line too. Total is now **ten** `@source_loc_scope` decorators (five scheduling + four softmax arith + the O store); the residual on the function line is correspondingly smaller and is now dominated by backend `s_nop`/`s_waitcnt` (no source line) plus the `exp2` / causal-mask `select` arith-layer ops that `9f29c0de` targets. Debug-off ISA still byte-identical, perf unchanged.

One clarification on the "existing kernels byte-for-byte unaffected" point: it holds at the *artifact* level (the `source_loc` no-op path is byte-identical, and `gpu.barrier` / the `rocdl` sync wrappers strip to the same ISA on the debug-off `get_asm(enable_debug_info=False)` path). But because this PR edits `expr/meta.py` / `gpu.py` / `rocdl/__init__.py`, the JIT toolchain fingerprint changes, so every kernel cache-misses and recompiles **once** on first run after the update — recompiled ISA is identical, not skipped.
