### PR TITLE
Rename block_product to blocked_product to align with mlir

### DIFF
--- a/.claude/skills/flydsl-kernel-authoring/SKILL.md
+++ b/.claude/skills/flydsl-kernel-authoring/SKILL.md
@@ -129,7 +129,7 @@ Products combine two layouts to create a larger layout:
 ```python
 fx.logical_product(layout, tiler)   # Basic mode-wise concatenation
 fx.raked_product(thr, val)          # Interleaved access pattern (common for TiledCopy)
-fx.block_product(layout, tiler)     # Blocked access pattern
+fx.blocked_product(layout, tiler)   # Blocked access pattern
 fx.zipped_product(layout, tiler)    # Zipped modes
 fx.tiled_product(layout, tiler)     # Hierarchical tiled structure
 fx.flat_product(layout, tiler)      # Flattened result

--- a/docs/api/dsl.rst
+++ b/docs/api/dsl.rst
@@ -62,7 +62,7 @@ Layout Products & Divides
 - **fx.logical_product(a, b)** -- layout product
 - **fx.zipped_product**, **fx.tiled_product**, **fx.flat_product** -- product variants
 - **fx.raked_product(thr_layout, val_layout)** -- interleaved (raked) product
-- **fx.block_product(a, b)** -- blocked product
+- **fx.blocked_product(a, b)** -- blocked product
 
 Coordinate Mapping
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/cute_layout_algebra_guide.md
+++ b/docs/cute_layout_algebra_guide.md
@@ -145,7 +145,7 @@ Products combine two layouts to create higher-rank layouts. They differ in how t
 | **Tiled Product** | Like logical, but group by tile | `fx.tiled_product(A, B)` |
 | **Flat Product** | Flatten all result modes | `fx.flat_product(A, B)` |
 | **Raked Product** | Interleave A and B elements (raked distribution) | `fx.raked_product(A, B)` |
-| **Blocked Product** | Block A elements together, then B (blocked distribution) | `fx.block_product(A, B)` |
+| **Blocked Product** | Block A elements together, then B (blocked distribution) | `fx.blocked_product(A, B)` |
 
 > **Reference:** `include/cute/layout.hpp` — `logical_product()`, `zipped_product()`, `tiled_product()`, `flat_product()`, `raked_product()`, `blocked_product()`.
 

--- a/docs/layout_system_guide.md
+++ b/docs/layout_system_guide.md
@@ -30,7 +30,7 @@
 | | `fx.tiled_product(A, B)` | `fly.tiled_product` | Tiled product |
 | | `fx.flat_product(A, B)` | `fly.flat_product` | Flat product |
 | | `fx.raked_product(A, B)` | `fly.raked_product` | Raked product |
-| | `fx.block_product(A, B)` | `fly.block_product` | Blocked product |
+| | `fx.blocked_product(A, B)` | `fly.blocked_product` | Blocked product |
 | **Divides** | `fx.logical_divide(A, B)` | `fly.logical_divide` | Basic divide |
 | | `fx.zipped_divide(A, B)` | `fly.zipped_divide` | Zipped divide |
 | | `fx.tiled_divide(A, B)` | `fly.tiled_divide` | Tiled divide |
@@ -222,7 +222,7 @@ Products combine two layouts to create a larger layout. All products take `(layo
 | `tiled_product` | Creates hierarchical tiled structure. |
 | `flat_product` | Produces a flattened result. |
 | `raked_product` | Creates a raked (interleaved) access pattern. |
-| `block_product` | Creates a blocked access pattern. |
+| `blocked_product` | Creates a blocked access pattern. |
 
 ```python
 result = fx.logical_product(layout, tiler)
@@ -489,7 +489,7 @@ Which layout operation do I need?
 │
 ├── Combining layouts?
 │   ├── Sequential mapping → composition(A, B)
-│   ├── Extending threads → logical_product / raked_product / block_product
+│   ├── Extending threads → logical_product / raked_product / blocked_product
 │   └── Simplifying → coalesce(layout)
 │
 ├── Partitioning / tiling?

--- a/python/flydsl/expr/primitive.py
+++ b/python/flydsl/expr/primitive.py
@@ -149,7 +149,7 @@ __all__ = [
     "zipped_product",
     "tiled_product",
     "flat_product",
-    "block_product",
+    "blocked_product",
     "raked_product",
     "recast_layout",
     "tile_to_shape",
@@ -845,8 +845,8 @@ def flat_product(layout, tiler, loc=None, ip=None):
 
 
 @traced_op
-def block_product(layout, tiler, loc=None, ip=None):
-    return fly.block_product(layout, tiler, loc=loc, ip=ip)
+def blocked_product(layout, tiler, loc=None, ip=None):
+    return fly.blocked_product(layout, tiler, loc=loc, ip=ip)
 
 
 @traced_op


### PR DESCRIPTION
The Fly dialect op, C++ class (BlockedProductOp), and util (layoutBlockedProduct) already use the "blocked_product" naming. This finishes the rename on the Python DSL wrapper and docs so the public API matches CuTe's blocked_product.

This also fixes a latent bug: primitive.block_product called fly.block_product, which no longer exists in the generated bindings (the op mnemonic is fly.blocked_product).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
