### PR TITLE
[Refactor] Harden and speed up the JIT cache-key computation

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -46,6 +46,11 @@ jobs:
   # ---------------------------------------------------------------------------
   test:
     needs: check-signal
+    env:
+      # Some self-hosted runners configure a GitHub -> git-cache URL rewrite.
+      # If that cache is unavailable, checkout fails before the tests start.
+      GIT_CONFIG_GLOBAL: /dev/null
+      GIT_CONFIG_NOSYSTEM: "1"
     strategy:
       matrix:
         runners: [
@@ -349,6 +354,10 @@ jobs:
     needs: test
     name: Multi-GPU AllReduce Tests (${{ matrix.runners }})
     timeout-minutes: 120
+    env:
+      # Keep checkout independent of runner-local git-cache rewrites.
+      GIT_CONFIG_GLOBAL: /dev/null
+      GIT_CONFIG_NOSYSTEM: "1"
     if: |
       always() && (
         (github.event_name == 'pull_request' &&

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -201,12 +201,12 @@ jobs:
           docker exec -i flydsl_test bash <<'BASH'
           set -u
           cd /flydsl-test
-          rm -rf /tmp/flydsl-bench-main-*
-          rm -f /tmp/bench_main.csv /tmp/bench_prev_main.csv /tmp/bench_main_label /tmp/bench_prev_main_label
+          rm -rf /tmp/flydsl-bench-main-* /tmp/flydsl-bench-tag
+          rm -f /tmp/bench_main.csv /tmp/bench_latest_tag.csv /tmp/bench_main_label /tmp/bench_latest_tag_label
           git worktree prune || true
           git fetch origin main --depth=8
 
-          found=0
+          found_main=0
           idx=0
           for commit in $(git rev-list --max-count=8 FETCH_HEAD); do
             label="main"
@@ -237,29 +237,55 @@ jobs:
             )
             status=$?
             if [ "${status}" -eq 0 ] && [ -s "${csv}" ]; then
-              if [ "${found}" -eq 0 ]; then
-                cp "${csv}" /tmp/bench_main.csv
-                echo "${label}" >/tmp/bench_main_label
-              else
-                cp "${csv}" /tmp/bench_prev_main.csv
-                echo "${label}" >/tmp/bench_prev_main_label
-              fi
-              found=$((found + 1))
-              if [ "${found}" -ge 2 ]; then
-                break
-              fi
+              cp "${csv}" /tmp/bench_main.csv
+              echo "${label}" >/tmp/bench_main_label
+              found_main=1
+              break
             else
               echo "Benchmark baseline ${label} failed; trying older main commit."
             fi
             idx=$((idx + 1))
           done
 
-          if [ "${found}" -eq 0 ]; then
+          if [ "${found_main}" -eq 0 ]; then
             echo "No usable main benchmark baseline found."
-            exit 0
           fi
-          if [ "${found}" -eq 1 ]; then
-            echo "Only one usable main benchmark baseline found."
+
+          if git fetch origin 'refs/tags/v*:refs/tags/v*' --force --depth=1; then
+            latest_tag="$(git tag --list 'v*' --sort=-v:refname | sed -n '1p')"
+            if [ -n "${latest_tag}" ]; then
+              worktree="/tmp/flydsl-bench-tag"
+              csv="/tmp/bench_latest_tag_candidate.csv"
+              output="/tmp/bench_latest_tag.out"
+              log_dir="/tmp/flydsl_bench_${latest_tag}"
+              package_version="${latest_tag#v}"
+              echo "Trying benchmark baseline ${latest_tag} from pip package flydsl==${package_version}"
+
+              if git worktree add --detach "${worktree}" "${latest_tag}"; then
+                (
+                  set -e -o pipefail
+                  cd "${worktree}"
+                  python3 -m pip install --only-binary=:all: "flydsl==${package_version}" 2>&1 | tail -5
+                  export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
+                  export AITER_REPO=/tmp/aiter
+                  BENCH_LOG_DIR="${log_dir}" bash scripts/run_benchmark.sh 2>&1 | tee "${output}"
+                  python3 /flydsl-test/scripts/benchmark_output_to_csv.py "${output}" "${csv}"
+                )
+                status=$?
+                if [ "${status}" -eq 0 ] && [ -s "${csv}" ]; then
+                  cp "${csv}" /tmp/bench_latest_tag.csv
+                  echo "${latest_tag}" >/tmp/bench_latest_tag_label
+                else
+                  echo "Benchmark baseline ${latest_tag} failed."
+                fi
+              else
+                echo "Failed to create worktree for ${latest_tag}; skipping latest-tag comparison."
+              fi
+            else
+              echo "No v* tags found; skipping latest-tag comparison."
+            fi
+          else
+            echo "Failed to fetch tags; skipping latest-tag comparison."
           fi
           BASH
 
@@ -278,19 +304,19 @@ jobs:
               --baseline-label \"\${main_label}\" --current-label current
           "
 
-      - name: Check benchmark performance (current vs main~1)
+      - name: Check benchmark performance (current vs latest tag)
         if: steps.bench-baselines.outcome != 'skipped'
         timeout-minutes: 5
         run: |
           docker exec flydsl_test bash -c "
-            if [ ! -f /tmp/bench_prev_main.csv ]; then
-              echo 'No second usable main benchmark baseline found; skipping previous-main comparison.'
+            if [ ! -f /tmp/bench_latest_tag.csv ]; then
+              echo 'No usable latest-tag benchmark baseline found; skipping latest-tag comparison.'
               exit 0
             fi
             cd /flydsl-test
-            prev_main_label=\$(cat /tmp/bench_prev_main_label 2>/dev/null || echo main~1)
-            python3 scripts/compare_benchmark.py /tmp/bench_prev_main.csv /tmp/bench_current.csv \
-              --baseline-label \"\${prev_main_label}\" --current-label current
+            latest_tag_label=\$(cat /tmp/bench_latest_tag_label 2>/dev/null || echo latest-tag)
+            python3 scripts/compare_benchmark.py /tmp/bench_latest_tag.csv /tmp/bench_current.csv \
+              --baseline-label \"\${latest_tag_label}\" --current-label current
           "
 
       - name: Show benchmarks logs

--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -136,20 +136,21 @@ def convert_to_jit_arguments(
                 raise TypeError(
                     f"No DslType registered for JitArgument type {type(value).__name__} (parameter '{param_name}')"
                 )
+        elif isinstance(annotation, type) and issubclass(annotation, JitArgument):
+            # Annotation is a JitArgument (e.g. ``Stream``)
+            try:
+                jit_arg = annotation(value)
+            except Exception as e:
+                raise TypeError(f"Failed to construct JitArgument for parameter '{param_name}': {e}") from e
+            dsl_type = annotation
         else:
-            if isinstance(value, int) and annotation is Stream:
-                jit_arg = Stream(value)
-                dsl_type = Stream
-            else:
-                jit_arg_constructor, dsl_type = JitArgumentRegistry.get(type(value))
-                if jit_arg_constructor is None:
-                    raise TypeError(
-                        f"No JitArgument registered for type {type(value).__name__} (parameter '{param_name}')"
-                    )
-                try:
-                    jit_arg = jit_arg_constructor(value)
-                except Exception as e:
-                    raise TypeError(f"Failed to construct JitArgument for parameter '{param_name}': {e}") from e
+            jit_arg_constructor, dsl_type = JitArgumentRegistry.get(type(value))
+            if jit_arg_constructor is None:
+                raise TypeError(f"No JitArgument registered for type {type(value).__name__} (parameter '{param_name}')")
+            try:
+                jit_arg = jit_arg_constructor(value)
+            except Exception as e:
+                raise TypeError(f"Failed to construct JitArgument for parameter '{param_name}': {e}") from e
 
         param_names.append(param_name)
         jit_args.append(jit_arg)

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -17,7 +17,7 @@ from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from functools import lru_cache, partial
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from .._mlir import ir
 from .._mlir.dialects import func
@@ -105,6 +105,156 @@ def _create_mlir_context(*, load_dialects=True):
     if load_dialects:
         ctx.load_all_available_dialects()
     return ctx
+
+
+# Sentinel distinct from a real ``None`` snapshot value (a since-deleted global).
+_NOT_IN_BASELINE = object()
+
+
+# Environment variables that influence code generation. Their current values
+# enter the hot cache key so cross-process / cross-config artifacts don't collide.
+_CACHE_INVALIDATING_ENV_VARS = (
+    "FLYDSL_COMPILE_OPT_LEVEL",
+    "FLYDSL_COMPILE_BACKEND",
+    "FLYDSL_COMPILE_LLVM_DIR",
+    "ARCH",
+    "FLYDSL_GPU_ARCH",
+    "HSA_OVERRIDE_GFX_VERSION",
+    "FLYDSL_DEBUG_ENABLE_DEBUG_INFO",
+    "FLYDSL_EXTRA_SOURCE_DIRS",
+)
+
+
+# os._Environ keeps the live mapping in a plain dict (``_data``) keyed by the
+# OS-encoded bytes of each name; mutations to os.environ update it in place.
+# Reading it with pre-encoded keys skips os.environ.get's per-call key encoding,
+# which is ~5x faster on this hot path. Guarded: if the internal layout is
+# absent (non-posix / future CPython) we fall back to the public API. Values go
+# through os.fsdecode so the fast and slow paths — and thus two processes
+# sharing a cache dir — produce byte-for-byte identical keys.
+try:
+    _ENABLE_ENV_FAST_READ = isinstance(os.environ._data, dict)
+except Exception:
+    _ENABLE_ENV_FAST_READ = False
+_CACHE_INVALIDATING_ENV_VARS_ENCODED = tuple((n, os.fsencode(n)) for n in _CACHE_INVALIDATING_ENV_VARS)
+
+
+def _cache_invalidating_env_values() -> tuple:
+    # Re-read on every call: users may mutate os.environ mid-process (e.g.
+    # toggling FLYDSL_COMPILE_OPT_LEVEL between runs) and any caching here
+    # would freeze the first observed values into every subsequent cache key.
+    if _ENABLE_ENV_FAST_READ:
+        data = os.environ._data
+        return tuple((n, os.fsdecode(data[b]) if b in data else "") for n, b in _CACHE_INVALIDATING_ENV_VARS_ENCODED)
+    return tuple((n, os.environ.get(n, "")) for n in _CACHE_INVALIDATING_ENV_VARS)
+
+
+def _snapshot_global_value(val, *, stable):
+    """Summarize a captured global for the cache key / drift detection.
+
+    ``stable=True`` is cross-process-stable (no ``id()``, which is randomized per
+    process) so two processes importing the same module produce the same key —
+    suitable for folding into cache keys. ``stable=False`` includes ``id()`` so
+    in-process drift detection catches rebinding even when type/value look equal.
+    Scalars are summarized by value in both modes.
+    """
+    if isinstance(val, (int, float, bool, str, bytes, type(None))):
+        return ("scalar", val)
+    if stable:
+        if callable(val):
+            # qualname+module is stable across processes; repr would bake in
+            # <0x...> addresses for many callables.
+            qualname = getattr(val, "__qualname__", None) or getattr(val, "__name__", "?")
+            return ("callable", getattr(val, "__module__", "?"), qualname)
+        # Distinct instances of the same type collapse here; the stable=False
+        # path still catches rebinding via id().
+        return ("obj", type(val).__qualname__)
+    if callable(val):
+        return ("callable", id(val), repr(val))
+    return ("obj", id(val), type(val).__qualname__)
+
+
+def _discover_global_refs(func, owner_cls=None) -> List[Tuple[str, str, dict]]:
+    """Statically discover which module globals ``func`` and its (jit / kernel /
+    same-dir user) dependencies *read*.
+
+    The result depends only on the code objects in the dependency tree — NOT on
+    the current values of those globals — so it is stable across calls and can be
+    memoized per ``(func, owner_cls)``. The recursive walk (co_names + closures +
+    class members) therefore runs once instead of on every JIT call; the hot path
+    only re-reads the discovered values via :func:`_snapshot_refs`.
+
+    Returns a sorted list of ``(name, module_name, globals_dict)`` triples. The
+    snapshot is keyed on ``(name, module_name)`` so the same identifier appearing
+    in different modules doesn't collide. JitFunction / KernelFunction deps are
+    always recursed into (regardless of source location); plain Python helpers are
+    filtered by ``_is_user_function`` (same directory as the root file) to avoid
+    pulling stdlib / third-party globals into the snapshot.
+
+    ``owner_cls`` enables recursing into ``self.helper`` style method calls so
+    helpers attached to the owning class also have their globals tracked.
+    """
+    from .kernel_function import KernelFunction
+
+    try:
+        rootFile = inspect.getfile(func)
+    except (TypeError, OSError):
+        rootFile = ""
+    refs: Dict[Tuple[str, str], dict] = {}
+    visited: Set[int] = set()
+
+    def _walk(f, cls=None):
+        if id(f) in visited:
+            return
+        visited.add(id(f))
+        f_globals = getattr(f, "__globals__", {})
+        mod_name = f_globals.get("__name__", "?")
+        for name in f.__code__.co_names:
+            key = (name, mod_name)
+            if name in f_globals and key not in refs:
+                val = f_globals[name]
+                refs[key] = f_globals
+                underlying = _get_underlying_func(val)
+                if underlying is not None and (
+                    isinstance(val, (JitFunction, KernelFunction)) or _is_user_function(underlying, rootFile)
+                ):
+                    _walk(underlying)
+            # Also recurse through class-member helpers (self.helper(...))
+            if cls is not None:
+                try:
+                    obj = getattr(cls, name)
+                except AttributeError:
+                    obj = None
+                underlying = _get_underlying_func(obj) if obj is not None else None
+                if underlying is not None and _is_user_function(underlying, rootFile):
+                    _walk(underlying, cls=cls)
+        if f.__code__.co_freevars and getattr(f, "__closure__", None):
+            for _cname, cell in zip(f.__code__.co_freevars, f.__closure__):
+                try:
+                    val = cell.cell_contents
+                except ValueError:
+                    continue
+                underlying = _get_underlying_func(val)
+                if underlying is not None:
+                    _walk(underlying)
+
+    _walk(func, cls=owner_cls or _owner_class_from_func(func))
+    return [(name, mod_name, refs[(name, mod_name)]) for (name, mod_name) in sorted(refs)]
+
+
+def _snapshot_refs(refs: List[Tuple[str, str, dict]], *, stable: bool) -> Dict[Tuple[str, str], Any]:
+    """Read the *current* values of pre-discovered global refs into a snapshot.
+
+    Cheap O(N) dict reads with no recursion — this is what runs on every JIT call.
+    ``stable=True`` returns cross-process-stable values (no ``id()``), suitable for
+    folding into cache keys. ``stable=False`` returns id-bearing values used for
+    in-process drift detection.
+    """
+    out: Dict[Tuple[str, str], Any] = {}
+    for name, mod_name, var_dict in refs:
+        if name in var_dict:
+            out[(name, mod_name)] = _snapshot_global_value(var_dict[name], stable=stable)
+    return out
 
 
 class FlyDSLCompileError(RuntimeError):
@@ -346,9 +496,22 @@ def _collect_dependency_sources(
     visited: Optional[Set[int]] = None,
     owner_cls=None,
 ) -> List[str]:
+    from .kernel_function import KernelFunction
+
     if visited is None:
         visited = set()
     sources = []
+
+    def _emit(prefix: str, name: str, val, underlying):
+        # JitFunction has its own manager_key — use it as a stable identity
+        # so cross-directory deps are tracked without dragging in the full
+        # source file (which would force ad-hoc same-dir filtering).
+        if isinstance(val, JitFunction):
+            val._ensure_cache_manager()
+            sources.append(f"{prefix}jit:{name}:{val.manager_key}")
+            return False  # do not recurse: manager_key already covers transitive deps
+        sources.append(f"{prefix}{name}:{_get_func_source(underlying)}")
+        return True  # recurse to pick up nested helpers
 
     # 1) Scan global name references (co_names → __globals__)
     for name in func.__code__.co_names:
@@ -356,11 +519,15 @@ def _collect_dependency_sources(
         underlying = _get_underlying_func(obj)
         if underlying is None or id(underlying) in visited:
             continue
-        if not _is_user_function(underlying, rootFile):
+        # Always include JitFunction/KernelFunction regardless of source location;
+        # plain helpers stay behind the same-dir filter to avoid stdlib pollution.
+        is_jit_like = isinstance(obj, (JitFunction, KernelFunction))
+        if not is_jit_like and not _is_user_function(underlying, rootFile):
             continue
         visited.add(id(underlying))
-        sources.append(f"{name}:{_get_func_source(underlying)}")
-        sources.extend(_collect_dependency_sources(underlying, rootFile, visited))
+        should_recurse = _emit("", name, obj, underlying)
+        if should_recurse:
+            sources.extend(_collect_dependency_sources(underlying, rootFile, visited))
 
     # 2) Scan closure variables (co_freevars → __closure__) for callable
     #    dependencies.  This catches @flyc.kernel functions defined in an
@@ -375,8 +542,9 @@ def _collect_dependency_sources(
             if underlying is None or id(underlying) in visited:
                 continue
             visited.add(id(underlying))
-            sources.append(f"closure:{name}:{_get_func_source(underlying)}")
-            sources.extend(_collect_dependency_sources(underlying, rootFile, visited))
+            should_recurse = _emit("closure:", name, val, underlying)
+            if should_recurse:
+                sources.extend(_collect_dependency_sources(underlying, rootFile, visited))
 
     owner_cls = owner_cls or _owner_class_from_func(func)
     if owner_cls is not None:
@@ -901,9 +1069,9 @@ def _resolve_jit_arg_type(arg, annotation):
     logic as convert_to_jit_arguments.  Returns the type (not an instance)."""
     from .jit_argument import JitArgumentRegistry
 
-    if isinstance(arg, int) and annotation is Stream:
-        return Stream
-    if hasattr(arg, "__get_c_pointers__"):
+    if isinstance(annotation, type) and issubclass(annotation, JitArgument):
+        return annotation
+    if isinstance(arg, JitArgument):
         return type(arg)
     constructor, _ = JitArgumentRegistry.get(type(arg))
     return constructor
@@ -1031,10 +1199,22 @@ class JitFunction:
         self._call_state_cache = {}  # cache_key -> CallState
         self._sig = None  # lazy: set on first call
         self._has_self_param = False  # lazy: set in _ensure_sig
-        self._target = None  # lazy: GPUTarget resolved once in _ensure_sig
+        self._backend_target = None  # lazy: GPUTarget resolved once in _ensure_sig
         self._mem_cache = {}
         self._last_compiled = None  # (cache_key, CompiledArtifact) for compile()
         self._extern_linkage_keys = set()
+
+        # snapshot the used globals on first compile and RAISE on any later drift.
+        self._used_global_vals: Optional[Dict[Tuple[str, str], Any]] = None
+        # owner_cls -> discovered global refs. The (recursive) discovery is a pure
+        # function of the dependency tree's code objects, so it's memoized here and
+        # the hot path only re-snapshots the current values.
+        self._global_refs_cache: Dict[Any, List[Tuple[str, str, dict]]] = {}
+        # owner_cls -> pre-built ``("_globals_", ...)`` cache-key segment. The
+        # globals folded into the key cannot change without the drift check
+        # raising first, so the segment is built once and reused on every cache
+        # hit (matching Triton, which never re-snapshots globals per launch).
+        self._globals_prefix_cache: Dict[Any, tuple] = {}
 
     def __get__(self, obj, objtype=None):
         # when used as a method on a class bind the owning instance as the
@@ -1042,6 +1222,31 @@ class JitFunction:
         if obj is None:
             return self
         return partial(self.__call__, obj)
+
+    def _get_global_refs(self, owner_cls=None) -> List[Tuple[str, str, dict]]:
+        """Memoized global-ref discovery (see :func:`_discover_global_refs`)."""
+        cache = self._global_refs_cache
+        if owner_cls not in cache:
+            cache[owner_cls] = _discover_global_refs(self.func, owner_cls)
+        return cache[owner_cls]
+
+    def _check_globals_drift(self, owner_cls=None) -> None:
+        """Raise if any captured global value has changed since first compile."""
+        baseline = self._used_global_vals
+        for name, mod_name, var_dict in self._get_global_refs(owner_cls):
+            key = (name, mod_name)
+            old = baseline.get(key, _NOT_IN_BASELINE)
+            if old is _NOT_IN_BASELINE:
+                continue
+            new = _snapshot_global_value(var_dict[name], stable=False) if name in var_dict else None
+            if new != old:
+                raise RuntimeError(
+                    f"FlyDSL: global '{name}' (module '{mod_name}') used by @flyc.jit "
+                    f"'{self.func.__name__}' changed since first compile "
+                    f"(old={old!r}, new={new!r}). Capturing live globals is unsafe; "
+                    "restart the process or avoid mutating the global. Prefer passing "
+                    "the value as an explicit argument so it participates in the cache key."
+                )
 
     def cache_info(self) -> Optional[CacheInfo]:
         """Return cache statistics, or ``None`` if the disk cache is disabled."""
@@ -1061,7 +1266,10 @@ class JitFunction:
             self._sig = full_sig.replace(parameters=params[1:])
         else:
             self._sig = full_sig
-        self._target = get_backend().target  # resolve once; frozen dataclass, hashable
+        # NOTE: do NOT cache device_id here — torch.cuda.set_device() can move
+        # subsequent launches to a different GPU, and a frozen device_id would
+        # let the new device silently hit the old device's cache entry.
+        self._backend_target = get_backend().target  # frozen dataclass, stable
 
     def _ensure_cache_manager(self, owner_cls=None):
         if self.manager_key is not None and self._manager_owner_cls is owner_cls:
@@ -1105,10 +1313,13 @@ class JitFunction:
         * JitArgument-driven: the call value is (or is wrapped into) a
           ``JitArgument`` and its ``cache_signature()`` is appended.
         """
+        from ..runtime.device_runtime import get_device_runtime
         from .jit_argument import JitArgumentRegistry
 
         sig = self._sig
-        key_parts = [("_target_", self._target)]
+        # Re-read device_id and env vars on every call.
+        target = (self._backend_target, get_device_runtime().current_device_id())
+        key_parts = [("_env_", _cache_invalidating_env_values()), ("_target_", target)]
         if self.compile_hints:
             key_parts.append(("_hints_", tuple(sorted((k, str(v)) for k, v in self.compile_hints.items()))))
 
@@ -1142,6 +1353,31 @@ class JitFunction:
 
         return tuple(key_parts)
 
+    def _globals_key_prefix(self, owner_cls=None) -> tuple:
+        """Memoized ``("_globals_", ...)`` cache-key segment for ``owner_cls``.
+
+        Built once from the first-call snapshot and reused on every cache hit.
+        Safe to memoize: any change to a folded global is caught by the drift
+        check, which raises before a stale segment could be used.
+
+        The stable snapshot is folded in so two processes that observe different
+        values for the same captured global cannot share an artifact —
+        cross-process silent stale hits are prevented even though in-process drift
+        detection (which raises) never runs in the second process.
+        """
+        cache = self._globals_prefix_cache
+        if owner_cls not in cache:
+            stable = _snapshot_refs(self._get_global_refs(owner_cls), stable=True)
+            cache[owner_cls] = (("_globals_", tuple(sorted(stable.items()))),) if stable else ()
+        return cache[owner_cls]
+
+    def _build_full_cache_key(self, bound_arguments, *, owner_cls=None, bound_self=None):
+        """Build the complete cache key: arg signatures + stable globals snapshot + self type."""
+        cache_key = self._globals_key_prefix(owner_cls) + self._resolve_and_make_cache_key(bound_arguments)
+        if bound_self is not None:
+            cache_key = (("_self_type_", type(bound_self)),) + cache_key
+        return cache_key
+
     @staticmethod
     def _cache_key_to_str(cache_key) -> str:
         """Convert tuple cache key to string for disk cache."""
@@ -1161,13 +1397,17 @@ class JitFunction:
         owner_cls = type(bound_self) if bound_self is not None else None
         self._ensure_cache_manager(owner_cls)
 
+        # snapshot the used globals on first compile and RAISE on any later change.
+        if self._used_global_vals is None:
+            self._used_global_vals = _snapshot_refs(self._get_global_refs(owner_cls), stable=False)
+        else:
+            self._check_globals_drift(owner_cls)
+
         sig = self._sig
         bound = sig.bind(*args, **kwargs)
         bound.apply_defaults()
 
-        cache_key = self._resolve_and_make_cache_key(bound.arguments)
-        if bound_self is not None:
-            cache_key = (("_self_type_", type(bound_self)),) + cache_key
+        cache_key = self._build_full_cache_key(bound.arguments, owner_cls=owner_cls, bound_self=bound_self)
 
         args_tuple = tuple(bound.arguments.values())
 
@@ -1457,7 +1697,7 @@ def _compile_impl(func, *args) -> CompiledFunction:
     sig = jf._sig  # guaranteed initialized after __call__
     bound = sig.bind(*args)
     bound.apply_defaults()
-    cache_key = jf._resolve_and_make_cache_key(bound.arguments)
+    cache_key = jf._build_full_cache_key(bound.arguments)
     args_tuple = tuple(bound.arguments.values())
 
     # Look up the CompiledArtifact.  We must hold a direct reference to it

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -1228,8 +1228,11 @@ class JitFunction:
         self._last_compiled = None  # (cache_key, CompiledArtifact) for compile()
         self._extern_linkage_keys = set()
 
-        # snapshot the used globals on first compile and RAISE on any later drift.
-        self._used_global_vals: Optional[Dict[Tuple[str, str], Any]] = None
+        # owner_cls -> first-compile snapshot of the used globals; RAISE on any
+        # later drift. Keyed by owner_cls (like the refs/prefix caches below) so a
+        # JIT method reused across owner classes drift-checks each class against
+        # its own baseline instead of the first owner's.
+        self._used_global_vals: Dict[Any, Dict[Tuple[str, str], Any]] = {}
         # owner_cls -> discovered global refs. The (recursive) discovery is a pure
         # function of the dependency tree's code objects, so it's memoized here and
         # the hot path only re-snapshots the current values.
@@ -1256,7 +1259,7 @@ class JitFunction:
 
     def _check_globals_drift(self, owner_cls=None) -> None:
         """Raise if any captured global value has changed since first compile."""
-        baseline = self._used_global_vals
+        baseline = self._used_global_vals[owner_cls]
         for name, mod_name, var_dict in self._get_global_refs(owner_cls):
             key = (name, mod_name)
             old = baseline.get(key, _NOT_IN_BASELINE)
@@ -1421,9 +1424,10 @@ class JitFunction:
         owner_cls = type(bound_self) if bound_self is not None else None
         self._ensure_cache_manager(owner_cls)
 
-        # snapshot the used globals on first compile and RAISE on any later change.
-        if self._used_global_vals is None:
-            self._used_global_vals = _snapshot_refs(self._get_global_refs(owner_cls), stable=False)
+        # snapshot the used globals on first compile (per owner_cls) and RAISE on
+        # any later change.
+        if owner_cls not in self._used_global_vals:
+            self._used_global_vals[owner_cls] = _snapshot_refs(self._get_global_refs(owner_cls), stable=False)
         else:
             self._check_globals_drift(owner_cls)
 

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -1293,9 +1293,6 @@ class JitFunction:
             self._sig = full_sig.replace(parameters=params[1:])
         else:
             self._sig = full_sig
-        # NOTE: do NOT cache device_id here — torch.cuda.set_device() can move
-        # subsequent launches to a different GPU, and a frozen device_id would
-        # let the new device silently hit the old device's cache entry.
         self._backend_target = get_backend().target  # frozen dataclass, stable
 
     def _ensure_cache_manager(self, owner_cls=None):
@@ -1340,13 +1337,11 @@ class JitFunction:
         * JitArgument-driven: the call value is (or is wrapped into) a
           ``JitArgument`` and its ``cache_signature()`` is appended.
         """
-        from ..runtime.device_runtime import get_device_runtime
         from .jit_argument import JitArgumentRegistry
 
         sig = self._sig
-        # Re-read device_id and env vars on every call.
-        target = (self._backend_target, get_device_runtime().current_device_id())
-        key_parts = [("_env_", _cache_invalidating_env_values()), ("_target_", target)]
+        # Re-read env vars on every call.
+        key_parts = [("_env_", _cache_invalidating_env_values()), ("_target_", self._backend_target)]
         if self.compile_hints:
             key_parts.append(("_hints_", tuple(sorted((k, str(v)) for k, v in self.compile_hints.items()))))
 

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -149,29 +149,53 @@ def _cache_invalidating_env_values() -> tuple:
     return tuple((n, os.environ.get(n, "")) for n in _CACHE_INVALIDATING_ENV_VARS)
 
 
-def _snapshot_global_value(val, *, stable):
+def _snapshot_global_value(val, *, stable, _path=()):
     """Summarize a captured global for the cache key / drift detection.
 
     ``stable=True`` is cross-process-stable (no ``id()``, which is randomized per
     process) so two processes importing the same module produce the same key —
     suitable for folding into cache keys. ``stable=False`` includes ``id()`` so
     in-process drift detection catches rebinding even when type/value look equal.
-    Scalars are summarized by value in both modes.
+    ``_path`` carries the ids of containers currently being walked, breaking reference cycles.
+
+    Scalars and builtin containers (tuple/list/dict/set) are summarized **by
+    value**, recursively, in both modes — so different contents produce different
+    keys (cross-process) and in-place mutation is detected (in-process).
     """
     if isinstance(val, (int, float, bool, str, bytes, type(None))):
         return ("scalar", val)
-    if stable:
-        if callable(val):
+    if isinstance(val, (tuple, list, set, frozenset, dict)):
+        if id(val) in _path:
+            return ("cycle", type(val).__qualname__)
+        _path = _path + (id(val),)
+        kind = type(val).__qualname__
+        if isinstance(val, dict):
+            # sort by repr for a canonical, comparison-safe order (mixed key types)
+            items = sorted(
+                (
+                    (
+                        _snapshot_global_value(k, stable=stable, _path=_path),
+                        _snapshot_global_value(v, stable=stable, _path=_path),
+                    )
+                    for k, v in val.items()
+                ),
+                key=repr,
+            )
+            return ("dict", tuple(items))
+        elems = (_snapshot_global_value(v, stable=stable, _path=_path) for v in val)
+        if isinstance(val, (set, frozenset)):
+            # sets are unordered: sort by repr for a canonical order
+            return (kind, tuple(sorted(elems, key=repr)))
+        return (kind, tuple(elems))
+    if callable(val):
+        if stable:
             # qualname+module is stable across processes; repr would bake in
             # <0x...> addresses for many callables.
             qualname = getattr(val, "__qualname__", None) or getattr(val, "__name__", "?")
             return ("callable", getattr(val, "__module__", "?"), qualname)
-        # Distinct instances of the same type collapse here; the stable=False
-        # path still catches rebinding via id().
-        return ("obj", type(val).__qualname__)
-    if callable(val):
         return ("callable", id(val), repr(val))
-    return ("obj", id(val), type(val).__qualname__)
+    # Opaque object: stable collapses to type; drift keeps id to catch rebinding.
+    return ("obj", type(val).__qualname__) if stable else ("obj", id(val), type(val).__qualname__)
 
 
 def _discover_global_refs(func, owner_cls=None) -> List[Tuple[str, str, dict]]:

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -107,6 +107,24 @@ fp8,8192,8192,8192,128,256,128,2
 int8,9728,8192,8320,128,256,128,2
 '
 
+# SplitK HGEMM shapes:
+# "dtype,M,N,K,tile_m,tile_n,tile_k,stages,split_k,block_m_warps,block_n_warps,block_k_warps"
+HGEMM_SHAPES_GFX950='
+fp16,2048,2048,2048,128,128,64,4,1,4,4,1
+bf16,32,384,7168,32,64,64,5,16,2,2,1
+'
+HGEMM_SHAPES_CDNA3='
+fp16,4096,4096,4096,128,128,64,2,1,2,2,1
+bf16,32,384,7168,16,64,128,2,14,1,2,1
+'
+
+# FP8 8-wave row-scale GEMM shapes (gfx950 only):
+# "M,N,K,tile_m,tile_n,preshuffle_b"
+FP8_GEMM_8WAVE_ROWSCALE_SHAPES='
+5120,5120,8320,256,256,0
+8192,8192,8192,256,256,0
+'
+
 # FP4 GEMM shapes (requires --wfp4, gfx950 only): "M,N,K,tile_m,tile_n,tile_k"
 GEMM_FP4_SHAPES='
 8192,8192,8192,64,128,256
@@ -181,6 +199,7 @@ Usage:
 
 Supported ops:
   softmax | layernorm | rmsnorm | flash_attn | mla | gemm | moe
+  (gemm includes preshuffle GEMM, SplitK HGEMM, and FP8 8-wave row-scale GEMM)
 USAGE
 }
 
@@ -722,7 +741,107 @@ if [ "${RUN_PRESHUFFLE_GEMM}" -eq 1 ] && [ "${IS_CDNA}" = "true" ]; then
     set -- $row
     _emit_row "$1" "$2" "$3" "$4" "$5"
   done
-  
+
+  if [ -n "${HGEMM_SHAPES:-}" ]; then
+    hgemm_shapes="${HGEMM_SHAPES}"
+  else
+    case "${GPU_ARCH}" in
+      gfx95*) hgemm_shapes="${HGEMM_SHAPES_GFX950}" ;;
+      *) hgemm_shapes="${HGEMM_SHAPES_CDNA3}" ;;
+    esac
+  fi
+
+  for shape in $hgemm_shapes; do
+    oldIFS=$IFS
+    IFS=,
+    # shellcheck disable=SC2086 # intentional word-splitting on IFS=,
+    set -- $shape
+    IFS=$oldIFS
+    dtype=$1; M=$2; N=$3; K=$4; tile_m=$5; tile_n=$6; tile_k=$7
+    stages=$8; split_k=$9; block_m_warps=${10}; block_n_warps=${11}; block_k_warps=${12}
+    log="${BENCH_LOG_DIR}/hgemm_${M}x${N}x${K}_${dtype}_t${tile_m}x${tile_n}x${tile_k}_s${stages}_sk${split_k}.log"
+    if python3 tests/kernels/test_hgemm_splitk.py \
+      --dtype "$dtype" \
+      --num_warmup 3 \
+      --num_iters 50 \
+      -m "$M" \
+      -n "$N" \
+      -k "$K" \
+      --TILE_M "$tile_m" \
+      --TILE_N "$tile_n" \
+      --TILE_K "$tile_k" \
+      --STAGES "$stages" \
+      --SPLIT_K "$split_k" \
+      --BLOCK_M_WARPS "$block_m_warps" \
+      --BLOCK_N_WARPS "$block_n_warps" \
+      --BLOCK_K_WARPS "$block_k_warps" >"${log}" 2>&1; then
+      if grep -q "Skipped:" "${log}"; then
+        shape_tag="${M}x${N}x${K}_tile${tile_m}x${tile_n}x${tile_k}_sk${split_k}"
+        _emit_row "hgemm" "${shape_tag}" "${dtype}" "skip" "skip"
+      else
+        SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+        shape_tag="${M}x${N}x${K}_tile${tile_m}x${tile_n}x${tile_k}_sk${split_k}"
+        row="$(_py_parse_and_emit hgemm "${shape_tag}" "${dtype}" "${log}")"
+        set -- $row
+        _emit_row "$1" "$2" "$3" "$4" "$5"
+      fi
+    else
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      echo "hgemm failed. Log: ${log}" >&2
+      _show_fail_log "${log}" "hgemm"
+    fi
+  done
+
+  if [ -n "${FP8_GEMM_8WAVE_ROWSCALE_SHAPES:-}" ]; then
+    for shape in $FP8_GEMM_8WAVE_ROWSCALE_SHAPES; do
+      [ -z "$shape" ] && continue
+      oldIFS=$IFS
+      IFS=,
+      # shellcheck disable=SC2086 # intentional word-splitting on IFS=,
+      set -- $shape
+      IFS=$oldIFS
+      M=$1; N=$2; K=$3; tile_m=$4; tile_n=$5; preshuffle_b=$6
+      dtype="fp8"
+      preshuffle_flag=""
+      preshuffle_tag="rowmajor"
+      if [ "${preshuffle_b}" = "1" ] || [ "${preshuffle_b}" = "true" ]; then
+        preshuffle_flag="--preshuffle_b"
+        preshuffle_tag="preshuffle_b"
+      fi
+      log="${BENCH_LOG_DIR}/fp8_gemm_8wave_rowscale_${M}x${N}x${K}_t${tile_m}x${tile_n}_${preshuffle_tag}.log"
+      if python3 tests/kernels/test_fp8_gemm_rowscale.py \
+        --wave_8 \
+        --num_warmups 10 \
+        --num_iters 100 \
+        -M "$M" \
+        -N "$N" \
+        -K "$K" \
+        --tile_m "$tile_m" \
+        --tile_n "$tile_n" \
+        ${preshuffle_flag} >"${log}" 2>&1; then
+        if grep -q "Skipped:" "${log}"; then
+          shape_tag="${M}x${N}x${K}_tile${tile_m}x${tile_n}_${preshuffle_tag}"
+          _emit_row "fp8_8wave_rowscale" "${shape_tag}" "${dtype}" "skip" "skip"
+        else
+          SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+          shape_tag="${M}x${N}x${K}_tile${tile_m}x${tile_n}_${preshuffle_tag}"
+          row="$(_py_parse_and_emit fp8_8wave_rowscale "${shape_tag}" "${dtype}" "${log}")"
+          set -- $row
+          _emit_row "$1" "$2" "$3" "$4" "$5"
+        fi
+      else
+        if grep -q "requires CDNA4\|Skipped:" "${log}" 2>/dev/null; then
+          shape_tag="${M}x${N}x${K}_tile${tile_m}x${tile_n}_${preshuffle_tag}"
+          _emit_row "fp8_8wave_rowscale" "${shape_tag}" "${dtype}" "skip" "skip"
+        else
+          FAIL_COUNT=$((FAIL_COUNT + 1))
+          echo "fp8 8wave row-scale gemm failed. Log: ${log}" >&2
+          _show_fail_log "${log}" "fp8_8wave_rowscale"
+        fi
+      fi
+    done
+  fi
+
   # FP4 GEMM (gfx950 only)
   for shape in $GEMM_FP4_SHAPES; do
     [ -z "$shape" ] && continue

--- a/tests/unit/test_compile_hints.py
+++ b/tests/unit/test_compile_hints.py
@@ -217,7 +217,7 @@ class TestCacheKeyIncludesTarget:
     architectures produce different cache entries."""
 
     def test_cache_key_contains_target(self):
-        """First element of the cache key tuple must be ('_target_', GPUTarget(...))."""
+        """Cache key must carry ('_target_', (GPUTarget, device_id))."""
         from flydsl.compiler.backends import GPUTarget, get_backend
 
         jf = _noop_launch
@@ -229,16 +229,19 @@ class TestCacheKeyIncludesTarget:
         key = jf._resolve_and_make_cache_key(bound.arguments)
 
         assert isinstance(key, tuple)
-        assert len(key) >= 1
-        name, val = key[0]
-        assert name == "_target_"
-        assert isinstance(val, GPUTarget)
-        assert val == get_backend().target
+        target_entry = next((v for k, v in key if k == "_target_"), None)
+        assert target_entry is not None
+        gpu_target, device_id = target_entry
+        assert isinstance(gpu_target, GPUTarget)
+        assert gpu_target == get_backend().target
+        assert isinstance(device_id, int)
 
     def test_different_arch_gives_different_key(self, monkeypatch):
-        """Monkeypatch ARCH env var + reset _sig → different GPUTarget →
-        different cache key.  _target is resolved once in _ensure_sig(),
-        so we must reset _sig to force re-resolution after changing ARCH."""
+        """Monkeypatch ARCH env var → different GPUTarget → different cache key.
+
+        _backend_target is resolved once in _ensure_sig(); we reset _sig to
+        force re-resolution after changing ARCH.
+        """
         from flydsl.compiler.backends import _make_backend, get_backend
 
         jf = _noop_launch
@@ -249,9 +252,8 @@ class TestCacheKeyIncludesTarget:
         bound.apply_defaults()
 
         key1 = jf._resolve_and_make_cache_key(bound.arguments)
-        saved_target = jf._target
+        saved_target = jf._backend_target
 
-        # Monkeypatch to a different arch (ARCH is the env var for env.compile.arch)
         real_arch = get_backend().target.arch
         fake_arch = "gfx950" if real_arch != "gfx950" else "gfx942"
 
@@ -259,19 +261,20 @@ class TestCacheKeyIncludesTarget:
         _make_backend.cache_clear()
 
         try:
-            # Reset _sig/_target to force re-resolution with new ARCH
             jf._sig = None
-            jf._target = None
+            jf._backend_target = None
             jf._ensure_sig()
 
             key2 = jf._resolve_and_make_cache_key(bound.arguments)
             assert key1 != key2
-            assert key1[0][1].arch != key2[0][1].arch
+            t1 = next(v for k, v in key1 if k == "_target_")
+            t2 = next(v for k, v in key2 if k == "_target_")
+            assert t1[0].arch != t2[0].arch
         finally:
             monkeypatch.delenv("ARCH", raising=False)
             _make_backend.cache_clear()
             jf._sig = sig
-            jf._target = saved_target
+            jf._backend_target = saved_target
 
 
 class TestCacheDisabledRegression:

--- a/tests/unit/test_compile_hints.py
+++ b/tests/unit/test_compile_hints.py
@@ -217,7 +217,9 @@ class TestCacheKeyIncludesTarget:
     architectures produce different cache entries."""
 
     def test_cache_key_contains_target(self):
-        """Cache key must carry ('_target_', (GPUTarget, device_id))."""
+        """Cache key must carry an arch-only ('_target_', GPUTarget). The kernel
+        binary is device-independent, so the key has no device id and the same
+        artifact is shared across same-arch GPUs."""
         from flydsl.compiler.backends import GPUTarget, get_backend
 
         jf = _noop_launch
@@ -230,11 +232,8 @@ class TestCacheKeyIncludesTarget:
 
         assert isinstance(key, tuple)
         target_entry = next((v for k, v in key if k == "_target_"), None)
-        assert target_entry is not None
-        gpu_target, device_id = target_entry
-        assert isinstance(gpu_target, GPUTarget)
-        assert gpu_target == get_backend().target
-        assert isinstance(device_id, int)
+        assert isinstance(target_entry, GPUTarget)
+        assert target_entry == get_backend().target
 
     def test_different_arch_gives_different_key(self, monkeypatch):
         """Monkeypatch ARCH env var → different GPUTarget → different cache key.
@@ -269,7 +268,7 @@ class TestCacheKeyIncludesTarget:
             assert key1 != key2
             t1 = next(v for k, v in key1 if k == "_target_")
             t2 = next(v for k, v in key2 if k == "_target_")
-            assert t1[0].arch != t2[0].arch
+            assert t1.arch != t2.arch
         finally:
             monkeypatch.delenv("ARCH", raising=False)
             _make_backend.cache_clear()

--- a/tests/unit/test_jit_cache_key_completeness.py
+++ b/tests/unit/test_jit_cache_key_completeness.py
@@ -229,3 +229,35 @@ def test_dict_global_inplace_mutation_raises(tmp_path, monkeypatch):
     mod.CFG["tile"] = 128  # in-place mutation (same object id)
     with pytest.raises(RuntimeError, match="CFG"):
         mod.k(A)
+
+
+def test_drift_baseline_is_per_owner_cls():
+    """A JIT method reused across owner classes must drift-check each class
+    against its own baseline, not the first owner's. Otherwise a global seen only
+    under the second owner is skipped (not in the first owner's baseline) and a
+    later mutation silently reuses the memoized key segment instead of raising."""
+    from flydsl.compiler.jit_function import _snapshot_refs
+
+    @flyc.jit
+    def launch(A: fx.Tensor):
+        return A
+
+    # Two owner classes whose discovered refs read different module globals.
+    g = {"__name__": "m", "FOO": 1, "BAR": 1}
+
+    class A:
+        pass
+
+    class B:
+        pass
+
+    launch._global_refs_cache[A] = [("FOO", "m", g)]
+    launch._global_refs_cache[B] = [("BAR", "m", g)]
+    launch._used_global_vals[A] = _snapshot_refs(launch._global_refs_cache[A], stable=False)
+    launch._used_global_vals[B] = _snapshot_refs(launch._global_refs_cache[B], stable=False)
+
+    g["BAR"] = 2  # mutate a global seen only under owner B
+
+    launch._check_globals_drift(A)  # A's baseline (FOO) unchanged → no raise
+    with pytest.raises(RuntimeError, match="BAR"):
+        launch._check_globals_drift(B)  # B's own baseline catches the BAR drift

--- a/tests/unit/test_jit_cache_key_completeness.py
+++ b/tests/unit/test_jit_cache_key_completeness.py
@@ -129,9 +129,7 @@ def test_globals_snapshot_folded_into_cache_key_default_mode():
     import textwrap
 
     with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
-        f.write(
-            textwrap.dedent(
-                """
+        f.write(textwrap.dedent("""
                 import flydsl.compiler as flyc
                 import flydsl.expr as fx
 
@@ -141,9 +139,7 @@ def test_globals_snapshot_folded_into_cache_key_default_mode():
                 def k(A: fx.Tensor):
                     # reference FOO so it lands in co_names and the snapshot
                     _ = FOO
-                """
-            )
-        )
+                """))
         path = f.name
 
     def _full_key(jit_fn, *args):

--- a/tests/unit/test_jit_cache_key_completeness.py
+++ b/tests/unit/test_jit_cache_key_completeness.py
@@ -83,18 +83,14 @@ def test_env_var_not_cached_within_process(monkeypatch):
     assert k1 != k2
 
 
-def test_device_id_in_cache_key_is_live():
-    """Regression: cache key's device_id slot must reflect the current device,
-    not a value frozen at first call.
+def test_cache_key_is_device_independent():
+    """The cache key's target is arch-only, with no device id component.
 
-    A previous implementation cached (target, device_id) inside _ensure_sig(),
-    so switching device with torch.cuda.set_device() after the first launch
-    would silently hit the other device's cached artifact.
-
-    device_id is now resolved through the active DeviceRuntime (per-backend),
-    queried live on every call.
+    The compiled kernel binary is device-independent, so a single in-process
+    artifact / func_exe is shared across same-arch GPUs (as on main). Folding a
+    device id into the key would needlessly split the cache per device.
     """
-    from flydsl.runtime.device_runtime import get_device_runtime
+    from flydsl.compiler.backends import GPUTarget, get_backend
 
     @flyc.jit
     def k(A: fx.Tensor):
@@ -102,10 +98,10 @@ def test_device_id_in_cache_key_is_live():
 
     A = torch.zeros(8, dtype=torch.float32)
     k._ensure_sig()
-    # Sanity check: target tuple's second slot is rebuilt per call, not cached.
     key1 = _key(k, A)
     target_entry = next(v for n, v in key1 if n == "_target_")
-    assert target_entry[1] == get_device_runtime().current_device_id()
+    assert isinstance(target_entry, GPUTarget)
+    assert target_entry == get_backend().target
 
 
 def test_globals_snapshot_folded_into_cache_key_default_mode():

--- a/tests/unit/test_jit_cache_key_completeness.py
+++ b/tests/unit/test_jit_cache_key_completeness.py
@@ -5,8 +5,6 @@ args, globals-drift detection, and the ir.Type fallback in ``_arg_cache_sig``.""
 
 from __future__ import annotations
 
-import os
-
 import pytest
 import torch
 
@@ -38,7 +36,7 @@ def test_env_var_drift_changes_cache_key(monkeypatch):
     assert k1 != k2, "cache key must change when whitelisted env var changes"
 
 
-def test_globals_drift_default_raises(tmp_path):
+def test_globals_drift_default_raises(tmp_path, monkeypatch):
     """mutating a referenced global must raise."""
     src = tmp_path / "drift_default.py"
     src.write_text(
@@ -54,16 +52,13 @@ def test_globals_drift_default_raises(tmp_path):
 
     spec = importlib.util.spec_from_file_location("drift_default", src)
     mod = importlib.util.module_from_spec(spec)
-    os.environ["COMPILE_ONLY"] = "1"
-    try:
-        spec.loader.exec_module(mod)
-        A = torch.zeros(8, dtype=torch.float32)
+    monkeypatch.setenv("COMPILE_ONLY", "1")  # auto-restored, no leak across tests
+    spec.loader.exec_module(mod)
+    A = torch.zeros(8, dtype=torch.float32)
+    mod.k(A)
+    mod.FOO = 2
+    with pytest.raises(RuntimeError, match="FOO"):
         mod.k(A)
-        mod.FOO = 2
-        with pytest.raises(RuntimeError, match="FOO"):
-            mod.k(A)
-    finally:
-        os.environ.pop("COMPILE_ONLY", None)
 
 
 def test_env_var_not_cached_within_process(monkeypatch):
@@ -176,3 +171,61 @@ def test_cache_signature_requires_protocol_method():
 
     with pytest.raises(TypeError, match="__cache_signature__"):
         cache_signature(_NoSig())
+
+
+def _load_mod(tmp_path, name, body):
+    import importlib.util
+
+    src = tmp_path / f"{name}.py"
+    src.write_text(body)
+    spec = importlib.util.spec_from_file_location(name, src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_container_global_folded_by_value_not_collapsed(tmp_path):
+    """A tuple/list/dict global must be folded into the key by *content*, not
+    collapsed to ('obj', <type>). Two independent loads (≈ two processes)
+    observing CFG=(128, 64) vs CFG=(128, 32) must produce different keys."""
+    body = (
+        "import flydsl.compiler as flyc\n"
+        "import flydsl.expr as fx\n"
+        "CFG = (128, 64)\n"
+        "@flyc.jit\n"
+        "def k(A: fx.Tensor):\n"
+        "    _ = CFG\n"
+        "    return A\n"
+    )
+
+    def _full_key(mod):
+        mod.k._ensure_sig()
+        bound = mod.k._sig.bind(torch.zeros(8, dtype=torch.float32))
+        bound.apply_defaults()
+        return mod.k._build_full_cache_key(bound.arguments)
+
+    k1 = _full_key(_load_mod(tmp_path, "cfg_a", body))
+    k2 = _full_key(_load_mod(tmp_path, "cfg_b", body.replace("(128, 64)", "(128, 32)")))
+    assert k1 != k2, "container global contents must participate in the cache key"
+
+
+def test_dict_global_inplace_mutation_raises(tmp_path, monkeypatch):
+    """In-place mutation of a referenced dict/list global must be detected by
+    drift (value-based snapshot), not silently reuse the old artifact."""
+    mod = _load_mod(
+        tmp_path,
+        "cfg_mut",
+        "import flydsl.compiler as flyc\n"
+        "import flydsl.expr as fx\n"
+        "CFG = {'tile': 64}\n"
+        "@flyc.jit\n"
+        "def k(A: fx.Tensor):\n"
+        "    _ = CFG\n"
+        "    return A\n",
+    )
+    monkeypatch.setenv("COMPILE_ONLY", "1")
+    A = torch.zeros(8, dtype=torch.float32)
+    mod.k(A)
+    mod.CFG["tile"] = 128  # in-place mutation (same object id)
+    with pytest.raises(RuntimeError, match="CFG"):
+        mod.k(A)

--- a/tests/unit/test_jit_cache_key_completeness.py
+++ b/tests/unit/test_jit_cache_key_completeness.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+"""Coverage for the cache-key completeness work: env-var drift, nested jit/kernel
+args, globals-drift detection, and the ir.Type fallback in ``_arg_cache_sig``."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.protocol import cache_signature
+
+
+def _key(jit_fn, *args):
+    jit_fn._ensure_sig()
+    bound = jit_fn._sig.bind(*args)
+    bound.apply_defaults()
+    return jit_fn._resolve_and_make_cache_key(bound.arguments)
+
+
+def test_env_var_drift_changes_cache_key(monkeypatch):
+    @flyc.jit
+    def k(A: fx.Tensor):
+        pass
+
+    A = torch.zeros(8, dtype=torch.float32)
+
+    monkeypatch.setenv("FLYDSL_COMPILE_OPT_LEVEL", "2")
+    k1 = _key(k, A)
+
+    monkeypatch.setenv("FLYDSL_COMPILE_OPT_LEVEL", "0")
+    k2 = _key(k, A)
+
+    assert k1 != k2, "cache key must change when whitelisted env var changes"
+
+
+def test_globals_drift_default_raises(tmp_path):
+    """mutating a referenced global must raise."""
+    src = tmp_path / "drift_default.py"
+    src.write_text(
+        "import flydsl.compiler as flyc\n"
+        "import flydsl.expr as fx\n"
+        "FOO = 1\n"
+        "@flyc.jit\n"
+        "def k(A: fx.Tensor):\n"
+        "    _ = FOO\n"
+        "    return A\n"
+    )
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("drift_default", src)
+    mod = importlib.util.module_from_spec(spec)
+    os.environ["COMPILE_ONLY"] = "1"
+    try:
+        spec.loader.exec_module(mod)
+        A = torch.zeros(8, dtype=torch.float32)
+        mod.k(A)
+        mod.FOO = 2
+        with pytest.raises(RuntimeError, match="FOO"):
+            mod.k(A)
+    finally:
+        os.environ.pop("COMPILE_ONLY", None)
+
+
+def test_env_var_not_cached_within_process(monkeypatch):
+    """Regression: env var lookup must re-read os.environ on every call.
+
+    A previous implementation wrapped _cache_invalidating_env_values in
+    lru_cache(maxsize=1), which froze the first observed values into every
+    subsequent cache key — flipping FLYDSL_COMPILE_OPT_LEVEL mid-process
+    produced a silent stale-hit.
+    """
+
+    @flyc.jit
+    def k(A: fx.Tensor):
+        pass
+
+    A = torch.zeros(8, dtype=torch.float32)
+
+    monkeypatch.setenv("FLYDSL_COMPILE_OPT_LEVEL", "2")
+    k1 = _key(k, A)
+    monkeypatch.setenv("FLYDSL_COMPILE_OPT_LEVEL", "0")
+    k2 = _key(k, A)
+    assert k1 != k2
+
+
+def test_device_id_in_cache_key_is_live():
+    """Regression: cache key's device_id slot must reflect the current device,
+    not a value frozen at first call.
+
+    A previous implementation cached (target, device_id) inside _ensure_sig(),
+    so switching device with torch.cuda.set_device() after the first launch
+    would silently hit the other device's cached artifact.
+
+    device_id is now resolved through the active DeviceRuntime (per-backend),
+    queried live on every call.
+    """
+    from flydsl.runtime.device_runtime import get_device_runtime
+
+    @flyc.jit
+    def k(A: fx.Tensor):
+        pass
+
+    A = torch.zeros(8, dtype=torch.float32)
+    k._ensure_sig()
+    # Sanity check: target tuple's second slot is rebuilt per call, not cached.
+    key1 = _key(k, A)
+    target_entry = next(v for n, v in key1 if n == "_target_")
+    assert target_entry[1] == get_device_runtime().current_device_id()
+
+
+def test_globals_snapshot_folded_into_cache_key_default_mode():
+    """Regression: the stable globals snapshot must be folded into the cache key
+    so two processes sharing a disk cache but observing different global values
+    cannot collide.
+
+    Each process is a fresh JitFunction instance that snapshots the global value
+    it observes on its first call (the snapshot is then memoized — within one
+    process a later change raises via drift detection rather than re-keying). So
+    cross-process divergence is modelled here by two independent module loads
+    with different ``FOO`` values, not by mutating one instance in place.
+    """
+    import importlib.util
+    import tempfile
+    import textwrap
+
+    with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+        f.write(
+            textwrap.dedent(
+                """
+                import flydsl.compiler as flyc
+                import flydsl.expr as fx
+
+                FOO = 7
+
+                @flyc.jit
+                def k(A: fx.Tensor):
+                    # reference FOO so it lands in co_names and the snapshot
+                    _ = FOO
+                """
+            )
+        )
+        path = f.name
+
+    def _full_key(jit_fn, *args):
+        jit_fn._ensure_sig()
+        bound = jit_fn._sig.bind(*args)
+        bound.apply_defaults()
+        return jit_fn._build_full_cache_key(bound.arguments)
+
+    def _load_with_foo(name, foo):
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        mod.FOO = foo  # set before first call, as a second process would observe it
+        return mod
+
+    A = torch.zeros(8, dtype=torch.float32)
+    # Two independent "processes" observing FOO=7 vs FOO=99 on their first call.
+    k1 = _full_key(_load_with_foo("_gkmod_a", 7).k, A)
+    k2 = _full_key(_load_with_foo("_gkmod_b", 99).k, A)
+    assert k1 != k2, "stable globals snapshot must be in cache key in default mode"
+
+
+def test_cache_signature_requires_protocol_method():
+    """Types lacking __cache_signature__ must raise — no silent type-only collapse.
+
+    With __cache_signature__ promoted to a required JitArgument protocol method,
+    cache_signature() no longer falls back to str(ir.Type). Unknown leaf objects
+    bottom out at the Constexpr encoder, which only accepts the supported scalar
+    shapes, so arbitrary instances raise instead of colliding under a shared key.
+    """
+
+    class _NoSig:
+        pass
+
+    with pytest.raises(TypeError, match="__cache_signature__"):
+        cache_signature(_NoSig())


### PR DESCRIPTION
Per-call cache key (jit_function.py):
- Require __cache_signature__ on every JitArgument; drop the str(ir.Type) fallback so unknown types raise instead of silently colliding under one key.
- Fold module globals into the key: a cross-process-stable snapshot plus Triton-style in-process drift detection that raises on change (no auto-recompile). Composite (name, module) identity so same-named globals across modules don't collide.
- target = (GPUTarget, device_id), read live per call so device switches and arch/env changes participate in the key (device_id via the active DeviceRuntime).
- Whitelisted code-gen env vars re-read live into the key (os._Environ._data fast path with a public-API fallback).
- Performance: memoize the recursive global-ref discovery and the globals key segment; per call only re-snapshots values and runs a lean drift loop.

jit_argument.py:
- Construct JitArgument-annotated params (e.g. Stream) via the annotation; remove the int+Stream special-case and the type fallback.

Tests:
- test_jit_cache_key_completeness.py: env drift, globals snapshot in key, globals drift raises, required __cache_signature__ protocol.
- test_compile_hints.py: _target_ entry is now (GPUTarget, device_id).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
