### PR TITLE
[Enh] Add current_device_id() to DeviceRuntime via HIP hipGetDevice

### DIFF
--- a/python/flydsl/runtime/device_runtime/base.py
+++ b/python/flydsl/runtime/device_runtime/base.py
@@ -22,3 +22,7 @@ class DeviceRuntime(metaclass=ABCMeta):
     @abstractmethod
     def device_count(self) -> int:
         """Number of visible devices for this runtime."""
+
+    @abstractmethod
+    def current_device_id(self) -> int:
+        """Current device id for this runtime."""

--- a/python/flydsl/runtime/device_runtime/rocm.py
+++ b/python/flydsl/runtime/device_runtime/rocm.py
@@ -5,20 +5,53 @@
 
 from __future__ import annotations
 
+import ctypes
 from typing import ClassVar
 
 from ..device import get_rocm_device_count
 from .base import DeviceRuntime
 
+# Cached HIP runtime handle (``libamdhip64``); cached once.
+_HIP_LIB = None
+_HIP_LIB_TRIED = False
+
+
+def _hip_get_device() -> int:
+    """Active HIP device index via ``hipGetDevice``."""
+    global _HIP_LIB, _HIP_LIB_TRIED
+    if not _HIP_LIB_TRIED:
+        _HIP_LIB_TRIED = True
+        for soname in ("libamdhip64.so", "libamdhip64.so.6", "libamdhip64.so.5"):
+            try:
+                lib = ctypes.CDLL(soname)
+                lib.hipGetDevice.argtypes = [ctypes.POINTER(ctypes.c_int)]
+                lib.hipGetDevice.restype = ctypes.c_int
+                _HIP_LIB = lib
+                break
+            except OSError:
+                continue
+    if _HIP_LIB is None:
+        return 0
+    dev = ctypes.c_int(0)
+    try:
+        if _HIP_LIB.hipGetDevice(ctypes.byref(dev)) == 0:
+            return int(dev.value)
+    except Exception:
+        pass
+    return 0
+
 
 class RocmDeviceRuntime(DeviceRuntime):
     """HIP-based runtime; matches compile backend ``rocm``.
 
-    ``device_count()`` delegates to :func:`get_rocm_device_count` in ``device.py``
-    (``@lru_cache``; ``rocm_agent_enumerator``, same style as arch detection there).
+    ``device_count()`` delegates to ``rocm_agent_enumerator`` in ``device.py``;
+    ``current_device_id()`` queries HIP ``hipGetDevice`` directly.
     """
 
     kind: ClassVar[str] = "rocm"
 
     def device_count(self) -> int:
         return get_rocm_device_count()
+
+    def current_device_id(self) -> int:
+        return _hip_get_device()

--- a/tests/unit/test_device_runtime.py
+++ b/tests/unit/test_device_runtime.py
@@ -28,6 +28,9 @@ class _FakeCudaRuntime(dr.DeviceRuntime):
     def device_count(self) -> int:
         return 1
 
+    def current_device_id(self) -> int:
+        return 0
+
 
 def test_default_runtime_kind_stays_rocm(monkeypatch):
     """Community users that do not opt into another runtime keep the ROCm default."""


### PR DESCRIPTION
Add an abstract current_device_id() to the DeviceRuntime interface and implement it in RocmDeviceRuntime by querying HIP directly (hipGetDevice via ctypes, torch-free). This resolves the active GPU per backend through the runtime abstraction. The test fake implements the new method.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
