### PR TITLE
[Enh] Add verifier for RecastIterOp to reject unsound pointer recasts

### DIFF
--- a/include/flydsl/Dialect/Fly/IR/FlyOps.td
+++ b/include/flydsl/Dialect/Fly/IR/FlyOps.td
@@ -471,6 +471,7 @@ def Fly_PtrStoreOp : Fly_Op<"ptr.store"> {
 def Fly_RecastIterOp : Fly_Op<"recast_iter", [Pure]> {
   let arguments = (ins Fly_Pointer:$src);
   let results = (outs Fly_Pointer:$result);
+  let hasVerifier = 1;
 }
 
 def Fly_MemRefAllocaOp : Fly_Op<"memref.alloca", []> {

--- a/lib/Dialect/Fly/IR/FlyOps.cpp
+++ b/lib/Dialect/Fly/IR/FlyOps.cpp
@@ -1963,3 +1963,29 @@ FLY_INFER_RETURN_TYPES(MemRefLoadVecOp) {
 }
 
 #undef FLY_INFER_RETURN_TYPES
+
+LogicalResult RecastIterOp::verify() {
+  auto srcTy = dyn_cast<PointerType>(getSrc().getType());
+  auto resultTy = dyn_cast<PointerType>(getResult().getType());
+  if (!srcTy || !resultTy)
+    return emitOpError("expected PointerType source and result");
+
+  if (srcTy.getAddressSpace() != resultTy.getAddressSpace())
+    return emitOpError("result pointer address space must match source");
+
+  // recast_iter only reinterprets the element type; it must not change the
+  // alignment guarantee in an unsound way. Narrowing the alignment is safe
+  // because a more strongly aligned pointer also satisfies any weaker alignment
+  // (for example, a 1024-byte-aligned pointer is necessarily 512-byte aligned),
+  // but claiming a stronger alignment than the source provides is not.
+  int32_t srcAlign = srcTy.getAlignment().getAlignment();
+  int32_t resultAlign = resultTy.getAlignment().getAlignment();
+  if (resultAlign <= 0 || srcAlign % resultAlign != 0)
+    return emitOpError("result pointer alignment must divide source alignment "
+                       "(narrowing is allowed, widening is not)");
+
+  if (srcTy.getSwizzle() != resultTy.getSwizzle())
+    return emitOpError("result pointer swizzle must match source");
+
+  return success();
+}

--- a/tests/mlir/Conversion/recast_iter_invalid.mlir
+++ b/tests/mlir/Conversion/recast_iter_invalid.mlir
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 FlyDSL Project Contributors
+// RUN: { not %fly-opt %s -split-input-file 2>&1; } | FileCheck %s
+
+// CHECK: result pointer address space must match source
+func.func @bad_recast_address_space(%ptr: !fly.ptr<f32, shared>) {
+  %bad = fly.recast_iter(%ptr) : (!fly.ptr<f32, shared>) -> !fly.ptr<f32, global>
+  return
+}
+
+// -----
+// Widening the alignment guarantee is unsound and must be rejected.
+// CHECK: result pointer alignment must divide source alignment
+func.func @bad_recast_alignment(%ptr: !fly.ptr<f32, shared, align<512>>) {
+  %bad = fly.recast_iter(%ptr) : (!fly.ptr<f32, shared, align<512>>) -> !fly.ptr<f32, shared, align<1024>>
+  return
+}
+
+// -----
+// CHECK: result pointer swizzle must match source
+func.func @bad_recast_swizzle(%ptr: !fly.ptr<f32, shared, align<1024>, swz<3,3,3>>) {
+  %bad = fly.recast_iter(%ptr) : (!fly.ptr<f32, shared, align<1024>, swz<3,3,3>>) -> !fly.ptr<f32, shared, align<1024>>
+  return
+}


### PR DESCRIPTION
Summary
fly.recast_iter reinterprets a pointer's element type, but its result type is supplied by the caller. Previously the result pointer was not validated at all — e.g. recasting a shared-memory pointer into global would silently flow through to lowering and cause undefined runtime behavior.

This PR adds a verifier for RecastIterOp that requires the result pointer to:

keep the same address space as the source (a reinterpret cannot move memory across address spaces);
only narrow the alignment guarantee (result alignment must divide source alignment) — narrowing is sound, widening is not;
keep the same swizzle.
Narrowing is intentionally allowed: existing kernels (e.g. preshuffle_gemm_v2) recast the 1024B-aligned dynamic shared base down to a 512B-aligned typed pointer.

Test
Adds tests/mlir/Conversion/recast_iter_invalid.mlir with FileCheck negative tests covering each rejected case (address-space change / alignment widening / swizzle change).