### PR TITLE
Fix CI checkout and fused RoPE f16 test

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -46,11 +46,6 @@ jobs:
   # ---------------------------------------------------------------------------
   test:
     needs: check-signal
-    env:
-      # Some self-hosted runners configure a GitHub -> git-cache URL rewrite.
-      # If that cache is unavailable, checkout fails before the tests start.
-      GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
-      GIT_CONFIG_NOSYSTEM: "1"
     strategy:
       matrix:
         runners: [
@@ -63,6 +58,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        env:
+          # Some self-hosted runners configure a GitHub -> git-cache URL rewrite.
+          # If that cache is unavailable, checkout fails before the tests start.
+          GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
+          GIT_CONFIG_NOSYSTEM: "1"
         with:
           repository: ${{ env.GITHUB_REPO_NAME }}
           ref: ${{ env.GITHUB_COMMIT_SHA }}
@@ -328,10 +328,6 @@ jobs:
     needs: test
     name: Multi-GPU AllReduce Tests (${{ matrix.runners }})
     timeout-minutes: 120
-    env:
-      # Keep checkout independent of runner-local git-cache rewrites.
-      GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
-      GIT_CONFIG_NOSYSTEM: "1"
     if: |
       always() && (
         (github.event_name == 'pull_request' &&
@@ -349,6 +345,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        env:
+          # Keep checkout independent of runner-local git-cache rewrites.
+          GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
+          GIT_CONFIG_NOSYSTEM: "1"
         with:
           repository: ${{ env.GITHUB_REPO_NAME }}
           ref: ${{ env.GITHUB_COMMIT_SHA }}

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -49,7 +49,7 @@ jobs:
     env:
       # Some self-hosted runners configure a GitHub -> git-cache URL rewrite.
       # If that cache is unavailable, checkout fails before the tests start.
-      GIT_CONFIG_GLOBAL: /dev/null
+      GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
       GIT_CONFIG_NOSYSTEM: "1"
     strategy:
       matrix:
@@ -330,7 +330,7 @@ jobs:
     timeout-minutes: 120
     env:
       # Keep checkout independent of runner-local git-cache rewrites.
-      GIT_CONFIG_GLOBAL: /dev/null
+      GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
       GIT_CONFIG_NOSYSTEM: "1"
     if: |
       always() && (

--- a/tests/kernels/test_fused_rope_cache.py
+++ b/tests/kernels/test_fused_rope_cache.py
@@ -397,7 +397,7 @@ def run_test(
     do_bench = bench or os.environ.get("FLYDSL_BENCH", "0") == "1"
 
     # AITER cross-check (and optional benchmark)
-    if HAS_AITER and not negative_slots and not apply_scale:
+    if HAS_AITER and dtype_str == "bf16" and not negative_slots and not apply_scale:
         # AITER Triton wrapper expects int64 slots/positions and 4D cos/sin
         slots_i64 = slot_mapping.to(torch.int64)
         pos_i64 = positions_i32.to(torch.int64)


### PR DESCRIPTION
## Summary
- Point CI checkout's global git config override at a writable runner temp file instead of `/dev/null`.
- Skip the optional AITER cross-check for f16 KV cache tests, since the current AITER wrapper only accepts BF16, FP8, or packed FP4 cache dtypes.

## Test plan
- Checked lints for `tests/kernels/test_fused_rope_cache.py`.
- Not run locally; the failing coverage requires GPU CI. Expected to unblock the checkout error and the four `test_f16` failures from https://github.com/ROCm/FlyDSL/actions/runs/26791779014/job/78979738822.


Made with [Cursor](https://cursor.com)