### PR TITLE
[Agent] Align format-code skill with CI style gate

### DIFF
--- a/.claude/skills/format-code/SKILL.md
+++ b/.claude/skills/format-code/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: format-code
 description: >
-  Format and clean up code before committing. Removes unused imports/variables from Python files
-  (autoflake/ruff), formats Python with black, and formats C/C++ with clang-format (Google style).
-  Use this skill whenever the user says "format code", "clean up code", "lint", "format before commit",
-  "code formatting", "/format-code", or wants to tidy up changed files before a git commit.
-  Also trigger when the user mentions autoflake, black, ruff, Python style checks, CI style failures,
-  or clang-format in the context of cleaning up their working tree.
+  Format and clean up changed files before committing, matching the project's CI style gate.
+  Formats Python with black + ruff and C/C++ with clang-format using the repository's
+  .clang-format. Use when the user says "format code", "clean up code", "lint",
+  "format before commit", "/format-code", or mentions black, ruff, clang-format, or CI style
+  failures while tidying their working tree.
 ---
 
 # Format Code
@@ -23,12 +22,12 @@ or modified in the working tree (`git diff`), so unchanged files are never touch
 For each changed file, the pipeline runs in order:
 
 1. **Project wrapper**: run the repo's style script when present, e.g. FlyDSL's `scripts/check_python_style.sh --fix`
-2. **Python (.py)**: autoflake/ruff (remove unused imports & variables) -> black (format)
-3. **C/C++ (.c, .cc, .cpp, .cxx, .h, .hpp, .hxx)**: clang-format with Google style
+2. **Python (.py)**: `ruff check --fix` (remove unused imports/variables, sort imports) -> `black` (format)
+3. **C/C++ (.c, .cc, .cpp, .cxx, .h, .hh, .hpp, .hxx, .cu, .cuh)**: clang-format using the repository's `.clang-format`
 
 ## Steps
 
-### 1. Ensure tools are installed
+### 1. Prefer the project wrapper
 
 First check whether the repo has a formatter wrapper. In FlyDSL, run:
 
@@ -36,26 +35,28 @@ First check whether the repo has a formatter wrapper. In FlyDSL, run:
 bash scripts/check_python_style.sh --fix
 ```
 
-If that succeeds, inspect the resulting diff and skip the generic Python steps below unless
+This wrapper runs `black -> ruff check --fix -> black` on the committed diff, exactly matching
+CI. If it succeeds, inspect the resulting diff and skip the generic Python steps below unless
 additional non-Python formatting is still needed. If required tooling is missing, use the
-repo's install option if available, e.g. `bash scripts/check_python_style.sh --install`.
+repo's install option, e.g. `bash scripts/check_python_style.sh --install`.
 
 ### 2. Ensure generic tools are installed
 
-Check each tool and install any that are missing. Do all checks first, then install in one batch.
+Check each tool and install any that are missing. Match the versions CI uses so local output
+matches the CI gate: FlyDSL's CI runs `clang-format-18`.
 
 ```bash
 # Check availability
-command -v autoflake &>/dev/null || NEED_PY=1
 command -v black &>/dev/null || NEED_PY=1
-command -v clang-format &>/dev/null || NEED_CF=1
+command -v ruff &>/dev/null || NEED_PY=1
+command -v clang-format-18 &>/dev/null || command -v clang-format &>/dev/null || NEED_CF=1
 
 # Install if needed
 if [ -n "$NEED_PY" ]; then
-  pip install autoflake black
+  pip install black ruff
 fi
 if [ -n "$NEED_CF" ]; then
-  sudo apt-get install -y clang-format 2>/dev/null || pip install clang-format
+  sudo apt-get install -y clang-format-18 2>/dev/null || pip install clang-format
 fi
 ```
 
@@ -71,28 +72,29 @@ If no files are changed, tell the user there is nothing to format and stop.
 
 ### 4. Format Python files
 
-For every `.py` file in the changed set:
+For every `.py` file in the changed set (run from the repo root so `pyproject.toml` config is
+picked up). This mirrors CI, which checks `black` formatting and `ruff check` (rules E/W/F/I):
 
 ```bash
-# Remove unused imports and variables (in-place)
-autoflake --in-place --remove-all-unused-imports --remove-unused-variables "$file"
-
-# Format with black (default settings)
+# Remove unused imports/variables and sort imports, then format
+ruff check --fix "$file"
 black "$file"
 ```
 
 ### 5. Format C/C++ files
 
-For every `.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`, `.hxx` file in the changed set:
+For every `.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hh`, `.hpp`, `.hxx`, `.cu`, `.cuh` file in the
+changed set. Do **not** pass `--style`: clang-format reads the repository's `.clang-format`
+(FlyDSL uses LLVM style with ColumnLimit 100), which is what CI checks. Prefer the CI version:
 
 ```bash
-clang-format -i --style=Google "$file"
+${CLANG_FORMAT:-clang-format-18} -i "$file"
 ```
 
 ### 6. Inspect diff and report summary
 
-Always inspect the diff after automatic fixes. Ruff/autoflake can remove variables that appear
-unused after simplifying a branch, but those variables may have been intentionally preserving a
+Always inspect the diff after automatic fixes. Ruff can remove variables that appear unused
+after simplifying a branch, but those variables may have been intentionally preserving a
 compile-time decision or local readability. If an auto-fix changes behavior instead of only
 format/import hygiene, restore the behavioral logic and rerun the formatter.
 
@@ -111,8 +113,8 @@ If any files were staged before formatting, remind the user to re-stage them
 - In FlyDSL, `scripts/check_python_style.sh --fix` is the source of truth for CI Python style.
   It checks the committed Python diff against `origin/main`; use `--include-local` when the
   user explicitly wants uncommitted or untracked Python files included too.
-- autoflake's `--remove-unused-variables` only removes simple unused assignments (e.g. `x = 1`
-  where `x` is never read). It does not remove unused functions or classes -- that requires
-  manual review.
-- black uses its default configuration. If the project has a `pyproject.toml` with `[tool.black]`
-  settings, black will pick those up automatically.
+- `ruff check --fix` removes unused imports (F401) and simple unused variables (F841) and sorts
+  imports (I). It does not remove unused functions or classes -- that requires manual review.
+- black and ruff read `pyproject.toml` ([tool.black] / [tool.ruff], line-length 120) automatically
+  when run from the repo root. Pin clang-format to the CI version (clang-format-18) so local
+  formatting does not drift from the CI check.


### PR DESCRIPTION
The format-code skill formatted C/C++ with `--style=Google`, which overrides the repository's `.clang-format` (LLVM style, ColumnLimit 100) that CI checks, so formatted C/C++ would fail the `clang-format-18` gate. Fix and tighten:

- C/C++: drop `--style=Google`; let clang-format read the repo `.clang-format`, and prefer `clang-format-18` to match CI.
- C/C++: add missing extensions `.hh`, `.cu`, `.cuh` to match the CI file set.
- Python: replace the autoflake+black fallback with `ruff check --fix` + black, matching CI's `ruff check` (rules E/W/F/I, including isort) and the wrapper.
- Condense the frontmatter description.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
