### PR TITLE
pa: vendor PA metadata scheduler, drop aiter get_pa_metadata_v1 dep

### DIFF
--- a/kernels/pa_decode_fp8.py
+++ b/kernels/pa_decode_fp8.py
@@ -997,6 +997,11 @@ def compile_pa_decode_metadata(
                 f"compile_pa_decode_metadata: unsupported small block_size={_block_size}; "
                 f"expected one of {_PA_DECODE_PS_SMALL_BLOCK_SIZES} or >= {KV_COMPUTE_BLOCK}."
             )
+        if per_token_kv:
+            raise NotImplementedError(
+                "compile_pa_decode_metadata: per_token_kv=True is not supported for "
+                "small block_size 16/64; small blocks use compile_pa_decode_ps."
+            )
         if not trans_v:
             raise NotImplementedError(
                 "compile_pa_decode_metadata: trans_v=False is not supported for small block_size 16/64."
@@ -1325,39 +1330,6 @@ def compile_pa_decode_metadata(
                         v_phys_blocks.append(fx.Vector.load(T.vec(1, T.i32), bt_lds_i32, [fx.Index(bt_lds_off)])[0])
                 return v_phys_blocks
 
-            def _meta_stage_small_block_kv_scales():
-                # Per-token K/V scale staging for small blocks (per_token_kv).
-                # A 256-token partition spans `_blocks_per_partition` physical
-                # pages whose indices are already staged in bt_lds_i32.  Each
-                # thread owns one LDS slot ``t`` (its partition-local token) and
-                # loads that token's scale from the page it belongs to.  Writes
-                # the same scale_lds_f32 layout as `_load_v_and_scales` so the
-                # cached-vec readers and v_max reduction work unchanged.
-                t = warp_id * fx.Int32(WARP_SIZE) + rowid * fx.Int32(MFMA_N) + lane16id
-                part_page = _udiv_const(t, _block_size)
-                tok_in_page = _urem_const(t, _block_size)
-                phys = fx.Vector.load(T.vec(1, T.i32), bt_lds_i32, [fx.Index(part_page)])[0]
-                scale_idx = phys * stride_ks_block + kv_h * stride_ks_head + tok_in_page
-                k_scale_scalar = buffer_ops.buffer_load(ks_rsrc, scale_idx, vec_width=1, dtype=fx.Float32)
-                v_scale_scalar = buffer_ops.buffer_load(vs_rsrc, scale_idx, vec_width=1, dtype=fx.Float32)
-                fx.Vector.from_elements([k_scale_scalar], dtype=fx.Float32).store(scale_lds_f32, [fx.Index(t)])
-                fx.Vector.from_elements([v_scale_scalar], dtype=fx.Float32).store(
-                    scale_lds_f32, [fx.Index(fx.Int32(LDS_SCALE_V_OFFSET) + t)]
-                )
-
-            def _meta_load_small_block_scale_vecs():
-                # Read the cached per-token K/V scale f32x4 vecs from LDS, matching
-                # the `cache_scale_vecs` layout produced by `_load_v_and_scales`.
-                k_scale_vecs = []
-                v_scale_vecs = []
-                for td in range_constexpr(TLOOP):
-                    row = _kv_tok_thread_base + arith.constant(td * MFMA_N, type=T.i32)
-                    k_scale_vecs.append(vector.load_op(T.f32x4, scale_lds_f32, [fx.Index(row)]))
-                    v_scale_vecs.append(
-                        vector.load_op(T.f32x4, scale_lds_f32, [fx.Index(fx.Int32(LDS_SCALE_V_OFFSET) + row)])
-                    )
-                return k_scale_vecs, v_scale_vecs
-
             # ── Pre-load Q for every MTP group ONCE per work item.  Each
             # group's q_frags / qi / qhi / qscale stay in registers across
             # the entire KV loop, so we pay the Q-load cost (global → LDS →
@@ -1453,10 +1425,7 @@ def compile_pa_decode_metadata(
                     flat.extend([_unwrap(rmax), _unwrap(rsum)])
                     flat.extend(_unwrap(out) for out in outs)
                 flat.extend(_unwrap(v) for v in k_flat)
-                # Large blocks loop-carry the next partition's prefetched scale
-                # scalars; small blocks stage per-token scales fresh each
-                # iteration from LDS, so nothing to carry.
-                if const_expr(cache_scale_vecs and per_token_kv and not _is_small_block):
+                if const_expr(cache_scale_vecs and per_token_kv):
                     flat.extend(_unwrap(v) for v in scale_scalars)
                 return flat
 
@@ -1464,7 +1433,7 @@ def compile_pa_decode_metadata(
                 base = state_width * _mtp_groups
                 states = [tuple(flat[state_width * i + j] for j in range(state_width)) for i in range(_mtp_groups)]
                 k_flat = list(flat[base : base + _N_K_h])
-                if const_expr(cache_scale_vecs and per_token_kv and not _is_small_block):
+                if const_expr(cache_scale_vecs and per_token_kv):
                     scale_scalars = tuple(flat[base + _N_K_h : base + _N_K_h + 2])
                 else:
                     scale_scalars = None
@@ -1518,13 +1487,6 @@ def compile_pa_decode_metadata(
                         head_size=_HEAD,
                         vhe_loop=_VHELOOP,
                     )
-                    if const_expr(cache_scale_vecs and per_token_kv):
-                        # Stage this partition's per-token K/V scales from the
-                        # gathered pages (bt_lds_i32 already populated above),
-                        # then read them back as cached f32x4 vecs.
-                        _meta_stage_small_block_kv_scales()
-                        gpu.barrier()
-                        k_scale_vecs, v_scale_vecs = _meta_load_small_block_scale_vecs()
                 else:
                     phys_block = buffer_ops.buffer_load(
                         kpi_rsrc, kv_page_base + _udiv_const(lp, _parts_per_block), vec_width=1, dtype=T.i32
@@ -2096,6 +2058,757 @@ def _pa_small_block_load_v_trans(
     return v_results
 
 
+@functools.lru_cache(maxsize=256)
+def compile_pa_decode_ps(
+    *,
+    block_size: int,
+    max_context_partition_num: int,
+    softmax_scale: float = None,
+    trans_v: bool = True,
+    query_group_size: int = 16,
+    per_token_kv: bool = False,
+    query_length: int = 1,
+    query_input_dtype: str = "bf16",
+    head_dim: int = 128,
+):
+    """Compile the small-block partition kernel.  See module-level comment."""
+    if block_size not in _PA_DECODE_PS_SMALL_BLOCK_SIZES:
+        raise ValueError(
+            f"compile_pa_decode_ps: unsupported block_size={block_size}; "
+            f"expected one of {_PA_DECODE_PS_SMALL_BLOCK_SIZES}."
+        )
+    if query_input_dtype not in ("bf16", "f16"):
+        raise ValueError("compile_pa_decode_ps currently expects bf16/f16 query inputs.")
+    if not trans_v:
+        raise NotImplementedError("compile_pa_decode_ps: trans_v=False not yet supported.")
+    if head_dim % QKHE_PER_FETCH != 0 or head_dim % (MFMA_N * NUM_WARPS) != 0 or head_dim % Q_ELEMS_PER_LANE != 0:
+        raise ValueError(f"Unsupported head_dim={head_dim}; must be a multiple of {MFMA_N * NUM_WARPS}.")
+    _HEAD = head_dim
+    _QKHELOOP = head_dim // QKHE_PER_FETCH
+    _VHELOOP = head_dim // MFMA_N // NUM_WARPS
+    _Q_LANES_PER_HEAD = head_dim // Q_ELEMS_PER_LANE
+    _N_K_h = TLOOP * _QKHELOOP * 2
+    _N_V_FLAT_h = 2 * VTLOOP * _VHELOOP
+
+    arch = get_hip_arch()
+    query_load_is_bf16 = query_input_dtype == "bf16"
+    if softmax_scale is None:
+        softmax_scale = 1.0 / (head_dim**0.5)
+    _softmax_scale = float(softmax_scale)
+    _block_size = block_size
+    _blocks_per_partition = KV_COMPUTE_BLOCK // _block_size
+
+    _mtp_groups = max(1, math.ceil(query_length * query_group_size / 16))
+
+    # LDS allocation — same layout as compile_pa_decode_metadata's small-block
+    # path.  per_token_kv adds a cross-warp v_scale_max region (appended to the
+    # softmax block) and a K/V per-token scale staging region.
+    LDS_VMAX_BYTES = NUM_WARPS * MFMA_N * 4 if const_expr(per_token_kv) else 0
+    LDS_SOFTMAX_TOTAL = LDS_SOFTMAX_BYTES + LDS_VMAX_BYTES
+    LDS_SCALE_TOTAL = LDS_SCALE_BYTES if const_expr(per_token_kv) else 0
+    # Unique global symbol per compile to avoid module-level symbol clashes
+    # when multiple compiled artifacts are loaded into the same GPU context.
+    _smem_sym_name = (
+        f"pa_ps_smallblk_smem_bs{block_size}_ql{query_length}"
+        f"_qgs{query_group_size}_tv{int(trans_v)}_qd{query_input_dtype}"
+        f"_ptkv{int(per_token_kv)}"
+    )
+    allocator = SmemAllocator(None, arch=arch, global_sym_name=_smem_sym_name)
+    logits_off = 0
+    allocator.ptr = LDS_LOGITS_BYTES
+    softmax_off = LDS_LOGITS_BYTES
+    allocator.ptr += LDS_SOFTMAX_TOTAL
+    # K/V per-token scale staging LDS (per_token_kv only).
+    scale_off_ps = softmax_off + LDS_SOFTMAX_TOTAL
+    allocator.ptr += LDS_SCALE_TOTAL
+    bt_off = scale_off_ps + LDS_SCALE_TOTAL
+    allocator.ptr += NUM_WARPS * TLOOP * 4
+
+    @flyc.kernel(known_block_size=(BLOCK_THREADS, 1, 1))
+    def pa_decode_ps_kernel(
+        exp_sums_ptr: fx.Tensor,
+        max_logits_ptr: fx.Tensor,
+        tmp_out_ptr: fx.Tensor,
+        query_ptr: fx.Tensor,
+        key_cache_ptr: fx.Tensor,
+        value_cache_ptr: fx.Tensor,
+        block_tables_ptr: fx.Tensor,
+        context_lengths_ptr: fx.Tensor,
+        key_scale_ptr: fx.Tensor,
+        value_scale_ptr: fx.Tensor,
+        stride_q_seq: Int32,
+        stride_q_head: Int32,
+        stride_k_block: Int32,
+        stride_k_head: Int32,
+        stride_v_block: Int32,
+        stride_v_head: Int32,
+        stride_es_seq: Int32,
+        stride_es_head: Int32,
+        stride_es_part: Int32,
+        stride_to_seq: Int32,
+        stride_to_head: Int32,
+        stride_to_part: Int32,
+        stride_to_group: Int32,
+        stride_bt_seq: Int32,
+        # Per-token K/V scale strides (per_token_kv only), metadata layout
+        # `[num_blocks, num_kv_heads, block_size]`:
+        #   stride_ks_block = num_kv_heads * block_size
+        #   stride_ks_head  = block_size
+        # Both 0 for per-tensor.
+        stride_ks_block: Int32,
+        stride_ks_head: Int32,
+    ):
+        tid = fx.Int32(gpu.thread_id("x"))
+        batch_idx = fx.Int32(gpu.block_id("x"))
+        kv_h = fx.Int32(gpu.block_id("y"))
+        partition_idx = fx.Int32(gpu.block_id("z"))
+
+        cl_global_ptr = _extract_global_ptr(context_lengths_ptr)
+        context_len = _global_load_i32(cl_global_ptr, batch_idx)
+
+        lane16id = tid & fx.Int32(15)
+        rowid = (tid >> fx.Int32(4)) & fx.Int32(3)
+        warp_id = tid >> fx.Int32(6)
+
+        q_rsrc = buffer_ops.create_buffer_resource(query_ptr, max_size=True)
+        k_global_ptr = _extract_global_ptr(key_cache_ptr)
+        v_global_ptr = _extract_global_ptr(value_cache_ptr)
+        bt_rsrc = buffer_ops.create_buffer_resource(block_tables_ptr, max_size=False)
+        es_rsrc = buffer_ops.create_buffer_resource(exp_sums_ptr, max_size=True)
+        ml_rsrc = buffer_ops.create_buffer_resource(max_logits_ptr, max_size=True)
+        to_rsrc = buffer_ops.create_buffer_resource(tmp_out_ptr, max_size=True)
+        ks_rsrc = buffer_ops.create_buffer_resource(key_scale_ptr, max_size=True)
+        vs_rsrc = buffer_ops.create_buffer_resource(value_scale_ptr, max_size=True)
+
+        q_scale_val = arith.constant(1.0, type=T.f32)
+        # Per-tensor K/V scales are loaded from index 0; per_token_kv uses
+        # per-token scales staged to LDS (see _stage_small_block_kv_scales).
+        if const_expr(per_token_kv):
+            k_scale_val = arith.constant(1.0, type=T.f32)
+            v_scale_val = arith.constant(1.0, type=T.f32)
+        else:
+            k_scale_val = buffer_ops.buffer_load(ks_rsrc, arith.constant(0, type=T.i32), vec_width=1)
+            v_scale_val = buffer_ops.buffer_load(vs_rsrc, arith.constant(0, type=T.i32), vec_width=1)
+
+        smem_base = allocator.get_base()
+        logits_lds_i32 = SmemPtr(smem_base, logits_off, T.i32, shape=(LDS_LOGITS_BYTES // 4,)).get()
+        softmax_lds_f32 = SmemPtr(smem_base, softmax_off, T.f32, shape=(LDS_SOFTMAX_TOTAL // 4,)).get()
+        logits_lds_i64 = SmemPtr(smem_base, logits_off, T.i64, shape=(LDS_LOGITS_BYTES // 8,)).get()
+        bt_lds_i32 = SmemPtr(smem_base, bt_off, T.i32, shape=(NUM_WARPS * TLOOP,)).get()
+        if const_expr(per_token_kv):
+            scale_lds_f32 = SmemPtr(smem_base, scale_off_ps, T.f32, shape=(LDS_SCALE_BYTES // 4,)).get()
+        else:
+            scale_lds_f32 = None
+
+        _softmax_scale_const = arith.constant(_softmax_scale, type=T.f32)
+        _softmax_q_scale = _softmax_scale_const * q_scale_val
+        _scale = _softmax_q_scale * k_scale_val
+        c_w = arith.constant(WARP_SIZE, type=T.i32)
+        NEG_INF = arith.constant(float("-inf"), type=T.f32)
+        ZERO_F = arith.constant(0.0, type=T.f32)
+        c_cps = arith.constant(KV_COMPUTE_BLOCK, type=T.i32)
+        c_query_group_size = arith.constant(query_group_size, type=T.i32)
+
+        local_qhead_idx = warp_id * arith.constant(4, type=T.i32) + rowid
+
+        (
+            _k_tok_thread_base_unused,
+            _c_tok_stride_dw_unused,
+            _k_he_off_dw_unused,
+            _v_tok_thread_off,
+            _vhead_elem_dw,
+            _kv_tok_thread_base,
+            _prob_wr_thread_base,
+            _pv_prob_read_base,
+            _sm_max_off,
+            _sm_sum_off,
+            _sm_rd_max_offs,
+            _sm_rd_sum_offs,
+            _sm_vmax_wr_off,
+            _sm_vmax_rd_offs,
+        ) = _build_pa_thread_invariants(
+            warp_id,
+            lane16id,
+            rowid,
+            trans_v=trans_v,
+            per_token_kv=per_token_kv,
+            qkhe_loop=_QKHELOOP,
+            vhe_loop=_VHELOOP,
+        )
+
+        (
+            _load_kv_scale_scalars_unused,
+            _load_v_and_scales_unused,
+            _store_vmax_warp,
+            _qk_and_intra_softmax,
+            _cross_warp_softmax_and_prob_pack,
+            _pv_mfma,
+        ) = _make_pa_phase_helpers(
+            trans_v=trans_v,
+            per_token_q=True,
+            per_token_kv=per_token_kv,
+            needs_mask=True,
+            query_length=query_length,
+            kv_h=kv_h,
+            v_global_ptr=v_global_ptr,
+            ks_rsrc=ks_rsrc,
+            vs_rsrc=vs_rsrc,
+            logits_lds_i32=logits_lds_i32,
+            logits_lds_i64=logits_lds_i64,
+            softmax_lds_f32=softmax_lds_f32,
+            scale_lds_f32=scale_lds_f32,
+            stride_ks_block=arith.constant(0, type=T.i32),
+            stride_ks_head=arith.constant(0, type=T.i32),
+            softmax_scale_base=_softmax_scale_const,
+            softmax_q_scale=_softmax_q_scale,
+            k_scale_val=k_scale_val,
+            scale=_scale,
+            v_scale_val=v_scale_val,
+            warp_id=warp_id,
+            lane16id=lane16id,
+            rowid=rowid,
+            k_tok_thread_base=_k_tok_thread_base_unused,
+            v_tok_thread_off=_v_tok_thread_off,
+            vhead_elem_dw=_vhead_elem_dw,
+            kv_tok_thread_base=_kv_tok_thread_base,
+            prob_wr_thread_base=_prob_wr_thread_base,
+            pv_prob_read_base=_pv_prob_read_base,
+            sm_max_off=_sm_max_off,
+            sm_sum_off=_sm_sum_off,
+            sm_rd_max_offs=_sm_rd_max_offs,
+            sm_rd_sum_offs=_sm_rd_sum_offs,
+            sm_vmax_wr_off=_sm_vmax_wr_off,
+            sm_vmax_rd_offs=_sm_vmax_rd_offs,
+            c_w=c_w,
+            neg_inf=NEG_INF,
+            zero_f=ZERO_F,
+            cache_scale_vecs=per_token_kv,
+            head_size=_HEAD,
+            qkhe_loop=_QKHELOOP,
+            vhe_loop=_VHELOOP,
+        )
+
+        def _store_partition_results(eqgs_lane, running_sum, running_max, outs_norm):
+            for vhe in range_constexpr(_VHELOOP):
+                hs_base = fx.Int32(vhe * NUM_WARPS * MFMA_N) + warp_id * fx.Int32(MFMA_N) + rowid * fx.Int32(4)
+                to_off = (
+                    batch_idx * stride_to_seq
+                    + kv_h * stride_to_head
+                    + partition_idx * stride_to_part
+                    + eqgs_lane * stride_to_group
+                    + hs_base
+                )
+                out_bf16 = fx.Vector(outs_norm[vhe]).to(fx.BFloat16)
+                buffer_ops.buffer_store(out_bf16, to_rsrc, to_off)
+            es_off = batch_idx * stride_es_seq + kv_h * stride_es_head + partition_idx * stride_es_part + eqgs_lane
+            buffer_ops.buffer_store(fx.Float32(running_sum), es_rsrc, es_off)
+            buffer_ops.buffer_store(fx.Float32(running_max), ml_rsrc, es_off)
+
+        # Slot covers one or more contiguous 256-token sub-partitions.  The
+        # inner scf.for loop walks those sub-partitions with online-softmax
+        # loop-carried state, mirroring the Gluon `for sequence_partition_idx`
+        # loop in `paged_attention_decode_ps`.
+        c_max_parts = arith.constant(max_context_partition_num, type=T.i32)
+        num_total_partitions = (context_len + c_cps - fx.Int32(1)) >> fx.Int32(8)
+        page_size_partitions = (num_total_partitions + c_max_parts - fx.Int32(1)) // c_max_parts
+        local_partition_start = partition_idx * page_size_partitions
+        local_partition_end_raw = (partition_idx + fx.Int32(1)) * page_size_partitions
+        local_partition_end = arith.select(
+            local_partition_end_raw < num_total_partitions,
+            local_partition_end_raw,
+            num_total_partitions,
+        )
+
+        def _unwrap(v):
+            return v.ir_value() if hasattr(v, "ir_value") else v
+
+        # Pack/unpack loop state.  State is `_mtp_groups` accumulators, each a
+        # tuple of (rmax, rsum, outs...), plus the current sub-partition's K
+        # and V tiles (k_flat: _N_K i64 scalars, v_flat: 2 * _N_V i64 scalars
+        # — each V element is i64x2, flattened to two scalars).  Both K and V
+        # are loop-carried so the body can use them while we prefetch the
+        # NEXT iteration's K and V (ping-pong).
+        state_width = 2 + _VHELOOP
+
+        def _pack_states(states, k_flat, v_flat):
+            flat = []
+            for st in states:
+                rmax, rsum = st[0], st[1]
+                outs = [st[2 + vhe] for vhe in range_constexpr(_VHELOOP)]
+                flat.extend([_unwrap(rmax), _unwrap(rsum)])
+                flat.extend(_unwrap(out) for out in outs)
+            flat.extend(_unwrap(v) for v in k_flat)
+            flat.extend(_unwrap(v) for v in v_flat)
+            return flat
+
+        def _unpack_states(flat):
+            base = state_width * _mtp_groups
+            states = [
+                tuple(flat[state_width * i + j] for j in range_constexpr(state_width))
+                for i in range_constexpr(_mtp_groups)
+            ]
+            k_flat = list(flat[base : base + _N_K_h])
+            v_flat = list(flat[base + _N_K_h : base + _N_K_h + _N_V_FLAT_h])
+            return states, k_flat, v_flat
+
+        init_states = [
+            tuple([NEG_INF, ZERO_F] + [arith.constant_vector(0.0, T.f32x4) for _ in range_constexpr(_VHELOOP)])
+            for _ in range(_mtp_groups)
+        ]
+
+        loop_start = fx.Index(arith.unwrap(local_partition_start))
+        loop_end = fx.Index(arith.unwrap(local_partition_end))
+        loop_step = arith.index(1)
+        last_partition_idx = local_partition_end - fx.Int32(1)
+
+        def _ptr8_to_v4i32(ptr8_val):
+            """Convert a `ptr addrspace(8)` buffer descriptor to `<4 x i32>`
+            via ptrtoint(i128) + bitcast.  Both forms are 128-bit type-puns
+            of the same SGPR-resident descriptor — the LLVM backend emits
+            zero instructions for this conversion (descriptor stays in
+            SGPRs)."""
+            from flydsl._mlir import ir as _ir
+            from flydsl._mlir.dialects import llvm as _llvm
+
+            i128_ty = _ir.IntegerType.get_signless(128)
+            v4i32_ty = _ir.VectorType.get([4], _ir.IntegerType.get_signless(32))
+            i128_val = _llvm.ptrtoint(i128_ty, ptr8_val)
+            return _llvm.bitcast(v4i32_ty, i128_val)
+
+        bt_rsrc_v4 = _ptr8_to_v4i32(bt_rsrc)
+
+        def _s_buffer_load(soffset_bytes_i32, vec_width: int):
+            """Scalar buffer load — emits s_buffer_load_dword[x4] via the LLVM
+            intrinsic, returning an SGPR value.  Requires `soffset_bytes_i32`
+            to be wave-uniform; the result is shared across all 64 lanes.
+
+            Saves the vmcnt(0) drain + readfirstlane that the VMEM
+            buffer_load path imposes (result lands in SGPR directly, frees
+            VMEM queue slots for V/K loads)."""
+            from flydsl._mlir import ir as _ir
+            from flydsl._mlir.dialects import llvm as _llvm
+            from flydsl.expr.rocdl import _to_ir as _rocdl_to_ir
+
+            i32_ty = _ir.IntegerType.get_signless(32)
+            if const_expr(vec_width == 1):
+                result_type = i32_ty
+                suffix = "i32"
+            elif const_expr(vec_width == 4):
+                result_type = _ir.VectorType.get([4], i32_ty)
+                suffix = "v4i32"
+            else:
+                raise ValueError(f"_s_buffer_load: unsupported vec_width={vec_width}")
+            cache_policy = arith.constant(0, type=T.i32)
+            return _llvm.call_intrinsic(
+                result_type,
+                f"llvm.amdgcn.s.buffer.load.{suffix}",
+                [
+                    _rocdl_to_ir(bt_rsrc_v4),
+                    _rocdl_to_ir(soffset_bytes_i32),
+                    _rocdl_to_ir(cache_policy),
+                ],
+                [],
+                [],
+            )
+
+        def _pa_small_block_stage_phys_blocks(partition_block_base):
+            # bt offset is wave-uniform (batch_idx and warp_id are constant
+            # per wave, partition_block_base is workgroup-uniform).  Use
+            # s_buffer_load to route through SMEM cache and land the result
+            # in SGPRs directly — eliminates the vmcnt(0) drain (was 25% of
+            # all kernel stalls) and the downstream readfirstlane.
+            if const_expr(block_size == 64):
+                bt_elem_off = batch_idx * stride_bt_seq + partition_block_base + warp_id
+                phys_blocks = _s_buffer_load(bt_elem_off * fx.Int32(4), vec_width=1)
+            else:
+                bt_elem_off = batch_idx * stride_bt_seq + partition_block_base + warp_id * fx.Int32(TLOOP)
+                phys_blocks = _s_buffer_load(bt_elem_off * fx.Int32(4), vec_width=TLOOP)
+            return phys_blocks
+
+        def _pa_small_block_store_phys_blocks_to_lds(phys_block_vec):
+            if (lane16id | rowid) == fx.Int32(0):
+                if const_expr(block_size == 64):
+                    # block_size=64: `_stage_phys_blocks` returned vec_width=1
+                    # → scalar i32, not a Vector.  Wrap in a 1-element
+                    # Vector so we can use the LDS `.store(...)` API.
+                    # Each warp writes 1 i32 to bt_lds_i32[warp_id];
+                    # `_load_v_phys_blocks_from_lds` reads back the 4-elem
+                    # vec starting at offset 0.
+                    fx.Vector.from_elements([phys_block_vec], dtype=fx.Int32).store(
+                        bt_lds_i32,
+                        [fx.Index(warp_id)],
+                    )
+                else:
+                    phys_block_vec.store(
+                        bt_lds_i32,
+                        [fx.Index(warp_id * fx.Int32(TLOOP))],
+                    )
+
+        def _pa_small_block_load_v_phys_blocks_from_lds():
+            v_phys_blocks = []
+            if const_expr(block_size == 64):
+                phys_block_vec = fx.Vector.load(T.vec(VTLOOP, T.i32), bt_lds_i32, [fx.Index(0)])
+                for vt in range_constexpr(VTLOOP):
+                    v_phys_blocks.append(phys_block_vec[vt])
+            else:
+                for vt in range_constexpr(VTLOOP):
+                    bt_lds_off = fx.Int32(vt * TLOOP) + rowid
+                    phys_block = fx.Vector.load(T.vec(1, T.i32), bt_lds_i32, [fx.Index(bt_lds_off)])[0]
+                    v_phys_blocks.append(phys_block)
+            return v_phys_blocks
+
+        # Pre-load the FIRST (== reverse-order start = last partition) sub-
+        # partition's block-table entries before Q setup so the dependent K
+        # prefetch below does not also pay the table latency.
+        # Empty-slot guard: when num_total_partitions < max_context_partition_num,
+        # CTAs with partition_idx >= num_total_partitions get
+        # local_partition_start >= num_total_partitions and the inner loop runs
+        # 0 iters.  But the prologue still issues block-table + K reads using
+        # `last_partition_idx`; clamp to 0 so all reads stay in-bounds (the
+        # results are unused since the loop never executes).
+        _safe_init_partition = arith.select(
+            local_partition_start < num_total_partitions,
+            last_partition_idx,
+            arith.constant(0, type=T.i32),
+        )
+        first_block_base = _safe_init_partition * fx.Int32(_blocks_per_partition)
+        first_phys_blocks = _pa_small_block_stage_phys_blocks(first_block_base)
+
+        # Pre-load Q for every MTP group ONCE before the KV loop.  Each group's
+        # q_frags / qi / qhi / qscale are kept in registers across the entire
+        # KV loop, so we pay the Q-load cost (global → LDS → registers) exactly
+        # once per CTA regardless of how many sub-partitions the slot covers.
+
+        q_frags_per_mtp = []
+        qi_per_mtp = []
+        qhi_per_mtp = []
+        qscale_per_mtp = []
+        for _mtp_g in range_constexpr(_mtp_groups):
+            mtp_prefetch = _prefetch_mtp_group_query(
+                q_rsrc,
+                batch_idx,
+                kv_h,
+                stride_q_seq,
+                stride_q_head,
+                lane16id,
+                local_qhead_idx,
+                mtp_group_idx=_mtp_g,
+                query_length=query_length,
+                query_group_size=query_group_size,
+                query_load_is_bf16=query_load_is_bf16,
+                q_lanes_per_head=_Q_LANES_PER_HEAD,
+            )
+            qi_val, qhi_pos, q_frags, query_scale_lane = _finish_mtp_group_q_fragments(
+                logits_lds_i32,
+                logits_lds_i64,
+                softmax_lds_f32,
+                mtp_prefetch,
+                lane16id,
+                rowid,
+                local_qhead_idx,
+                head_size=_HEAD,
+                qkhe_loop=_QKHELOOP,
+                q_lanes_per_head=_Q_LANES_PER_HEAD,
+            )
+            q_frags_per_mtp.append(q_frags)
+            qi_per_mtp.append(qi_val)
+            qhi_per_mtp.append(qhi_pos)
+            qscale_per_mtp.append(query_scale_lane)
+
+        _pa_small_block_store_phys_blocks_to_lds(first_phys_blocks)
+
+        # ── Per-token K/V scale staging (per_token_kv only) ──
+        # A 256-token partition spans `_blocks_per_partition` physical pages
+        # whose indices are staged in bt_lds_i32.  Each thread stages its own
+        # LDS slot ``t`` (= partition-local token) by reading that token's K/V
+        # scale from the page it belongs to, using the metadata scale layout
+        # `[num_blocks, num_kv_heads, block_size]`.  Mirrors the metadata kernel
+        # so the shared `_make_pa_phase_helpers` readers work unchanged.
+        def _stage_small_block_kv_scales():
+            t = warp_id * fx.Int32(WARP_SIZE) + rowid * fx.Int32(MFMA_N) + lane16id
+            part_page = _udiv_const(t, _block_size)
+            tok_in_page = _urem_const(t, _block_size)
+            phys = fx.Vector.load(T.vec(1, T.i32), bt_lds_i32, [fx.Index(part_page)])[0]
+            scale_idx = phys * stride_ks_block + kv_h * stride_ks_head + tok_in_page
+            k_scale_scalar = buffer_ops.buffer_load(ks_rsrc, scale_idx, vec_width=1, dtype=fx.Float32)
+            v_scale_scalar = buffer_ops.buffer_load(vs_rsrc, scale_idx, vec_width=1, dtype=fx.Float32)
+            fx.Vector.from_elements([k_scale_scalar], dtype=fx.Float32).store(scale_lds_f32, [fx.Index(t)])
+            fx.Vector.from_elements([v_scale_scalar], dtype=fx.Float32).store(
+                scale_lds_f32, [fx.Index(fx.Int32(LDS_SCALE_V_OFFSET) + t)]
+            )
+
+        def _load_small_block_scale_vecs():
+            k_scale_vecs = []
+            v_scale_vecs = []
+            for td in range_constexpr(TLOOP):
+                row = _kv_tok_thread_base + arith.constant(td * MFMA_N, type=T.i32)
+                k_scale_vecs.append(vector.load_op(T.f32x4, scale_lds_f32, [fx.Index(row)]))
+                v_scale_vecs.append(
+                    vector.load_op(T.f32x4, scale_lds_f32, [fx.Index(fx.Int32(LDS_SCALE_V_OFFSET) + row)])
+                )
+            return k_scale_vecs, v_scale_vecs
+
+        # Pre-load the FIRST sub-partition's K so the loop body can issue the
+        # next sub-partition's K prefetch in parallel with the current K's QK
+        # MFMA.  For empty slots (loop_start == loop_end), this k_flat0 is
+        # computed using local_partition_start but never used because the
+        # loop runs 0 iterations — the block_table buffer_load is bounded so
+        # any OOB lookup safely returns 0 (→ block 0, then masked out by the
+        # softmax causal bound).
+        k_flat0 = _pa_small_block_load_k_flat(
+            k_global_ptr,
+            kv_h,
+            stride_k_block,
+            stride_k_head,
+            lane16id,
+            rowid,
+            block_size=_block_size,
+            phys_blocks=first_phys_blocks,
+            qkhe_loop=_QKHELOOP,
+        )
+        gpu.barrier()
+        # ── Prologue V load ──
+        # V is cross-iter prefetched (ping-pong with K).  Issue iter 0's V
+        # load here so the loop body can issue iter N+1's V at the END of
+        # iter N alongside K, both hidden behind the next iter's QK MFMA.
+        # `_pa_small_block_load_v_phys_blocks_from_lds` reads the LDS-staged
+        # first_phys_blocks written above; the barrier guarantees visibility.
+        _v_phys_blocks0 = _pa_small_block_load_v_phys_blocks_from_lds()
+        _v_results0 = _pa_small_block_load_v_trans(
+            v_global_ptr,
+            kv_h,
+            stride_v_block,
+            stride_v_head,
+            warp_id,
+            lane16id,
+            rowid,
+            _v_phys_blocks0,
+            block_size=_block_size,
+            head_size=_HEAD,
+            vhe_loop=_VHELOOP,
+        )
+        v_flat0 = _flatten_v_results(_v_results0, vhe_loop=_VHELOOP)
+        # Note: no runtime `if _is_valid:` wrapping this loop.  See earlier
+        # commit log — the `ReplaceIfWithDispatch` rewriter copies the if-body
+        # into a synthetic Python function, and since the body contains
+        # `ast.Yield` from this scf.for, that function becomes a generator
+        # (returns a generator object without executing) — leaving the scf.if
+        # then-region empty.  Running the loop unconditionally is the correct
+        # workaround; empty slots iterate 0 times and yield the init state
+        # (NEG_INF, 0, 0, 0), which is the right empty-slot semantics.
+        for sub_part_ib, state in range(
+            loop_start,
+            loop_end,
+            loop_step,
+            init=_pack_states(init_states, k_flat0, v_flat0),
+        ):
+            cur_states, k_flat, v_flat = _unpack_states(state)
+            # Reverse iteration: scf.for walks sub_part_ib forward over
+            # [local_partition_start, local_partition_end); remap to walk
+            # sub_part_i32 from last_partition_idx down to local_partition_start
+            # so the sink-prone partition 0 is processed last.
+            _sub_raw_i32 = arith.index_cast(T.i32, sub_part_ib)
+            sub_part_i32 = last_partition_idx - (_sub_raw_i32 - local_partition_start)
+            sub_token_start = sub_part_i32 * c_cps
+
+            # Both K and V come from the loop-carried state (prefetched at the
+            # END of the previous iteration).  K's VMEM latency overlaps prev
+            # iter's PV MFMA; V's latency overlaps the entire next iter QK +
+            # softmax compute before PV consumes it.
+            k_ops = _unflatten_k(k_flat, qkhe_loop=_QKHELOOP)
+            v_results = _unflatten_v_results(v_flat, vhe_loop=_VHELOOP)
+
+            # ── Per-token K/V scale staging (per_token_kv only) ──
+            # bt_lds_i32 holds this partition's physical pages (staged in the
+            # prologue / previous iter's tail, barrier-visible).  Stage the
+            # per-token K/V scales to LDS once per partition and read the cached
+            # f32x4 vecs, reused across all MTP groups.
+            if const_expr(per_token_kv):
+                _stage_small_block_kv_scales()
+                gpu.barrier()
+                k_scale_vecs, v_scale_vecs = _load_small_block_scale_vecs()
+
+            # Compute the NEXT sub-partition's K base address (clamped to
+            # local_partition_start so the prefetch on the final loop
+            # iteration doesn't walk before the block_table window —
+            # k_next_flat is yielded out but never consumed since the loop
+            # terminates).  Reverse iteration: next == sub_part_i32 - 1.
+            next_part_i32 = sub_part_i32 - fx.Int32(1)
+            next_safe_part = arith.select(next_part_i32 >= local_partition_start, next_part_i32, local_partition_start)
+            next_block_base = next_safe_part * fx.Int32(_blocks_per_partition)
+
+            new_states = []
+            k_next_flat = None
+            for _mtp_g in range_constexpr(_mtp_groups):
+                state = cur_states[_mtp_g]
+                rmax, rsum = state[0], state[1]
+                outs = [state[2 + vhe] for vhe in range_constexpr(_VHELOOP)]
+                causal_bound = context_len + arith.constant(1 - query_length, type=T.i32) + qi_per_mtp[_mtp_g]
+
+                if const_expr(per_token_kv):
+                    d_out, v_scales = _qk_and_intra_softmax(
+                        k_ops,
+                        sub_token_start,
+                        q_frags_per_mtp[_mtp_g],
+                        causal_bound,
+                        query_scale_lane=qscale_per_mtp[_mtp_g],
+                        preloaded_scales=(k_scale_vecs, v_scale_vecs),
+                    )
+                else:
+                    d_out = _qk_and_intra_softmax(
+                        k_ops,
+                        sub_token_start,
+                        q_frags_per_mtp[_mtp_g],
+                        causal_bound,
+                        query_scale_lane=qscale_per_mtp[_mtp_g],
+                    )
+                    v_scales = None
+
+                if const_expr(_mtp_g == _mtp_groups - 1):
+                    next_phys_blocks = _pa_small_block_stage_phys_blocks(next_block_base)
+
+                # per_token_kv needs the cross-warp v_scale_max staged to LDS so
+                # _cross_warp_softmax_and_prob_pack can read it for norm_factor.
+                if const_expr(per_token_kv):
+                    _store_vmax_warp(sub_token_start, seq_end=context_len, v_scale_vecs=v_scales)
+
+                gpu.barrier()
+
+                rmax, rsum, outs, v_correction = _cross_warp_softmax_and_prob_pack(d_out, rmax, rsum, outs, v_scales)
+
+                # Issue the next sub-partition's K prefetch on the LAST MTP
+                # iter, after cross_warp_softmax_and_prob_pack but BEFORE
+                # _pv_mfma — same hoist as in pa_decode_metadata_kenrel's
+                # _process_block_split.  This lets the K VMEM load latency
+                # overlap with the upcoming PV MFMA compute.
+                if const_expr(_mtp_g == _mtp_groups - 1):
+                    _pa_small_block_store_phys_blocks_to_lds(next_phys_blocks)
+                    k_next_flat = _pa_small_block_load_k_flat(
+                        k_global_ptr,
+                        kv_h,
+                        stride_k_block,
+                        stride_k_head,
+                        lane16id,
+                        rowid,
+                        block_size=_block_size,
+                        phys_blocks=next_phys_blocks,
+                        qkhe_loop=_QKHELOOP,
+                    )
+                gpu.barrier()
+                outs = _pv_mfma(v_results, outs, v_correction)
+                new_states.append(tuple([rmax, rsum] + outs))
+
+            # ── Cross-iter V prefetch (ping-pong) ──
+            # Issue NEXT iter's V load AFTER PV MFMA: the current iter's V
+            # vgprs are now consumed and can be reused.  V phys_blocks come
+            # from the LDS-staged `next_phys_blocks` written above (the
+            # barrier after K prefetch ensures cross-warp visibility).  The
+            # V VMEM latency is hidden behind next iter's QK MFMA + softmax.
+            _v_phys_blocks_next = _pa_small_block_load_v_phys_blocks_from_lds()
+            _v_next_results = _pa_small_block_load_v_trans(
+                v_global_ptr,
+                kv_h,
+                stride_v_block,
+                stride_v_head,
+                warp_id,
+                lane16id,
+                rowid,
+                _v_phys_blocks_next,
+                block_size=_block_size,
+                head_size=_HEAD,
+                vhe_loop=_VHELOOP,
+            )
+            v_next_flat = _flatten_v_results(_v_next_results, vhe_loop=_VHELOOP)
+
+            results = yield _pack_states(new_states, k_next_flat, v_next_flat)
+
+        # Normalize and store one output slot per MTP group.
+        final_states, _final_k_flat, _final_v_flat = _unpack_states(results)
+        for _mtp_g in range_constexpr(_mtp_groups):
+            final_state = final_states[_mtp_g]
+            rmax_raw, rsum_raw = final_state[0], final_state[1]
+            outs_raw = [final_state[2 + vhe] for vhe in range_constexpr(_VHELOOP)]
+            running_max = fx.Float32(rmax_raw)
+            running_sum = fx.Float32(rsum_raw)
+            outs = [fx.Vector(out_raw) for out_raw in outs_raw]
+            outs_norm = _normalize_pa_output(running_sum, outs, ZERO_F)
+            eqgs_lane = qi_per_mtp[_mtp_g] * c_query_group_size + qhi_per_mtp[_mtp_g]
+            _store_partition_results(eqgs_lane, running_sum, running_max, outs_norm)
+
+    @flyc.jit
+    def launch_pa_decode_ps_small_block(
+        exp_sums: fx.Tensor,
+        max_logits: fx.Tensor,
+        tmp_out: fx.Tensor,
+        query: fx.Tensor,
+        key_cache: fx.Tensor,
+        value_cache: fx.Tensor,
+        block_tables: fx.Tensor,
+        context_lengths: fx.Tensor,
+        key_scale: fx.Tensor,
+        value_scale: fx.Tensor,
+        s_q_seq: Int32,
+        s_q_head: Int32,
+        s_k_block: Int32,
+        s_k_head: Int32,
+        s_v_block: Int32,
+        s_v_head: Int32,
+        s_es_seq: Int32,
+        s_es_head: Int32,
+        s_es_part: Int32,
+        s_to_seq: Int32,
+        s_to_head: Int32,
+        s_to_part: Int32,
+        s_to_group: Int32,
+        s_bt_seq: Int32,
+        s_ks_block: Int32,
+        s_ks_head: Int32,
+        gx: Int32,
+        gy: Int32,
+        gz: Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+        pa_decode_ps_kernel(
+            exp_sums,
+            max_logits,
+            tmp_out,
+            query,
+            key_cache,
+            value_cache,
+            block_tables,
+            context_lengths,
+            key_scale,
+            value_scale,
+            s_q_seq,
+            s_q_head,
+            s_k_block,
+            s_k_head,
+            s_v_block,
+            s_v_head,
+            s_es_seq,
+            s_es_head,
+            s_es_part,
+            s_to_seq,
+            s_to_head,
+            s_to_part,
+            s_to_group,
+            s_bt_seq,
+            s_ks_block,
+            s_ks_head,
+        ).launch(grid=(gx, gy, gz), block=(BLOCK_THREADS, 1, 1), stream=stream)
+
+    return {
+        "launch": launch_pa_decode_ps_small_block,
+        "kernel": pa_decode_ps_kernel,
+        "allocator": allocator,
+        "mtp_groups": _mtp_groups,
+    }
+
+
 def pa_decode_ps_launch(
     output: torch.Tensor,
     query: torch.Tensor,
@@ -2293,6 +3006,119 @@ def pa_decode_ps_launch(
             s,
         )
         return "ps_sw_partitioned"
+
+    # ── small-block (block_size 16/64) → grid partition kernel + reduce ──
+    # Key cache shape is [num_blocks, num_kv_heads, head_size // 16, block_size, 16].
+    block_size = key_cache.shape[-2]
+    if block_size in _PA_DECODE_PS_SMALL_BLOCK_SIZES:
+        if block_tables is None:
+            raise ValueError(
+                f"pa_decode_ps_launch: block_size={block_size} requires `block_tables` "
+                "(per-sequence physical block index table)."
+            )
+        batch_size = context_lengths.shape[0]
+        head_size = query.shape[-1]
+        eqgs = query_length * query_group_size
+        context_partition_size = KV_COMPUTE_BLOCK
+        blocks_per_partition = context_partition_size // block_size
+        if max_context_partition_num == 0:
+            max_context_partition_num = get_recommended_splits(
+                batch_size,
+                num_kv_heads,
+                split_kv_blocks=blocks_per_partition,
+            )
+        if is_graph_capturing and (exp_sums is None or max_logits is None or temporary_output is None):
+            raise ValueError(
+                "CUDA graph capture requires preallocated `exp_sums`, `max_logits`, "
+                "and `temporary_output` for the small-block PS path."
+            )
+        if exp_sums is None:
+            exp_sums = torch.zeros(
+                batch_size, num_kv_heads, max_context_partition_num, eqgs, device=dev, dtype=torch.float32
+            )
+        if max_logits is None:
+            max_logits = torch.full(
+                (batch_size, num_kv_heads, max_context_partition_num, eqgs),
+                float("-inf"),
+                device=dev,
+                dtype=torch.float32,
+            )
+        if temporary_output is None:
+            temporary_output = torch.zeros(
+                batch_size, num_kv_heads, max_context_partition_num, eqgs, head_size, device=dev, dtype=torch.bfloat16
+            )
+        compiled_small = compile_pa_decode_ps(
+            block_size=block_size,
+            max_context_partition_num=max_context_partition_num,
+            softmax_scale=softmax_scale,
+            trans_v=trans_v,
+            query_group_size=query_group_size,
+            per_token_kv=per_token_kv,
+            query_length=query_length,
+            query_input_dtype=query_input_dtype,
+            head_dim=int(head_size),
+        )
+        output_5d = output.reshape(batch_size, query_length, num_kv_heads, query_group_size, head_size)
+        compiled_small["launch"](
+            exp_sums,
+            max_logits,
+            temporary_output,
+            query,
+            key_cache,
+            value_cache,
+            block_tables,
+            context_lengths,
+            key_scale,
+            value_scale,
+            query.stride(0),
+            query.stride(1),
+            key_cache.stride(0),
+            key_cache.stride(1),
+            value_cache.stride(0),
+            value_cache.stride(1),
+            exp_sums.stride(0),
+            exp_sums.stride(1),
+            exp_sums.stride(2),
+            temporary_output.stride(0),
+            temporary_output.stride(1),
+            temporary_output.stride(2),
+            temporary_output.stride(3),
+            block_tables.stride(0),
+            stride_ks_block,
+            stride_ks_head,
+            batch_size,
+            num_kv_heads,
+            max_context_partition_num,
+            s,
+        )
+        compiled_sw_reduce = compile_pa_decode_sw_reduce(
+            max_context_partition_num=max_context_partition_num,
+            query_seq_len=query_length,
+            query_group_size=query_group_size,
+            head_size=head_size,
+            output_dtype_str=_get_output_dtype_str(output),
+        )
+        compiled_sw_reduce["launch"](
+            output_5d,
+            exp_sums,
+            max_logits,
+            temporary_output,
+            output_5d.stride(0),
+            output_5d.stride(1),
+            output_5d.stride(2),
+            output_5d.stride(3),
+            exp_sums.stride(0),
+            exp_sums.stride(1),
+            exp_sums.stride(2),
+            temporary_output.stride(0),
+            temporary_output.stride(1),
+            temporary_output.stride(2),
+            temporary_output.stride(3),
+            batch_size,
+            num_kv_heads,
+            s,
+        )
+        return "ps_small_block"
 
     if metadata is None:
         if is_graph_capturing:

--- a/kernels/pa_decode_fp8.py
+++ b/kernels/pa_decode_fp8.py
@@ -25,19 +25,19 @@ from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm
 from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl, vector
-from flydsl.expr import math as fly_math
 from flydsl.expr.typing import Int32, T
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
-from flydsl.utils.env import runtime as flydsl_runtime_env
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from kernels import dpp_utils
 from kernels.pa_decode_swa import compile_pa_decode_sw, compile_pa_decode_sw_reduce
 
 # ── Kernel geometry constants ────────────────────────────────────────
-QUERY_GROUP_SIZE = 16
-HEAD_SIZE = 128
 KV_BLOCK_SIZE = 1024  # physical page size (matches SP3 kBlockSize)
 KV_COMPUTE_BLOCK = 256  # tile size (matches SP3 kTileKV)
+# Persistent-grid oversubscription for the metadata decode path: launch
+# CU_count * this many workgroups so the HW keeps multiple workgroups resident
+# per CU (memory-latency hiding).  1 = original (1 wg/CU).
+_PA_METADATA_GRID_OVERSUB = 3
 NUM_WARPS = 4
 WARP_SIZE = 64
 BLOCK_THREADS = NUM_WARPS * WARP_SIZE  # 256
@@ -49,10 +49,10 @@ TLOOP = TOKENS_PER_WARP // MFMA_N  # 4
 ROWS_PER_WARP = WARP_SIZE // MFMA_N  # 4
 FP8_ELEMS_16B = 16  # 16 FP8 per 16-byte load
 QKHE_PER_FETCH = FP8_ELEMS_16B * ROWS_PER_WARP  # 64
-QKHELOOP = HEAD_SIZE // QKHE_PER_FETCH  # 2
 
-VHELOOP = HEAD_SIZE // MFMA_N // NUM_WARPS  # 2
 VTLOOP = NUM_WARPS  # 4
+Q_ELEMS_PER_LANE = 8
+Q_CHUNKS_PER_LANE = Q_ELEMS_PER_LANE // 4
 
 # LDS sizes
 PROB_ROW_STRIDE_BYTES = 40  # 32 data + 8 padding -> 0 bank conflict
@@ -70,11 +70,6 @@ LOG2E = 1.4426950408889634
 # with FP8 MFMA using up to a[44:47].
 PA_MFMA_AGPR_ALLOC = "48,48"
 PA_MFMA_AGPR_LLVM_OPTIONS = {"amdgpu-mfma-vgpr-form": False}
-
-# Number of loop-carried K values (i64)
-_N_K = TLOOP * QKHELOOP * 2  # 16
-# Number of loop-carried V values (i64)
-_N_V = VHELOOP * VTLOOP * 2  # 16
 
 # Tiles per block (1024 tokens / 256 tokens per tile = 4, matches SP3 kNumBlockTiles)
 TILES_PER_BLOCK = KV_BLOCK_SIZE // KV_COMPUTE_BLOCK  # 4
@@ -143,16 +138,70 @@ def _global_load_i64x2(global_ptr, byte_offset_i64):
     return llvm.LoadOp(T.i64x2, ptr, alignment=16).result
 
 
+def _global_load_i32(global_ptr, elem_offset_i32):
+    byte_offset_i64 = fx.Int64(elem_offset_i32) * fx.Int64(4)
+    ptr = buffer_ops.get_element_ptr(global_ptr, byte_offset=byte_offset_i64, elem_type=T.i8)
+    return llvm.LoadOp(T.i32, ptr, alignment=4).result
+
+
 def _rcp_f32(value):
     return rocdl.rcp(T.f32, value)
 
 
+def _exp2_amdgcn_scalar(scalar_value):
+    """Direct ``llvm.amdgcn.exp2.f32`` intrinsic call on one f32 scalar.
+
+    The default ``fly_math.exp2`` lowering routes through ``__ocml_exp2_f32``,
+    which (for full IEEE range/subnormal correctness) expands at codegen time
+    into ``v_exp_f32 + v_ldexp_f32`` per element.  The amdgcn intrinsic compiles
+    to a single ``v_exp_f32``, matching what Gluon emits for its softmax.
+    Skipping ldexp is safe here because softmax inputs are pre-clamped via
+    `safe_qk_max`/`safe_partition_max` so the operand is in the fast-range.
+    """
+    from flydsl._mlir.ir import F32Type
+
+    raw = (
+        arith.unwrap(scalar_value)
+        if hasattr(scalar_value, "ir_value") or hasattr(scalar_value, "type")
+        else scalar_value
+    )
+    f32_ty = F32Type.get()
+    return llvm.call_intrinsic(f32_ty, "llvm.amdgcn.exp2.f32", [raw], [], [])
+
+
 def _exp2_f32_fast(value):
-    return fly_math.exp2(value, fastmath=arith.FastMathFlags.fast)
+    """Compute 2^value (elementwise for vectors), using the amdgcn intrinsic
+    to avoid the ``v_exp_f32 + v_ldexp_f32`` pair OCML lowering produces."""
+    from flydsl._mlir.dialects import vector as _vector_dialect
+    from flydsl._mlir.ir import VectorType
+
+    raw = arith.unwrap(value) if hasattr(value, "ir_value") or hasattr(value, "type") else value
+    ty = raw.type
+    if isinstance(ty, VectorType):
+        n = ty.shape[0]
+        elems = []
+        for i in range(n):
+            scalar = _vector_dialect.extract(raw, static_position=[i], dynamic_position=[])
+            elems.append(_exp2_amdgcn_scalar(scalar))
+        return _vector_dialect.from_elements(ty, elems)
+    return _exp2_amdgcn_scalar(raw)
 
 
 def _mfma_agpr_value_attrs():
     return {"passthrough": [["amdgpu-agpr-alloc", PA_MFMA_AGPR_ALLOC]]}
+
+
+def _maxnumf(a, b):
+    """Non-NaN-propagating max, equivalent to ``a.maximumf(b)`` for non-NaN
+    inputs but lowers to a single ``v_max_f32`` instead of the
+    ``v_max_f32 + v_cmp_o_f32 + s_nop 1 + v_cndmask`` chain that
+    ``arith.maximumf`` emits for IEEE 754 NaN-propagation semantics.
+
+    Safe for PA softmax: inputs are either finite or -inf (from masking),
+    never NaN.  Each call site saves ~3 instructions + a 1-cycle VCC→VALU
+    s_nop hazard in the cross-warp max chain.
+    """
+    return type(a)(arith.maxnumf(arith.unwrap(a), arith.unwrap(b)))
 
 
 def _load_k_flat(
@@ -163,7 +212,7 @@ def _load_k_flat(
     c_tok_stride_dw,
     k_he_off_dw,
     *,
-    sched_vmem_after_load=True,
+    qkhe_loop: int = 2,
 ):
     k_flat = []
     tile_tok_base = tile_token_offset_i32 + k_tok_thread_base
@@ -171,11 +220,9 @@ def _load_k_flat(
     for td in range_constexpr(TLOOP):
         kbo = tile_tok_base + fx.Int32(td * MFMA_N)
         kbo_dw = kbo * c_tok_stride_dw
-        for qkhe in range_constexpr(QKHELOOP):
+        for qkhe in range_constexpr(qkhe_loop):
             ka_dw = k_block_base_dw_i64 + fx.Int64(kbo_dw + k_he_off_dw[qkhe])
             k2 = _global_load_i64x2(k_global_ptr, ka_dw * fx.Int64(4))
-            if const_expr(sched_vmem_after_load):
-                rocdl.sched_barrier(rocdl.mask_vmem_rd)
             k2_words = fx.Vector(k2)
             k_flat.append(k2_words[0])
             k_flat.append(k2_words[1])
@@ -183,8 +230,35 @@ def _load_k_flat(
     return k_flat
 
 
-def _unflatten_k(k_flat):
-    return [[k_flat[td * (QKHELOOP * 2) + j] for j in range(QKHELOOP * 2)] for td in range(TLOOP)]
+def _unflatten_k(k_flat, qkhe_loop: int = 2):
+    return [[k_flat[td * (qkhe_loop * 2) + j] for j in range(qkhe_loop * 2)] for td in range(TLOOP)]
+
+
+def _flatten_v_results(v_results, vhe_loop: int = 2):
+    """v_results[vt][vhe] = i64x2 → flat list of 2 * VTLOOP * vhe_loop scalar i64
+    values, in the same order ``_unflatten_v_results`` expects.  Used to carry
+    V data through scf.for state (which only accepts scalar values)."""
+    flat = []
+    for vt in range(VTLOOP):
+        for vhe in range(vhe_loop):
+            v_i64x2 = fx.Vector(v_results[vt][vhe])
+            flat.append(v_i64x2[0])
+            flat.append(v_i64x2[1])
+    return flat
+
+
+def _unflatten_v_results(v_flat, vhe_loop: int = 2):
+    """Inverse of ``_flatten_v_results``: rebuild v_results[vt][vhe] = i64x2."""
+    v_results = []
+    idx = 0
+    for vt in range(VTLOOP):
+        vhe_data = []
+        for vhe in range(vhe_loop):
+            v_i64x2 = vector.from_elements(T.vec(2, T.i64), [v_flat[idx], v_flat[idx + 1]])
+            vhe_data.append(v_i64x2)
+            idx += 2
+        v_results.append(vhe_data)
+    return v_results
 
 
 def _build_pa_thread_invariants(
@@ -194,20 +268,22 @@ def _build_pa_thread_invariants(
     *,
     trans_v,
     per_token_kv,
+    qkhe_loop: int = 2,
+    vhe_loop: int = 2,
 ):
     c_tokens_per_warp = fx.Int32(TOKENS_PER_WARP)
     c_mfma_n = fx.Int32(MFMA_N)
     k_tok_thread_base = warp_id * c_tokens_per_warp + lane16id
     c_tok_stride_dw = fx.Int32(FP8_ELEMS_16B // 4)
     c_he_stride_dw = fx.Int32(KV_BLOCK_SIZE * FP8_ELEMS_16B // 4)
-    k_he_off_dw = [rowid * c_he_stride_dw + fx.Int32(qkhe * 4) * c_he_stride_dw for qkhe in range(QKHELOOP)]
+    k_he_off_dw = [rowid * c_he_stride_dw + fx.Int32(qkhe * 4) * c_he_stride_dw for qkhe in range(qkhe_loop)]
 
-    vhead_elems = [fx.Int32(vhe * NUM_WARPS * MFMA_N) + warp_id * c_mfma_n + lane16id for vhe in range(VHELOOP)]
+    vhead_elems = [fx.Int32(vhe * NUM_WARPS * MFMA_N) + warp_id * c_mfma_n + lane16id for vhe in range(vhe_loop)]
     v_tok_thread_off = [fx.Int32(vt * TOKENS_PER_WARP) + rowid * c_mfma_n for vt in range(VTLOOP)]
     if const_expr(trans_v):
-        vhead_elem_dw = [vhead_elems[vhe] * fx.Int32(FP8_ELEMS_16B // 4) for vhe in range(VHELOOP)]
+        vhead_elem_dw = [vhead_elems[vhe] * fx.Int32(FP8_ELEMS_16B // 4) for vhe in range(vhe_loop)]
     else:
-        vhead_elem_dw = [vhead_elems[vhe] * fx.Int32(KV_BLOCK_SIZE // 4) for vhe in range(VHELOOP)]
+        vhead_elem_dw = [vhead_elems[vhe] * fx.Int32(KV_BLOCK_SIZE // 4) for vhe in range(vhe_loop)]
 
     kv_tok_thread_base = warp_id * c_tokens_per_warp + rowid * 4
     rowid_8x8 = rowid >> fx.Int32(1)
@@ -300,14 +376,18 @@ def _prefetch_q_chunks(
     lane16id,
     *,
     query_load_is_bf16,
+    q_lanes_per_head,
 ):
     # bf16/f16 + in-kernel query_scale path.  Each lane owns 8 Q elements,
     # loaded as 2 × vec_width=4 buffer loads (4 bf16/f16 elems per load = 8 B,
     # element offset += 4 per iter).  After FP8 packing each load produces
     # one i32 word, so the per-lane store is `vec<2, i32>` = 8 B = 1 i64.
-    q_elem = q_base + lane16id * 8
+    q_load_lane = lane16id
+    if const_expr(q_lanes_per_head < MFMA_N):
+        q_load_lane = arith.select(lane16id < fx.Int32(q_lanes_per_head), lane16id, fx.Int32(0))
+    q_elem = q_base + q_load_lane * fx.Int32(Q_ELEMS_PER_LANE)
     q_chunks = []
-    for qwi in range_constexpr(2):
+    for qwi in range_constexpr(Q_CHUNKS_PER_LANE):
         q_chunks.append(
             buffer_ops.buffer_load(
                 q_rsrc,
@@ -328,28 +408,33 @@ def _finish_q_fragments(
     lane16id,
     rowid,
     local_qhead_idx,
+    *,
+    head_size: int,
+    qkhe_loop: int,
+    q_lanes_per_head: int,
 ):
     # LDS Q layout (compact, per-qhead contiguous):
     #   Q[head=h][hd=d]  at byte offset  h * HEAD_SIZE + d   (FP8 after conversion)
-    # Total Q footprint = 16 qheads * 128 B = 2048 B, aliased with the later P
-    # writes via `logits_lds_i32 / logits_lds_i64` (same base).
+    # Total Q footprint = 16 qheads * HEAD_SIZE bytes, aliased with the later P
+    # writes via `logits_lds_i32 / logits_lds_i64` (same base).  For HEAD_SIZE=64,
+    # only the first 8 lanes write Q for each qhead.
     #
     # Writer: thread (warp_id W, rowid R', lane16id L') owns qhead = W*4 + R' =
     # `local_qhead_idx`, and within that qhead owns the 8 FP8 elements at
     # head_dim [L'*8 .. L'*8+7].  We therefore write 2 i32 words (= 1 i64 = 8 B)
-    # at `local_qhead_idx * 128 + lane16id * 8`.
+    # at `local_qhead_idx * HEAD_SIZE + lane16id * 8`.
     #
     # Reader: MFMA lane layout for mfma_f32_16x16x32_fp8_fp8 (B = Q^T, N = qhead,
     # K = head_dim) — reverse-engineered from `_load_k_flat`: thread (rowid R,
     # lane16id L) consumes, for k_step = qkhe*2 + qkr,
     #   Q[head = L][hd = (qkhe*4 + R) * 16 + qkr * 8 + 0..7]
-    # i.e. the read byte offset is `L * 128 + qkhe*64 + R*16 + qkr*8`.
-    c_head_size = fx.Int32(HEAD_SIZE)
+    # i.e. the read byte offset is `L * HEAD_SIZE + qkhe*64 + R*16 + qkr*8`.
+    c_head_size = fx.Int32(head_size)
     lds_q_base = local_qhead_idx * c_head_size + lane16id * 8
     abs_mask = fx.Vector.filled(4, 0x7FFFFFFF, fx.Int32)
     c_zero_f = fx.Float32(0.0)
     c_one_f = fx.Float32(1.0)
-    fx.Float32(FP8_MAX)
+
     q_f32_chunks = []
     local_max = c_zero_f
     for q_src in q_chunks:
@@ -359,10 +444,10 @@ def _finish_q_fragments(
         q_abs_i32 = q_i32 & abs_mask
         q_abs = q_abs_i32.bitcast(fx.Float32)
         chunk_max = q_abs.reduce("max")
-        local_max = local_max.maximumf(chunk_max)
+        local_max = _maxnumf(local_max, chunk_max)
 
     for sh in [8, 4, 2, 1]:
-        local_max = local_max.maximumf(dpp_utils.dpp_xor_f32(local_max, sh))
+        local_max = _maxnumf(local_max, dpp_utils.dpp_xor_f32(local_max, sh))
     query_scale_lane = fx.Float32(
         arith.select(
             local_max > c_zero_f,
@@ -385,16 +470,20 @@ def _finish_q_fragments(
 
     v01 = fx.Vector.from_elements([q_w0, q_w1], dtype=fx.Int32)
     lds_q_i32 = lds_q_base >> fx.Int32(2)
-    v01.store(logits_lds_i32, [fx.Index(lds_q_i32)])
+    if const_expr(q_lanes_per_head < MFMA_N):
+        if lane16id < fx.Int32(q_lanes_per_head):
+            v01.store(logits_lds_i32, [fx.Index(lds_q_i32)])
+    else:
+        v01.store(logits_lds_i32, [fx.Index(lds_q_i32)])
 
     q_frags = []
     gpu.barrier()
     query_scale_lane = fx.Vector.load(T.vec(1, fx.Float32.ir_type), softmax_lds_f32, [fx.Index(lane16id)])[0].ir_value()
-    for qkhe in range_constexpr(QKHELOOP):
+    for qkhe in range_constexpr(qkhe_loop):
         for qkr in range_constexpr(2):
             # See layout comment above. Byte offset:
             #   lane16id * HEAD_SIZE + qkhe*64 + rowid*16 + qkr*8
-            lds_rd_byte = (lane16id << fx.Int32(7)) + fx.Int32(qkhe << 6) + (rowid << fx.Int32(4)) + fx.Int32(qkr << 3)
+            lds_rd_byte = lane16id * c_head_size + fx.Int32(qkhe << 6) + (rowid << fx.Int32(4)) + fx.Int32(qkr << 3)
             lds_rd_base = lds_rd_byte >> fx.Int32(3)
             q_v1 = fx.Vector.load(T.vec(1, T.i64), logits_lds_i64, [fx.Index(lds_rd_base)])
             q_frags.append(q_v1[0])
@@ -414,6 +503,7 @@ def _prefetch_mtp_group_query(
     query_length,
     query_group_size,
     query_load_is_bf16,
+    q_lanes_per_head,
 ):
     qi_val, qhi_pos, qi_for_q, local_qhead_idx_for_q = _compute_mtp_group_state(
         lane16id,
@@ -432,6 +522,7 @@ def _prefetch_mtp_group_query(
         q_base,
         lane16id,
         query_load_is_bf16=query_load_is_bf16,
+        q_lanes_per_head=q_lanes_per_head,
     )
     return qi_val, qhi_pos, q_chunks
 
@@ -444,6 +535,10 @@ def _finish_mtp_group_q_fragments(
     lane16id,
     rowid,
     local_qhead_idx,
+    *,
+    head_size: int,
+    qkhe_loop: int,
+    q_lanes_per_head: int,
 ):
     qi_val, qhi_pos, q_chunks = mtp_prefetch
     q_frags, query_scale_lane = _finish_q_fragments(
@@ -454,20 +549,22 @@ def _finish_mtp_group_q_fragments(
         lane16id,
         rowid,
         local_qhead_idx,
+        head_size=head_size,
+        qkhe_loop=qkhe_loop,
+        q_lanes_per_head=q_lanes_per_head,
     )
     return qi_val, qhi_pos, q_frags, query_scale_lane
 
 
-def _normalize_pa_output(running_sum, out0, out1, zero_f):
+def _normalize_pa_output(running_sum, outs, zero_f):
     one_f = fx.Float32(1.0).ir_value()
     safe_sum = arith.select(running_sum > zero_f, running_sum, one_f)
     inv_sum = _rcp_f32(safe_sum)
-    return [
-        out0 * vector.broadcast(T.f32x4, inv_sum),
-        out1 * vector.broadcast(T.f32x4, inv_sum),
-    ]
+    inv_sum_vec = vector.broadcast(T.f32x4, inv_sum)
+    return [out * inv_sum_vec for out in outs]
 
 
+@flyc.jit
 def _make_pa_phase_helpers(
     *,
     trans_v,
@@ -509,9 +606,20 @@ def _make_pa_phase_helpers(
     neg_inf,
     zero_f,
     cache_scale_vecs=False,
-    sched_vmem_after_load=True,
-    preload_pv_operands=False,
+    p_scale_lane=None,
+    p_scale_inv_lane=None,
+    k_scale_per_token=False,
+    head_size: int = 128,
+    qkhe_loop: int = 2,
+    vhe_loop: int = 2,
 ):
+    _has_p_scale = p_scale_lane is not None
+    # k_scale_per_token: K scale is staged to scale_lds_f32 by the caller
+    # (used by pa_decode_ps_kernel small-block path when per_token_kv=False
+    # but K is per-token-quantized).  Routes K-scale loading through
+    # `_load_k_scale_vec` (same as per_token_kv) without enabling the rest
+    # of the per_token_kv machinery (V scale, vmax LDS staging, etc).
+    _k_scale_per_token_eff = k_scale_per_token or per_token_kv
     apply_causal_mask = needs_mask or query_length > 1
     pv_prob_i64_indices = []
     for vt in range_constexpr(VTLOOP):
@@ -563,27 +671,22 @@ def _make_pa_phase_helpers(
                 scale_lds_f32,
                 [fx.Index(fx.Int32(LDS_SCALE_V_OFFSET) + scale_stage_token)],
             )
-            if const_expr(sched_vmem_after_load):
-                rocdl.sched_barrier(rocdl.mask_vmem_rd)
-            else:
-                rocdl.sched_barrier(0)
+            rocdl.sched_barrier(0)
 
         v_results = []
         for vt in range_constexpr(VTLOOP):
             vhe_data = []
-            for vhe in range_constexpr(VHELOOP):
+            for vhe in range_constexpr(vhe_loop):
                 v_token_in_block = tile_token_offset_i32 + v_tok_thread_off[vt]
                 if const_expr(trans_v):
                     vt_group = v_token_in_block >> fx.Int32(4)
                     va_dw_delta = (
-                        vt_group * arith.constant(HEAD_SIZE * FP8_ELEMS_16B // 4, type=T.i32) + vhead_elem_dw[vhe]
+                        vt_group * arith.constant(head_size * FP8_ELEMS_16B // 4, type=T.i32) + vhead_elem_dw[vhe]
                     )
                 else:
                     va_dw_delta = vhead_elem_dw[vhe] + (v_token_in_block >> fx.Int32(2))
                 va_byte = (v_block_base_dw + fx.Int64(va_dw_delta)) * fx.Int64(4)
                 v_i64x2 = _global_load_i64x2(v_global_ptr, va_byte)
-                if const_expr(sched_vmem_after_load):
-                    rocdl.sched_barrier(rocdl.mask_vmem_rd)
                 vhe_data.append(v_i64x2)
             v_results.append(vhe_data)
 
@@ -637,9 +740,9 @@ def _make_pa_phase_helpers(
                         vs_i = vector.extract(vs, static_position=[i], dynamic_position=[])
                         vs_i = arith.select(kv_tok < seq_end, vs_i, zero_f)
                         vs = vector.insert(vs_i, vs, static_position=[i], dynamic_position=[])
-                v_max_warp = v_max_warp.maximumf(fx.Vector(vs).reduce("max"))
+                v_max_warp = _maxnumf(v_max_warp, fx.Vector(vs).reduce("max"))
             for sh in [32, 16]:
-                v_max_warp = v_max_warp.maximumf(v_max_warp.shuffle_xor(arith.constant(sh, type=T.i32), c_w))
+                v_max_warp = _maxnumf(v_max_warp, v_max_warp.shuffle_xor(arith.constant(sh, type=T.i32), c_w))
             vector.store(
                 fx.Vector.from_elements([v_max_warp], dtype=fx.Float32),
                 softmax_lds_f32,
@@ -653,45 +756,25 @@ def _make_pa_phase_helpers(
             dtype=fx.Int32,
         )
 
-    def _apply_token_mask_vec(logit_vec, td: int, kv_tok_base, causal_bound, seq_start, false_value):
+    def _apply_token_mask_vec(logit_vec, td: int, kv_tok_base, causal_bound, false_value):
         tok_vec = _token_vec_i32(kv_tok_base, td)
-        if const_expr(apply_causal_mask and seq_start is not None):
-            in_range = (tok_vec < causal_bound) & (tok_vec >= seq_start)
-        elif const_expr(apply_causal_mask):
+        if const_expr(apply_causal_mask):
             in_range = tok_vec < causal_bound
-        else:
-            in_range = tok_vec >= seq_start
-        return arith.select(in_range, logit_vec, vector.broadcast(T.f32x4, arith.unwrap(false_value)))
+            return arith.select(in_range, logit_vec, vector.broadcast(T.f32x4, arith.unwrap(false_value)))
+        return logit_vec
 
     def _qk_and_intra_softmax(
         k_ops,
         partition_start,
-        v_block_base_dw,
-        tile_token_offset_i32,
         q_frags,
         causal_bound,
         query_scale_lane=None,
         *,
-        phys_block,
-        preloaded_v_and_scales=None,
-        seq_start=None,
-        precomputed_vmax=False,
+        preloaded_scales=None,
     ):
-        if const_expr(preloaded_v_and_scales is not None):
+        if const_expr(preloaded_scales is not None):
             if const_expr(cache_scale_vecs and per_token_kv):
-                v_results, k_scale_vecs, v_scale_vecs = preloaded_v_and_scales
-            else:
-                v_results = preloaded_v_and_scales
-        else:
-            loaded_v_and_scales = _load_v_and_scales(
-                v_block_base_dw,
-                tile_token_offset_i32,
-                phys_block=phys_block,
-            )
-            if const_expr(cache_scale_vecs and per_token_kv):
-                v_results, k_scale_vecs, v_scale_vecs = loaded_v_and_scales
-            else:
-                v_results = loaded_v_and_scales
+                k_scale_vecs, v_scale_vecs = preloaded_scales
 
         query_scale_vec = None
         if const_expr(per_token_q):
@@ -699,9 +782,9 @@ def _make_pa_phase_helpers(
         d_out = []
         for td in range_constexpr(TLOOP):
             acc = arith.constant_vector(0.0, T.f32x4)
-            for k_step in range_constexpr(QKHELOOP * 2):
+            for k_step in range_constexpr(qkhe_loop * 2):
                 acc = rocdl.mfma_f32_16x16x32_fp8_fp8(T.f32x4, [k_ops[td][k_step], q_frags[k_step], acc, 0, 0, 0])
-            if const_expr(per_token_kv):
+            if const_expr(_k_scale_per_token_eff):
                 if const_expr(cache_scale_vecs and per_token_kv):
                     k_scale_vec = _get_k_scale_vec(td, k_scale_vecs)
                 else:
@@ -718,146 +801,107 @@ def _make_pa_phase_helpers(
                 else:
                     d_out.append(acc * vector.broadcast(T.f32x4, scale))
 
-        apply_range_mask = seq_start is not None
-        kv_tok_base = (
-            partition_start + kv_tok_thread_base if const_expr(apply_causal_mask or apply_range_mask) else None
-        )
+        kv_tok_base = partition_start + kv_tok_thread_base if const_expr(apply_causal_mask) else None
         qk_max = neg_inf
         for td in range_constexpr(TLOOP):
             logits_vec = d_out[td]
             if const_expr(kv_tok_base is not None):
-                logits_vec = _apply_token_mask_vec(logits_vec, td, kv_tok_base, causal_bound, seq_start, neg_inf)
+                logits_vec = _apply_token_mask_vec(logits_vec, td, kv_tok_base, causal_bound, neg_inf)
                 d_out[td] = logits_vec
-            qk_max = qk_max.maximumf(fx.Vector(logits_vec).reduce("max"))
+            qk_max = _maxnumf(qk_max, fx.Vector(logits_vec).reduce("max"))
         for sh in [32, 16]:
-            qk_max = qk_max.maximumf(qk_max.shuffle_xor(arith.constant(sh, type=T.i32), c_w))
+            qk_max = _maxnumf(qk_max, qk_max.shuffle_xor(arith.constant(sh, type=T.i32), c_w))
         vector.store(
             fx.Vector.from_elements([qk_max], dtype=fx.Float32),
             softmax_lds_f32,
             [sm_max_off],
         )
 
-        exp_sum = zero_f
-        safe_qk_max = arith.select(qk_max > neg_inf, qk_max, zero_f) if const_expr(kv_tok_base is not None) else qk_max
+        if const_expr(cache_scale_vecs and per_token_kv):
+            return d_out, v_scale_vecs
+        return d_out
+
+    def _cross_warp_softmax_and_prob_pack(d_out, rmax, rsum, outs, v_scale_vecs):
+        partition_max = neg_inf
+        partition_sum = zero_f
+        max_vec = fx.Vector(vector.load_op(T.f32x4, softmax_lds_f32, [sm_rd_max_offs[0]]))
+        for w in range_constexpr(NUM_WARPS):
+            partition_max = _maxnumf(partition_max, max_vec[w])
+
+        new_rmax = _maxnumf(rmax, partition_max)
+        safe_eff_max = arith.select(partition_max > neg_inf, new_rmax, zero_f) if const_expr(needs_mask) else new_rmax
+        local_exp_sum = zero_f
         for td in range_constexpr(TLOOP):
-            diff_vec = fx.Vector(d_out[td]) - vector.broadcast(T.f32x4, arith.unwrap(safe_qk_max))
+            diff_vec = fx.Vector(d_out[td]) - vector.broadcast(T.f32x4, arith.unwrap(safe_eff_max))
             p_vec = _exp2_f32_fast(diff_vec * vector.broadcast(T.f32x4, arith.unwrap(fx.Float32(LOG2E))))
-            exp_sum = exp_sum + fx.Vector(p_vec).reduce("add")
+            local_exp_sum = local_exp_sum + fx.Vector(p_vec).reduce("add")
             d_out[td] = p_vec
         for sh in [32, 16]:
-            exp_sum = exp_sum + exp_sum.shuffle_xor(arith.constant(sh, type=T.i32), c_w)
+            local_exp_sum = local_exp_sum + local_exp_sum.shuffle_xor(arith.constant(sh, type=T.i32), c_w)
         vector.store(
-            fx.Vector.from_elements([exp_sum], dtype=fx.Float32),
+            fx.Vector.from_elements([local_exp_sum], dtype=fx.Float32),
             softmax_lds_f32,
             [sm_sum_off],
         )
-
-        if const_expr(per_token_kv and not precomputed_vmax):
-            v_max_warp = zero_f
-            for td in range_constexpr(TLOOP):
-                if const_expr(cache_scale_vecs and per_token_kv):
-                    vs = _get_v_scale_vec(td, v_scale_vecs)
-                else:
-                    vs = _get_v_scale_vec(td)
-                for i in range_constexpr(4):
-                    if const_expr(kv_tok_base is not None):
-                        kv_tok = kv_tok_base + arith.constant(td * MFMA_N + i, type=T.i32)
-                        vs_i = vector.extract(vs, static_position=[i], dynamic_position=[])
-                        if const_expr(apply_causal_mask and apply_range_mask):
-                            in_range = (kv_tok < causal_bound) & (kv_tok >= seq_start)
-                            vs_i = arith.select(in_range, vs_i, zero_f)
-                        elif const_expr(apply_causal_mask):
-                            vs_i = arith.select(kv_tok < causal_bound, vs_i, zero_f)
-                        elif const_expr(apply_range_mask):
-                            vs_i = arith.select(kv_tok >= seq_start, vs_i, zero_f)
-                        vs = vector.insert(vs_i, vs, static_position=[i], dynamic_position=[])
-                v_max_warp = v_max_warp.maximumf(fx.Vector(vs).reduce("max"))
-            for sh in [32, 16]:
-                v_max_warp = v_max_warp.maximumf(v_max_warp.shuffle_xor(arith.constant(sh, type=T.i32), c_w))
-            vector.store(
-                fx.Vector.from_elements([v_max_warp], dtype=fx.Float32),
-                softmax_lds_f32,
-                [sm_vmax_wr_off],
-            )
-        if const_expr(cache_scale_vecs and per_token_kv):
-            return d_out, v_results, v_scale_vecs
-        return d_out, v_results
-
-    def _cross_warp_softmax_and_prob_pack(d_out, rmax, rsum, o0, o1, v_scale_vecs=None):
-        partition_max = neg_inf
-        partition_sum = zero_f
-        warp_rescale_factors = []
-        max_vec = fx.Vector(vector.load_op(T.f32x4, softmax_lds_f32, [sm_rd_max_offs[0]]))
-        for w in range_constexpr(NUM_WARPS):
-            w_max = max_vec[w]
-            partition_max = partition_max.maximumf(w_max)
-            warp_rescale_factors.append(w_max)
-        sum_vec = fx.Vector(vector.load_op(T.f32x4, softmax_lds_f32, [sm_rd_sum_offs[0]]))
-        for w in range_constexpr(NUM_WARPS):
-            diff_w = warp_rescale_factors[w] - partition_max
-            if const_expr(needs_mask):
-                diff_w = arith.select(partition_max > neg_inf, diff_w, zero_f)
-            wf = _exp2_f32_fast(diff_w * fx.Float32(LOG2E).ir_value())
-            w_sum = sum_vec[w]
-            wf_sum = arith.mulf(arith.unwrap(w_sum), arith.unwrap(wf), fastmath=arith.FastMathFlags.contract)
-            partition_sum = arith.addf(arith.unwrap(partition_sum), wf_sum, fastmath=arith.FastMathFlags.contract)
-            warp_rescale_factors[w] = wf
-
-        my_warp_rescale = warp_rescale_factors[0]
-        for w in range_constexpr(1, NUM_WARPS):
-            my_warp_rescale = arith.select(
-                warp_id == arith.constant(w, type=T.i32),
-                warp_rescale_factors[w],
-                my_warp_rescale,
-            )
-
-        new_rmax = rmax.maximumf(partition_max)
         if const_expr(needs_mask):
             accum_scale = arith.select(
                 rmax > neg_inf,
                 _exp2_f32_fast((rmax - new_rmax) * fx.Float32(LOG2E).ir_value()),
                 zero_f,
             )
-            part_to_new = arith.select(
-                partition_max > neg_inf,
-                _exp2_f32_fast((partition_max - new_rmax) * fx.Float32(LOG2E).ir_value()),
-                zero_f,
-            )
         else:
             accum_scale = _exp2_f32_fast((rmax - new_rmax) * fx.Float32(LOG2E).ir_value())
-            part_to_new = _exp2_f32_fast((partition_max - new_rmax) * fx.Float32(LOG2E).ir_value())
+
+        gpu.barrier()
+        sum_vec = fx.Vector(vector.load_op(T.f32x4, softmax_lds_f32, [sm_rd_sum_offs[0]]))
+        for w in range_constexpr(NUM_WARPS):
+            partition_sum = arith.addf(
+                arith.unwrap(partition_sum), arith.unwrap(sum_vec[w]), fastmath=arith.FastMathFlags.contract
+            )
 
         accum_sum = arith.mulf(arith.unwrap(accum_scale), arith.unwrap(rsum), fastmath=arith.FastMathFlags.contract)
-        partition_sum_scaled = arith.mulf(
-            arith.unwrap(partition_sum),
-            arith.unwrap(part_to_new),
-            fastmath=arith.FastMathFlags.contract,
-        )
-        rsum = arith.addf(accum_sum, partition_sum_scaled, fastmath=arith.FastMathFlags.contract)
+        rsum = arith.addf(accum_sum, arith.unwrap(partition_sum), fastmath=arith.FastMathFlags.contract)
         rmax = new_rmax
-        o0 = o0 * vector.broadcast(T.f32x4, accum_scale)
-        o1 = o1 * vector.broadcast(T.f32x4, accum_scale)
+        accum_scale_vec = vector.broadcast(T.f32x4, arith.unwrap(accum_scale))
+        for vhe in range_constexpr(vhe_loop):
+            outs[vhe] = outs[vhe] * accum_scale_vec
 
         if const_expr(per_token_kv):
             v_max_global = zero_f
             vmax_vec = fx.Vector(vector.load_op(T.f32x4, softmax_lds_f32, [sm_vmax_rd_offs[0]]))
             for w in range_constexpr(NUM_WARPS):
                 w_vmax = vmax_vec[w]
-                v_max_global = v_max_global.maximumf(w_vmax)
+                v_max_global = _maxnumf(v_max_global, w_vmax)
             v_max_scaled = v_max_global * fx.Float32(1.0 / FP8_MAX).ir_value()
             v_max_safe_scaled = v_max_scaled + fx.Float32(1e-8 / FP8_MAX).ir_value()
             norm_factor = _rcp_f32(v_max_safe_scaled)
-            prob_scale = my_warp_rescale
-            v_correction = v_max_scaled * part_to_new
-            for td in range_constexpr(TLOOP):
-                d_out[td] = d_out[td] * (
-                    _get_v_scale_vec(td, v_scale_vecs) * vector.broadcast(T.f32x4, prob_scale * norm_factor)
+            v_correction = v_max_scaled
+            if const_expr(_has_p_scale):
+                v_correction = arith.mulf(
+                    arith.unwrap(v_correction),
+                    arith.unwrap(p_scale_inv_lane),
+                    fastmath=arith.FastMathFlags.contract,
                 )
-        else:
-            prob_scale = my_warp_rescale * part_to_new
-            v_correction = v_scale_val
+                _vec_norm_p = arith.mulf(
+                    arith.unwrap(norm_factor),
+                    arith.unwrap(p_scale_lane),
+                    fastmath=arith.FastMathFlags.contract,
+                )
+            else:
+                _vec_norm_p = arith.unwrap(norm_factor)
             for td in range_constexpr(TLOOP):
-                d_out[td] = d_out[td] * vector.broadcast(T.f32x4, prob_scale)
+                d_out[td] = d_out[td] * (_get_v_scale_vec(td, v_scale_vecs) * vector.broadcast(T.f32x4, _vec_norm_p))
+        else:
+            v_correction = v_scale_val
+            if const_expr(_has_p_scale):
+                v_correction = arith.mulf(
+                    arith.unwrap(v_correction),
+                    arith.unwrap(p_scale_inv_lane),
+                    fastmath=arith.FastMathFlags.contract,
+                )
+                _ps_bcast = vector.broadcast(T.f32x4, arith.unwrap(p_scale_lane))
+                for td in range_constexpr(TLOOP):
+                    d_out[td] = d_out[td] * _ps_bcast
 
         for td in range_constexpr(TLOOP):
             p0 = vector.extract(d_out[td], static_position=[0], dynamic_position=[])
@@ -870,161 +914,47 @@ def _make_pa_phase_helpers(
             i32_off = byte_base >> fx.Int32(2)
             pk_vec = vector.from_elements(T.vec(1, T.i32), [pk])
             vector.store(pk_vec, logits_lds_i32, [fx.Index(i32_off)])
-        return rmax, rsum, o0, o1, v_correction
+        return rmax, rsum, outs, v_correction
 
-    def _pv_mfma(v_ops, o0, o1, v_correction):
+    def _pv_mfma(v_ops, outs, v_correction):
         v_correction = fx.Float32(v_correction).ir_value()
         fm_contract = arith.FastMathFlags.contract
         v_correction_vec = vector.broadcast(T.f32x4, v_correction)
-        if const_expr(preload_pv_operands):
-            v_i64s = []
-            for vhe in range_constexpr(VHELOOP):
-                for vt in range_constexpr(VTLOOP):
-                    v_i64x2 = fx.Vector(v_ops[vt][vhe])
-                    for j in range_constexpr(2):
-                        v_i64s.append(v_i64x2[j])
-            p_i64s = []
+
+        # ── Batch-load all P_i64 from LDS upfront ──
+        # `p_i64` depends only on (vt, j), NOT on vhe, so the previous
+        # per-vhe inner LDS load was redundant: VHELOOP × VTLOOP*2 reads
+        # of the same VTLOOP*2 LDS slots.  Issue all VTLOOP*2 ds_read_b64
+        # ops once at the start so the compiler pipelines them — lgkmcnt
+        # drains during the address arithmetic before the MFMA chain.
+        p_i64_all = []
+        for vt in range_constexpr(VTLOOP):
+            for j in range_constexpr(2):
+                p_i64_idx = pv_prob_i64_indices[vt * 2 + j]
+                p_i64_all.append(fx.Vector.load(T.vec(1, T.i64), logits_lds_i64, [p_i64_idx])[0])
+
+        for vhe in range_constexpr(vhe_loop):
+            tmp_out = arith.constant_vector(0.0, T.f32x4)
             for vt in range_constexpr(VTLOOP):
+                v_i64x2 = fx.Vector(v_ops[vt][vhe])
                 for j in range_constexpr(2):
-                    p_i64_idx = pv_prob_i64_indices[vt * 2 + j]
-                    p_i64s.append(fx.Vector.load(T.vec(1, T.i64), logits_lds_i64, [p_i64_idx])[0])
-            for vhe in range_constexpr(VHELOOP):
-                tmp_out = arith.constant_vector(0.0, T.f32x4)
-                for vt in range_constexpr(VTLOOP):
-                    for j in range_constexpr(2):
-                        tmp_out = rocdl.mfma_f32_16x16x32_fp8_fp8(
-                            T.f32x4,
-                            [
-                                v_i64s[vhe * VTLOOP * 2 + vt * 2 + j],
-                                p_i64s[vt * 2 + j],
-                                tmp_out,
-                                0,
-                                0,
-                                0,
-                            ],
-                        )
-                if const_expr(vhe == 0):
-                    o0 = arith.addf(
-                        arith.mulf(tmp_out, v_correction_vec, fastmath=fm_contract),
-                        o0,
-                        fastmath=fm_contract,
+                    tmp_out = rocdl.mfma_f32_16x16x32_fp8_fp8(
+                        T.f32x4,
+                        [
+                            v_i64x2[j],
+                            p_i64_all[vt * 2 + j],
+                            tmp_out,
+                            0,
+                            0,
+                            0,
+                        ],
                     )
-                else:
-                    o1 = arith.addf(
-                        arith.mulf(tmp_out, v_correction_vec, fastmath=fm_contract),
-                        o1,
-                        fastmath=fm_contract,
-                    )
-        else:
-            for vhe in range_constexpr(VHELOOP):
-                tmp_out = arith.constant_vector(0.0, T.f32x4)
-                for vt in range_constexpr(VTLOOP):
-                    v_i64x2 = fx.Vector(v_ops[vt][vhe])
-                    for j in range_constexpr(2):
-                        p_i64_idx = pv_prob_i64_indices[vt * 2 + j]
-                        p_i64 = fx.Vector.load(T.vec(1, T.i64), logits_lds_i64, [p_i64_idx])[0]
-                        tmp_out = rocdl.mfma_f32_16x16x32_fp8_fp8(
-                            T.f32x4,
-                            [
-                                v_i64x2[j],
-                                p_i64,
-                                tmp_out,
-                                0,
-                                0,
-                                0,
-                            ],
-                        )
-                if const_expr(vhe == 0):
-                    o0 = arith.addf(
-                        arith.mulf(tmp_out, v_correction_vec, fastmath=fm_contract),
-                        o0,
-                        fastmath=fm_contract,
-                    )
-                else:
-                    o1 = arith.addf(
-                        arith.mulf(tmp_out, v_correction_vec, fastmath=fm_contract),
-                        o1,
-                        fastmath=fm_contract,
-                    )
-        return o0, o1
-
-    def _finalize_block_split_group(
-        d_out,
-        v_ops,
-        partition_start,
-        causal_bound,
-        rmax,
-        rsum,
-        o0,
-        o1,
-        *,
-        seq_start=None,
-    ):
-        apply_range_mask = seq_start is not None
-
-        kv_tok_base = (
-            partition_start + kv_tok_thread_base if const_expr(apply_causal_mask or apply_range_mask) else None
-        )
-        qk_max = neg_inf
-        for td in range_constexpr(TLOOP):
-            logits_vec = d_out[td]
-            if const_expr(kv_tok_base is not None):
-                logits_vec = _apply_token_mask_vec(logits_vec, td, kv_tok_base, causal_bound, seq_start, neg_inf)
-                d_out[td] = logits_vec
-            qk_max = qk_max.maximumf(fx.Vector(logits_vec).reduce("max"))
-        for sh in [32, 16]:
-            qk_max = qk_max.maximumf(qk_max.shuffle_xor(arith.constant(sh, type=T.i32), c_w))
-        vector.store(
-            fx.Vector.from_elements([qk_max], dtype=fx.Float32),
-            softmax_lds_f32,
-            [sm_max_off],
-        )
-
-        exp_sum = zero_f
-        safe_qk_max = arith.select(qk_max > neg_inf, qk_max, zero_f) if const_expr(kv_tok_base is not None) else qk_max
-        for td in range_constexpr(TLOOP):
-            diff_vec = fx.Vector(d_out[td]) - vector.broadcast(T.f32x4, arith.unwrap(safe_qk_max))
-            p_vec = _exp2_f32_fast(diff_vec * vector.broadcast(T.f32x4, arith.unwrap(fx.Float32(LOG2E))))
-            exp_sum = exp_sum + fx.Vector(p_vec).reduce("add")
-            d_out[td] = p_vec
-        for sh in [32, 16]:
-            exp_sum = exp_sum + exp_sum.shuffle_xor(arith.constant(sh, type=T.i32), c_w)
-        vector.store(
-            fx.Vector.from_elements([exp_sum], dtype=fx.Float32),
-            softmax_lds_f32,
-            [sm_sum_off],
-        )
-
-        if const_expr(per_token_kv):
-            v_max_warp = zero_f
-            for td in range_constexpr(TLOOP):
-                vs = _load_v_scale_vec(td)
-                for i in range_constexpr(4):
-                    if const_expr(kv_tok_base is not None):
-                        kv_tok = kv_tok_base + arith.constant(td * MFMA_N + i, type=T.i32)
-                        vs_i = vector.extract(vs, static_position=[i], dynamic_position=[])
-                        if const_expr(apply_causal_mask and apply_range_mask):
-                            in_range = (kv_tok < causal_bound) & (kv_tok >= seq_start)
-                            vs_i = arith.select(in_range, vs_i, zero_f)
-                        elif const_expr(apply_causal_mask):
-                            vs_i = arith.select(kv_tok < causal_bound, vs_i, zero_f)
-                        elif const_expr(apply_range_mask):
-                            vs_i = arith.select(kv_tok >= seq_start, vs_i, zero_f)
-                        vs = vector.insert(vs_i, vs, static_position=[i], dynamic_position=[])
-                v_max_warp = v_max_warp.maximumf(fx.Vector(vs).reduce("max"))
-            for sh in [32, 16]:
-                v_max_warp = v_max_warp.maximumf(v_max_warp.shuffle_xor(arith.constant(sh, type=T.i32), c_w))
-            vector.store(
-                fx.Vector.from_elements([v_max_warp], dtype=fx.Float32),
-                softmax_lds_f32,
-                [sm_vmax_wr_off],
+            outs[vhe] = arith.addf(
+                arith.mulf(tmp_out, v_correction_vec, fastmath=fm_contract),
+                outs[vhe],
+                fastmath=fm_contract,
             )
-
-        gpu.barrier()
-        rmax, rsum, o0, o1, v_correction = _cross_warp_softmax_and_prob_pack(d_out, rmax, rsum, o0, o1)
-        gpu.barrier()
-        o0, o1 = _pv_mfma(v_ops, o0, o1, v_correction)
-        return rmax, rsum, o0, o1
+        return outs
 
     return (
         _load_kv_scale_scalars,
@@ -1033,124 +963,81 @@ def _make_pa_phase_helpers(
         _qk_and_intra_softmax,
         _cross_warp_softmax_and_prob_pack,
         _pv_mfma,
-        _finalize_block_split_group,
     )
 
 
-def _expand_pa_metadata_for_block_splits(
-    work_indptr: torch.Tensor,
-    work_info: torch.Tensor,
-    query_length: int,
-    *,
-    block_split_factor: int = TILES_PER_BLOCK,
-):
-    """Expand PA metadata so each 1024-token work tile reduces 4 block-split partials.
-
-    `get_pa_metadata_v1()` only materializes split partials and uses `partial_idx=-1`
-    for direct tiles that write final output directly. With `grid_z=4`, every work item
-    becomes four partials, so direct tiles must also participate in the reduce stage.
-    """
-
-    dev = work_info.device
-    valid_work = int(work_indptr[-1].item())
-    work_info_cpu = work_info[:valid_work].cpu()
-
-    if valid_work == 0:
-        empty_reduce_indptr = torch.zeros(1, dtype=torch.int32, device=dev)
-        empty_reduce_final_map = torch.empty((0, 2), dtype=torch.int32, device=dev)
-        empty_reduce_partial_map = torch.empty((0,), dtype=torch.int32, device=dev)
-        return work_info[:0].contiguous(), empty_reduce_indptr, empty_reduce_final_map, empty_reduce_partial_map
-
-    group_order = []
-    group_slot_keys = {}
-    group_slot_seen = {}
-    row_slot_keys = []
-
-    for wi in range(valid_work):
-        row = work_info_cpu[wi]
-        q_start = int(row[2].item())
-        q_end = int(row[3].item())
-        orig_partial_idx = int(row[1].item())
-        group_key = (q_start, q_end)
-        if group_key not in group_slot_keys:
-            group_order.append(group_key)
-            group_slot_keys[group_key] = []
-            group_slot_seen[group_key] = set()
-
-        if orig_partial_idx >= 0:
-            slot_key = ("split", orig_partial_idx)
-        else:
-            slot_key = ("direct", q_start, q_end)
-
-        if slot_key not in group_slot_seen[group_key]:
-            group_slot_seen[group_key].add(slot_key)
-            group_slot_keys[group_key].append(slot_key)
-        row_slot_keys.append(slot_key)
-
-    slot_id_by_key = {}
-    next_slot_id = 0
-    for group_key in group_order:
-        for slot_key in group_slot_keys[group_key]:
-            if slot_key not in slot_id_by_key:
-                slot_id_by_key[slot_key] = next_slot_id
-                next_slot_id += 1
-
-    for wi, slot_key in enumerate(row_slot_keys):
-        work_info_cpu[wi, 1] = slot_id_by_key[slot_key] * query_length
-
-    reduce_indptr_cpu = torch.zeros(len(group_order) + 1, dtype=torch.int32)
-    reduce_final_map_cpu = torch.empty((len(group_order), 2), dtype=torch.int32)
-    reduce_partial_map_entries = []
-    running = 0
-
-    for group_idx, group_key in enumerate(group_order):
-        q_start, q_end = group_key
-        reduce_final_map_cpu[group_idx, 0] = q_start
-        reduce_final_map_cpu[group_idx, 1] = q_end
-        for slot_key in group_slot_keys[group_key]:
-            slot_id = slot_id_by_key[slot_key]
-            base_row = slot_id * query_length * block_split_factor
-            for block_split_idx in range(block_split_factor):
-                reduce_partial_map_entries.append(base_row + block_split_idx * query_length)
-                running += 1
-        reduce_indptr_cpu[group_idx + 1] = running
-
-    work_info_out = work_info_cpu.to(device=dev).contiguous()
-    reduce_indptr = reduce_indptr_cpu.to(device=dev)
-    reduce_final_map = reduce_final_map_cpu.to(device=dev)
-    reduce_partial_map = torch.tensor(reduce_partial_map_entries, dtype=torch.int32, device=dev)
-    return work_info_out, reduce_indptr, reduce_final_map, reduce_partial_map
-
-
 # =====================================================================
-# compile_pa_decode_ps — Persistent Scheduling PA decode kernel
+# compile_pa_decode_metadata — Persistent Scheduling PA decode kernel
 # =====================================================================
 @functools.lru_cache(maxsize=256)
-def compile_pa_decode_ps(
+def compile_pa_decode_metadata(
     softmax_scale=None,
     trans_v=False,
     needs_mask=True,
-    query_group_size=QUERY_GROUP_SIZE,
+    query_group_size=16,
     per_token_kv=False,
     query_length: int = 1,
     query_input_dtype: str = "packed_fp8",
+    head_dim: int = 128,
+    block_size: int = KV_BLOCK_SIZE,
+    output_dtype_str: str = "bf16",
 ):
     """Compile a PS-mode PA decode kernel.
 
     This does NOT bake in num_seqs/num_kv_heads/num_partitions because PS mode
-    uses dynamic work distribution. Grid = (num_sm, 1, 4).
+    uses dynamic work distribution. Grid = (num_sm, 1, 1).
+
+    The worklist is load-balanced at ``KV_COMPUTE_BLOCK`` (256-token) **partition**
+    granularity (see ``get_pa_metadata``): ``work_info.kv_start/kv_end`` are
+    cumulative partition indices.  Each work item is decoded as a range of
+    256-token partitions; for ``block_size < 256`` each partition gathers
+    ``256 // block_size`` physical pages, and for ``block_size > 256`` (1024) each
+    partition is a 256-token sub-tile of one physical page.  ``partial_qo_loc``
+    (``work_info[1]``) ``< 0`` writes the final output directly to ``out``;
+    ``>= 0`` writes a partial slot that ``pa_reduce_v1`` later combines.
     """
     arch = get_hip_arch()
+    if head_dim % QKHE_PER_FETCH != 0 or head_dim % (MFMA_N * NUM_WARPS) != 0 or head_dim % Q_ELEMS_PER_LANE != 0:
+        raise ValueError(f"Unsupported head_dim={head_dim}; must be a multiple of {MFMA_N * NUM_WARPS}.")
+    _HEAD = head_dim
+    _QKHELOOP = head_dim // QKHE_PER_FETCH
+    _VHELOOP = head_dim // MFMA_N // NUM_WARPS
+    _Q_LANES_PER_HEAD = head_dim // Q_ELEMS_PER_LANE
+    _N_K_h = TLOOP * _QKHELOOP * 2
     query_packed_fp8 = query_input_dtype == "packed_fp8"
     query_load_is_bf16 = query_input_dtype == "bf16"
     query_scale_in_kernel = not query_packed_fp8
     cache_scale_vecs = True
     if const_expr(query_packed_fp8):
-        raise ValueError("`compile_pa_decode_ps` only supports bf16/f16 queries with kernel-internal query scale.")
+        raise ValueError(
+            "`compile_pa_decode_metadata` only supports bf16/f16 queries with kernel-internal query scale."
+        )
     if softmax_scale is None:
-        softmax_scale = 1.0 / (HEAD_SIZE**0.5)
+        softmax_scale = 1.0 / (head_dim**0.5)
     _softmax_scale = float(softmax_scale)
-    _bs = KV_BLOCK_SIZE  # 1024 for PS mode (matches SP3 kBlockSize)
+    _block_size = int(block_size)
+    _bs = _block_size
+    # A partition is KV_COMPUTE_BLOCK (256) tokens.  For small blocks each
+    # partition gathers ``_blocks_per_partition`` physical pages; for block_size
+    # >= 256 each physical page holds ``_parts_per_block`` partitions (sub-tiles).
+    _is_small_block = _block_size < KV_COMPUTE_BLOCK
+    _blocks_per_partition = KV_COMPUTE_BLOCK // _block_size if _is_small_block else 1
+    _parts_per_block = _block_size // KV_COMPUTE_BLOCK if not _is_small_block else 1
+    if _is_small_block:
+        if _block_size not in _PA_DECODE_PS_SMALL_BLOCK_SIZES:
+            raise ValueError(
+                f"compile_pa_decode_metadata: unsupported small block_size={_block_size}; "
+                f"expected one of {_PA_DECODE_PS_SMALL_BLOCK_SIZES} or >= {KV_COMPUTE_BLOCK}."
+            )
+        if per_token_kv:
+            raise NotImplementedError(
+                "compile_pa_decode_metadata: per_token_kv=True is not supported for "
+                "small block_size 16/64; use per-tensor quantization."
+            )
+        if not trans_v:
+            raise NotImplementedError(
+                "compile_pa_decode_metadata: trans_v=False is not supported for small block_size 16/64."
+            )
 
     # LDS allocation
     # Extra LDS for cross-warp v_scale_max reduction (per_token_kv only):
@@ -1158,17 +1045,22 @@ def compile_pa_decode_ps(
     LDS_VMAX_BYTES = NUM_WARPS * MFMA_N * 4 if const_expr(per_token_kv) else 0  # 256 or 0
     LDS_SOFTMAX_TOTAL = LDS_SOFTMAX_BYTES + LDS_VMAX_BYTES
     LDS_SCALE_TOTAL = LDS_SCALE_BYTES if const_expr(per_token_kv) else 0
-    allocator = SmemAllocator(None, arch=arch, global_sym_name="pa_ps_smem")
+    allocator = SmemAllocator(None, arch=arch, global_sym_name=f"pa_ps_smem_bs{_block_size}")
     logits_off = 0
     allocator.ptr = LDS_LOGITS_BYTES
     softmax_off = LDS_LOGITS_BYTES
     allocator.ptr += LDS_SOFTMAX_TOTAL
     scale_off = softmax_off + LDS_SOFTMAX_TOTAL
     allocator.ptr += LDS_SCALE_TOTAL
+    # Phys-block staging LDS for the small-block path (cross-warp visibility of
+    # the per-warp page indices so V can read all blocks of a partition).
+    bt_off = scale_off + LDS_SCALE_TOTAL
+    if _is_small_block:
+        allocator.ptr += NUM_WARPS * TLOOP * 4
 
     # ── @flyc.kernel ─────────────────────────────────────────────────
-    @flyc.kernel
-    def pa_decode_ps_kernel(
+    @flyc.kernel(known_block_size=(BLOCK_THREADS, 1, 1))
+    def pa_decode_metadata_kenrel(
         out_ptr: fx.Tensor,  # output [batch, num_q_heads, head_size]
         partial_out_ptr: fx.Tensor,  # partial output [num_partials, 1, nhead, head_dim] fp32
         partial_lse_ptr: fx.Tensor,  # partial LSE [num_partials, 1, nhead, 1] fp32
@@ -1182,6 +1074,7 @@ def compile_pa_decode_ps(
         work_info_ptr: fx.Tensor,  # [num_work, 8] int32 (flattened to 1D)
         kv_page_indices_ptr: fx.Tensor,  # [total_pages] int32
         kv_indptr_ptr: fx.Tensor,  # [num_seqs + 1] int32 — prefix sum of pages per seq
+        partition_indptr_ptr: fx.Tensor,  # [num_seqs + 1] int32 — prefix sum of partitions per seq
         stride_q_seq: Int32,
         stride_q_head: Int32,
         stride_k_block: Int32,
@@ -1207,6 +1100,7 @@ def compile_pa_decode_ps(
 
         # ── Buffer resources ──
         q_rsrc = buffer_ops.create_buffer_resource(query_ptr, max_size=True)
+        out_rsrc = buffer_ops.create_buffer_resource(out_ptr, max_size=True)
         k_global_ptr = _extract_global_ptr(key_cache_ptr)
         v_global_ptr = _extract_global_ptr(value_cache_ptr)
         po_rsrc = buffer_ops.create_buffer_resource(partial_out_ptr, max_size=True)
@@ -1216,6 +1110,7 @@ def compile_pa_decode_ps(
         winfo_rsrc = buffer_ops.create_buffer_resource(work_info_ptr, max_size=True)
         kpi_rsrc = buffer_ops.create_buffer_resource(kv_page_indices_ptr, max_size=True)
         kvindptr_rsrc = buffer_ops.create_buffer_resource(kv_indptr_ptr, max_size=True)
+        pip_rsrc = buffer_ops.create_buffer_resource(partition_indptr_ptr, max_size=True)
         ks_rsrc = buffer_ops.create_buffer_resource(key_scale_ptr, max_size=True)
         vs_rsrc = buffer_ops.create_buffer_resource(value_scale_ptr, max_size=True)
 
@@ -1235,6 +1130,9 @@ def compile_pa_decode_ps(
         scale_lds_f32 = None
         if const_expr(per_token_kv):
             scale_lds_f32 = SmemPtr(smem_base, scale_off, T.f32, shape=(LDS_SCALE_BYTES // 4,)).get()
+        bt_lds_i32 = None
+        if const_expr(_is_small_block):
+            bt_lds_i32 = SmemPtr(smem_base, bt_off, T.i32, shape=(NUM_WARPS * TLOOP,)).get()
 
         # ── Constants ──
         c_kb = stride_k_block
@@ -1248,10 +1146,8 @@ def compile_pa_decode_ps(
         c_w = arith.constant(WARP_SIZE, type=T.i32)
         NEG_INF = arith.constant(float("-inf"), type=T.f32)
         ZERO_F = arith.constant(0.0, type=T.f32)
-        c_cps = arith.constant(KV_COMPUTE_BLOCK, type=T.i32)
+        c_cps = arith.constant(KV_COMPUTE_BLOCK, type=T.i32)  # 256-token partition
         c_one = arith.constant(1, type=T.i32)
-        c_bs = arith.constant(_bs, type=T.i32)
-        c_tpb = arith.constant(TILES_PER_BLOCK, type=T.i32)
 
         local_qhead_idx = warp_id * arith.constant(4, type=T.i32) + rowid
         (
@@ -1275,11 +1171,15 @@ def compile_pa_decode_ps(
             rowid,
             trans_v=trans_v,
             per_token_kv=per_token_kv,
+            qkhe_loop=_QKHELOOP,
+            vhe_loop=_VHELOOP,
         )
 
         # ── Work loop bounds ──
-        work_start = buffer_ops.buffer_load(wi_rsrc, cu_id, vec_width=1, dtype=T.i32)
-        work_end = buffer_ops.buffer_load(wi_rsrc, cu_id + c_one, vec_width=1, dtype=T.i32)
+        # wi[cu_id] and wi[cu_id+1] are adjacent int32; load both in one vec2 load.
+        work_bounds = buffer_ops.buffer_load(wi_rsrc, cu_id, vec_width=2, dtype=T.i32)
+        work_start = vector.extract(work_bounds, static_position=[0], dynamic_position=[])
+        work_end = vector.extract(work_bounds, static_position=[1], dynamic_position=[])
 
         # ════════════════════════════════════════════════════════════
         # Outer work loop — iterate over assigned work items
@@ -1292,26 +1192,35 @@ def compile_pa_decode_ps(
         for _wi in range(_work_start_idx, _work_end_idx, _work_step):
             work_idx = arith.index_cast(T.i32, _wi)
 
-            # ── Load work_info[work_idx] — 8 × int32 ──
+            # ── Load work_info[work_idx] — 8 × int32, as 2 × vec4 loads ──
+            # info_base is a multiple of 8, so both dwordx4 loads are naturally
+            # aligned (info_base @ 32 B, info_base+4 @ 16 B).  Fields 3 and 6 are
+            # currently unused and simply not extracted.
             info_base = work_idx * arith.constant(8, type=T.i32)
-            batch_idx = buffer_ops.buffer_load(winfo_rsrc, info_base, vec_width=1, dtype=T.i32)
-            partial_idx = buffer_ops.buffer_load(winfo_rsrc, info_base + c_one, vec_width=1, dtype=T.i32)
-            kv_start = buffer_ops.buffer_load(
-                winfo_rsrc, info_base + arith.constant(4, type=T.i32), vec_width=1, dtype=T.i32
+            wi_lo = buffer_ops.buffer_load(winfo_rsrc, info_base, vec_width=4, dtype=T.i32)
+            wi_hi = buffer_ops.buffer_load(
+                winfo_rsrc, info_base + arith.constant(4, type=T.i32), vec_width=4, dtype=T.i32
             )
-            kv_end = buffer_ops.buffer_load(
-                winfo_rsrc, info_base + arith.constant(5, type=T.i32), vec_width=1, dtype=T.i32
-            )
-            q_head_range = buffer_ops.buffer_load(
-                winfo_rsrc, info_base + arith.constant(7, type=T.i32), vec_width=1, dtype=T.i32
-            )
+            batch_idx = vector.extract(wi_lo, static_position=[0], dynamic_position=[])
+            partial_idx = vector.extract(wi_lo, static_position=[1], dynamic_position=[])
+            qo_start = vector.extract(wi_lo, static_position=[2], dynamic_position=[])
+            kv_start = vector.extract(wi_hi, static_position=[0], dynamic_position=[])
+            kv_end = vector.extract(wi_hi, static_position=[1], dynamic_position=[])
+            q_head_range = vector.extract(wi_hi, static_position=[3], dynamic_position=[])
 
-            # Absolute token offset for the first page of this work item within its sequence.
-            # kv_start is an absolute index into kv_page_indices; kv_indptr[batch_idx] is
-            # the page index where this sequence starts.  Their difference * KV_BLOCK_SIZE
-            # gives the token offset from sequence start to the first token we process.
-            kv_indptr_batch = buffer_ops.buffer_load(kvindptr_rsrc, batch_idx, vec_width=1, dtype=T.i32)
-            kv_start_abs_tok = (kv_start - kv_indptr_batch) * c_bs
+            # work_info.kv_start/kv_end are cumulative partition indices (256-token
+            # units, summed across batches).  partition_indptr[batch] gives the
+            # cumulative-partition base for this sequence (→ local partition index),
+            # kv_indptr[batch] gives the physical-page base into kv_page_indices.
+            kv_part_base = buffer_ops.buffer_load(pip_rsrc, batch_idx, vec_width=1, dtype=T.i32)
+            # kv_indptr[batch] / kv_indptr[batch+1] in one dwordx2 load: this
+            # sequence's physical-page base and end in the flat kv_page_indices
+            # array.  kv_page_end clamps small-block page-gather reads so the last
+            # (partial) partition never reads past the sequence.
+            _kvind2 = buffer_ops.buffer_load(kvindptr_rsrc, batch_idx, vec_width=2, dtype=T.i32)
+            kv_page_base = vector.extract(_kvind2, static_position=[0], dynamic_position=[])
+            kv_page_end = vector.extract(_kvind2, static_position=[1], dynamic_position=[])
+            local_part_start = kv_start - kv_part_base
 
             # Derive kv_head from q_head_range
             q_head_start = q_head_range & arith.constant(0xFFFF, type=T.i32)
@@ -1319,8 +1228,6 @@ def compile_pa_decode_ps(
 
             # Context length for this sequence
             context_len = buffer_ops.buffer_load(cl_rsrc, batch_idx, vec_width=1, dtype=T.i32)
-            # ── Prologue: load first block's tile 0 K data ──
-            first_phys_block = buffer_ops.buffer_load(kpi_rsrc, kv_start, vec_width=1, dtype=T.i32)
             # Head offsets for K and V cache
             _k_head_off = kv_h * c_kh
             _v_head_off = kv_h * c_vh
@@ -1328,11 +1235,10 @@ def compile_pa_decode_ps(
             (
                 _load_kv_scale_scalars,
                 _load_v_and_scales,
-                _store_vmax_warp_unused,
+                _store_vmax_warp,
                 _qk_and_intra_softmax,
                 _cross_warp_softmax_and_prob_pack,
                 _pv_mfma,
-                _finalize_block_split_group_unused,
             ) = _make_pa_phase_helpers(
                 trans_v=trans_v,
                 per_token_q=query_scale_in_kernel,
@@ -1373,149 +1279,116 @@ def compile_pa_decode_ps(
                 neg_inf=NEG_INF,
                 zero_f=ZERO_F,
                 cache_scale_vecs=cache_scale_vecs,
-                sched_vmem_after_load=False,
-                preload_pv_operands=True,
+                head_size=_HEAD,
+                qkhe_loop=_QKHELOOP,
+                vhe_loop=_VHELOOP,
             )
 
             # ════════════════════════════════════════════════════════
             # Inner KV loop — one CTA processes one 256-token sub-tile
             # across all 1024-token physical blocks in the work item.
+            # Below: MTP groups loop is nested INSIDE the KV loop so that
+            # K and V are loaded once per physical block and reused across
+            # all MTP groups.  Q is hoisted out of the KV loop (loaded once
+            # per work item, kept in registers).
             # ════════════════════════════════════════════════════════
             def _unwrap(v):
                 return v.ir_value() if hasattr(v, "ir_value") else v
 
-            def _pack_state(rmax, rsum, o0, o1, k_flat, scale_scalars=None):
-                state = [rmax, rsum, o0, o1] + k_flat
-                if const_expr(cache_scale_vecs and per_token_kv):
-                    state += list(scale_scalars)
-                return [_unwrap(v) for v in state]
-
-            def _unpack_state(state):
-                k_flat = list(state[4 : 4 + _N_K])
-                if const_expr(per_token_kv):
-                    scale_scalars = tuple(state[4 + _N_K : 6 + _N_K])
-                else:
-                    scale_scalars = None
-                return state[0], state[1], state[2], state[3], k_flat, scale_scalars
-
-            def _process_block_split(
-                phys_block,
-                block_idx_in_work,
-                rmax,
-                rsum,
-                o0,
-                o1,
-                tile_token_offset_i32,
-                k_ops,
-                scale_scalars,
-                next_phys_block=None,
-                next_k_base=None,
-            ):
-                """Process one 256-token block split inside a 1024-token KV page."""
-                partition_start = kv_start_abs_tok + block_idx_in_work * c_bs + tile_token_offset_i32
-                v_base = _compute_block_base_dw_i64(phys_block, c_vb, _v_head_off)
-                preloaded_v_and_scales = _load_v_and_scales(
-                    v_base,
-                    tile_token_offset_i32,
-                    phys_block=phys_block,
-                    preloaded_scale_scalars=scale_scalars,
-                )
-                if const_expr(per_token_kv):
-                    d_out, v_ops, v_scales = _qk_and_intra_softmax(
-                        k_ops,
-                        partition_start,
-                        v_base,
-                        tile_token_offset_i32,
-                        q_frags,
-                        causal_bound,
-                        query_scale_lane=query_scale_lane,
-                        phys_block=phys_block,
-                        preloaded_v_and_scales=preloaded_v_and_scales,
-                    )
-                else:
-                    d_out, v_ops = _qk_and_intra_softmax(
-                        k_ops,
-                        partition_start,
-                        v_base,
-                        tile_token_offset_i32,
-                        q_frags,
-                        causal_bound,
-                        query_scale_lane=query_scale_lane,
-                        phys_block=phys_block,
-                        preloaded_v_and_scales=preloaded_v_and_scales,
-                    )
-                    v_scales = None
-
-                gpu.barrier()
-                rmax, rsum, o0, o1, v_correction = _cross_warp_softmax_and_prob_pack(
-                    d_out, rmax, rsum, o0, o1, v_scales
-                )
-                if const_expr(next_k_base is not None):
-                    next_scale_scalars = _load_kv_scale_scalars(tile_token_offset_i32, next_phys_block)
-                    k_next_flat = _load_k_flat(
-                        k_global_ptr,
-                        next_k_base,
-                        tile_token_offset_i32,
-                        _k_tok_thread_base,
-                        _c_tok_stride_dw,
-                        _k_he_off_dw,
-                        sched_vmem_after_load=False,
-                    )
-                else:
-                    k_next_flat = None
-                    next_scale_scalars = None
-
-                gpu.barrier()
-                o0, o1 = _pv_mfma(v_ops, o0, o1, v_correction)
-                return rmax, rsum, o0, o1, k_next_flat, next_scale_scalars
-
-            # Metadata remaps every work tile into a partial slot shared across q-head ranges.
-            # grid_z then expands each slot into 4 block-split partials.
             c_ql = arith.constant(query_length, type=T.i32)
             c_zero_i32 = arith.constant(0, type=T.i32)
-            block_split_idx = gpu.block_idx.z
-            tile_token_offset = block_split_idx * c_cps
-            _partial_ge_zero = partial_idx >= c_zero_i32
-            _po_row_base = arith.select(
-                _partial_ge_zero,
-                partial_idx * c_tpb + block_split_idx * c_ql + c_ql,
-                c_zero_i32,
-            )
+            c_bpp = arith.constant(_blocks_per_partition, type=T.i32)
 
-            # Unified loop bounds (shared across mtp_g passes — blocks don't change per mtp_g)
-            num_blocks_in_work = kv_end - kv_start
-            last_block_idx_val = num_blocks_in_work - c_one
+            # Output target: partial_qo_loc (work_info[1]) < 0 → write the final
+            # output directly; >= 0 → write a partial slot (combined later by
+            # pa_reduce_v1).  The partial buffer reserves the first `query_length`
+            # rows (pa_reduce_v1 runs on partial_output[query_length:]), so the
+            # partial row base is `partial_idx + query_length`.  qo_start
+            # (work_info[2]) is the final-output row base for direct works.
+            _is_direct = partial_idx < c_zero_i32
+            _po_row_base = partial_idx + c_ql
+
+            # Loop over the work item's partitions: [kv_start, kv_end) cumulative
+            # partition indices → num_parts local 256-token partitions, in reverse
+            # (sink-prone partition 0 processed last for online-softmax stability).
+            num_parts_in_work = kv_end - kv_start
+            last_part_idx_val = num_parts_in_work - c_one
             _loop_start_g = arith.index(0)
-            _loop_stop_g = fx.Index(arith.unwrap(num_blocks_in_work))
+            _loop_stop_g = fx.Index(arith.unwrap(num_parts_in_work))
             _loop_step_g = arith.index(1)
 
-            # ── MTP groups: Python compile-time loop — one MLIR KV-loop per group ──
-            # Use range_constexpr so AST rewriter keeps this as a plain Python loop
             _mtp_groups = math.ceil(query_length * query_group_size / 16)
-            next_mtp_prefetch = None
+
+            # ── Small-block (16/64) physical-page gather helpers ──
+            # A 256-token partition spans `_blocks_per_partition` physical pages.
+            # Each warp loads its own K page(s); the per-warp page indices are
+            # staged to LDS so every warp can read all pages for the V load.
+            # (Only used when `_is_small_block`; for block_size >= 256 a partition
+            # is a 256-token sub-tile of a single physical page.)
+            _kpi_last = kv_page_end - c_one  # last in-bounds page index for this seq
+
+            def _meta_load_phys_clamped(elem_idx):
+                # Clamp to the sequence's page range so the last (partial) partition
+                # never reads past the flat kv_page_indices window (kpi_rsrc has no
+                # HW bounds check).  Out-of-range lanes map to tokens >= context_len,
+                # which softmax masks to 0, so the clamped block's content is unused.
+                safe = arith.select(elem_idx < kv_page_end, elem_idx, _kpi_last)
+                return buffer_ops.buffer_load(kpi_rsrc, safe, vec_width=1, dtype=T.i32)
+
+            def _meta_stage_phys(local_part):
+                page_base = kv_page_base + local_part * c_bpp
+                if const_expr(_block_size == 64):
+                    return _meta_load_phys_clamped(page_base + warp_id)
+                wbase = page_base + warp_id * arith.constant(TLOOP, type=T.i32)
+                elems = [_meta_load_phys_clamped(wbase + arith.constant(td, type=T.i32)) for td in range(TLOOP)]
+                return fx.Vector.from_elements(elems, dtype=fx.Int32)
+
+            def _meta_store_phys_to_lds(phys_vec):
+                if (lane16id | rowid) == c_zero_i32:
+                    if const_expr(_block_size == 64):
+                        fx.Vector.from_elements([phys_vec], dtype=fx.Int32).store(bt_lds_i32, [fx.Index(warp_id)])
+                    else:
+                        phys_vec.store(bt_lds_i32, [fx.Index(warp_id * arith.constant(TLOOP, type=T.i32))])
+
+            def _meta_load_v_phys_from_lds():
+                v_phys_blocks = []
+                if const_expr(_block_size == 64):
+                    phys_block_vec = fx.Vector.load(T.vec(VTLOOP, T.i32), bt_lds_i32, [fx.Index(0)])
+                    for vt in range_constexpr(VTLOOP):
+                        v_phys_blocks.append(phys_block_vec[vt])
+                else:
+                    for vt in range_constexpr(VTLOOP):
+                        bt_lds_off = arith.constant(vt * TLOOP, type=T.i32) + rowid
+                        v_phys_blocks.append(fx.Vector.load(T.vec(1, T.i32), bt_lds_i32, [fx.Index(bt_lds_off)])[0])
+                return v_phys_blocks
+
+            # ── Pre-load Q for every MTP group ONCE per work item.  Each
+            # group's q_frags / qi / qhi / qscale stay in registers across
+            # the entire KV loop, so we pay the Q-load cost (global → LDS →
+            # registers) exactly once per work-item regardless of how many
+            # blocks the work item spans.
+            q_frags_per_mtp = []
+            qi_per_mtp = []
+            qhi_per_mtp = []
+            qscale_per_mtp = []
             for _mtp_g in range_constexpr(_mtp_groups):
-                # Between passes: barrier ensures prev pass's LDS prob-reads are done
                 if const_expr(_mtp_g > 0):
                     gpu.barrier()
-
-                if const_expr(_mtp_g == 0):
-                    mtp_prefetch = _prefetch_mtp_group_query(
-                        q_rsrc,
-                        batch_idx,
-                        kv_h,
-                        stride_q_seq,
-                        stride_q_head,
-                        lane16id,
-                        local_qhead_idx,
-                        mtp_group_idx=_mtp_g,
-                        query_length=query_length,
-                        query_group_size=query_group_size,
-                        query_load_is_bf16=query_load_is_bf16,
-                    )
-                else:
-                    mtp_prefetch = next_mtp_prefetch
-
-                qi_val, qhi_pos, q_frags, query_scale_lane = _finish_mtp_group_q_fragments(
+                mtp_prefetch = _prefetch_mtp_group_query(
+                    q_rsrc,
+                    batch_idx,
+                    kv_h,
+                    stride_q_seq,
+                    stride_q_head,
+                    lane16id,
+                    local_qhead_idx,
+                    mtp_group_idx=_mtp_g,
+                    query_length=query_length,
+                    query_group_size=query_group_size,
+                    query_load_is_bf16=query_load_is_bf16,
+                    q_lanes_per_head=_Q_LANES_PER_HEAD,
+                )
+                _qi, _qhi, _qfrags, _qscale = _finish_mtp_group_q_fragments(
                     logits_lds_i32,
                     logits_lds_i64,
                     softmax_lds_f32,
@@ -1523,125 +1396,287 @@ def compile_pa_decode_ps(
                     lane16id,
                     rowid,
                     local_qhead_idx,
+                    head_size=_HEAD,
+                    qkhe_loop=_QKHELOOP,
+                    q_lanes_per_head=_Q_LANES_PER_HEAD,
                 )
+                qi_per_mtp.append(_qi)
+                qhi_per_mtp.append(_qhi)
+                q_frags_per_mtp.append(_qfrags)
+                qscale_per_mtp.append(_qscale)
+            gpu.barrier()
 
-                if const_expr(_mtp_g + 1 < _mtp_groups):
-                    next_mtp_prefetch = _prefetch_mtp_group_query(
-                        q_rsrc,
-                        batch_idx,
-                        kv_h,
-                        stride_q_seq,
-                        stride_q_head,
-                        lane16id,
-                        local_qhead_idx,
-                        mtp_group_idx=_mtp_g + 1,
-                        query_length=query_length,
-                        query_group_size=query_group_size,
-                        query_load_is_bf16=query_load_is_bf16,
-                    )
+            # MTP causal bound per group (depends only on qi, computed once).
+            causal_bound_per_mtp = [
+                context_len + arith.constant(1 - query_length, type=T.i32) + qi_per_mtp[_mtp_g]
+                for _mtp_g in range(_mtp_groups)
+            ]
 
-                gpu.barrier()
-
-                # MTP causal bound for this lane's qi_val token
-                causal_bound = context_len + arith.constant(1 - query_length, type=T.i32) + qi_val
-
-                # ── K init: load this CTA's 256-token block split for the first block ──
-                first_k_base = _compute_block_base_dw_i64(first_phys_block, c_kb, _k_head_off)
-                scale_scalars = _load_kv_scale_scalars(tile_token_offset, first_phys_block)
-                k_flat = _load_k_flat(
+            # ── K init: load the reverse-start (last) partition's K (loop-carried) ──
+            local_last_part = local_part_start + last_part_idx_val
+            if const_expr(_is_small_block):
+                _first_phys_blocks = _meta_stage_phys(local_last_part)
+                k_flat0 = _pa_small_block_load_k_flat(
+                    k_global_ptr,
+                    kv_h,
+                    c_kb,
+                    c_kh,
+                    lane16id,
+                    rowid,
+                    block_size=_block_size,
+                    phys_blocks=_first_phys_blocks,
+                    qkhe_loop=_QKHELOOP,
+                )
+                scale_scalars0 = None
+            else:
+                _first_phys_block = buffer_ops.buffer_load(
+                    kpi_rsrc, kv_page_base + _udiv_const(local_last_part, _parts_per_block), vec_width=1, dtype=T.i32
+                )
+                _first_tile_tok = _urem_const(local_last_part, _parts_per_block) * c_cps
+                first_k_base = _compute_block_base_dw_i64(_first_phys_block, c_kb, _k_head_off)
+                scale_scalars0 = _load_kv_scale_scalars(_first_tile_tok, _first_phys_block)
+                k_flat0 = _load_k_flat(
                     k_global_ptr,
                     first_k_base,
-                    tile_token_offset,
+                    _first_tile_tok,
                     _k_tok_thread_base,
                     _c_tok_stride_dw,
                     _k_he_off_dw,
-                    sched_vmem_after_load=False,
+                    qkhe_loop=_QKHELOOP,
                 )
 
-                init_state = _pack_state(
-                    NEG_INF,
-                    ZERO_F,
-                    arith.constant_vector(0.0, T.f32x4),
-                    arith.constant_vector(0.0, T.f32x4),
-                    k_flat,
-                    scale_scalars,
-                )
+            # Multi-MTP state packing: (rmax, rsum, outs...) per MTP group,
+            # + _N_K_h K values, + 2 scale scalars (per_token_kv only).
+            state_width = 2 + _VHELOOP
 
-                for ib, state in range(_loop_start_g, _loop_stop_g, _loop_step_g, init=init_state):
-                    running_max, running_sum, out0, out1, k_flat, scale_scalars = _unpack_state(state)
-                    block_idx = arith.index_cast(T.i32, ib)
+            def _pack_states_kv(states, k_flat, scale_scalars=None):
+                flat = []
+                for st in states:
+                    rmax, rsum = st[0], st[1]
+                    outs = [st[2 + vhe] for vhe in range_constexpr(_VHELOOP)]
+                    flat.extend([_unwrap(rmax), _unwrap(rsum)])
+                    flat.extend(_unwrap(out) for out in outs)
+                flat.extend(_unwrap(v) for v in k_flat)
+                if const_expr(cache_scale_vecs and per_token_kv):
+                    flat.extend(_unwrap(v) for v in scale_scalars)
+                return flat
 
-                    phys_block = buffer_ops.buffer_load(kpi_rsrc, kv_start + block_idx, vec_width=1, dtype=T.i32)
-                    next_idx_raw = block_idx + c_one
-                    next_idx_clamped = arith.select(next_idx_raw < num_blocks_in_work, next_idx_raw, last_block_idx_val)
+            def _unpack_states_kv(flat):
+                base = state_width * _mtp_groups
+                states = [tuple(flat[state_width * i + j] for j in range(state_width)) for i in range(_mtp_groups)]
+                k_flat = list(flat[base : base + _N_K_h])
+                if const_expr(cache_scale_vecs and per_token_kv):
+                    scale_scalars = tuple(flat[base + _N_K_h : base + _N_K_h + 2])
+                else:
+                    scale_scalars = None
+                return states, k_flat, scale_scalars
+
+            init_states = [
+                tuple([NEG_INF, ZERO_F] + [arith.constant_vector(0.0, T.f32x4) for _ in range_constexpr(_VHELOOP)])
+                for _ in range(_mtp_groups)
+            ]
+
+            # ════════════════════════════════════════════════════════
+            # KV outer loop — iterate over physical blocks in this work
+            # item.  MTP processing happens INSIDE the loop body so that
+            # K and V are loaded once per block and reused across all
+            # MTP groups.
+            # ════════════════════════════════════════════════════════
+            for ib, state in range(
+                _loop_start_g,
+                _loop_stop_g,
+                _loop_step_g,
+                init=_pack_states_kv(init_states, k_flat0, scale_scalars0),
+            ):
+                cur_states, k_flat, scale_scalars = _unpack_states_kv(state)
+                # Reverse iteration: scf.for walks ib forward (0..N-1); remap to
+                # the local partition index lp = N-1..0 so the sink-prone first
+                # partition is processed last.
+                rel_part = last_part_idx_val - arith.index_cast(T.i32, ib)
+                lp = local_part_start + rel_part
+                next_rel = rel_part - c_one
+                next_rel_clamped = arith.select(next_rel >= c_zero_i32, next_rel, c_zero_i32)
+                next_lp = local_part_start + next_rel_clamped
+
+                k_ops = _unflatten_k(k_flat, qkhe_loop=_QKHELOOP)
+                partition_start = lp * c_cps  # within-sequence token offset of this 256-tile
+
+                # Load V (and per-token scales if applicable) ONCE per partition;
+                # reused across all MTP groups below.
+                if const_expr(_is_small_block):
+                    _meta_store_phys_to_lds(_meta_stage_phys(lp))
+                    gpu.barrier()
+                    v_ops = _pa_small_block_load_v_trans(
+                        v_global_ptr,
+                        kv_h,
+                        c_vb,
+                        c_vh,
+                        warp_id,
+                        lane16id,
+                        rowid,
+                        _meta_load_v_phys_from_lds(),
+                        block_size=_block_size,
+                        head_size=_HEAD,
+                        vhe_loop=_VHELOOP,
+                    )
+                else:
+                    phys_block = buffer_ops.buffer_load(
+                        kpi_rsrc, kv_page_base + _udiv_const(lp, _parts_per_block), vec_width=1, dtype=T.i32
+                    )
+                    tile_token_offset = _urem_const(lp, _parts_per_block) * c_cps
+                    v_base = _compute_block_base_dw_i64(phys_block, c_vb, _v_head_off)
+                    if const_expr(cache_scale_vecs and per_token_kv):
+                        v_ops, k_scale_vecs, v_scale_vecs = _load_v_and_scales(
+                            v_base,
+                            tile_token_offset,
+                            phys_block=phys_block,
+                            preloaded_scale_scalars=scale_scalars,
+                        )
+                    else:
+                        v_ops = _load_v_and_scales(
+                            v_base,
+                            tile_token_offset,
+                            phys_block=phys_block,
+                            preloaded_scale_scalars=scale_scalars,
+                        )
+                new_states = []
+                for _mtp_g in range_constexpr(_mtp_groups):
+                    if const_expr(_mtp_g > 0):
+                        gpu.barrier()
+                    state = cur_states[_mtp_g]
+                    rmax, rsum = state[0], state[1]
+                    outs = [state[2 + vhe] for vhe in range_constexpr(_VHELOOP)]
+
+                    if const_expr(cache_scale_vecs and per_token_kv):
+                        d_out, v_scales = _qk_and_intra_softmax(
+                            k_ops,
+                            partition_start,
+                            q_frags_per_mtp[_mtp_g],
+                            causal_bound_per_mtp[_mtp_g],
+                            query_scale_lane=qscale_per_mtp[_mtp_g],
+                            preloaded_scales=(k_scale_vecs, v_scale_vecs),
+                        )
+                    else:
+                        d_out = _qk_and_intra_softmax(
+                            k_ops,
+                            partition_start,
+                            q_frags_per_mtp[_mtp_g],
+                            causal_bound_per_mtp[_mtp_g],
+                            query_scale_lane=qscale_per_mtp[_mtp_g],
+                        )
+                        v_scales = None
+
+                    # Bugfix: per_token_kv path needs v_max staged to LDS so
+                    # _cross_warp_softmax_and_prob_pack can read it for
+                    # norm_factor.  Without this write the read sees stale/
+                    # uninitialized LDS and produces NaN.
+                    if const_expr(per_token_kv):
+                        _store_vmax_warp(partition_start, seq_end=context_len, v_scale_vecs=v_scales)
+
+                    gpu.barrier()
+                    rmax, rsum, outs, v_correction = _cross_warp_softmax_and_prob_pack(
+                        d_out, rmax, rsum, outs, v_scales
+                    )
+                    gpu.barrier()
+                    outs = _pv_mfma(v_ops, outs, v_correction)
+                    new_states.append(tuple([rmax, rsum] + outs))
+
+                # Prefetch next partition's K (once per iter, after all MTP groups)
+                if const_expr(_is_small_block):
+                    k_next_flat = _pa_small_block_load_k_flat(
+                        k_global_ptr,
+                        kv_h,
+                        c_kb,
+                        c_kh,
+                        lane16id,
+                        rowid,
+                        block_size=_block_size,
+                        phys_blocks=_meta_stage_phys(next_lp),
+                        qkhe_loop=_QKHELOOP,
+                    )
+                    next_scale_scalars = None
+                else:
                     next_phys_block = buffer_ops.buffer_load(
-                        kpi_rsrc, kv_start + next_idx_clamped, vec_width=1, dtype=T.i32
+                        kpi_rsrc, kv_page_base + _udiv_const(next_lp, _parts_per_block), vec_width=1, dtype=T.i32
                     )
+                    next_tile_tok = _urem_const(next_lp, _parts_per_block) * c_cps
                     next_k_base = _compute_block_base_dw_i64(next_phys_block, c_kb, _k_head_off)
-
-                    k_ops = _unflatten_k(k_flat)
-
-                    running_max, running_sum, out0, out1, k_next_flat, next_scale_scalars = _process_block_split(
-                        phys_block,
-                        block_idx,
-                        running_max,
-                        running_sum,
-                        out0,
-                        out1,
-                        tile_token_offset,
-                        k_ops,
-                        scale_scalars,
-                        next_phys_block=next_phys_block,
-                        next_k_base=next_k_base,
+                    next_scale_scalars = _load_kv_scale_scalars(next_tile_tok, next_phys_block)
+                    k_next_flat = _load_k_flat(
+                        k_global_ptr,
+                        next_k_base,
+                        next_tile_tok,
+                        _k_tok_thread_base,
+                        _c_tok_stride_dw,
+                        _k_he_off_dw,
+                        qkhe_loop=_QKHELOOP,
                     )
 
-                    results = yield _pack_state(
-                        running_max,
-                        running_sum,
-                        out0,
-                        out1,
-                        k_next_flat,
-                        next_scale_scalars,
-                    )
+                results = yield _pack_states_kv(new_states, k_next_flat, next_scale_scalars)
 
-                running_max, running_sum, out0, out1, _, _ = _unpack_state(results)
+            # ── Normalize + store one slot per MTP group ──
+            # partial_qo_loc (work_info[1]) < 0 → write the fully-normalized output
+            # directly to `out` at row qo_start+qi; >= 0 → write a partial slot
+            # (+LSE) at row partial_idx+query_length+qi for pa_reduce_v1.
+            final_states, _, _ = _unpack_states_kv(results)
+            from flydsl._mlir.dialects import math as _mlir_math
 
-                # ── Normalize output ──
-                outelems_norm = _normalize_pa_output(running_sum, out0, out1, ZERO_F)
+            def _store_out_vec(vec_f32x4, elem_off):
+                if const_expr(output_dtype_str == "f32"):
+                    buffer_ops.buffer_store(vec_f32x4, out_rsrc, elem_off)
+                elif const_expr(output_dtype_str == "f16"):
+                    buffer_ops.buffer_store(fx.Vector(vec_f32x4).to(fx.Float16), out_rsrc, elem_off)
+                else:
+                    buffer_ops.buffer_store(fx.Vector(vec_f32x4).to(fx.BFloat16), out_rsrc, elem_off)
 
-                for vhe in range_constexpr(VHELOOP):
-                    hs_base = (
-                        arith.constant(vhe * NUM_WARPS * MFMA_N, type=T.i32)
-                        + warp_id * arith.constant(MFMA_N, type=T.i32)
-                        + rowid * arith.constant(4, type=T.i32)
-                    )
-                    # qhi_pos: mtp_g-based head position within kv_head group
-                    qhead = kv_h * arith.constant(query_group_size, type=T.i32) + qhi_pos
-                    _po_row = _po_row_base + qi_val
-                    po_off = _po_row * stride_po_ql + qhead * arith.constant(HEAD_SIZE, type=T.i32) + hs_base
+            for _mtp_g in range_constexpr(_mtp_groups):
+                final_state = final_states[_mtp_g]
+                rmax_raw, rsum_raw = final_state[0], final_state[1]
+                outs_raw = [final_state[2 + vhe] for vhe in range_constexpr(_VHELOOP)]
+                running_max = fx.Float32(rmax_raw)
+                running_sum = fx.Float32(rsum_raw)
+                outs = [fx.Vector(out_raw) for out_raw in outs_raw]
+                outelems_norm = _normalize_pa_output(running_sum, outs, ZERO_F)
+                qi_val_mg = qi_per_mtp[_mtp_g]
+                qhi_pos_mg = qhi_per_mtp[_mtp_g]
+                qhead = kv_h * arith.constant(query_group_size, type=T.i32) + qhi_pos_mg
 
-                    # pa_reduce_v1 expects normalized partial output from every block split.
+                if _is_direct:
+                    out_row = qo_start + qi_val_mg
+                    for vhe in range_constexpr(_VHELOOP):
+                        hs_base = (
+                            arith.constant(vhe * NUM_WARPS * MFMA_N, type=T.i32)
+                            + warp_id * arith.constant(MFMA_N, type=T.i32)
+                            + rowid * arith.constant(4, type=T.i32)
+                        )
+                        out_off = out_row * stride_out_seq + qhead * stride_out_head + hs_base
+                        _store_out_vec(outelems_norm[vhe], out_off)
+                else:
+                    _po_row = _po_row_base + qi_val_mg
+                    for vhe in range_constexpr(_VHELOOP):
+                        hs_base = (
+                            arith.constant(vhe * NUM_WARPS * MFMA_N, type=T.i32)
+                            + warp_id * arith.constant(MFMA_N, type=T.i32)
+                            + rowid * arith.constant(4, type=T.i32)
+                        )
+                        po_off = _po_row * stride_po_ql + qhead * arith.constant(_HEAD, type=T.i32) + hs_base
+                        buffer_ops.buffer_store(
+                            outelems_norm[vhe], po_rsrc, po_off * arith.constant(4, type=T.i32), offset_is_bytes=True
+                        )
+
+                    # LSE (split partials only)
+                    safe_sum_lse = arith.select(running_sum > ZERO_F, running_sum, arith.constant(1.0, type=T.f32))
+                    log_sum = _mlir_math.log(safe_sum_lse, fastmath=arith.FastMathFlags.fast)
+                    lse_val = running_max + log_sum
+                    pl_off = _po_row * stride_pl_ql + qhead
+                    lse_as_i32 = arith.bitcast(T.i32, arith.unwrap(lse_val))
                     buffer_ops.buffer_store(
-                        outelems_norm[vhe], po_rsrc, po_off * arith.constant(4, type=T.i32), offset_is_bytes=True
+                        lse_as_i32, pl_rsrc, pl_off * arith.constant(4, type=T.i32), offset_is_bytes=True
                     )
-
-                # ── LSE ──
-                safe_sum_lse = arith.select(running_sum > ZERO_F, running_sum, arith.constant(1.0, type=T.f32))
-                from flydsl._mlir.dialects import math as _mlir_math
-
-                log_sum = _mlir_math.log(safe_sum_lse, fastmath=arith.FastMathFlags.fast)
-                lse_val = running_max + log_sum
-                qhead_lse = kv_h * arith.constant(query_group_size, type=T.i32) + qhi_pos
-                _po_row_lse = _po_row_base + qi_val
-                pl_off = _po_row_lse * stride_pl_ql + qhead_lse
-                lse_as_i32 = arith.bitcast(T.i32, lse_val)
-                buffer_ops.buffer_store(
-                    lse_as_i32, pl_rsrc, pl_off * arith.constant(4, type=T.i32), offset_is_bytes=True
-                )
 
     # ── @flyc.jit launch wrapper ─────────────────────────────────────
     @flyc.jit
-    def launch_pa_decode_ps(
+    def launch_pa_decode_metadata(
         out,
         po,
         pl,
@@ -1655,6 +1690,7 @@ def compile_pa_decode_ps(
         work_info,
         kv_page_indices,
         kv_indptr,
+        partition_indptr,
         s_q_seq,
         s_q_head,
         s_k_block,
@@ -1676,7 +1712,7 @@ def compile_pa_decode_ps(
         ctx = CompilationContext.get_current()
         with ir.InsertionPoint(ctx.gpu_module_body):
             allocator.finalize()
-        pa_decode_ps_kernel(
+        pa_decode_metadata_kenrel(
             out,
             po,
             pl,
@@ -1690,6 +1726,7 @@ def compile_pa_decode_ps(
             work_info,
             kv_page_indices,
             kv_indptr,
+            partition_indptr,
             s_q_seq,
             s_q_head,
             s_k_block,
@@ -1704,14 +1741,14 @@ def compile_pa_decode_ps(
             s_ks_head,
             s_po_ql,
             s_pl_ql,
-            value_attrs=_mfma_agpr_value_attrs(),
-        ).launch(grid=(num_sm, 1, TILES_PER_BLOCK), block=(BLOCK_THREADS, 1, 1), stream=stream)
+            # value_attrs=_mfma_agpr_value_attrs(),
+        ).launch(grid=(num_sm, 1, 1), block=(BLOCK_THREADS, 1, 1), stream=stream)
 
-    launch_pa_decode_ps.compile_hints["llvm_options"] = PA_MFMA_AGPR_LLVM_OPTIONS
+    # launch_pa_decode_metadata.compile_hints["llvm_options"] = PA_MFMA_AGPR_LLVM_OPTIONS
 
     return {
-        "launch": launch_pa_decode_ps,
-        "kernel": pa_decode_ps_kernel,
+        "launch": launch_pa_decode_metadata,
+        "kernel": pa_decode_metadata_kenrel,
         "allocator": allocator,
     }
 
@@ -1728,17 +1765,27 @@ def get_pa_metadata(
     kv_indptr: torch.Tensor,
     num_query_heads: int,
     num_kv_heads: int,
+    partition_size: int = KV_COMPUTE_BLOCK,
 ):
     """Compute PA metadata (worklist, reduce maps) via get_pa_metadata_v1.
 
-    Then expand each 1024-token work tile into 4 block-split partials so the PS
-    kernel can launch with `grid=(num_sm, 1, 4)` and still reuse `pa_reduce_v1`.
+    The worklist is now load-balanced at **partition** granularity
+    (``partition_size`` tokens, default ``KV_COMPUTE_BLOCK=256``) rather than at
+    physical block granularity: ``kv_granularity = partition_size``, so each
+    scheduled work unit is one partition and ``work_info.kv_start/kv_end`` are
+    cumulative **partition** indices (in ``partition_size``-token units), not
+    page indices. The partition↔block relationship for the consumer is:
+    ``partition_size > block_size`` → ``partition_size // block_size`` blocks per
+    partition; otherwise ``block_size // partition_size`` partitions per block.
+
+    NOTE: the consuming decode kernel must interpret kv_start/kv_end as partition
+    indices accordingly.
 
     Returns a dict with: work_indptr, work_info_flat, reduce_indptr,
     reduce_final_map, reduce_partial_map, num_sm, partial_output,
     partial_lse, stride_po_partial, stride_pl_partial.
     """
-    from aiter.ops.attention import get_pa_metadata_info_v1, get_pa_metadata_v1
+    from kernels.pa_metadata import get_pa_metadata_info_v1, get_pa_metadata_v1
 
     dev = query.device
     batch_size = context_lengths.shape[0]
@@ -1746,9 +1793,24 @@ def get_pa_metadata(
     head_size = query.shape[-1]
 
     props = torch.cuda.get_device_properties(dev)
-    num_sm = props.multi_processor_count
+    # Oversubscribe the persistent grid: the decode kernel is memory-latency-bound
+    # and only ~3 workgroups/CU fit by VGPR, but the worklist defaults to 1 wg/CU
+    # (grid = CU count).  Distributing work across num_cu = CU_count * OVERSUB bins
+    # (and launching that many workgroups) lets the HW keep multiple workgroups
+    # resident per CU → more waves in flight → better latency hiding.
+    base_cu = props.multi_processor_count
+    num_sm = base_cu * _PA_METADATA_GRID_OVERSUB
+    num_sm = (num_sm // num_kv_heads) * num_kv_heads  # keep divisible by num_kv_heads
 
     seqlens_qo_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device=dev) * query_length
+
+    # Cumulative-partition prefix sum (in partition_size-token units).  The decode
+    # kernel needs partition_base[batch] = partition_indptr[batch] to convert a
+    # global cumulative partition index (work_info.kv_start/kv_end) into a local
+    # within-sequence partition index.
+    _parts_per_batch = (context_lengths.to(torch.int32) + (partition_size - 1)) // partition_size
+    partition_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=dev)
+    partition_indptr[1:] = torch.cumsum(_parts_per_batch, dim=0).to(torch.int32)
 
     block_size = key_cache.shape[-2] if len(key_cache.shape) == 5 else key_cache.shape[-2]
 
@@ -1759,7 +1821,7 @@ def get_pa_metadata(
         (reduce_indptr_size, reduce_indptr_type),
         (reduce_final_map_size, reduce_final_map_type),
         (reduce_partial_map_size, reduce_partial_map_type),
-    ) = get_pa_metadata_info_v1(batch_size, num_kv_heads)
+    ) = get_pa_metadata_info_v1(batch_size, num_kv_heads, num_cu=num_sm)
 
     work_metadata_ptrs = torch.empty(work_meta_data_size, dtype=work_meta_data_type, device=dev)
     work_indptr = torch.empty(work_indptr_size, dtype=work_indptr_type, device=dev)
@@ -1781,20 +1843,25 @@ def get_pa_metadata(
         reduce_indptr,
         reduce_final_map,
         reduce_partial_map,
-        kv_granularity=max(block_size, 16),
+        kv_granularity=partition_size,
         block_size=block_size,
         max_seqlen_qo=query_length,
         uni_seqlen_qo=query_length,
         fast_mode=True,
         max_split_per_batch=-1,
+        num_cu=num_sm,
     )
 
-    work_info, reduce_indptr, reduce_final_map, reduce_partial_map = _expand_pa_metadata_for_block_splits(
-        work_indptr, work_info, query_length, block_split_factor=TILES_PER_BLOCK
-    )
+    # The FlyDSL get_pa_metadata_v1 produces the reduce_* maps natively
+    # (faithful to the C++ kernel), so work_info / reduce_* are consumed directly
+    # (no post-hoc expansion). work_info.kv_start/kv_end are partition indices and
+    # work_info[:,1] (partial_qo_loc) is -1 for direct works or a partition-row
+    # offset for split works.
     work_info_flat = work_info.reshape(-1).contiguous()
 
-    num_partials = reduce_partial_map.size(0)
+    # Number of partial slots = reduce_indptr[-1] (= last_reduce_indptr). Each
+    # split partial occupies query_length rows in the partial buffer.
+    num_partials = int(reduce_indptr[-1].item())
     max_qlen = query_length
     partial_output = torch.empty(
         ((num_partials + 1) * max_qlen, 1, num_query_heads, head_size), dtype=torch.float32, device=dev
@@ -1809,6 +1876,7 @@ def get_pa_metadata(
     return {
         "work_indptr": work_indptr,
         "work_info_flat": work_info_flat,
+        "partition_indptr": partition_indptr,
         "reduce_indptr": reduce_indptr,
         "reduce_final_map": reduce_final_map,
         "reduce_partial_map": reduce_partial_map,
@@ -1883,15 +1951,972 @@ def _get_output_dtype_str(output: torch.Tensor) -> str:
     )
 
 
-def get_sw_ps_max_context_partition_num(
-    sliding_window: int,
+def get_recommended_splits(
+    num_sequences: int,
+    num_kv_heads: int,
+    split_kv_blocks: int = 1,
+    *,
+    sliding_window: int = 0,
     context_partition_size: int = KV_COMPUTE_BLOCK,
     query_length: int = 1,
 ) -> int:
-    if sliding_window <= 0:
-        return 0
-    window_token_count = sliding_window + query_length
-    return _cdiv(window_token_count - 1, context_partition_size) + 1
+    """Recommend ``max_context_partition_num`` for PS partitioned paths.
+
+    For sliding-window PS, this includes the old
+    ``get_sw_ps_max_context_partition_num`` token-window calculation. For
+    non-sliding PS, this mirrors ``get_recommended_splits`` in
+    ``aiter/ops/triton/gluon/pa_decode_gluon.py`` so FlyDSL callers do not need
+    to depend on aiter for the host-side split count.
+    """
+    if sliding_window > 0:
+        window_token_count = sliding_window + query_length
+        return _cdiv(window_token_count - 1, context_partition_size) + 1
+
+    props = torch.cuda.get_device_properties(torch.device("cuda"))
+    # Reference uses occupancy = 2 (see `get_occupancy()` in the Gluon module).
+    occupancy = 2
+    num_sm = props.multi_processor_count * occupancy
+    denom = max(1, num_sequences * num_kv_heads * split_kv_blocks)
+    n = _cdiv(num_sm, denom) * split_kv_blocks
+    return max(4, min(n, 8))
+
+
+# =====================================================================
+# compile_pa_decode_ps — partition kernel for block_size 16/64
+# =====================================================================
+#
+# Mirrors `paged_attention_decode_ps`
+# (aiter/ops/triton/gluon/pa_decode_gluon.py:2167) for the
+# `KV_BLOCK_SIZE < CONTEXT_PARTITION_SIZE` case.  Grid is partition-based:
+#   (batch, num_kv_heads, max_context_partition_num)
+# Each CTA owns one 256-token context partition spanning
+# `256 // block_size` physical KV blocks and writes its partial
+# (exp_sum, max_logit, attention_output) into intermediate tensors that
+# are reduced by `compile_pa_decode_sw_reduce`.
+#
+# Supports per-tensor KV quant only (per_token_kv path is NotImplementedError).
+#
+# Known limitation: launching multiple instances of this kernel back-to-back
+# in the same Python process with *different* compile-cache keys (e.g. two
+# different `query_length` values) currently crashes the GPU after the first
+# launch.  Single-process workflows that compile only one specialisation work
+# correctly; the test harness should isolate runs (e.g. spawn a fresh process
+# per (block_size, query_length) tuple) until the underlying multi-compile
+# clash is resolved.
+_PA_DECODE_PS_SMALL_BLOCK_SIZES = (16, 64)
+
+# Route small block_size (16/64) through the load-balanced worklist (metadata)
+# path — `compile_pa_decode_metadata` now gathers 256//block_size physical pages
+# per partition.  Set False to fall back to the grid-based `compile_pa_decode_ps`
+# kernel (kept for reference / A-B comparison).
+_PA_DECODE_PS_SMALL_BLOCK_VIA_METADATA = True
+
+
+@flyc.jit
+def _pa_small_block_load_k_flat(
+    k_global_ptr,
+    kv_h_i32,
+    stride_k_block_i32,
+    stride_k_head_i32,
+    lane16id_i32,
+    rowid_i32,
+    *,
+    block_size: int,
+    phys_blocks,
+    qkhe_loop: int = 2,
+):
+    """Load K data for one warp's 64-token slice of a 256-token partition.
+
+    Returns ``k_flat`` (a list of ``TLOOP * qkhe_loop * 2`` i64 scalars) compatible
+    with ``_unflatten_k`` and downstream MFMA invocations.
+    """
+    c_he_stride_dw = fx.Int32(block_size * FP8_ELEMS_16B // 4)
+    c_tok_stride_dw = fx.Int32(FP8_ELEMS_16B // 4)
+    k_he_off_dw = [rowid_i32 * c_he_stride_dw + fx.Int32(qkhe * 4) * c_he_stride_dw for qkhe in range(qkhe_loop)]
+    k_head_off = kv_h_i32 * stride_k_head_i32
+
+    k_flat = []
+    if const_expr(block_size == 64):
+        # Each warp owns exactly one physical block (64 tokens).
+        phys_block = phys_blocks
+        k_block_base_dw = _compute_block_base_dw_i64(phys_block, stride_k_block_i32, k_head_off)
+        for td in range_constexpr(TLOOP):
+            within_block_token = fx.Int32(td * MFMA_N) + lane16id_i32
+            kbo_dw = within_block_token * c_tok_stride_dw
+            for qkhe in range_constexpr(qkhe_loop):
+                ka_dw = k_block_base_dw + fx.Int64(kbo_dw + k_he_off_dw[qkhe])
+                k2 = _global_load_i64x2(k_global_ptr, ka_dw * fx.Int64(4))
+                k2_words = fx.Vector(k2)
+                k_flat.append(k2_words[0])
+                k_flat.append(k2_words[1])
+    else:
+        # block_size == 16: each warp spans 4 blocks (one MFMA tile per block).
+        within_block_token = lane16id_i32
+        kbo_dw = within_block_token * c_tok_stride_dw
+        for td in range_constexpr(TLOOP):
+            phys_block = phys_blocks[td]
+            k_block_base_dw = _compute_block_base_dw_i64(phys_block, stride_k_block_i32, k_head_off)
+            for qkhe in range_constexpr(qkhe_loop):
+                ka_dw = k_block_base_dw + fx.Int64(kbo_dw + k_he_off_dw[qkhe])
+                k2 = _global_load_i64x2(k_global_ptr, ka_dw * fx.Int64(4))
+                rocdl.sched_barrier(rocdl.mask_vmem_rd)
+                k2_words = fx.Vector(k2)
+                k_flat.append(k2_words[0])
+                k_flat.append(k2_words[1])
+    return k_flat
+
+
+@flyc.jit
+def _pa_small_block_load_v_trans(
+    v_global_ptr,
+    kv_h_i32,
+    stride_v_block_i32,
+    stride_v_head_i32,
+    warp_id_i32,
+    lane16id_i32,
+    rowid_i32,
+    v_phys_blocks,
+    *,
+    block_size: int,
+    head_size: int = 128,
+    vhe_loop: int = 2,
+):
+    """Load V tiles for one CTA's 256-token partition (``trans_v=True``).
+
+    Returns ``v_results[vt][vhe]`` (i64x2) indexed exactly as the reference
+    ``_load_v_and_scales`` so it can be passed as ``preloaded_v_and_scales``.
+    """
+    v_head_off = kv_h_i32 * stride_v_head_i32
+    vhead_elems = [
+        fx.Int32(vhe * NUM_WARPS * MFMA_N) + warp_id_i32 * fx.Int32(MFMA_N) + lane16id_i32 for vhe in range(vhe_loop)
+    ]
+    vhead_elem_dw = [vhead_elems[vhe] * fx.Int32(FP8_ELEMS_16B // 4) for vhe in range(vhe_loop)]
+    c_subblock_dw = fx.Int32(head_size * FP8_ELEMS_16B // 4)
+
+    v_results = []
+    for vt in range_constexpr(VTLOOP):
+        phys_block = v_phys_blocks[vt]
+        if const_expr(block_size == 64):
+            # vt selects the physical block (4 blocks per partition); rowid
+            # selects the 16-token sub-block within that physical block.
+            sub_block_idx = rowid_i32
+        else:
+            # block_size == 16: (vt * 4 + rowid) selects the block; only one
+            # 16-token sub-block per physical block, so sub_block_idx == 0.
+            sub_block_idx = fx.Int32(0)
+        v_block_base_dw = _compute_block_base_dw_i64(phys_block, stride_v_block_i32, v_head_off)
+        vhe_data = []
+        for vhe in range_constexpr(vhe_loop):
+            va_dw_delta = sub_block_idx * c_subblock_dw + vhead_elem_dw[vhe]
+            va_byte = (v_block_base_dw + fx.Int64(va_dw_delta)) * fx.Int64(4)
+            v_i64x2 = _global_load_i64x2(v_global_ptr, va_byte)
+            vhe_data.append(v_i64x2)
+        v_results.append(vhe_data)
+    return v_results
+
+
+@functools.lru_cache(maxsize=256)
+def compile_pa_decode_ps(
+    *,
+    block_size: int,
+    max_context_partition_num: int,
+    softmax_scale: float = None,
+    trans_v: bool = True,
+    query_group_size: int = 16,
+    per_token_kv: bool = False,
+    query_length: int = 1,
+    query_input_dtype: str = "bf16",
+    has_p_scale: bool = False,
+    v_scale_per_head: bool = False,
+    k_scale_per_token: bool = False,
+    head_dim: int = 128,
+):
+    """Compile the small-block partition kernel.  See module-level comment."""
+    if block_size not in _PA_DECODE_PS_SMALL_BLOCK_SIZES:
+        raise ValueError(
+            f"compile_pa_decode_ps: unsupported block_size={block_size}; "
+            f"expected one of {_PA_DECODE_PS_SMALL_BLOCK_SIZES}."
+        )
+    if query_input_dtype not in ("bf16", "f16"):
+        raise ValueError("compile_pa_decode_ps currently expects bf16/f16 query inputs.")
+    if not trans_v:
+        raise NotImplementedError("compile_pa_decode_ps: trans_v=False not yet supported.")
+    if per_token_kv:
+        raise NotImplementedError(
+            "compile_pa_decode_ps: per_token_kv=True not yet supported; " "use per-tensor quantization for now."
+        )
+    if head_dim % QKHE_PER_FETCH != 0 or head_dim % (MFMA_N * NUM_WARPS) != 0 or head_dim % Q_ELEMS_PER_LANE != 0:
+        raise ValueError(f"Unsupported head_dim={head_dim}; must be a multiple of {MFMA_N * NUM_WARPS}.")
+    _HEAD = head_dim
+    _QKHELOOP = head_dim // QKHE_PER_FETCH
+    _VHELOOP = head_dim // MFMA_N // NUM_WARPS
+    _Q_LANES_PER_HEAD = head_dim // Q_ELEMS_PER_LANE
+    _N_K_h = TLOOP * _QKHELOOP * 2
+    _N_V_FLAT_h = 2 * VTLOOP * _VHELOOP
+
+    arch = get_hip_arch()
+    query_load_is_bf16 = query_input_dtype == "bf16"
+    if softmax_scale is None:
+        softmax_scale = 1.0 / (head_dim**0.5)
+    _softmax_scale = float(softmax_scale)
+    _block_size = block_size
+    _blocks_per_partition = KV_COMPUTE_BLOCK // _block_size
+
+    _mtp_groups = max(1, math.ceil(query_length * query_group_size / 16))
+
+    # LDS allocation — same layout as compile_pa_decode_sw, minus the per-token
+    # scale staging area since per_token_kv is not yet supported here.
+    LDS_SOFTMAX_TOTAL = LDS_SOFTMAX_BYTES
+    # Unique global symbol per compile to avoid module-level symbol clashes
+    # when multiple compiled artifacts are loaded into the same GPU context.
+    _smem_sym_name = (
+        f"pa_ps_smallblk_smem_bs{block_size}_ql{query_length}"
+        f"_qgs{query_group_size}_tv{int(trans_v)}_qd{query_input_dtype}"
+        f"_ptkv{int(per_token_kv)}_kpt{int(k_scale_per_token)}"
+    )
+    allocator = SmemAllocator(None, arch=arch, global_sym_name=_smem_sym_name)
+    logits_off = 0
+    allocator.ptr = LDS_LOGITS_BYTES
+    softmax_off = LDS_LOGITS_BYTES
+    allocator.ptr += LDS_SOFTMAX_TOTAL
+    bt_off = softmax_off + LDS_SOFTMAX_TOTAL
+    allocator.ptr += NUM_WARPS * TLOOP * 4
+    # K-per-token scale staging LDS: KV_COMPUTE_BLOCK (=256) fp32 = 1024 bytes
+    # per partition.  Allocated only when k_scale_per_token is enabled.
+    if k_scale_per_token:
+        scale_off_ps = bt_off + NUM_WARPS * TLOOP * 4
+        allocator.ptr += KV_COMPUTE_BLOCK * 4
+    else:
+        scale_off_ps = 0
+
+    @flyc.kernel(known_block_size=(BLOCK_THREADS, 1, 1))
+    def pa_decode_ps_kernel(
+        exp_sums_ptr: fx.Tensor,
+        max_logits_ptr: fx.Tensor,
+        tmp_out_ptr: fx.Tensor,
+        query_ptr: fx.Tensor,
+        key_cache_ptr: fx.Tensor,
+        value_cache_ptr: fx.Tensor,
+        block_tables_ptr: fx.Tensor,
+        context_lengths_ptr: fx.Tensor,
+        key_scale_ptr: fx.Tensor,
+        value_scale_ptr: fx.Tensor,
+        stride_q_seq: Int32,
+        stride_q_head: Int32,
+        stride_k_block: Int32,
+        stride_k_head: Int32,
+        stride_v_block: Int32,
+        stride_v_head: Int32,
+        stride_es_seq: Int32,
+        stride_es_head: Int32,
+        stride_es_part: Int32,
+        stride_to_seq: Int32,
+        stride_to_head: Int32,
+        stride_to_part: Int32,
+        stride_to_group: Int32,
+        stride_bt_seq: Int32,
+        p_scale_ptr: fx.Tensor,
+        p_scale_inv_ptr: fx.Tensor,
+        # K-scale strides for the packed layout
+        # `[num_blocks, scale_rows, num_kv_heads, head_dim]` fp8 (viewed as fp32).
+        # All values are in fp32 elements (4 fp8 bytes = 1 fp32).
+        #   stride_ks_block      = scale_rows * num_kv_heads * (head_dim/4) = num_kv_heads*block_size
+        #   stride_ks_scale_row  = num_kv_heads * (head_dim/4)
+        #   stride_ks_head       = head_dim / 4
+        # All 0 for per-tensor or non-per-token paths.
+        stride_ks_block_param: Int32,
+        stride_ks_scale_row_param: Int32,
+        stride_ks_head_param: Int32,
+    ):
+        tid = fx.Int32(gpu.thread_id("x"))
+        batch_idx = fx.Int32(gpu.block_id("x"))
+        kv_h = fx.Int32(gpu.block_id("y"))
+        partition_idx = fx.Int32(gpu.block_id("z"))
+
+        cl_global_ptr = _extract_global_ptr(context_lengths_ptr)
+        context_len = _global_load_i32(cl_global_ptr, batch_idx)
+
+        lane16id = tid & fx.Int32(15)
+        rowid = (tid >> fx.Int32(4)) & fx.Int32(3)
+        warp_id = tid >> fx.Int32(6)
+
+        q_rsrc = buffer_ops.create_buffer_resource(query_ptr, max_size=True)
+        k_global_ptr = _extract_global_ptr(key_cache_ptr)
+        v_global_ptr = _extract_global_ptr(value_cache_ptr)
+        bt_rsrc = buffer_ops.create_buffer_resource(block_tables_ptr, max_size=False)
+        es_rsrc = buffer_ops.create_buffer_resource(exp_sums_ptr, max_size=True)
+        ml_rsrc = buffer_ops.create_buffer_resource(max_logits_ptr, max_size=True)
+        to_rsrc = buffer_ops.create_buffer_resource(tmp_out_ptr, max_size=True)
+        ks_rsrc = buffer_ops.create_buffer_resource(key_scale_ptr, max_size=True)
+        vs_rsrc = buffer_ops.create_buffer_resource(value_scale_ptr, max_size=True)
+
+        q_scale_val = arith.constant(1.0, type=T.f32)
+        k_scale_val = buffer_ops.buffer_load(ks_rsrc, arith.constant(0, type=T.i32), vec_width=1)
+        # V scale: per-tensor (offset 0) by default; per-kv-head (offset kv_h)
+        # when `v_scale_per_head=True` — matches the test's VS layout
+        # `(num_kv_heads,)` fp32 from quant_paged_cache_perhead.
+        if const_expr(v_scale_per_head):
+            v_scale_val = buffer_ops.buffer_load(vs_rsrc, kv_h, vec_width=1)
+        else:
+            v_scale_val = buffer_ops.buffer_load(vs_rsrc, arith.constant(0, type=T.i32), vec_width=1)
+
+        smem_base = allocator.get_base()
+        logits_lds_i32 = SmemPtr(smem_base, logits_off, T.i32, shape=(LDS_LOGITS_BYTES // 4,)).get()
+        softmax_lds_f32 = SmemPtr(smem_base, softmax_off, T.f32, shape=(LDS_SOFTMAX_TOTAL // 4,)).get()
+        logits_lds_i64 = SmemPtr(smem_base, logits_off, T.i64, shape=(LDS_LOGITS_BYTES // 8,)).get()
+        bt_lds_i32 = SmemPtr(smem_base, bt_off, T.i32, shape=(NUM_WARPS * TLOOP,)).get()
+        if const_expr(k_scale_per_token):
+            scale_lds_f32 = SmemPtr(smem_base, scale_off_ps, T.f32, shape=(KV_COMPUTE_BLOCK,)).get()
+        else:
+            scale_lds_f32 = None
+
+        _softmax_scale_const = arith.constant(_softmax_scale, type=T.f32)
+        _softmax_q_scale = _softmax_scale_const * q_scale_val
+        _scale = _softmax_q_scale * k_scale_val
+        c_w = arith.constant(WARP_SIZE, type=T.i32)
+        NEG_INF = arith.constant(float("-inf"), type=T.f32)
+        ZERO_F = arith.constant(0.0, type=T.f32)
+        c_cps = arith.constant(KV_COMPUTE_BLOCK, type=T.i32)
+        c_query_group_size = arith.constant(query_group_size, type=T.i32)
+
+        local_qhead_idx = warp_id * arith.constant(4, type=T.i32) + rowid
+
+        if const_expr(has_p_scale):
+            _ps_rsrc = buffer_ops.create_buffer_resource(p_scale_ptr, max_size=True)
+            _psi_rsrc = buffer_ops.create_buffer_resource(p_scale_inv_ptr, max_size=True)
+            # local_qhead_idx may span [0, 16) when query_length * query_group_size > query_group_size;
+            # the actual q-head within a kv-group is `local_qhead_idx % query_group_size`.
+            # Global q-head index = kv_h * query_group_size + within-group.
+            _qh_in_group = _urem_const(local_qhead_idx, query_group_size)
+            _q_head_global = kv_h * c_query_group_size + _qh_in_group
+            _p_scale_lane = buffer_ops.buffer_load(_ps_rsrc, _q_head_global, vec_width=1)
+            _p_scale_inv_lane = buffer_ops.buffer_load(_psi_rsrc, _q_head_global, vec_width=1)
+        else:
+            _p_scale_lane = None
+            _p_scale_inv_lane = None
+
+        (
+            _k_tok_thread_base_unused,
+            _c_tok_stride_dw_unused,
+            _k_he_off_dw_unused,
+            _v_tok_thread_off,
+            _vhead_elem_dw,
+            _kv_tok_thread_base,
+            _prob_wr_thread_base,
+            _pv_prob_read_base,
+            _sm_max_off,
+            _sm_sum_off,
+            _sm_rd_max_offs,
+            _sm_rd_sum_offs,
+            _sm_vmax_wr_off,
+            _sm_vmax_rd_offs,
+        ) = _build_pa_thread_invariants(
+            warp_id,
+            lane16id,
+            rowid,
+            trans_v=trans_v,
+            per_token_kv=per_token_kv,
+            qkhe_loop=_QKHELOOP,
+            vhe_loop=_VHELOOP,
+        )
+
+        (
+            _load_kv_scale_scalars_unused,
+            _load_v_and_scales_unused,
+            _store_vmax_warp_unused,
+            _qk_and_intra_softmax,
+            _cross_warp_softmax_and_prob_pack,
+            _pv_mfma,
+        ) = _make_pa_phase_helpers(
+            trans_v=trans_v,
+            per_token_q=True,
+            per_token_kv=per_token_kv,
+            needs_mask=True,
+            query_length=query_length,
+            kv_h=kv_h,
+            v_global_ptr=v_global_ptr,
+            ks_rsrc=ks_rsrc,
+            vs_rsrc=vs_rsrc,
+            logits_lds_i32=logits_lds_i32,
+            logits_lds_i64=logits_lds_i64,
+            softmax_lds_f32=softmax_lds_f32,
+            scale_lds_f32=scale_lds_f32,
+            stride_ks_block=arith.constant(0, type=T.i32),
+            stride_ks_head=arith.constant(0, type=T.i32),
+            softmax_scale_base=_softmax_scale_const,
+            softmax_q_scale=_softmax_q_scale,
+            k_scale_val=k_scale_val,
+            scale=_scale,
+            v_scale_val=v_scale_val,
+            warp_id=warp_id,
+            lane16id=lane16id,
+            rowid=rowid,
+            k_tok_thread_base=_k_tok_thread_base_unused,
+            v_tok_thread_off=_v_tok_thread_off,
+            vhead_elem_dw=_vhead_elem_dw,
+            kv_tok_thread_base=_kv_tok_thread_base,
+            prob_wr_thread_base=_prob_wr_thread_base,
+            pv_prob_read_base=_pv_prob_read_base,
+            sm_max_off=_sm_max_off,
+            sm_sum_off=_sm_sum_off,
+            sm_rd_max_offs=_sm_rd_max_offs,
+            sm_rd_sum_offs=_sm_rd_sum_offs,
+            sm_vmax_wr_off=_sm_vmax_wr_off,
+            sm_vmax_rd_offs=_sm_vmax_rd_offs,
+            c_w=c_w,
+            neg_inf=NEG_INF,
+            zero_f=ZERO_F,
+            p_scale_lane=_p_scale_lane,
+            p_scale_inv_lane=_p_scale_inv_lane,
+            k_scale_per_token=k_scale_per_token,
+            head_size=_HEAD,
+            qkhe_loop=_QKHELOOP,
+            vhe_loop=_VHELOOP,
+        )
+
+        def _store_partition_results(eqgs_lane, running_sum, running_max, outs_norm):
+            for vhe in range_constexpr(_VHELOOP):
+                hs_base = fx.Int32(vhe * NUM_WARPS * MFMA_N) + warp_id * fx.Int32(MFMA_N) + rowid * fx.Int32(4)
+                to_off = (
+                    batch_idx * stride_to_seq
+                    + kv_h * stride_to_head
+                    + partition_idx * stride_to_part
+                    + eqgs_lane * stride_to_group
+                    + hs_base
+                )
+                out_bf16 = fx.Vector(outs_norm[vhe]).to(fx.BFloat16)
+                buffer_ops.buffer_store(out_bf16, to_rsrc, to_off)
+            es_off = batch_idx * stride_es_seq + kv_h * stride_es_head + partition_idx * stride_es_part + eqgs_lane
+            buffer_ops.buffer_store(fx.Float32(running_sum), es_rsrc, es_off)
+            buffer_ops.buffer_store(fx.Float32(running_max), ml_rsrc, es_off)
+
+        # Slot covers one or more contiguous 256-token sub-partitions.  The
+        # inner scf.for loop walks those sub-partitions with online-softmax
+        # loop-carried state, mirroring the Gluon `for sequence_partition_idx`
+        # loop in `paged_attention_decode_ps`.
+        c_max_parts = arith.constant(max_context_partition_num, type=T.i32)
+        num_total_partitions = (context_len + c_cps - fx.Int32(1)) >> fx.Int32(8)
+        page_size_partitions = (num_total_partitions + c_max_parts - fx.Int32(1)) // c_max_parts
+        local_partition_start = partition_idx * page_size_partitions
+        local_partition_end_raw = (partition_idx + fx.Int32(1)) * page_size_partitions
+        local_partition_end = arith.select(
+            local_partition_end_raw < num_total_partitions,
+            local_partition_end_raw,
+            num_total_partitions,
+        )
+
+        def _unwrap(v):
+            return v.ir_value() if hasattr(v, "ir_value") else v
+
+        # Pack/unpack loop state.  State is `_mtp_groups` accumulators, each a
+        # tuple of (rmax, rsum, outs...), plus the current sub-partition's K
+        # and V tiles (k_flat: _N_K i64 scalars, v_flat: 2 * _N_V i64 scalars
+        # — each V element is i64x2, flattened to two scalars).  Both K and V
+        # are loop-carried so the body can use them while we prefetch the
+        # NEXT iteration's K and V (ping-pong).
+        state_width = 2 + _VHELOOP
+
+        def _pack_states(states, k_flat, v_flat, k_scale_scalar=None):
+            flat = []
+            for st in states:
+                rmax, rsum = st[0], st[1]
+                outs = [st[2 + vhe] for vhe in range_constexpr(_VHELOOP)]
+                flat.extend([_unwrap(rmax), _unwrap(rsum)])
+                flat.extend(_unwrap(out) for out in outs)
+            flat.extend(_unwrap(v) for v in k_flat)
+            flat.extend(_unwrap(v) for v in v_flat)
+            # When k_scale_per_token, the per-thread K-scale scalar is
+            # cross-iter-prefetched into VGPR via the loop's init/yield path.
+            if const_expr(k_scale_per_token):
+                flat.append(_unwrap(k_scale_scalar))
+            return flat
+
+        def _unpack_states(flat):
+            base = state_width * _mtp_groups
+            states = [
+                tuple(flat[state_width * i + j] for j in range_constexpr(state_width))
+                for i in range_constexpr(_mtp_groups)
+            ]
+            k_flat = list(flat[base : base + _N_K_h])
+            v_flat = list(flat[base + _N_K_h : base + _N_K_h + _N_V_FLAT_h])
+            k_scale_scalar = flat[base + _N_K_h + _N_V_FLAT_h] if const_expr(k_scale_per_token) else None
+            return states, k_flat, v_flat, k_scale_scalar
+
+        init_states = [
+            tuple([NEG_INF, ZERO_F] + [arith.constant_vector(0.0, T.f32x4) for _ in range_constexpr(_VHELOOP)])
+            for _ in range(_mtp_groups)
+        ]
+
+        loop_start = fx.Index(arith.unwrap(local_partition_start))
+        loop_end = fx.Index(arith.unwrap(local_partition_end))
+        loop_step = arith.index(1)
+        last_partition_idx = local_partition_end - fx.Int32(1)
+
+        def _ptr8_to_v4i32(ptr8_val):
+            """Convert a `ptr addrspace(8)` buffer descriptor to `<4 x i32>`
+            via ptrtoint(i128) + bitcast.  Both forms are 128-bit type-puns
+            of the same SGPR-resident descriptor — the LLVM backend emits
+            zero instructions for this conversion (descriptor stays in
+            SGPRs)."""
+            from flydsl._mlir import ir as _ir
+            from flydsl._mlir.dialects import llvm as _llvm
+
+            i128_ty = _ir.IntegerType.get_signless(128)
+            v4i32_ty = _ir.VectorType.get([4], _ir.IntegerType.get_signless(32))
+            i128_val = _llvm.ptrtoint(i128_ty, ptr8_val)
+            return _llvm.bitcast(v4i32_ty, i128_val)
+
+        bt_rsrc_v4 = _ptr8_to_v4i32(bt_rsrc)
+
+        def _s_buffer_load(soffset_bytes_i32, vec_width: int):
+            """Scalar buffer load — emits s_buffer_load_dword[x4] via the LLVM
+            intrinsic, returning an SGPR value.  Requires `soffset_bytes_i32`
+            to be wave-uniform; the result is shared across all 64 lanes.
+
+            Saves the vmcnt(0) drain + readfirstlane that the VMEM
+            buffer_load path imposes (result lands in SGPR directly, frees
+            VMEM queue slots for V/K loads)."""
+            from flydsl._mlir.dialects import llvm as _llvm
+            from flydsl._mlir import ir as _ir
+            from flydsl.expr.rocdl import _to_ir as _rocdl_to_ir
+
+            i32_ty = _ir.IntegerType.get_signless(32)
+            if const_expr(vec_width == 1):
+                result_type = i32_ty
+                suffix = "i32"
+            elif const_expr(vec_width == 4):
+                result_type = _ir.VectorType.get([4], i32_ty)
+                suffix = "v4i32"
+            else:
+                raise ValueError(f"_s_buffer_load: unsupported vec_width={vec_width}")
+            cache_policy = arith.constant(0, type=T.i32)
+            return _llvm.call_intrinsic(
+                result_type,
+                f"llvm.amdgcn.s.buffer.load.{suffix}",
+                [
+                    _rocdl_to_ir(bt_rsrc_v4),
+                    _rocdl_to_ir(soffset_bytes_i32),
+                    _rocdl_to_ir(cache_policy),
+                ],
+                [],
+                [],
+            )
+
+        def _pa_small_block_stage_phys_blocks(partition_block_base):
+            # bt offset is wave-uniform (batch_idx and warp_id are constant
+            # per wave, partition_block_base is workgroup-uniform).  Use
+            # s_buffer_load to route through SMEM cache and land the result
+            # in SGPRs directly — eliminates the vmcnt(0) drain (was 25% of
+            # all kernel stalls) and the downstream readfirstlane.
+            if const_expr(block_size == 64):
+                bt_elem_off = batch_idx * stride_bt_seq + partition_block_base + warp_id
+                phys_blocks = _s_buffer_load(bt_elem_off * fx.Int32(4), vec_width=1)
+            else:
+                bt_elem_off = batch_idx * stride_bt_seq + partition_block_base + warp_id * fx.Int32(TLOOP)
+                phys_blocks = _s_buffer_load(bt_elem_off * fx.Int32(4), vec_width=TLOOP)
+            return phys_blocks
+
+        def _pa_small_block_store_phys_blocks_to_lds(phys_block_vec):
+            if (lane16id | rowid) == fx.Int32(0):
+                if const_expr(block_size == 64):
+                    # block_size=64: `_stage_phys_blocks` returned vec_width=1
+                    # → scalar i32, not a Vector.  Wrap in a 1-element
+                    # Vector so we can use the LDS `.store(...)` API.
+                    # Each warp writes 1 i32 to bt_lds_i32[warp_id];
+                    # `_load_v_phys_blocks_from_lds` reads back the 4-elem
+                    # vec starting at offset 0.
+                    fx.Vector.from_elements([phys_block_vec], dtype=fx.Int32).store(
+                        bt_lds_i32,
+                        [fx.Index(warp_id)],
+                    )
+                else:
+                    phys_block_vec.store(
+                        bt_lds_i32,
+                        [fx.Index(warp_id * fx.Int32(TLOOP))],
+                    )
+
+        def _pa_small_block_load_v_phys_blocks_from_lds():
+            v_phys_blocks = []
+            if const_expr(block_size == 64):
+                phys_block_vec = fx.Vector.load(T.vec(VTLOOP, T.i32), bt_lds_i32, [fx.Index(0)])
+                for vt in range_constexpr(VTLOOP):
+                    v_phys_blocks.append(phys_block_vec[vt])
+            else:
+                for vt in range_constexpr(VTLOOP):
+                    bt_lds_off = fx.Int32(vt * TLOOP) + rowid
+                    phys_block = fx.Vector.load(T.vec(1, T.i32), bt_lds_i32, [fx.Index(bt_lds_off)])[0]
+                    v_phys_blocks.append(phys_block)
+            return v_phys_blocks
+
+        # Pre-load the FIRST (== reverse-order start = last partition) sub-
+        # partition's block-table entries before Q setup so the dependent K
+        # prefetch below does not also pay the table latency.
+        # Empty-slot guard: when num_total_partitions < max_context_partition_num,
+        # CTAs with partition_idx >= num_total_partitions get
+        # local_partition_start >= num_total_partitions and the inner loop runs
+        # 0 iters.  But the prologue still issues block-table + K reads using
+        # `last_partition_idx`; clamp to 0 so all reads stay in-bounds (the
+        # results are unused since the loop never executes).
+        _safe_init_partition = arith.select(
+            local_partition_start < num_total_partitions,
+            last_partition_idx,
+            arith.constant(0, type=T.i32),
+        )
+        first_block_base = _safe_init_partition * fx.Int32(_blocks_per_partition)
+        first_phys_blocks = _pa_small_block_stage_phys_blocks(first_block_base)
+
+        # Pre-load Q for every MTP group ONCE before the KV loop.  Each group's
+        # q_frags / qi / qhi / qscale are kept in registers across the entire
+        # KV loop, so we pay the Q-load cost (global → LDS → registers) exactly
+        # once per CTA regardless of how many sub-partitions the slot covers.
+
+        q_frags_per_mtp = []
+        qi_per_mtp = []
+        qhi_per_mtp = []
+        qscale_per_mtp = []
+        for _mtp_g in range_constexpr(_mtp_groups):
+            mtp_prefetch = _prefetch_mtp_group_query(
+                q_rsrc,
+                batch_idx,
+                kv_h,
+                stride_q_seq,
+                stride_q_head,
+                lane16id,
+                local_qhead_idx,
+                mtp_group_idx=_mtp_g,
+                query_length=query_length,
+                query_group_size=query_group_size,
+                query_load_is_bf16=query_load_is_bf16,
+                q_lanes_per_head=_Q_LANES_PER_HEAD,
+            )
+            qi_val, qhi_pos, q_frags, query_scale_lane = _finish_mtp_group_q_fragments(
+                logits_lds_i32,
+                logits_lds_i64,
+                softmax_lds_f32,
+                mtp_prefetch,
+                lane16id,
+                rowid,
+                local_qhead_idx,
+                head_size=_HEAD,
+                qkhe_loop=_QKHELOOP,
+                q_lanes_per_head=_Q_LANES_PER_HEAD,
+            )
+            q_frags_per_mtp.append(q_frags)
+            qi_per_mtp.append(qi_val)
+            qhi_per_mtp.append(qhi_pos)
+            qscale_per_mtp.append(query_scale_lane)
+
+        _pa_small_block_store_phys_blocks_to_lds(first_phys_blocks)
+
+        # ── K-scale buffer_load helpers (k_scale_per_token only) ──
+        # When enabled, K-scale per-token is loaded via cross-iter prefetch:
+        # each thread holds ONE fp32 K-scale in a loop-carried VGPR.  The
+        # prologue loads iter 0's K-scale; each iter loads iter (N+1)'s
+        # K-scale during its own body, hiding the buffer_load latency behind
+        # the iter's compute.  The actual ds_write to scale_lds happens at
+        # the START of the next iter (consuming the carried VGPR), with the
+        # full preceding iter's work hiding the load.
+        def _ks_buffer_load_for(my_phys, my_tok):
+            _H4 = _HEAD // 4
+            sr_idx = my_tok // fx.Int32(_H4)
+            d_in_row = my_tok - sr_idx * fx.Int32(_H4)
+            ks_off = (
+                my_phys * stride_ks_block_param
+                + sr_idx * stride_ks_scale_row_param
+                + kv_h * stride_ks_head_param
+                + d_in_row
+            )
+            return buffer_ops.buffer_load(ks_rsrc, ks_off, vec_width=1, dtype=fx.Float32)
+
+        def _load_my_k_scale_from_vgpr(next_phys_blocks_):
+            """Issue THIS thread's K-scale buffer_load using the in-VGPR
+            ``next_phys_blocks`` (avoids LDS round-trip)."""
+            if const_expr(_block_size == 64):
+                my_phys = next_phys_blocks_  # scalar (vec_width=1 from buffer_load)
+                my_tok = rowid * fx.Int32(MFMA_N) + lane16id
+            else:
+                # block_size==16: extract next_phys_blocks_[rowid] via 3 selects.
+                my_phys = vector.extract(
+                    arith.unwrap(next_phys_blocks_), static_position=[], dynamic_position=[fx.Index(rowid)]
+                )
+                my_tok = lane16id
+            return _ks_buffer_load_for(my_phys, my_tok)
+
+        def _stage_k_scale_to_lds(k_scale_scalar):
+            stage_tok = warp_id * fx.Int32(WARP_SIZE) + rowid * fx.Int32(MFMA_N) + lane16id
+            fx.Vector.from_elements([k_scale_scalar], dtype=fx.Float32).store(
+                scale_lds_f32,
+                [fx.Index(stage_tok)],
+            )
+
+        # Pre-load the FIRST sub-partition's K so the loop body can issue the
+        # next sub-partition's K prefetch in parallel with the current K's QK
+        # MFMA.  For empty slots (loop_start == loop_end), this k_flat0 is
+        # computed using local_partition_start but never used because the
+        # loop runs 0 iterations — the block_table buffer_load is bounded so
+        # any OOB lookup safely returns 0 (→ block 0, then masked out by the
+        # softmax causal bound).
+        k_flat0 = _pa_small_block_load_k_flat(
+            k_global_ptr,
+            kv_h,
+            stride_k_block,
+            stride_k_head,
+            lane16id,
+            rowid,
+            block_size=_block_size,
+            phys_blocks=first_phys_blocks,
+            qkhe_loop=_QKHELOOP,
+        )
+        # Prefetch iter 0's K-scale into VGPR using the VGPR phys directly
+        # (avoids an LDS read-after-write hazard since `first_phys_blocks`
+        # is already in registers).  Each thread holds 1 fp32; loop carries
+        # it via init and stages to scale_lds at iter 0's start.
+        if const_expr(k_scale_per_token):
+            k_scale_init = _load_my_k_scale_from_vgpr(first_phys_blocks)
+        else:
+            k_scale_init = None
+        gpu.barrier()
+        # ── Prologue V load ──
+        # V is cross-iter prefetched (ping-pong with K).  Issue iter 0's V
+        # load here so the loop body can issue iter N+1's V at the END of
+        # iter N alongside K, both hidden behind the next iter's QK MFMA.
+        # `_pa_small_block_load_v_phys_blocks_from_lds` reads the LDS-staged
+        # first_phys_blocks written above; the barrier guarantees visibility.
+        _v_phys_blocks0 = _pa_small_block_load_v_phys_blocks_from_lds()
+        _v_results0 = _pa_small_block_load_v_trans(
+            v_global_ptr,
+            kv_h,
+            stride_v_block,
+            stride_v_head,
+            warp_id,
+            lane16id,
+            rowid,
+            _v_phys_blocks0,
+            block_size=_block_size,
+            head_size=_HEAD,
+            vhe_loop=_VHELOOP,
+        )
+        v_flat0 = _flatten_v_results(_v_results0, vhe_loop=_VHELOOP)
+        # Note: no runtime `if _is_valid:` wrapping this loop.  See earlier
+        # commit log — the `ReplaceIfWithDispatch` rewriter copies the if-body
+        # into a synthetic Python function, and since the body contains
+        # `ast.Yield` from this scf.for, that function becomes a generator
+        # (returns a generator object without executing) — leaving the scf.if
+        # then-region empty.  Running the loop unconditionally is the correct
+        # workaround; empty slots iterate 0 times and yield the init state
+        # (NEG_INF, 0, 0, 0), which is the right empty-slot semantics.
+        for sub_part_ib, state in range(
+            loop_start,
+            loop_end,
+            loop_step,
+            init=_pack_states(init_states, k_flat0, v_flat0, k_scale_init),
+        ):
+            cur_states, k_flat, v_flat, k_scale_cur = _unpack_states(state)
+            # Reverse iteration: scf.for walks sub_part_ib forward over
+            # [local_partition_start, local_partition_end); remap to walk
+            # sub_part_i32 from last_partition_idx down to local_partition_start
+            # so the sink-prone partition 0 is processed last.
+            _sub_raw_i32 = arith.index_cast(T.i32, sub_part_ib)
+            sub_part_i32 = last_partition_idx - (_sub_raw_i32 - local_partition_start)
+            sub_token_start = sub_part_i32 * c_cps
+
+            # Both K and V come from the loop-carried state (prefetched at the
+            # END of the previous iteration).  K's VMEM latency overlaps prev
+            # iter's PV MFMA; V's latency overlaps the entire next iter QK +
+            # softmax compute before PV consumes it.
+            k_ops = _unflatten_k(k_flat, qkhe_loop=_QKHELOOP)
+            v_results = _unflatten_v_results(v_flat, vhe_loop=_VHELOOP)
+
+            # ── K-scale staging from loop-carried VGPR ──
+            # k_scale_cur was prefetched in the PREVIOUS iter (or prologue
+            # for iter 0), so the buffer_load latency is fully overlapped
+            # with prev iter's compute — no vmcnt drain here.
+            #
+            # No cross-warp barrier needed: each warp stages its own 64
+            # slots (warp_id*64 + ...) and `_get_k_scale_vec` reads only
+            # its own warp's slots, so K-scale staging is purely
+            # warp-local.  The compiler-emitted s_waitcnt lgkmcnt at the
+            # downstream ds_read handles the intra-wave RAW hazard.
+            if const_expr(k_scale_per_token):
+                _stage_k_scale_to_lds(k_scale_cur)
+
+            # Compute the NEXT sub-partition's K base address (clamped to
+            # local_partition_start so the prefetch on the final loop
+            # iteration doesn't walk before the block_table window —
+            # k_next_flat is yielded out but never consumed since the loop
+            # terminates).  Reverse iteration: next == sub_part_i32 - 1.
+            next_part_i32 = sub_part_i32 - fx.Int32(1)
+            next_safe_part = arith.select(next_part_i32 >= local_partition_start, next_part_i32, local_partition_start)
+            next_block_base = next_safe_part * fx.Int32(_blocks_per_partition)
+
+            new_states = []
+            k_next_flat = None
+            k_scale_next = None
+            for _mtp_g in range_constexpr(_mtp_groups):
+                state = cur_states[_mtp_g]
+                rmax, rsum = state[0], state[1]
+                outs = [state[2 + vhe] for vhe in range_constexpr(_VHELOOP)]
+                causal_bound = context_len + arith.constant(1 - query_length, type=T.i32) + qi_per_mtp[_mtp_g]
+
+                d_out = _qk_and_intra_softmax(
+                    k_ops,
+                    sub_token_start,
+                    q_frags_per_mtp[_mtp_g],
+                    causal_bound,
+                    query_scale_lane=qscale_per_mtp[_mtp_g],
+                )
+
+                if const_expr(_mtp_g == _mtp_groups - 1):
+                    next_phys_blocks = _pa_small_block_stage_phys_blocks(next_block_base)
+                    # ── Cross-iter K-scale prefetch ──
+                    # Issue next iter's K-scale fetch using the VGPR
+                    # next_phys_blocks (avoids LDS round-trip).  Carried via
+                    # loop yield → consumed at next iter's `_stage_k_scale_to_lds`,
+                    # giving an ENTIRE iter of compute to hide the load.
+                    if const_expr(k_scale_per_token):
+                        k_scale_next = _load_my_k_scale_from_vgpr(next_phys_blocks)
+
+                gpu.barrier()
+
+                rmax, rsum, outs, v_correction = _cross_warp_softmax_and_prob_pack(d_out, rmax, rsum, outs, None)
+
+                # Issue the next sub-partition's K prefetch on the LAST MTP
+                # iter, after cross_warp_softmax_and_prob_pack but BEFORE
+                # _pv_mfma — same hoist as in pa_decode_metadata_kenrel's
+                # _process_block_split.  This lets the K VMEM load latency
+                # overlap with the upcoming PV MFMA compute.
+                if const_expr(_mtp_g == _mtp_groups - 1):
+                    _pa_small_block_store_phys_blocks_to_lds(next_phys_blocks)
+                    k_next_flat = _pa_small_block_load_k_flat(
+                        k_global_ptr,
+                        kv_h,
+                        stride_k_block,
+                        stride_k_head,
+                        lane16id,
+                        rowid,
+                        block_size=_block_size,
+                        phys_blocks=next_phys_blocks,
+                        qkhe_loop=_QKHELOOP,
+                    )
+                gpu.barrier()
+                outs = _pv_mfma(v_results, outs, v_correction)
+                new_states.append(tuple([rmax, rsum] + outs))
+
+            # ── Cross-iter V prefetch (ping-pong) ──
+            # Issue NEXT iter's V load AFTER PV MFMA: the current iter's V
+            # vgprs are now consumed and can be reused.  V phys_blocks come
+            # from the LDS-staged `next_phys_blocks` written above (the
+            # barrier after K prefetch ensures cross-warp visibility).  The
+            # V VMEM latency is hidden behind next iter's QK MFMA + softmax.
+            _v_phys_blocks_next = _pa_small_block_load_v_phys_blocks_from_lds()
+            _v_next_results = _pa_small_block_load_v_trans(
+                v_global_ptr,
+                kv_h,
+                stride_v_block,
+                stride_v_head,
+                warp_id,
+                lane16id,
+                rowid,
+                _v_phys_blocks_next,
+                block_size=_block_size,
+                head_size=_HEAD,
+                vhe_loop=_VHELOOP,
+            )
+            v_next_flat = _flatten_v_results(_v_next_results, vhe_loop=_VHELOOP)
+
+            results = yield _pack_states(new_states, k_next_flat, v_next_flat, k_scale_next)
+
+        # Normalize and store one output slot per MTP group.
+        final_states, _final_k_flat, _final_v_flat, _final_k_scale = _unpack_states(results)
+        for _mtp_g in range_constexpr(_mtp_groups):
+            final_state = final_states[_mtp_g]
+            rmax_raw, rsum_raw = final_state[0], final_state[1]
+            outs_raw = [final_state[2 + vhe] for vhe in range_constexpr(_VHELOOP)]
+            running_max = fx.Float32(rmax_raw)
+            running_sum = fx.Float32(rsum_raw)
+            outs = [fx.Vector(out_raw) for out_raw in outs_raw]
+            outs_norm = _normalize_pa_output(running_sum, outs, ZERO_F)
+            eqgs_lane = qi_per_mtp[_mtp_g] * c_query_group_size + qhi_per_mtp[_mtp_g]
+            _store_partition_results(eqgs_lane, running_sum, running_max, outs_norm)
+
+    @flyc.jit
+    def launch_pa_decode_ps_small_block(
+        exp_sums: fx.Tensor,
+        max_logits: fx.Tensor,
+        tmp_out: fx.Tensor,
+        query: fx.Tensor,
+        key_cache: fx.Tensor,
+        value_cache: fx.Tensor,
+        block_tables: fx.Tensor,
+        context_lengths: fx.Tensor,
+        key_scale: fx.Tensor,
+        value_scale: fx.Tensor,
+        s_q_seq: Int32,
+        s_q_head: Int32,
+        s_k_block: Int32,
+        s_k_head: Int32,
+        s_v_block: Int32,
+        s_v_head: Int32,
+        s_es_seq: Int32,
+        s_es_head: Int32,
+        s_es_part: Int32,
+        s_to_seq: Int32,
+        s_to_head: Int32,
+        s_to_part: Int32,
+        s_to_group: Int32,
+        s_bt_seq: Int32,
+        p_scale: fx.Tensor,
+        p_scale_inv: fx.Tensor,
+        s_ks_block: Int32,
+        s_ks_scale_row: Int32,
+        s_ks_head: Int32,
+        gx: Int32,
+        gy: Int32,
+        gz: Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+        pa_decode_ps_kernel(
+            exp_sums,
+            max_logits,
+            tmp_out,
+            query,
+            key_cache,
+            value_cache,
+            block_tables,
+            context_lengths,
+            key_scale,
+            value_scale,
+            s_q_seq,
+            s_q_head,
+            s_k_block,
+            s_k_head,
+            s_v_block,
+            s_v_head,
+            s_es_seq,
+            s_es_head,
+            s_es_part,
+            s_to_seq,
+            s_to_head,
+            s_to_part,
+            s_to_group,
+            s_bt_seq,
+            p_scale,
+            p_scale_inv,
+            s_ks_block,
+            s_ks_scale_row,
+            s_ks_head,
+        ).launch(grid=(gx, gy, gz), block=(BLOCK_THREADS, 1, 1), stream=stream)
+
+    return {
+        "launch": launch_pa_decode_ps_small_block,
+        "kernel": pa_decode_ps_kernel,
+        "allocator": allocator,
+        "mtp_groups": _mtp_groups,
+    }
 
 
 def pa_decode_ps_launch(
@@ -1913,6 +2938,10 @@ def pa_decode_ps_launch(
     exp_sums: torch.Tensor = None,
     max_logits: torch.Tensor = None,
     temporary_output: torch.Tensor = None,
+    p_scale: torch.Tensor = None,
+    p_scale_inv: torch.Tensor = None,
+    v_scale_per_head: bool = False,
+    k_scale_per_token: bool = False,
     stream=None,
 ) -> str:
     """Launch PA decode with persistent scheduling.
@@ -1928,11 +2957,7 @@ def pa_decode_ps_launch(
 
     dev = query.device
     is_graph_capturing = _is_current_stream_capturing()
-    if is_graph_capturing and not flydsl_runtime_env.enable_cache:
-        raise ValueError(
-            "CUDA graph capture for `pa_decode_ps_launch` requires "
-            "`FLYDSL_RUNTIME_ENABLE_CACHE=1` so compiled launch artifacts stay alive."
-        )
+
     key_scale = _prepare_scale_tensor(
         "key_scale",
         key_scale,
@@ -1952,15 +2977,11 @@ def pa_decode_ps_launch(
         )
 
     # Detect per-token vs per-tensor quantization from scale tensor dimensionality
-    per_token_kv = key_scale.ndim > 1  # per-tensor: shape [1]; per-token: shape [blocks, heads, block_size, 1]
-
-    if metadata is None:
-        if is_graph_capturing:
-            raise ValueError(
-                "CUDA graph capture requires precomputed `metadata`; "
-                "call `get_pa_metadata()` before capture and pass it via `metadata=`."
-            )
-        metadata = get_pa_metadata(query, key_cache, context_lengths, kv_indptr, num_query_heads, num_kv_heads)
+    # k_scale_per_token routes K scale through the small-block kernel's per-token
+    # LDS-staging path WITHOUT enabling the legacy per_token_kv mode (which
+    # forces both K and V into per-token and is only supported by the metadata
+    # kernel).  When k_scale_per_token=True, per_token_kv is forced False.
+    per_token_kv = (not k_scale_per_token) and key_scale.ndim > 1
 
     query_length = query.shape[0] // context_lengths.shape[0]
     query_group_size = num_query_heads // num_kv_heads
@@ -1983,10 +3004,12 @@ def pa_decode_ps_launch(
         eqgs = query_length * query_group_size
         context_partition_size = KV_COMPUTE_BLOCK
         if max_context_partition_num == 0:
-            max_context_partition_num = get_sw_ps_max_context_partition_num(
-                sliding_window,
-                context_partition_size,
-                query_length,
+            max_context_partition_num = get_recommended_splits(
+                batch_size,
+                num_kv_heads,
+                sliding_window=sliding_window,
+                context_partition_size=context_partition_size,
+                query_length=query_length,
             )
         if is_graph_capturing and (exp_sums is None or max_logits is None or temporary_output is None):
             raise ValueError(
@@ -2027,6 +3050,7 @@ def pa_decode_ps_launch(
             query_length=query_length,
             query_input_dtype=query_input_dtype,
             fuse_partitions=fuse_sw_partitions,
+            head_dim=int(head_size),
         )
 
         compiled_sw["launch"](
@@ -2099,21 +3123,202 @@ def pa_decode_ps_launch(
         )
         return "ps_sw_partitioned"
 
+    # ---- small-block (block_size 16/64) partition path -----------------
+    # Key cache shape is [num_blocks, num_kv_heads, head_size // 16, block_size, 16].
+    # By default block_size 16/64 is routed through the metadata/worklist path
+    # below (see `_PA_DECODE_PS_SMALL_BLOCK_VIA_METADATA`); this grid-based branch
+    # is kept for reference and taken only when that flag is disabled.
+    block_size = key_cache.shape[-2]
+    # Hybrid dispatch: the metadata/worklist path supports only per-tensor K/V
+    # scales for small blocks.  Route 16/64 there only when per-token K-scale and
+    # per-head V-scale (and legacy per_token_kv) are all disabled; otherwise use
+    # the grid `compile_pa_decode_ps` kernel, which implements those features.
+    _small_via_metadata = (
+        _PA_DECODE_PS_SMALL_BLOCK_VIA_METADATA
+        and not k_scale_per_token
+        and not v_scale_per_head
+        and not per_token_kv
+    )
+    if block_size in _PA_DECODE_PS_SMALL_BLOCK_SIZES and not _small_via_metadata:
+        if block_tables is None:
+            raise ValueError(
+                f"pa_decode_ps_launch: block_size={block_size} requires `block_tables` "
+                "(per-sequence physical block index table)."
+            )
+        batch_size = context_lengths.shape[0]
+        head_size = query.shape[-1]
+        eqgs = query_length * query_group_size
+        context_partition_size = KV_COMPUTE_BLOCK
+        blocks_per_partition = context_partition_size // block_size
+        if max_context_partition_num == 0:
+            max_context_partition_num = get_recommended_splits(
+                batch_size,
+                num_kv_heads,
+                split_kv_blocks=blocks_per_partition,
+            )
+        if is_graph_capturing and (exp_sums is None or max_logits is None or temporary_output is None):
+            raise ValueError(
+                "CUDA graph capture requires preallocated `exp_sums`, `max_logits`, "
+                "and `temporary_output` for the small-block PS path."
+            )
+        if exp_sums is None:
+            exp_sums = torch.zeros(
+                batch_size,
+                num_kv_heads,
+                max_context_partition_num,
+                eqgs,
+                device=dev,
+                dtype=torch.float32,
+            )
+        if max_logits is None:
+            max_logits = torch.full(
+                (batch_size, num_kv_heads, max_context_partition_num, eqgs),
+                float("-inf"),
+                device=dev,
+                dtype=torch.float32,
+            )
+        if temporary_output is None:
+            temporary_output = torch.zeros(
+                batch_size,
+                num_kv_heads,
+                max_context_partition_num,
+                eqgs,
+                head_size,
+                device=dev,
+                dtype=torch.bfloat16,
+            )
+        _has_p_scale = p_scale is not None and p_scale_inv is not None
+        if (p_scale is None) != (p_scale_inv is None):
+            raise ValueError("p_scale and p_scale_inv must both be set or both be None.")
+        if not _has_p_scale:
+            _p_scale_arg = torch.empty(num_query_heads, dtype=torch.float32, device=dev)
+            _p_scale_inv_arg = torch.empty(num_query_heads, dtype=torch.float32, device=dev)
+        else:
+            _p_scale_arg = p_scale.contiguous().to(torch.float32)
+            _p_scale_inv_arg = p_scale_inv.contiguous().to(torch.float32)
+        compiled_small = compile_pa_decode_ps(
+            block_size=block_size,
+            max_context_partition_num=max_context_partition_num,
+            softmax_scale=softmax_scale,
+            trans_v=trans_v,
+            query_group_size=query_group_size,
+            per_token_kv=per_token_kv,
+            query_length=query_length,
+            query_input_dtype=query_input_dtype,
+            has_p_scale=_has_p_scale,
+            v_scale_per_head=v_scale_per_head,
+            k_scale_per_token=k_scale_per_token,
+            head_dim=int(head_size),
+        )
+        # K-scale strides for per-token mode: expect key_scale packed layout
+        # `[num_blocks, scale_rows, num_kv_heads, head_dim]` fp8 viewed as fp32.
+        # All strides in fp32 elements (4 fp8 bytes = 1 fp32).
+        if k_scale_per_token:
+            _H4 = int(head_size) // 4
+            # ceil(block_size*4 / head_size) so block_size*4 bytes always fit
+            # in scale_rows*head_dim bytes (padded with zeros when needed,
+            # e.g. block_size=16 with head_size=128 → scale_rows=1).
+            _scale_rows = (int(block_size) * 4 + int(head_size) - 1) // int(head_size)
+            _s_ks_block_arg = _scale_rows * int(num_kv_heads) * _H4
+            _s_ks_scale_row_arg = int(num_kv_heads) * _H4
+            _s_ks_head_arg = _H4
+        else:
+            _s_ks_block_arg = 0
+            _s_ks_scale_row_arg = 0
+            _s_ks_head_arg = 0
+        output_5d = output.reshape(batch_size, query_length, num_kv_heads, query_group_size, head_size)
+        compiled_small["launch"](
+            exp_sums,
+            max_logits,
+            temporary_output,
+            query,
+            key_cache,
+            value_cache,
+            block_tables,
+            context_lengths,
+            key_scale,
+            value_scale,
+            query.stride(0),
+            query.stride(1),
+            key_cache.stride(0),
+            key_cache.stride(1),
+            value_cache.stride(0),
+            value_cache.stride(1),
+            exp_sums.stride(0),
+            exp_sums.stride(1),
+            exp_sums.stride(2),
+            temporary_output.stride(0),
+            temporary_output.stride(1),
+            temporary_output.stride(2),
+            temporary_output.stride(3),
+            block_tables.stride(0),
+            _p_scale_arg,
+            _p_scale_inv_arg,
+            _s_ks_block_arg,
+            _s_ks_scale_row_arg,
+            _s_ks_head_arg,
+            batch_size,
+            num_kv_heads,
+            max_context_partition_num,
+            s,
+        )
+        compiled_sw_reduce = compile_pa_decode_sw_reduce(
+            max_context_partition_num=max_context_partition_num,
+            query_seq_len=query_length,
+            query_group_size=query_group_size,
+            head_size=head_size,
+            output_dtype_str=_get_output_dtype_str(output),
+        )
+        compiled_sw_reduce["launch"](
+            output_5d,
+            exp_sums,
+            max_logits,
+            temporary_output,
+            output_5d.stride(0),
+            output_5d.stride(1),
+            output_5d.stride(2),
+            output_5d.stride(3),
+            exp_sums.stride(0),
+            exp_sums.stride(1),
+            exp_sums.stride(2),
+            temporary_output.stride(0),
+            temporary_output.stride(1),
+            temporary_output.stride(2),
+            temporary_output.stride(3),
+            batch_size,
+            num_kv_heads,
+            s,
+        )
+        return "ps_small_block"
+
+    if metadata is None:
+        if is_graph_capturing:
+            raise ValueError(
+                "CUDA graph capture requires precomputed `metadata`; "
+                "call `get_pa_metadata()` before capture and pass it via `metadata=`."
+            )
+        metadata = get_pa_metadata(query, key_cache, context_lengths, kv_indptr, num_query_heads, num_kv_heads)
+
     work_indptr = metadata["work_indptr"]
     work_info_flat = metadata["work_info_flat"]
+    partition_indptr = metadata["partition_indptr"]
     partial_output = metadata["partial_output"]
     partial_lse = metadata["partial_lse"]
     stride_po_partial = metadata["stride_po_partial"]
     stride_pl_partial = metadata["stride_pl_partial"]
     num_sm = metadata["num_sm"]
 
-    compiled = compile_pa_decode_ps(
+    metadata_block_size = key_cache.shape[-2]
+    compiled = compile_pa_decode_metadata(
         softmax_scale=softmax_scale,
         trans_v=trans_v,
         query_group_size=query_group_size,
         per_token_kv=per_token_kv,
         query_length=query_length,
         query_input_dtype=query_input_dtype,
+        head_dim=int(query.shape[-1]),
+        block_size=int(metadata_block_size),
+        output_dtype_str=_get_output_dtype_str(output),
     )
 
     stride_po_ql = metadata.get("stride_po_ql", num_query_heads * query.shape[-1])
@@ -2133,6 +3338,7 @@ def pa_decode_ps_launch(
         work_info_flat,
         kv_page_indices,
         kv_indptr,
+        partition_indptr,
         query.stride(0),
         query.stride(1),
         key_cache.stride(0),

--- a/kernels/pa_decode_fp8.py
+++ b/kernels/pa_decode_fp8.py
@@ -1016,7 +1016,6 @@ def compile_pa_decode_metadata(
         softmax_scale = 1.0 / (head_dim**0.5)
     _softmax_scale = float(softmax_scale)
     _block_size = int(block_size)
-    _bs = _block_size
     # A partition is KV_COMPUTE_BLOCK (256) tokens.  For small blocks each
     # partition gathers ``_blocks_per_partition`` physical pages; for block_size
     # >= 256 each physical page holds ``_parts_per_block`` partitions (sub-tiles).
@@ -3134,10 +3133,7 @@ def pa_decode_ps_launch(
     # per-head V-scale (and legacy per_token_kv) are all disabled; otherwise use
     # the grid `compile_pa_decode_ps` kernel, which implements those features.
     _small_via_metadata = (
-        _PA_DECODE_PS_SMALL_BLOCK_VIA_METADATA
-        and not k_scale_per_token
-        and not v_scale_per_head
-        and not per_token_kv
+        _PA_DECODE_PS_SMALL_BLOCK_VIA_METADATA and not k_scale_per_token and not v_scale_per_head and not per_token_kv
     )
     if block_size in _PA_DECODE_PS_SMALL_BLOCK_SIZES and not _small_via_metadata:
         if block_tables is None:

--- a/kernels/pa_decode_fp8.py
+++ b/kernels/pa_decode_fp8.py
@@ -606,20 +606,10 @@ def _make_pa_phase_helpers(
     neg_inf,
     zero_f,
     cache_scale_vecs=False,
-    p_scale_lane=None,
-    p_scale_inv_lane=None,
-    k_scale_per_token=False,
     head_size: int = 128,
     qkhe_loop: int = 2,
     vhe_loop: int = 2,
 ):
-    _has_p_scale = p_scale_lane is not None
-    # k_scale_per_token: K scale is staged to scale_lds_f32 by the caller
-    # (used by pa_decode_ps_kernel small-block path when per_token_kv=False
-    # but K is per-token-quantized).  Routes K-scale loading through
-    # `_load_k_scale_vec` (same as per_token_kv) without enabling the rest
-    # of the per_token_kv machinery (V scale, vmax LDS staging, etc).
-    _k_scale_per_token_eff = k_scale_per_token or per_token_kv
     apply_causal_mask = needs_mask or query_length > 1
     pv_prob_i64_indices = []
     for vt in range_constexpr(VTLOOP):
@@ -784,7 +774,7 @@ def _make_pa_phase_helpers(
             acc = arith.constant_vector(0.0, T.f32x4)
             for k_step in range_constexpr(qkhe_loop * 2):
                 acc = rocdl.mfma_f32_16x16x32_fp8_fp8(T.f32x4, [k_ops[td][k_step], q_frags[k_step], acc, 0, 0, 0])
-            if const_expr(_k_scale_per_token_eff):
+            if const_expr(per_token_kv):
                 if const_expr(cache_scale_vecs and per_token_kv):
                     k_scale_vec = _get_k_scale_vec(td, k_scale_vecs)
                 else:
@@ -876,32 +866,11 @@ def _make_pa_phase_helpers(
             v_max_safe_scaled = v_max_scaled + fx.Float32(1e-8 / FP8_MAX).ir_value()
             norm_factor = _rcp_f32(v_max_safe_scaled)
             v_correction = v_max_scaled
-            if const_expr(_has_p_scale):
-                v_correction = arith.mulf(
-                    arith.unwrap(v_correction),
-                    arith.unwrap(p_scale_inv_lane),
-                    fastmath=arith.FastMathFlags.contract,
-                )
-                _vec_norm_p = arith.mulf(
-                    arith.unwrap(norm_factor),
-                    arith.unwrap(p_scale_lane),
-                    fastmath=arith.FastMathFlags.contract,
-                )
-            else:
-                _vec_norm_p = arith.unwrap(norm_factor)
+            _vec_norm_p = arith.unwrap(norm_factor)
             for td in range_constexpr(TLOOP):
                 d_out[td] = d_out[td] * (_get_v_scale_vec(td, v_scale_vecs) * vector.broadcast(T.f32x4, _vec_norm_p))
         else:
             v_correction = v_scale_val
-            if const_expr(_has_p_scale):
-                v_correction = arith.mulf(
-                    arith.unwrap(v_correction),
-                    arith.unwrap(p_scale_inv_lane),
-                    fastmath=arith.FastMathFlags.contract,
-                )
-                _ps_bcast = vector.broadcast(T.f32x4, arith.unwrap(p_scale_lane))
-                for td in range_constexpr(TLOOP):
-                    d_out[td] = d_out[td] * _ps_bcast
 
         for td in range_constexpr(TLOOP):
             p0 = vector.extract(d_out[td], static_position=[0], dynamic_position=[])
@@ -1027,11 +996,6 @@ def compile_pa_decode_metadata(
             raise ValueError(
                 f"compile_pa_decode_metadata: unsupported small block_size={_block_size}; "
                 f"expected one of {_PA_DECODE_PS_SMALL_BLOCK_SIZES} or >= {KV_COMPUTE_BLOCK}."
-            )
-        if per_token_kv:
-            raise NotImplementedError(
-                "compile_pa_decode_metadata: per_token_kv=True is not supported for "
-                "small block_size 16/64; use per-tensor quantization."
             )
         if not trans_v:
             raise NotImplementedError(
@@ -1361,6 +1325,39 @@ def compile_pa_decode_metadata(
                         v_phys_blocks.append(fx.Vector.load(T.vec(1, T.i32), bt_lds_i32, [fx.Index(bt_lds_off)])[0])
                 return v_phys_blocks
 
+            def _meta_stage_small_block_kv_scales():
+                # Per-token K/V scale staging for small blocks (per_token_kv).
+                # A 256-token partition spans `_blocks_per_partition` physical
+                # pages whose indices are already staged in bt_lds_i32.  Each
+                # thread owns one LDS slot ``t`` (its partition-local token) and
+                # loads that token's scale from the page it belongs to.  Writes
+                # the same scale_lds_f32 layout as `_load_v_and_scales` so the
+                # cached-vec readers and v_max reduction work unchanged.
+                t = warp_id * fx.Int32(WARP_SIZE) + rowid * fx.Int32(MFMA_N) + lane16id
+                part_page = _udiv_const(t, _block_size)
+                tok_in_page = _urem_const(t, _block_size)
+                phys = fx.Vector.load(T.vec(1, T.i32), bt_lds_i32, [fx.Index(part_page)])[0]
+                scale_idx = phys * stride_ks_block + kv_h * stride_ks_head + tok_in_page
+                k_scale_scalar = buffer_ops.buffer_load(ks_rsrc, scale_idx, vec_width=1, dtype=fx.Float32)
+                v_scale_scalar = buffer_ops.buffer_load(vs_rsrc, scale_idx, vec_width=1, dtype=fx.Float32)
+                fx.Vector.from_elements([k_scale_scalar], dtype=fx.Float32).store(scale_lds_f32, [fx.Index(t)])
+                fx.Vector.from_elements([v_scale_scalar], dtype=fx.Float32).store(
+                    scale_lds_f32, [fx.Index(fx.Int32(LDS_SCALE_V_OFFSET) + t)]
+                )
+
+            def _meta_load_small_block_scale_vecs():
+                # Read the cached per-token K/V scale f32x4 vecs from LDS, matching
+                # the `cache_scale_vecs` layout produced by `_load_v_and_scales`.
+                k_scale_vecs = []
+                v_scale_vecs = []
+                for td in range_constexpr(TLOOP):
+                    row = _kv_tok_thread_base + arith.constant(td * MFMA_N, type=T.i32)
+                    k_scale_vecs.append(vector.load_op(T.f32x4, scale_lds_f32, [fx.Index(row)]))
+                    v_scale_vecs.append(
+                        vector.load_op(T.f32x4, scale_lds_f32, [fx.Index(fx.Int32(LDS_SCALE_V_OFFSET) + row)])
+                    )
+                return k_scale_vecs, v_scale_vecs
+
             # ── Pre-load Q for every MTP group ONCE per work item.  Each
             # group's q_frags / qi / qhi / qscale stay in registers across
             # the entire KV loop, so we pay the Q-load cost (global → LDS →
@@ -1456,7 +1453,10 @@ def compile_pa_decode_metadata(
                     flat.extend([_unwrap(rmax), _unwrap(rsum)])
                     flat.extend(_unwrap(out) for out in outs)
                 flat.extend(_unwrap(v) for v in k_flat)
-                if const_expr(cache_scale_vecs and per_token_kv):
+                # Large blocks loop-carry the next partition's prefetched scale
+                # scalars; small blocks stage per-token scales fresh each
+                # iteration from LDS, so nothing to carry.
+                if const_expr(cache_scale_vecs and per_token_kv and not _is_small_block):
                     flat.extend(_unwrap(v) for v in scale_scalars)
                 return flat
 
@@ -1464,7 +1464,7 @@ def compile_pa_decode_metadata(
                 base = state_width * _mtp_groups
                 states = [tuple(flat[state_width * i + j] for j in range(state_width)) for i in range(_mtp_groups)]
                 k_flat = list(flat[base : base + _N_K_h])
-                if const_expr(cache_scale_vecs and per_token_kv):
+                if const_expr(cache_scale_vecs and per_token_kv and not _is_small_block):
                     scale_scalars = tuple(flat[base + _N_K_h : base + _N_K_h + 2])
                 else:
                     scale_scalars = None
@@ -1518,6 +1518,13 @@ def compile_pa_decode_metadata(
                         head_size=_HEAD,
                         vhe_loop=_VHELOOP,
                     )
+                    if const_expr(cache_scale_vecs and per_token_kv):
+                        # Stage this partition's per-token K/V scales from the
+                        # gathered pages (bt_lds_i32 already populated above),
+                        # then read them back as cached f32x4 vecs.
+                        _meta_stage_small_block_kv_scales()
+                        gpu.barrier()
+                        k_scale_vecs, v_scale_vecs = _meta_load_small_block_scale_vecs()
                 else:
                     phys_block = buffer_ops.buffer_load(
                         kpi_rsrc, kv_page_base + _udiv_const(lp, _parts_per_block), vec_width=1, dtype=T.i32
@@ -1980,35 +1987,10 @@ def get_recommended_splits(
     return max(4, min(n, 8))
 
 
-# =====================================================================
-# compile_pa_decode_ps — partition kernel for block_size 16/64
-# =====================================================================
-#
-# Mirrors `paged_attention_decode_ps`
-# (aiter/ops/triton/gluon/pa_decode_gluon.py:2167) for the
-# `KV_BLOCK_SIZE < CONTEXT_PARTITION_SIZE` case.  Grid is partition-based:
-#   (batch, num_kv_heads, max_context_partition_num)
-# Each CTA owns one 256-token context partition spanning
-# `256 // block_size` physical KV blocks and writes its partial
-# (exp_sum, max_logit, attention_output) into intermediate tensors that
-# are reduced by `compile_pa_decode_sw_reduce`.
-#
-# Supports per-tensor KV quant only (per_token_kv path is NotImplementedError).
-#
-# Known limitation: launching multiple instances of this kernel back-to-back
-# in the same Python process with *different* compile-cache keys (e.g. two
-# different `query_length` values) currently crashes the GPU after the first
-# launch.  Single-process workflows that compile only one specialisation work
-# correctly; the test harness should isolate runs (e.g. spawn a fresh process
-# per (block_size, query_length) tuple) until the underlying multi-compile
-# clash is resolved.
+# Small block_size (16/64) is routed through the load-balanced worklist
+# (metadata) path: `compile_pa_decode_metadata` gathers 256//block_size physical
+# pages per 256-token partition, for both per-tensor and per-token KV quant.
 _PA_DECODE_PS_SMALL_BLOCK_SIZES = (16, 64)
-
-# Route small block_size (16/64) through the load-balanced worklist (metadata)
-# path — `compile_pa_decode_metadata` now gathers 256//block_size physical pages
-# per partition.  Set False to fall back to the grid-based `compile_pa_decode_ps`
-# kernel (kept for reference / A-B comparison).
-_PA_DECODE_PS_SMALL_BLOCK_VIA_METADATA = True
 
 
 @flyc.jit
@@ -2114,810 +2096,6 @@ def _pa_small_block_load_v_trans(
     return v_results
 
 
-@functools.lru_cache(maxsize=256)
-def compile_pa_decode_ps(
-    *,
-    block_size: int,
-    max_context_partition_num: int,
-    softmax_scale: float = None,
-    trans_v: bool = True,
-    query_group_size: int = 16,
-    per_token_kv: bool = False,
-    query_length: int = 1,
-    query_input_dtype: str = "bf16",
-    has_p_scale: bool = False,
-    v_scale_per_head: bool = False,
-    k_scale_per_token: bool = False,
-    head_dim: int = 128,
-):
-    """Compile the small-block partition kernel.  See module-level comment."""
-    if block_size not in _PA_DECODE_PS_SMALL_BLOCK_SIZES:
-        raise ValueError(
-            f"compile_pa_decode_ps: unsupported block_size={block_size}; "
-            f"expected one of {_PA_DECODE_PS_SMALL_BLOCK_SIZES}."
-        )
-    if query_input_dtype not in ("bf16", "f16"):
-        raise ValueError("compile_pa_decode_ps currently expects bf16/f16 query inputs.")
-    if not trans_v:
-        raise NotImplementedError("compile_pa_decode_ps: trans_v=False not yet supported.")
-    if per_token_kv:
-        raise NotImplementedError(
-            "compile_pa_decode_ps: per_token_kv=True not yet supported; " "use per-tensor quantization for now."
-        )
-    if head_dim % QKHE_PER_FETCH != 0 or head_dim % (MFMA_N * NUM_WARPS) != 0 or head_dim % Q_ELEMS_PER_LANE != 0:
-        raise ValueError(f"Unsupported head_dim={head_dim}; must be a multiple of {MFMA_N * NUM_WARPS}.")
-    _HEAD = head_dim
-    _QKHELOOP = head_dim // QKHE_PER_FETCH
-    _VHELOOP = head_dim // MFMA_N // NUM_WARPS
-    _Q_LANES_PER_HEAD = head_dim // Q_ELEMS_PER_LANE
-    _N_K_h = TLOOP * _QKHELOOP * 2
-    _N_V_FLAT_h = 2 * VTLOOP * _VHELOOP
-
-    arch = get_hip_arch()
-    query_load_is_bf16 = query_input_dtype == "bf16"
-    if softmax_scale is None:
-        softmax_scale = 1.0 / (head_dim**0.5)
-    _softmax_scale = float(softmax_scale)
-    _block_size = block_size
-    _blocks_per_partition = KV_COMPUTE_BLOCK // _block_size
-
-    _mtp_groups = max(1, math.ceil(query_length * query_group_size / 16))
-
-    # LDS allocation — same layout as compile_pa_decode_sw, minus the per-token
-    # scale staging area since per_token_kv is not yet supported here.
-    LDS_SOFTMAX_TOTAL = LDS_SOFTMAX_BYTES
-    # Unique global symbol per compile to avoid module-level symbol clashes
-    # when multiple compiled artifacts are loaded into the same GPU context.
-    _smem_sym_name = (
-        f"pa_ps_smallblk_smem_bs{block_size}_ql{query_length}"
-        f"_qgs{query_group_size}_tv{int(trans_v)}_qd{query_input_dtype}"
-        f"_ptkv{int(per_token_kv)}_kpt{int(k_scale_per_token)}"
-    )
-    allocator = SmemAllocator(None, arch=arch, global_sym_name=_smem_sym_name)
-    logits_off = 0
-    allocator.ptr = LDS_LOGITS_BYTES
-    softmax_off = LDS_LOGITS_BYTES
-    allocator.ptr += LDS_SOFTMAX_TOTAL
-    bt_off = softmax_off + LDS_SOFTMAX_TOTAL
-    allocator.ptr += NUM_WARPS * TLOOP * 4
-    # K-per-token scale staging LDS: KV_COMPUTE_BLOCK (=256) fp32 = 1024 bytes
-    # per partition.  Allocated only when k_scale_per_token is enabled.
-    if k_scale_per_token:
-        scale_off_ps = bt_off + NUM_WARPS * TLOOP * 4
-        allocator.ptr += KV_COMPUTE_BLOCK * 4
-    else:
-        scale_off_ps = 0
-
-    @flyc.kernel(known_block_size=(BLOCK_THREADS, 1, 1))
-    def pa_decode_ps_kernel(
-        exp_sums_ptr: fx.Tensor,
-        max_logits_ptr: fx.Tensor,
-        tmp_out_ptr: fx.Tensor,
-        query_ptr: fx.Tensor,
-        key_cache_ptr: fx.Tensor,
-        value_cache_ptr: fx.Tensor,
-        block_tables_ptr: fx.Tensor,
-        context_lengths_ptr: fx.Tensor,
-        key_scale_ptr: fx.Tensor,
-        value_scale_ptr: fx.Tensor,
-        stride_q_seq: Int32,
-        stride_q_head: Int32,
-        stride_k_block: Int32,
-        stride_k_head: Int32,
-        stride_v_block: Int32,
-        stride_v_head: Int32,
-        stride_es_seq: Int32,
-        stride_es_head: Int32,
-        stride_es_part: Int32,
-        stride_to_seq: Int32,
-        stride_to_head: Int32,
-        stride_to_part: Int32,
-        stride_to_group: Int32,
-        stride_bt_seq: Int32,
-        p_scale_ptr: fx.Tensor,
-        p_scale_inv_ptr: fx.Tensor,
-        # K-scale strides for the packed layout
-        # `[num_blocks, scale_rows, num_kv_heads, head_dim]` fp8 (viewed as fp32).
-        # All values are in fp32 elements (4 fp8 bytes = 1 fp32).
-        #   stride_ks_block      = scale_rows * num_kv_heads * (head_dim/4) = num_kv_heads*block_size
-        #   stride_ks_scale_row  = num_kv_heads * (head_dim/4)
-        #   stride_ks_head       = head_dim / 4
-        # All 0 for per-tensor or non-per-token paths.
-        stride_ks_block_param: Int32,
-        stride_ks_scale_row_param: Int32,
-        stride_ks_head_param: Int32,
-    ):
-        tid = fx.Int32(gpu.thread_id("x"))
-        batch_idx = fx.Int32(gpu.block_id("x"))
-        kv_h = fx.Int32(gpu.block_id("y"))
-        partition_idx = fx.Int32(gpu.block_id("z"))
-
-        cl_global_ptr = _extract_global_ptr(context_lengths_ptr)
-        context_len = _global_load_i32(cl_global_ptr, batch_idx)
-
-        lane16id = tid & fx.Int32(15)
-        rowid = (tid >> fx.Int32(4)) & fx.Int32(3)
-        warp_id = tid >> fx.Int32(6)
-
-        q_rsrc = buffer_ops.create_buffer_resource(query_ptr, max_size=True)
-        k_global_ptr = _extract_global_ptr(key_cache_ptr)
-        v_global_ptr = _extract_global_ptr(value_cache_ptr)
-        bt_rsrc = buffer_ops.create_buffer_resource(block_tables_ptr, max_size=False)
-        es_rsrc = buffer_ops.create_buffer_resource(exp_sums_ptr, max_size=True)
-        ml_rsrc = buffer_ops.create_buffer_resource(max_logits_ptr, max_size=True)
-        to_rsrc = buffer_ops.create_buffer_resource(tmp_out_ptr, max_size=True)
-        ks_rsrc = buffer_ops.create_buffer_resource(key_scale_ptr, max_size=True)
-        vs_rsrc = buffer_ops.create_buffer_resource(value_scale_ptr, max_size=True)
-
-        q_scale_val = arith.constant(1.0, type=T.f32)
-        k_scale_val = buffer_ops.buffer_load(ks_rsrc, arith.constant(0, type=T.i32), vec_width=1)
-        # V scale: per-tensor (offset 0) by default; per-kv-head (offset kv_h)
-        # when `v_scale_per_head=True` — matches the test's VS layout
-        # `(num_kv_heads,)` fp32 from quant_paged_cache_perhead.
-        if const_expr(v_scale_per_head):
-            v_scale_val = buffer_ops.buffer_load(vs_rsrc, kv_h, vec_width=1)
-        else:
-            v_scale_val = buffer_ops.buffer_load(vs_rsrc, arith.constant(0, type=T.i32), vec_width=1)
-
-        smem_base = allocator.get_base()
-        logits_lds_i32 = SmemPtr(smem_base, logits_off, T.i32, shape=(LDS_LOGITS_BYTES // 4,)).get()
-        softmax_lds_f32 = SmemPtr(smem_base, softmax_off, T.f32, shape=(LDS_SOFTMAX_TOTAL // 4,)).get()
-        logits_lds_i64 = SmemPtr(smem_base, logits_off, T.i64, shape=(LDS_LOGITS_BYTES // 8,)).get()
-        bt_lds_i32 = SmemPtr(smem_base, bt_off, T.i32, shape=(NUM_WARPS * TLOOP,)).get()
-        if const_expr(k_scale_per_token):
-            scale_lds_f32 = SmemPtr(smem_base, scale_off_ps, T.f32, shape=(KV_COMPUTE_BLOCK,)).get()
-        else:
-            scale_lds_f32 = None
-
-        _softmax_scale_const = arith.constant(_softmax_scale, type=T.f32)
-        _softmax_q_scale = _softmax_scale_const * q_scale_val
-        _scale = _softmax_q_scale * k_scale_val
-        c_w = arith.constant(WARP_SIZE, type=T.i32)
-        NEG_INF = arith.constant(float("-inf"), type=T.f32)
-        ZERO_F = arith.constant(0.0, type=T.f32)
-        c_cps = arith.constant(KV_COMPUTE_BLOCK, type=T.i32)
-        c_query_group_size = arith.constant(query_group_size, type=T.i32)
-
-        local_qhead_idx = warp_id * arith.constant(4, type=T.i32) + rowid
-
-        if const_expr(has_p_scale):
-            _ps_rsrc = buffer_ops.create_buffer_resource(p_scale_ptr, max_size=True)
-            _psi_rsrc = buffer_ops.create_buffer_resource(p_scale_inv_ptr, max_size=True)
-            # local_qhead_idx may span [0, 16) when query_length * query_group_size > query_group_size;
-            # the actual q-head within a kv-group is `local_qhead_idx % query_group_size`.
-            # Global q-head index = kv_h * query_group_size + within-group.
-            _qh_in_group = _urem_const(local_qhead_idx, query_group_size)
-            _q_head_global = kv_h * c_query_group_size + _qh_in_group
-            _p_scale_lane = buffer_ops.buffer_load(_ps_rsrc, _q_head_global, vec_width=1)
-            _p_scale_inv_lane = buffer_ops.buffer_load(_psi_rsrc, _q_head_global, vec_width=1)
-        else:
-            _p_scale_lane = None
-            _p_scale_inv_lane = None
-
-        (
-            _k_tok_thread_base_unused,
-            _c_tok_stride_dw_unused,
-            _k_he_off_dw_unused,
-            _v_tok_thread_off,
-            _vhead_elem_dw,
-            _kv_tok_thread_base,
-            _prob_wr_thread_base,
-            _pv_prob_read_base,
-            _sm_max_off,
-            _sm_sum_off,
-            _sm_rd_max_offs,
-            _sm_rd_sum_offs,
-            _sm_vmax_wr_off,
-            _sm_vmax_rd_offs,
-        ) = _build_pa_thread_invariants(
-            warp_id,
-            lane16id,
-            rowid,
-            trans_v=trans_v,
-            per_token_kv=per_token_kv,
-            qkhe_loop=_QKHELOOP,
-            vhe_loop=_VHELOOP,
-        )
-
-        (
-            _load_kv_scale_scalars_unused,
-            _load_v_and_scales_unused,
-            _store_vmax_warp_unused,
-            _qk_and_intra_softmax,
-            _cross_warp_softmax_and_prob_pack,
-            _pv_mfma,
-        ) = _make_pa_phase_helpers(
-            trans_v=trans_v,
-            per_token_q=True,
-            per_token_kv=per_token_kv,
-            needs_mask=True,
-            query_length=query_length,
-            kv_h=kv_h,
-            v_global_ptr=v_global_ptr,
-            ks_rsrc=ks_rsrc,
-            vs_rsrc=vs_rsrc,
-            logits_lds_i32=logits_lds_i32,
-            logits_lds_i64=logits_lds_i64,
-            softmax_lds_f32=softmax_lds_f32,
-            scale_lds_f32=scale_lds_f32,
-            stride_ks_block=arith.constant(0, type=T.i32),
-            stride_ks_head=arith.constant(0, type=T.i32),
-            softmax_scale_base=_softmax_scale_const,
-            softmax_q_scale=_softmax_q_scale,
-            k_scale_val=k_scale_val,
-            scale=_scale,
-            v_scale_val=v_scale_val,
-            warp_id=warp_id,
-            lane16id=lane16id,
-            rowid=rowid,
-            k_tok_thread_base=_k_tok_thread_base_unused,
-            v_tok_thread_off=_v_tok_thread_off,
-            vhead_elem_dw=_vhead_elem_dw,
-            kv_tok_thread_base=_kv_tok_thread_base,
-            prob_wr_thread_base=_prob_wr_thread_base,
-            pv_prob_read_base=_pv_prob_read_base,
-            sm_max_off=_sm_max_off,
-            sm_sum_off=_sm_sum_off,
-            sm_rd_max_offs=_sm_rd_max_offs,
-            sm_rd_sum_offs=_sm_rd_sum_offs,
-            sm_vmax_wr_off=_sm_vmax_wr_off,
-            sm_vmax_rd_offs=_sm_vmax_rd_offs,
-            c_w=c_w,
-            neg_inf=NEG_INF,
-            zero_f=ZERO_F,
-            p_scale_lane=_p_scale_lane,
-            p_scale_inv_lane=_p_scale_inv_lane,
-            k_scale_per_token=k_scale_per_token,
-            head_size=_HEAD,
-            qkhe_loop=_QKHELOOP,
-            vhe_loop=_VHELOOP,
-        )
-
-        def _store_partition_results(eqgs_lane, running_sum, running_max, outs_norm):
-            for vhe in range_constexpr(_VHELOOP):
-                hs_base = fx.Int32(vhe * NUM_WARPS * MFMA_N) + warp_id * fx.Int32(MFMA_N) + rowid * fx.Int32(4)
-                to_off = (
-                    batch_idx * stride_to_seq
-                    + kv_h * stride_to_head
-                    + partition_idx * stride_to_part
-                    + eqgs_lane * stride_to_group
-                    + hs_base
-                )
-                out_bf16 = fx.Vector(outs_norm[vhe]).to(fx.BFloat16)
-                buffer_ops.buffer_store(out_bf16, to_rsrc, to_off)
-            es_off = batch_idx * stride_es_seq + kv_h * stride_es_head + partition_idx * stride_es_part + eqgs_lane
-            buffer_ops.buffer_store(fx.Float32(running_sum), es_rsrc, es_off)
-            buffer_ops.buffer_store(fx.Float32(running_max), ml_rsrc, es_off)
-
-        # Slot covers one or more contiguous 256-token sub-partitions.  The
-        # inner scf.for loop walks those sub-partitions with online-softmax
-        # loop-carried state, mirroring the Gluon `for sequence_partition_idx`
-        # loop in `paged_attention_decode_ps`.
-        c_max_parts = arith.constant(max_context_partition_num, type=T.i32)
-        num_total_partitions = (context_len + c_cps - fx.Int32(1)) >> fx.Int32(8)
-        page_size_partitions = (num_total_partitions + c_max_parts - fx.Int32(1)) // c_max_parts
-        local_partition_start = partition_idx * page_size_partitions
-        local_partition_end_raw = (partition_idx + fx.Int32(1)) * page_size_partitions
-        local_partition_end = arith.select(
-            local_partition_end_raw < num_total_partitions,
-            local_partition_end_raw,
-            num_total_partitions,
-        )
-
-        def _unwrap(v):
-            return v.ir_value() if hasattr(v, "ir_value") else v
-
-        # Pack/unpack loop state.  State is `_mtp_groups` accumulators, each a
-        # tuple of (rmax, rsum, outs...), plus the current sub-partition's K
-        # and V tiles (k_flat: _N_K i64 scalars, v_flat: 2 * _N_V i64 scalars
-        # — each V element is i64x2, flattened to two scalars).  Both K and V
-        # are loop-carried so the body can use them while we prefetch the
-        # NEXT iteration's K and V (ping-pong).
-        state_width = 2 + _VHELOOP
-
-        def _pack_states(states, k_flat, v_flat, k_scale_scalar=None):
-            flat = []
-            for st in states:
-                rmax, rsum = st[0], st[1]
-                outs = [st[2 + vhe] for vhe in range_constexpr(_VHELOOP)]
-                flat.extend([_unwrap(rmax), _unwrap(rsum)])
-                flat.extend(_unwrap(out) for out in outs)
-            flat.extend(_unwrap(v) for v in k_flat)
-            flat.extend(_unwrap(v) for v in v_flat)
-            # When k_scale_per_token, the per-thread K-scale scalar is
-            # cross-iter-prefetched into VGPR via the loop's init/yield path.
-            if const_expr(k_scale_per_token):
-                flat.append(_unwrap(k_scale_scalar))
-            return flat
-
-        def _unpack_states(flat):
-            base = state_width * _mtp_groups
-            states = [
-                tuple(flat[state_width * i + j] for j in range_constexpr(state_width))
-                for i in range_constexpr(_mtp_groups)
-            ]
-            k_flat = list(flat[base : base + _N_K_h])
-            v_flat = list(flat[base + _N_K_h : base + _N_K_h + _N_V_FLAT_h])
-            k_scale_scalar = flat[base + _N_K_h + _N_V_FLAT_h] if const_expr(k_scale_per_token) else None
-            return states, k_flat, v_flat, k_scale_scalar
-
-        init_states = [
-            tuple([NEG_INF, ZERO_F] + [arith.constant_vector(0.0, T.f32x4) for _ in range_constexpr(_VHELOOP)])
-            for _ in range(_mtp_groups)
-        ]
-
-        loop_start = fx.Index(arith.unwrap(local_partition_start))
-        loop_end = fx.Index(arith.unwrap(local_partition_end))
-        loop_step = arith.index(1)
-        last_partition_idx = local_partition_end - fx.Int32(1)
-
-        def _ptr8_to_v4i32(ptr8_val):
-            """Convert a `ptr addrspace(8)` buffer descriptor to `<4 x i32>`
-            via ptrtoint(i128) + bitcast.  Both forms are 128-bit type-puns
-            of the same SGPR-resident descriptor — the LLVM backend emits
-            zero instructions for this conversion (descriptor stays in
-            SGPRs)."""
-            from flydsl._mlir import ir as _ir
-            from flydsl._mlir.dialects import llvm as _llvm
-
-            i128_ty = _ir.IntegerType.get_signless(128)
-            v4i32_ty = _ir.VectorType.get([4], _ir.IntegerType.get_signless(32))
-            i128_val = _llvm.ptrtoint(i128_ty, ptr8_val)
-            return _llvm.bitcast(v4i32_ty, i128_val)
-
-        bt_rsrc_v4 = _ptr8_to_v4i32(bt_rsrc)
-
-        def _s_buffer_load(soffset_bytes_i32, vec_width: int):
-            """Scalar buffer load — emits s_buffer_load_dword[x4] via the LLVM
-            intrinsic, returning an SGPR value.  Requires `soffset_bytes_i32`
-            to be wave-uniform; the result is shared across all 64 lanes.
-
-            Saves the vmcnt(0) drain + readfirstlane that the VMEM
-            buffer_load path imposes (result lands in SGPR directly, frees
-            VMEM queue slots for V/K loads)."""
-            from flydsl._mlir import ir as _ir
-            from flydsl._mlir.dialects import llvm as _llvm
-            from flydsl.expr.rocdl import _to_ir as _rocdl_to_ir
-
-            i32_ty = _ir.IntegerType.get_signless(32)
-            if const_expr(vec_width == 1):
-                result_type = i32_ty
-                suffix = "i32"
-            elif const_expr(vec_width == 4):
-                result_type = _ir.VectorType.get([4], i32_ty)
-                suffix = "v4i32"
-            else:
-                raise ValueError(f"_s_buffer_load: unsupported vec_width={vec_width}")
-            cache_policy = arith.constant(0, type=T.i32)
-            return _llvm.call_intrinsic(
-                result_type,
-                f"llvm.amdgcn.s.buffer.load.{suffix}",
-                [
-                    _rocdl_to_ir(bt_rsrc_v4),
-                    _rocdl_to_ir(soffset_bytes_i32),
-                    _rocdl_to_ir(cache_policy),
-                ],
-                [],
-                [],
-            )
-
-        def _pa_small_block_stage_phys_blocks(partition_block_base):
-            # bt offset is wave-uniform (batch_idx and warp_id are constant
-            # per wave, partition_block_base is workgroup-uniform).  Use
-            # s_buffer_load to route through SMEM cache and land the result
-            # in SGPRs directly — eliminates the vmcnt(0) drain (was 25% of
-            # all kernel stalls) and the downstream readfirstlane.
-            if const_expr(block_size == 64):
-                bt_elem_off = batch_idx * stride_bt_seq + partition_block_base + warp_id
-                phys_blocks = _s_buffer_load(bt_elem_off * fx.Int32(4), vec_width=1)
-            else:
-                bt_elem_off = batch_idx * stride_bt_seq + partition_block_base + warp_id * fx.Int32(TLOOP)
-                phys_blocks = _s_buffer_load(bt_elem_off * fx.Int32(4), vec_width=TLOOP)
-            return phys_blocks
-
-        def _pa_small_block_store_phys_blocks_to_lds(phys_block_vec):
-            if (lane16id | rowid) == fx.Int32(0):
-                if const_expr(block_size == 64):
-                    # block_size=64: `_stage_phys_blocks` returned vec_width=1
-                    # → scalar i32, not a Vector.  Wrap in a 1-element
-                    # Vector so we can use the LDS `.store(...)` API.
-                    # Each warp writes 1 i32 to bt_lds_i32[warp_id];
-                    # `_load_v_phys_blocks_from_lds` reads back the 4-elem
-                    # vec starting at offset 0.
-                    fx.Vector.from_elements([phys_block_vec], dtype=fx.Int32).store(
-                        bt_lds_i32,
-                        [fx.Index(warp_id)],
-                    )
-                else:
-                    phys_block_vec.store(
-                        bt_lds_i32,
-                        [fx.Index(warp_id * fx.Int32(TLOOP))],
-                    )
-
-        def _pa_small_block_load_v_phys_blocks_from_lds():
-            v_phys_blocks = []
-            if const_expr(block_size == 64):
-                phys_block_vec = fx.Vector.load(T.vec(VTLOOP, T.i32), bt_lds_i32, [fx.Index(0)])
-                for vt in range_constexpr(VTLOOP):
-                    v_phys_blocks.append(phys_block_vec[vt])
-            else:
-                for vt in range_constexpr(VTLOOP):
-                    bt_lds_off = fx.Int32(vt * TLOOP) + rowid
-                    phys_block = fx.Vector.load(T.vec(1, T.i32), bt_lds_i32, [fx.Index(bt_lds_off)])[0]
-                    v_phys_blocks.append(phys_block)
-            return v_phys_blocks
-
-        # Pre-load the FIRST (== reverse-order start = last partition) sub-
-        # partition's block-table entries before Q setup so the dependent K
-        # prefetch below does not also pay the table latency.
-        # Empty-slot guard: when num_total_partitions < max_context_partition_num,
-        # CTAs with partition_idx >= num_total_partitions get
-        # local_partition_start >= num_total_partitions and the inner loop runs
-        # 0 iters.  But the prologue still issues block-table + K reads using
-        # `last_partition_idx`; clamp to 0 so all reads stay in-bounds (the
-        # results are unused since the loop never executes).
-        _safe_init_partition = arith.select(
-            local_partition_start < num_total_partitions,
-            last_partition_idx,
-            arith.constant(0, type=T.i32),
-        )
-        first_block_base = _safe_init_partition * fx.Int32(_blocks_per_partition)
-        first_phys_blocks = _pa_small_block_stage_phys_blocks(first_block_base)
-
-        # Pre-load Q for every MTP group ONCE before the KV loop.  Each group's
-        # q_frags / qi / qhi / qscale are kept in registers across the entire
-        # KV loop, so we pay the Q-load cost (global → LDS → registers) exactly
-        # once per CTA regardless of how many sub-partitions the slot covers.
-
-        q_frags_per_mtp = []
-        qi_per_mtp = []
-        qhi_per_mtp = []
-        qscale_per_mtp = []
-        for _mtp_g in range_constexpr(_mtp_groups):
-            mtp_prefetch = _prefetch_mtp_group_query(
-                q_rsrc,
-                batch_idx,
-                kv_h,
-                stride_q_seq,
-                stride_q_head,
-                lane16id,
-                local_qhead_idx,
-                mtp_group_idx=_mtp_g,
-                query_length=query_length,
-                query_group_size=query_group_size,
-                query_load_is_bf16=query_load_is_bf16,
-                q_lanes_per_head=_Q_LANES_PER_HEAD,
-            )
-            qi_val, qhi_pos, q_frags, query_scale_lane = _finish_mtp_group_q_fragments(
-                logits_lds_i32,
-                logits_lds_i64,
-                softmax_lds_f32,
-                mtp_prefetch,
-                lane16id,
-                rowid,
-                local_qhead_idx,
-                head_size=_HEAD,
-                qkhe_loop=_QKHELOOP,
-                q_lanes_per_head=_Q_LANES_PER_HEAD,
-            )
-            q_frags_per_mtp.append(q_frags)
-            qi_per_mtp.append(qi_val)
-            qhi_per_mtp.append(qhi_pos)
-            qscale_per_mtp.append(query_scale_lane)
-
-        _pa_small_block_store_phys_blocks_to_lds(first_phys_blocks)
-
-        # ── K-scale buffer_load helpers (k_scale_per_token only) ──
-        # When enabled, K-scale per-token is loaded via cross-iter prefetch:
-        # each thread holds ONE fp32 K-scale in a loop-carried VGPR.  The
-        # prologue loads iter 0's K-scale; each iter loads iter (N+1)'s
-        # K-scale during its own body, hiding the buffer_load latency behind
-        # the iter's compute.  The actual ds_write to scale_lds happens at
-        # the START of the next iter (consuming the carried VGPR), with the
-        # full preceding iter's work hiding the load.
-        def _ks_buffer_load_for(my_phys, my_tok):
-            _H4 = _HEAD // 4
-            sr_idx = my_tok // fx.Int32(_H4)
-            d_in_row = my_tok - sr_idx * fx.Int32(_H4)
-            ks_off = (
-                my_phys * stride_ks_block_param
-                + sr_idx * stride_ks_scale_row_param
-                + kv_h * stride_ks_head_param
-                + d_in_row
-            )
-            return buffer_ops.buffer_load(ks_rsrc, ks_off, vec_width=1, dtype=fx.Float32)
-
-        def _load_my_k_scale_from_vgpr(next_phys_blocks_):
-            """Issue THIS thread's K-scale buffer_load using the in-VGPR
-            ``next_phys_blocks`` (avoids LDS round-trip)."""
-            if const_expr(_block_size == 64):
-                my_phys = next_phys_blocks_  # scalar (vec_width=1 from buffer_load)
-                my_tok = rowid * fx.Int32(MFMA_N) + lane16id
-            else:
-                # block_size==16: extract next_phys_blocks_[rowid] via 3 selects.
-                my_phys = vector.extract(
-                    arith.unwrap(next_phys_blocks_), static_position=[], dynamic_position=[fx.Index(rowid)]
-                )
-                my_tok = lane16id
-            return _ks_buffer_load_for(my_phys, my_tok)
-
-        def _stage_k_scale_to_lds(k_scale_scalar):
-            stage_tok = warp_id * fx.Int32(WARP_SIZE) + rowid * fx.Int32(MFMA_N) + lane16id
-            fx.Vector.from_elements([k_scale_scalar], dtype=fx.Float32).store(
-                scale_lds_f32,
-                [fx.Index(stage_tok)],
-            )
-
-        # Pre-load the FIRST sub-partition's K so the loop body can issue the
-        # next sub-partition's K prefetch in parallel with the current K's QK
-        # MFMA.  For empty slots (loop_start == loop_end), this k_flat0 is
-        # computed using local_partition_start but never used because the
-        # loop runs 0 iterations — the block_table buffer_load is bounded so
-        # any OOB lookup safely returns 0 (→ block 0, then masked out by the
-        # softmax causal bound).
-        k_flat0 = _pa_small_block_load_k_flat(
-            k_global_ptr,
-            kv_h,
-            stride_k_block,
-            stride_k_head,
-            lane16id,
-            rowid,
-            block_size=_block_size,
-            phys_blocks=first_phys_blocks,
-            qkhe_loop=_QKHELOOP,
-        )
-        # Prefetch iter 0's K-scale into VGPR using the VGPR phys directly
-        # (avoids an LDS read-after-write hazard since `first_phys_blocks`
-        # is already in registers).  Each thread holds 1 fp32; loop carries
-        # it via init and stages to scale_lds at iter 0's start.
-        if const_expr(k_scale_per_token):
-            k_scale_init = _load_my_k_scale_from_vgpr(first_phys_blocks)
-        else:
-            k_scale_init = None
-        gpu.barrier()
-        # ── Prologue V load ──
-        # V is cross-iter prefetched (ping-pong with K).  Issue iter 0's V
-        # load here so the loop body can issue iter N+1's V at the END of
-        # iter N alongside K, both hidden behind the next iter's QK MFMA.
-        # `_pa_small_block_load_v_phys_blocks_from_lds` reads the LDS-staged
-        # first_phys_blocks written above; the barrier guarantees visibility.
-        _v_phys_blocks0 = _pa_small_block_load_v_phys_blocks_from_lds()
-        _v_results0 = _pa_small_block_load_v_trans(
-            v_global_ptr,
-            kv_h,
-            stride_v_block,
-            stride_v_head,
-            warp_id,
-            lane16id,
-            rowid,
-            _v_phys_blocks0,
-            block_size=_block_size,
-            head_size=_HEAD,
-            vhe_loop=_VHELOOP,
-        )
-        v_flat0 = _flatten_v_results(_v_results0, vhe_loop=_VHELOOP)
-        # Note: no runtime `if _is_valid:` wrapping this loop.  See earlier
-        # commit log — the `ReplaceIfWithDispatch` rewriter copies the if-body
-        # into a synthetic Python function, and since the body contains
-        # `ast.Yield` from this scf.for, that function becomes a generator
-        # (returns a generator object without executing) — leaving the scf.if
-        # then-region empty.  Running the loop unconditionally is the correct
-        # workaround; empty slots iterate 0 times and yield the init state
-        # (NEG_INF, 0, 0, 0), which is the right empty-slot semantics.
-        for sub_part_ib, state in range(
-            loop_start,
-            loop_end,
-            loop_step,
-            init=_pack_states(init_states, k_flat0, v_flat0, k_scale_init),
-        ):
-            cur_states, k_flat, v_flat, k_scale_cur = _unpack_states(state)
-            # Reverse iteration: scf.for walks sub_part_ib forward over
-            # [local_partition_start, local_partition_end); remap to walk
-            # sub_part_i32 from last_partition_idx down to local_partition_start
-            # so the sink-prone partition 0 is processed last.
-            _sub_raw_i32 = arith.index_cast(T.i32, sub_part_ib)
-            sub_part_i32 = last_partition_idx - (_sub_raw_i32 - local_partition_start)
-            sub_token_start = sub_part_i32 * c_cps
-
-            # Both K and V come from the loop-carried state (prefetched at the
-            # END of the previous iteration).  K's VMEM latency overlaps prev
-            # iter's PV MFMA; V's latency overlaps the entire next iter QK +
-            # softmax compute before PV consumes it.
-            k_ops = _unflatten_k(k_flat, qkhe_loop=_QKHELOOP)
-            v_results = _unflatten_v_results(v_flat, vhe_loop=_VHELOOP)
-
-            # ── K-scale staging from loop-carried VGPR ──
-            # k_scale_cur was prefetched in the PREVIOUS iter (or prologue
-            # for iter 0), so the buffer_load latency is fully overlapped
-            # with prev iter's compute — no vmcnt drain here.
-            #
-            # No cross-warp barrier needed: each warp stages its own 64
-            # slots (warp_id*64 + ...) and `_get_k_scale_vec` reads only
-            # its own warp's slots, so K-scale staging is purely
-            # warp-local.  The compiler-emitted s_waitcnt lgkmcnt at the
-            # downstream ds_read handles the intra-wave RAW hazard.
-            if const_expr(k_scale_per_token):
-                _stage_k_scale_to_lds(k_scale_cur)
-
-            # Compute the NEXT sub-partition's K base address (clamped to
-            # local_partition_start so the prefetch on the final loop
-            # iteration doesn't walk before the block_table window —
-            # k_next_flat is yielded out but never consumed since the loop
-            # terminates).  Reverse iteration: next == sub_part_i32 - 1.
-            next_part_i32 = sub_part_i32 - fx.Int32(1)
-            next_safe_part = arith.select(next_part_i32 >= local_partition_start, next_part_i32, local_partition_start)
-            next_block_base = next_safe_part * fx.Int32(_blocks_per_partition)
-
-            new_states = []
-            k_next_flat = None
-            k_scale_next = None
-            for _mtp_g in range_constexpr(_mtp_groups):
-                state = cur_states[_mtp_g]
-                rmax, rsum = state[0], state[1]
-                outs = [state[2 + vhe] for vhe in range_constexpr(_VHELOOP)]
-                causal_bound = context_len + arith.constant(1 - query_length, type=T.i32) + qi_per_mtp[_mtp_g]
-
-                d_out = _qk_and_intra_softmax(
-                    k_ops,
-                    sub_token_start,
-                    q_frags_per_mtp[_mtp_g],
-                    causal_bound,
-                    query_scale_lane=qscale_per_mtp[_mtp_g],
-                )
-
-                if const_expr(_mtp_g == _mtp_groups - 1):
-                    next_phys_blocks = _pa_small_block_stage_phys_blocks(next_block_base)
-                    # ── Cross-iter K-scale prefetch ──
-                    # Issue next iter's K-scale fetch using the VGPR
-                    # next_phys_blocks (avoids LDS round-trip).  Carried via
-                    # loop yield → consumed at next iter's `_stage_k_scale_to_lds`,
-                    # giving an ENTIRE iter of compute to hide the load.
-                    if const_expr(k_scale_per_token):
-                        k_scale_next = _load_my_k_scale_from_vgpr(next_phys_blocks)
-
-                gpu.barrier()
-
-                rmax, rsum, outs, v_correction = _cross_warp_softmax_and_prob_pack(d_out, rmax, rsum, outs, None)
-
-                # Issue the next sub-partition's K prefetch on the LAST MTP
-                # iter, after cross_warp_softmax_and_prob_pack but BEFORE
-                # _pv_mfma — same hoist as in pa_decode_metadata_kenrel's
-                # _process_block_split.  This lets the K VMEM load latency
-                # overlap with the upcoming PV MFMA compute.
-                if const_expr(_mtp_g == _mtp_groups - 1):
-                    _pa_small_block_store_phys_blocks_to_lds(next_phys_blocks)
-                    k_next_flat = _pa_small_block_load_k_flat(
-                        k_global_ptr,
-                        kv_h,
-                        stride_k_block,
-                        stride_k_head,
-                        lane16id,
-                        rowid,
-                        block_size=_block_size,
-                        phys_blocks=next_phys_blocks,
-                        qkhe_loop=_QKHELOOP,
-                    )
-                gpu.barrier()
-                outs = _pv_mfma(v_results, outs, v_correction)
-                new_states.append(tuple([rmax, rsum] + outs))
-
-            # ── Cross-iter V prefetch (ping-pong) ──
-            # Issue NEXT iter's V load AFTER PV MFMA: the current iter's V
-            # vgprs are now consumed and can be reused.  V phys_blocks come
-            # from the LDS-staged `next_phys_blocks` written above (the
-            # barrier after K prefetch ensures cross-warp visibility).  The
-            # V VMEM latency is hidden behind next iter's QK MFMA + softmax.
-            _v_phys_blocks_next = _pa_small_block_load_v_phys_blocks_from_lds()
-            _v_next_results = _pa_small_block_load_v_trans(
-                v_global_ptr,
-                kv_h,
-                stride_v_block,
-                stride_v_head,
-                warp_id,
-                lane16id,
-                rowid,
-                _v_phys_blocks_next,
-                block_size=_block_size,
-                head_size=_HEAD,
-                vhe_loop=_VHELOOP,
-            )
-            v_next_flat = _flatten_v_results(_v_next_results, vhe_loop=_VHELOOP)
-
-            results = yield _pack_states(new_states, k_next_flat, v_next_flat, k_scale_next)
-
-        # Normalize and store one output slot per MTP group.
-        final_states, _final_k_flat, _final_v_flat, _final_k_scale = _unpack_states(results)
-        for _mtp_g in range_constexpr(_mtp_groups):
-            final_state = final_states[_mtp_g]
-            rmax_raw, rsum_raw = final_state[0], final_state[1]
-            outs_raw = [final_state[2 + vhe] for vhe in range_constexpr(_VHELOOP)]
-            running_max = fx.Float32(rmax_raw)
-            running_sum = fx.Float32(rsum_raw)
-            outs = [fx.Vector(out_raw) for out_raw in outs_raw]
-            outs_norm = _normalize_pa_output(running_sum, outs, ZERO_F)
-            eqgs_lane = qi_per_mtp[_mtp_g] * c_query_group_size + qhi_per_mtp[_mtp_g]
-            _store_partition_results(eqgs_lane, running_sum, running_max, outs_norm)
-
-    @flyc.jit
-    def launch_pa_decode_ps_small_block(
-        exp_sums: fx.Tensor,
-        max_logits: fx.Tensor,
-        tmp_out: fx.Tensor,
-        query: fx.Tensor,
-        key_cache: fx.Tensor,
-        value_cache: fx.Tensor,
-        block_tables: fx.Tensor,
-        context_lengths: fx.Tensor,
-        key_scale: fx.Tensor,
-        value_scale: fx.Tensor,
-        s_q_seq: Int32,
-        s_q_head: Int32,
-        s_k_block: Int32,
-        s_k_head: Int32,
-        s_v_block: Int32,
-        s_v_head: Int32,
-        s_es_seq: Int32,
-        s_es_head: Int32,
-        s_es_part: Int32,
-        s_to_seq: Int32,
-        s_to_head: Int32,
-        s_to_part: Int32,
-        s_to_group: Int32,
-        s_bt_seq: Int32,
-        p_scale: fx.Tensor,
-        p_scale_inv: fx.Tensor,
-        s_ks_block: Int32,
-        s_ks_scale_row: Int32,
-        s_ks_head: Int32,
-        gx: Int32,
-        gy: Int32,
-        gz: Int32,
-        stream: fx.Stream = fx.Stream(None),
-    ):
-        allocator.finalized = False
-        ctx = CompilationContext.get_current()
-        with ir.InsertionPoint(ctx.gpu_module_body):
-            allocator.finalize()
-        pa_decode_ps_kernel(
-            exp_sums,
-            max_logits,
-            tmp_out,
-            query,
-            key_cache,
-            value_cache,
-            block_tables,
-            context_lengths,
-            key_scale,
-            value_scale,
-            s_q_seq,
-            s_q_head,
-            s_k_block,
-            s_k_head,
-            s_v_block,
-            s_v_head,
-            s_es_seq,
-            s_es_head,
-            s_es_part,
-            s_to_seq,
-            s_to_head,
-            s_to_part,
-            s_to_group,
-            s_bt_seq,
-            p_scale,
-            p_scale_inv,
-            s_ks_block,
-            s_ks_scale_row,
-            s_ks_head,
-        ).launch(grid=(gx, gy, gz), block=(BLOCK_THREADS, 1, 1), stream=stream)
-
-    return {
-        "launch": launch_pa_decode_ps_small_block,
-        "kernel": pa_decode_ps_kernel,
-        "allocator": allocator,
-        "mtp_groups": _mtp_groups,
-    }
-
-
 def pa_decode_ps_launch(
     output: torch.Tensor,
     query: torch.Tensor,
@@ -2937,10 +2115,6 @@ def pa_decode_ps_launch(
     exp_sums: torch.Tensor = None,
     max_logits: torch.Tensor = None,
     temporary_output: torch.Tensor = None,
-    p_scale: torch.Tensor = None,
-    p_scale_inv: torch.Tensor = None,
-    v_scale_per_head: bool = False,
-    k_scale_per_token: bool = False,
     stream=None,
 ) -> str:
     """Launch PA decode with persistent scheduling.
@@ -2975,12 +2149,10 @@ def pa_decode_ps_launch(
             "bf16/f16 query inputs with kernel-internal query scale computation."
         )
 
-    # Detect per-token vs per-tensor quantization from scale tensor dimensionality
-    # k_scale_per_token routes K scale through the small-block kernel's per-token
-    # LDS-staging path WITHOUT enabling the legacy per_token_kv mode (which
-    # forces both K and V into per-token and is only supported by the metadata
-    # kernel).  When k_scale_per_token=True, per_token_kv is forced False.
-    per_token_kv = (not k_scale_per_token) and key_scale.ndim > 1
+    # Detect per-token vs per-tensor quantization from scale tensor
+    # dimensionality: a >1-D scale tensor carries one scale per (block, head,
+    # token), which enables the per-token K/V path in the metadata kernel.
+    per_token_kv = key_scale.ndim > 1
 
     query_length = query.shape[0] // context_lengths.shape[0]
     query_group_size = num_query_heads // num_kv_heads
@@ -3121,171 +2293,6 @@ def pa_decode_ps_launch(
             s,
         )
         return "ps_sw_partitioned"
-
-    # ---- small-block (block_size 16/64) partition path -----------------
-    # Key cache shape is [num_blocks, num_kv_heads, head_size // 16, block_size, 16].
-    # By default block_size 16/64 is routed through the metadata/worklist path
-    # below (see `_PA_DECODE_PS_SMALL_BLOCK_VIA_METADATA`); this grid-based branch
-    # is kept for reference and taken only when that flag is disabled.
-    block_size = key_cache.shape[-2]
-    # Hybrid dispatch: the metadata/worklist path supports only per-tensor K/V
-    # scales for small blocks.  Route 16/64 there only when per-token K-scale and
-    # per-head V-scale (and legacy per_token_kv) are all disabled; otherwise use
-    # the grid `compile_pa_decode_ps` kernel, which implements those features.
-    _small_via_metadata = (
-        _PA_DECODE_PS_SMALL_BLOCK_VIA_METADATA and not k_scale_per_token and not v_scale_per_head and not per_token_kv
-    )
-    if block_size in _PA_DECODE_PS_SMALL_BLOCK_SIZES and not _small_via_metadata:
-        if block_tables is None:
-            raise ValueError(
-                f"pa_decode_ps_launch: block_size={block_size} requires `block_tables` "
-                "(per-sequence physical block index table)."
-            )
-        batch_size = context_lengths.shape[0]
-        head_size = query.shape[-1]
-        eqgs = query_length * query_group_size
-        context_partition_size = KV_COMPUTE_BLOCK
-        blocks_per_partition = context_partition_size // block_size
-        if max_context_partition_num == 0:
-            max_context_partition_num = get_recommended_splits(
-                batch_size,
-                num_kv_heads,
-                split_kv_blocks=blocks_per_partition,
-            )
-        if is_graph_capturing and (exp_sums is None or max_logits is None or temporary_output is None):
-            raise ValueError(
-                "CUDA graph capture requires preallocated `exp_sums`, `max_logits`, "
-                "and `temporary_output` for the small-block PS path."
-            )
-        if exp_sums is None:
-            exp_sums = torch.zeros(
-                batch_size,
-                num_kv_heads,
-                max_context_partition_num,
-                eqgs,
-                device=dev,
-                dtype=torch.float32,
-            )
-        if max_logits is None:
-            max_logits = torch.full(
-                (batch_size, num_kv_heads, max_context_partition_num, eqgs),
-                float("-inf"),
-                device=dev,
-                dtype=torch.float32,
-            )
-        if temporary_output is None:
-            temporary_output = torch.zeros(
-                batch_size,
-                num_kv_heads,
-                max_context_partition_num,
-                eqgs,
-                head_size,
-                device=dev,
-                dtype=torch.bfloat16,
-            )
-        _has_p_scale = p_scale is not None and p_scale_inv is not None
-        if (p_scale is None) != (p_scale_inv is None):
-            raise ValueError("p_scale and p_scale_inv must both be set or both be None.")
-        if not _has_p_scale:
-            _p_scale_arg = torch.empty(num_query_heads, dtype=torch.float32, device=dev)
-            _p_scale_inv_arg = torch.empty(num_query_heads, dtype=torch.float32, device=dev)
-        else:
-            _p_scale_arg = p_scale.contiguous().to(torch.float32)
-            _p_scale_inv_arg = p_scale_inv.contiguous().to(torch.float32)
-        compiled_small = compile_pa_decode_ps(
-            block_size=block_size,
-            max_context_partition_num=max_context_partition_num,
-            softmax_scale=softmax_scale,
-            trans_v=trans_v,
-            query_group_size=query_group_size,
-            per_token_kv=per_token_kv,
-            query_length=query_length,
-            query_input_dtype=query_input_dtype,
-            has_p_scale=_has_p_scale,
-            v_scale_per_head=v_scale_per_head,
-            k_scale_per_token=k_scale_per_token,
-            head_dim=int(head_size),
-        )
-        # K-scale strides for per-token mode: expect key_scale packed layout
-        # `[num_blocks, scale_rows, num_kv_heads, head_dim]` fp8 viewed as fp32.
-        # All strides in fp32 elements (4 fp8 bytes = 1 fp32).
-        if k_scale_per_token:
-            _H4 = int(head_size) // 4
-            # ceil(block_size*4 / head_size) so block_size*4 bytes always fit
-            # in scale_rows*head_dim bytes (padded with zeros when needed,
-            # e.g. block_size=16 with head_size=128 → scale_rows=1).
-            _scale_rows = (int(block_size) * 4 + int(head_size) - 1) // int(head_size)
-            _s_ks_block_arg = _scale_rows * int(num_kv_heads) * _H4
-            _s_ks_scale_row_arg = int(num_kv_heads) * _H4
-            _s_ks_head_arg = _H4
-        else:
-            _s_ks_block_arg = 0
-            _s_ks_scale_row_arg = 0
-            _s_ks_head_arg = 0
-        output_5d = output.reshape(batch_size, query_length, num_kv_heads, query_group_size, head_size)
-        compiled_small["launch"](
-            exp_sums,
-            max_logits,
-            temporary_output,
-            query,
-            key_cache,
-            value_cache,
-            block_tables,
-            context_lengths,
-            key_scale,
-            value_scale,
-            query.stride(0),
-            query.stride(1),
-            key_cache.stride(0),
-            key_cache.stride(1),
-            value_cache.stride(0),
-            value_cache.stride(1),
-            exp_sums.stride(0),
-            exp_sums.stride(1),
-            exp_sums.stride(2),
-            temporary_output.stride(0),
-            temporary_output.stride(1),
-            temporary_output.stride(2),
-            temporary_output.stride(3),
-            block_tables.stride(0),
-            _p_scale_arg,
-            _p_scale_inv_arg,
-            _s_ks_block_arg,
-            _s_ks_scale_row_arg,
-            _s_ks_head_arg,
-            batch_size,
-            num_kv_heads,
-            max_context_partition_num,
-            s,
-        )
-        compiled_sw_reduce = compile_pa_decode_sw_reduce(
-            max_context_partition_num=max_context_partition_num,
-            query_seq_len=query_length,
-            query_group_size=query_group_size,
-            head_size=head_size,
-            output_dtype_str=_get_output_dtype_str(output),
-        )
-        compiled_sw_reduce["launch"](
-            output_5d,
-            exp_sums,
-            max_logits,
-            temporary_output,
-            output_5d.stride(0),
-            output_5d.stride(1),
-            output_5d.stride(2),
-            output_5d.stride(3),
-            exp_sums.stride(0),
-            exp_sums.stride(1),
-            exp_sums.stride(2),
-            temporary_output.stride(0),
-            temporary_output.stride(1),
-            temporary_output.stride(2),
-            temporary_output.stride(3),
-            batch_size,
-            num_kv_heads,
-            s,
-        )
-        return "ps_small_block"
 
     if metadata is None:
         if is_graph_capturing:

--- a/kernels/pa_decode_fp8.py
+++ b/kernels/pa_decode_fp8.py
@@ -2475,8 +2475,8 @@ def compile_pa_decode_ps(
             Saves the vmcnt(0) drain + readfirstlane that the VMEM
             buffer_load path imposes (result lands in SGPR directly, frees
             VMEM queue slots for V/K loads)."""
-            from flydsl._mlir.dialects import llvm as _llvm
             from flydsl._mlir import ir as _ir
+            from flydsl._mlir.dialects import llvm as _llvm
             from flydsl.expr.rocdl import _to_ir as _rocdl_to_ir
 
             i32_ty = _ir.IntegerType.get_signless(32)

--- a/kernels/pa_decode_swa.py
+++ b/kernels/pa_decode_swa.py
@@ -20,8 +20,6 @@ from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from kernels import dpp_utils
 
 # ── Kernel geometry constants ────────────────────────────────────────
-QUERY_GROUP_SIZE = 16
-HEAD_SIZE = 128
 KV_BLOCK_SIZE = 1024  # physical page size (matches SP3 kBlockSize)
 KV_COMPUTE_BLOCK = 256  # tile size (matches SP3 kTileKV)
 NUM_WARPS = 4
@@ -35,13 +33,10 @@ TLOOP = TOKENS_PER_WARP // MFMA_N  # 4
 ROWS_PER_WARP = WARP_SIZE // MFMA_N  # 4
 FP8_ELEMS_16B = 16  # 16 FP8 per 16-byte load
 QKHE_PER_FETCH = FP8_ELEMS_16B * ROWS_PER_WARP  # 64
-QKHELOOP = HEAD_SIZE // QKHE_PER_FETCH  # 2
 
-VHELOOP = HEAD_SIZE // MFMA_N // NUM_WARPS  # 2
 VTLOOP = NUM_WARPS  # 4
 Q_ELEMS_PER_LANE = 8
 Q_CHUNKS_PER_LANE = Q_ELEMS_PER_LANE // 4
-Q_LANES_PER_HEAD = HEAD_SIZE // Q_ELEMS_PER_LANE
 
 # LDS sizes
 PROB_ROW_STRIDE_BYTES = 40  # 32 data + 8 padding -> 0 bank conflict
@@ -53,11 +48,6 @@ LDS_SCALE_BYTES = (LDS_SCALE_V_OFFSET + KV_COMPUTE_BLOCK) * 4  # K/V per-token s
 
 FP8_MAX = 240.0
 LOG2E = 1.4426950408889634
-
-# Number of loop-carried K values (i64)
-_N_K = TLOOP * QKHELOOP * 2  # 16
-# Number of loop-carried V values (i64)
-_N_V = VHELOOP * VTLOOP * 2  # 16
 
 # Tiles per block (1024 tokens / 256 tokens per tile = 4, matches SP3 kNumBlockTiles)
 TILES_PER_BLOCK = KV_BLOCK_SIZE // KV_COMPUTE_BLOCK  # 4
@@ -147,6 +137,7 @@ def _load_k_flat(
     k_he_off_dw,
     *,
     sched_vmem_after_load=True,
+    qkhe_loop: int = 2,
 ):
     k_flat = []
     tile_tok_base = tile_token_offset_i32 + k_tok_thread_base
@@ -154,7 +145,7 @@ def _load_k_flat(
     for td in range_constexpr(TLOOP):
         kbo = tile_tok_base + fx.Int32(td * MFMA_N)
         kbo_dw = kbo * c_tok_stride_dw
-        for qkhe in range_constexpr(QKHELOOP):
+        for qkhe in range_constexpr(qkhe_loop):
             ka_dw = k_block_base_dw_i64 + fx.Int64(kbo_dw + k_he_off_dw[qkhe])
             k2 = _global_load_i64x2(k_global_ptr, ka_dw * fx.Int64(4))
             if const_expr(sched_vmem_after_load):
@@ -166,8 +157,8 @@ def _load_k_flat(
     return k_flat
 
 
-def _unflatten_k(k_flat):
-    return [[k_flat[td * (QKHELOOP * 2) + j] for j in range(QKHELOOP * 2)] for td in range(TLOOP)]
+def _unflatten_k(k_flat, qkhe_loop: int = 2):
+    return [[k_flat[td * (qkhe_loop * 2) + j] for j in range(qkhe_loop * 2)] for td in range(TLOOP)]
 
 
 def _build_pa_thread_invariants(
@@ -177,20 +168,22 @@ def _build_pa_thread_invariants(
     *,
     trans_v,
     per_token_kv,
+    qkhe_loop: int = 2,
+    vhe_loop: int = 2,
 ):
     c_tokens_per_warp = fx.Int32(TOKENS_PER_WARP)
     c_mfma_n = fx.Int32(MFMA_N)
     k_tok_thread_base = warp_id * c_tokens_per_warp + lane16id
     c_tok_stride_dw = fx.Int32(FP8_ELEMS_16B // 4)
     c_he_stride_dw = fx.Int32(KV_BLOCK_SIZE * FP8_ELEMS_16B // 4)
-    k_he_off_dw = [rowid * c_he_stride_dw + fx.Int32(qkhe * 4) * c_he_stride_dw for qkhe in range(QKHELOOP)]
+    k_he_off_dw = [rowid * c_he_stride_dw + fx.Int32(qkhe * 4) * c_he_stride_dw for qkhe in range(qkhe_loop)]
 
-    vhead_elems = [fx.Int32(vhe * NUM_WARPS * MFMA_N) + warp_id * c_mfma_n + lane16id for vhe in range(VHELOOP)]
+    vhead_elems = [fx.Int32(vhe * NUM_WARPS * MFMA_N) + warp_id * c_mfma_n + lane16id for vhe in range(vhe_loop)]
     v_tok_thread_off = [fx.Int32(vt * TOKENS_PER_WARP) + rowid * c_mfma_n for vt in range(VTLOOP)]
     if const_expr(trans_v):
-        vhead_elem_dw = [vhead_elems[vhe] * fx.Int32(FP8_ELEMS_16B // 4) for vhe in range(VHELOOP)]
+        vhead_elem_dw = [vhead_elems[vhe] * fx.Int32(FP8_ELEMS_16B // 4) for vhe in range(vhe_loop)]
     else:
-        vhead_elem_dw = [vhead_elems[vhe] * fx.Int32(KV_BLOCK_SIZE // 4) for vhe in range(VHELOOP)]
+        vhead_elem_dw = [vhead_elems[vhe] * fx.Int32(KV_BLOCK_SIZE // 4) for vhe in range(vhe_loop)]
 
     kv_tok_thread_base = warp_id * c_tokens_per_warp + rowid * 4
     rowid_8x8 = rowid >> fx.Int32(1)
@@ -284,14 +277,15 @@ def _prefetch_q_chunks(
     lane16id,
     *,
     query_load_is_bf16,
+    q_lanes_per_head,
 ):
     # bf16/f16 + in-kernel query_scale path.  Each lane owns 8 Q elements,
     # loaded as 2 × vec_width=4 buffer loads (4 bf16/f16 elems per load = 8 B,
     # element offset += 4 per iter).  After FP8 packing each load produces
     # one i32 word, so the per-lane store is `vec<2, i32>` = 8 B = 1 i64.
     q_load_lane = lane16id
-    if const_expr(Q_LANES_PER_HEAD < MFMA_N):
-        q_load_lane = arith.select(lane16id < fx.Int32(Q_LANES_PER_HEAD), lane16id, fx.Int32(0))
+    if const_expr(q_lanes_per_head < MFMA_N):
+        q_load_lane = arith.select(lane16id < fx.Int32(q_lanes_per_head), lane16id, fx.Int32(0))
     q_elem = q_base + q_load_lane * fx.Int32(Q_ELEMS_PER_LANE)
     q_chunks = []
     for qwi in range_constexpr(Q_CHUNKS_PER_LANE):
@@ -315,6 +309,10 @@ def _finish_q_fragments(
     lane16id,
     rowid,
     local_qhead_idx,
+    *,
+    head_size: int,
+    qkhe_loop: int,
+    q_lanes_per_head: int,
 ):
     # LDS Q layout (compact, per-qhead contiguous):
     #   Q[head=h][hd=d]  at byte offset  h * HEAD_SIZE + d   (FP8 after conversion)
@@ -332,7 +330,7 @@ def _finish_q_fragments(
     # lane16id L) consumes, for k_step = qkhe*2 + qkr,
     #   Q[head = L][hd = (qkhe*4 + R) * 16 + qkr * 8 + 0..7]
     # i.e. the read byte offset is `L * HEAD_SIZE + qkhe*64 + R*16 + qkr*8`.
-    c_head_size = fx.Int32(HEAD_SIZE)
+    c_head_size = fx.Int32(head_size)
     lds_q_base = local_qhead_idx * c_head_size + lane16id * 8
     abs_mask = fx.Vector.filled(4, 0x7FFFFFFF, fx.Int32)
     c_zero_f = fx.Float32(0.0)
@@ -373,8 +371,8 @@ def _finish_q_fragments(
 
     v01 = fx.Vector.from_elements([q_w0, q_w1], dtype=fx.Int32)
     lds_q_i32 = lds_q_base >> fx.Int32(2)
-    if const_expr(Q_LANES_PER_HEAD < MFMA_N):
-        if lane16id < fx.Int32(Q_LANES_PER_HEAD):
+    if const_expr(q_lanes_per_head < MFMA_N):
+        if lane16id < fx.Int32(q_lanes_per_head):
             v01.store(logits_lds_i32, [fx.Index(lds_q_i32)])
     else:
         v01.store(logits_lds_i32, [fx.Index(lds_q_i32)])
@@ -382,7 +380,7 @@ def _finish_q_fragments(
     q_frags = []
     gpu.barrier()
     query_scale_lane = fx.Vector.load(T.vec(1, fx.Float32.ir_type), softmax_lds_f32, [fx.Index(lane16id)])[0].ir_value()
-    for qkhe in range_constexpr(QKHELOOP):
+    for qkhe in range_constexpr(qkhe_loop):
         for qkr in range_constexpr(2):
             # See layout comment above. Byte offset:
             #   lane16id * HEAD_SIZE + qkhe*64 + rowid*16 + qkr*8
@@ -407,6 +405,7 @@ def _prefetch_sw_mtp_group_queries(
     query_length,
     query_group_size,
     query_load_is_bf16,
+    q_lanes_per_head,
 ):
     mtp_prefetches = []
     c_query_length = arith.constant(query_length, type=T.i32)
@@ -427,6 +426,7 @@ def _prefetch_sw_mtp_group_queries(
             q_base,
             lane16id,
             query_load_is_bf16=query_load_is_bf16,
+            q_lanes_per_head=q_lanes_per_head,
         )
         mtp_prefetches.append((qi_val, qhi_pos, q_chunks))
     return mtp_prefetches
@@ -442,6 +442,9 @@ def _finish_sw_mtp_subgroup_q_fragments(
     local_qhead_idx,
     *,
     mtp_subgroup_idx,
+    head_size: int,
+    qkhe_loop: int,
+    q_lanes_per_head: int,
 ):
     qi_val, qhi_pos, q_chunks = mtp_prefetches[mtp_subgroup_idx]
     q_frags, query_scale_lane = _finish_q_fragments(
@@ -452,16 +455,19 @@ def _finish_sw_mtp_subgroup_q_fragments(
         lane16id,
         rowid,
         local_qhead_idx,
+        head_size=head_size,
+        qkhe_loop=qkhe_loop,
+        q_lanes_per_head=q_lanes_per_head,
     )
     return qi_val, qhi_pos, q_frags, query_scale_lane
 
 
-def _normalize_pa_output(running_sum, outs, zero_f):
+def _normalize_pa_output(running_sum, outs, zero_f, vhe_loop: int = 2):
     one_f = fx.Float32(1.0).ir_value()
     safe_sum = arith.select(running_sum > zero_f, running_sum, one_f)
     inv_sum = _rcp_f32(safe_sum)
     normalized_outs = []
-    for vhe in range_constexpr(VHELOOP):
+    for vhe in range_constexpr(vhe_loop):
         normalized_outs.append(outs[vhe] * vector.broadcast(T.f32x4, inv_sum))
     return normalized_outs
 
@@ -506,6 +512,9 @@ def _make_pa_phase_helpers(
     c_w,
     neg_inf,
     zero_f,
+    head_size: int = 128,
+    qkhe_loop: int = 2,
+    vhe_loop: int = 2,
 ):
     # Sliding-window decode always needs an upper-bound mask: even for a
     # single query, the tail block can contain tokens beyond context_len.
@@ -561,12 +570,12 @@ def _make_pa_phase_helpers(
         v_results = []
         for vt in range_constexpr(VTLOOP):
             vhe_data = []
-            for vhe in range_constexpr(VHELOOP):
+            for vhe in range_constexpr(vhe_loop):
                 v_token_in_block = tile_token_offset_i32 + v_tok_thread_off[vt]
                 if const_expr(trans_v):
                     vt_group = v_token_in_block >> fx.Int32(4)
                     va_dw_delta = (
-                        vt_group * arith.constant(HEAD_SIZE * FP8_ELEMS_16B // 4, type=T.i32) + vhead_elem_dw[vhe]
+                        vt_group * arith.constant(head_size * FP8_ELEMS_16B // 4, type=T.i32) + vhead_elem_dw[vhe]
                     )
                 else:
                     va_dw_delta = vhead_elem_dw[vhe] + (v_token_in_block >> fx.Int32(2))
@@ -641,7 +650,7 @@ def _make_pa_phase_helpers(
         d_out = []
         for td in range_constexpr(TLOOP):
             acc = arith.constant_vector(0.0, T.f32x4)
-            for k_step in range_constexpr(QKHELOOP * 2):
+            for k_step in range_constexpr(qkhe_loop * 2):
                 acc = rocdl.mfma_f32_16x16x32_fp8_fp8(T.f32x4, [k_ops[td][k_step], q_frags[k_step], acc, 0, 0, 0])
             if const_expr(per_token_kv):
                 k_scale_vec = _load_k_scale_vec(td)
@@ -744,7 +753,7 @@ def _make_pa_phase_helpers(
         rsum = arith.addf(accum_sum, partition_sum_scaled, fastmath=arith.FastMathFlags.contract)
         rmax = new_rmax
         accum_scale_vec = vector.broadcast(T.f32x4, arith.unwrap(accum_scale))
-        for vhe in range_constexpr(VHELOOP):
+        for vhe in range_constexpr(vhe_loop):
             outs[vhe] = outs[vhe] * accum_scale_vec
 
         if const_expr(per_token_kv):
@@ -785,7 +794,7 @@ def _make_pa_phase_helpers(
         v_correction = fx.Float32(v_correction).ir_value()
         fm_contract = arith.FastMathFlags.contract
         v_correction_vec = vector.broadcast(T.f32x4, v_correction)
-        for vhe in range_constexpr(VHELOOP):
+        for vhe in range_constexpr(vhe_loop):
             tmp_out = arith.constant_vector(0.0, T.f32x4)
             for vt in range_constexpr(VTLOOP):
                 v_i64x2 = fx.Vector(v_ops[vt][vhe])
@@ -1188,11 +1197,12 @@ def compile_pa_decode_sw(
     sliding_window: int,  # required > 0 -- baked as compile-time constant
     softmax_scale=None,
     trans_v=False,
-    query_group_size=QUERY_GROUP_SIZE,
+    query_group_size=16,
     per_token_kv=False,
     query_length: int = 1,
     query_input_dtype: str = "bf16",
     fuse_partitions: bool = False,
+    head_dim: int = 128,
 ):
     """Compile a Gluon-style partitioned PA decode kernel for sliding window.
 
@@ -1205,9 +1215,15 @@ def compile_pa_decode_sw(
     arch = get_hip_arch()
     if query_input_dtype not in ("bf16", "f16"):
         raise ValueError("`compile_pa_decode_sw` only supports bf16/f16 query inputs.")
+    if head_dim % QKHE_PER_FETCH != 0 or head_dim % (MFMA_N * NUM_WARPS) != 0 or head_dim % Q_ELEMS_PER_LANE != 0:
+        raise ValueError(f"Unsupported head_dim={head_dim}; must be a multiple of {MFMA_N * NUM_WARPS}.")
+    _HEAD = head_dim
+    _QKHELOOP = head_dim // QKHE_PER_FETCH
+    _VHELOOP = head_dim // MFMA_N // NUM_WARPS
+    _Q_LANES_PER_HEAD = head_dim // Q_ELEMS_PER_LANE
     query_load_is_bf16 = query_input_dtype == "bf16"
     if softmax_scale is None:
-        softmax_scale = 1.0 / (HEAD_SIZE**0.5)
+        softmax_scale = 1.0 / (head_dim**0.5)
     _softmax_scale = float(softmax_scale)
     _bs = KV_BLOCK_SIZE  # 1024
     _max_context_partition_num = get_sw_max_context_partition_num(
@@ -1228,7 +1244,7 @@ def compile_pa_decode_sw(
     scale_off = allocator.ptr
     allocator.ptr += LDS_SCALE_TOTAL
 
-    @flyc.kernel
+    @flyc.kernel(known_block_size=(BLOCK_THREADS, 1, 1))
     def pa_decode_sw_kernel(
         exp_sums_ptr: fx.Tensor,  # [batch, kv_heads, max_parts, eqgs] f32
         max_logits_ptr: fx.Tensor,  # [batch, kv_heads, max_parts, eqgs] f32
@@ -1333,6 +1349,8 @@ def compile_pa_decode_sw(
             rowid,
             trans_v=trans_v,
             per_token_kv=per_token_kv,
+            qkhe_loop=_QKHELOOP,
+            vhe_loop=_VHELOOP,
         )
 
         # ── Context length and partition mapping ──
@@ -1398,6 +1416,9 @@ def compile_pa_decode_sw(
             c_w=c_w,
             neg_inf=NEG_INF,
             zero_f=ZERO_F,
+            head_size=_HEAD,
+            qkhe_loop=_QKHELOOP,
+            vhe_loop=_VHELOOP,
         )
 
         def _process_block_split(
@@ -1432,7 +1453,7 @@ def compile_pa_decode_sw(
             return fx.Float32(value).ir_value().bitcast(fx.Int32.ir_type)
 
         def _store_partition_results(eqgs_lane, running_sum, running_max, outelems_norm):
-            for vhe in range_constexpr(VHELOOP):
+            for vhe in range_constexpr(_VHELOOP):
                 hs_base = fx.Int32(vhe * NUM_WARPS * MFMA_N) + warp_id * fx.Int32(MFMA_N) + rowid * 4
                 to_off = (
                     batch_idx * stride_to_seq
@@ -1451,13 +1472,13 @@ def compile_pa_decode_sw(
             buffer_ops.buffer_store(ml_i32, ml_rsrc, es_off * 4, offset_is_bytes=True)
 
         def _store_group_results(qi_val, qhi_pos, running_sum, running_max, outs):
-            outelems_norm = _normalize_pa_output(running_sum, outs, ZERO_F)
+            outelems_norm = _normalize_pa_output(running_sum, outs, ZERO_F, vhe_loop=_VHELOOP)
             eqgs_lane = qi_val * fx.Int32(query_group_size) + qhi_pos
             _store_partition_results(eqgs_lane, running_sum, running_max, outelems_norm)
 
         def _store_fused_group_results(qi_val, qhi_pos, running_sum, outs):
-            outelems_norm = _normalize_pa_output(running_sum, outs, ZERO_F)
-            for vhe in range_constexpr(VHELOOP):
+            outelems_norm = _normalize_pa_output(running_sum, outs, ZERO_F, vhe_loop=_VHELOOP)
+            for vhe in range_constexpr(_VHELOOP):
                 hs_base = fx.Int32(vhe * NUM_WARPS * MFMA_N) + warp_id * fx.Int32(MFMA_N) + rowid * 4
                 out_off = (
                     batch_idx * stride_out_bs
@@ -1470,7 +1491,7 @@ def compile_pa_decode_sw(
                 buffer_ops.buffer_store(out_i32, out_rsrc, out_off * 2, offset_is_bytes=True)
 
         def _write_empty_partition():
-            zero_output = [fx.Vector.filled(4, 0.0, fx.Float32) for _ in range_constexpr(VHELOOP)]
+            zero_output = [fx.Vector.filled(4, 0.0, fx.Float32) for _ in range_constexpr(_VHELOOP)]
             qi_val, qhi_pos, _, _ = _compute_sw_mtp_group_state(
                 lane16id,
                 local_qhead_idx,
@@ -1509,6 +1530,7 @@ def compile_pa_decode_sw(
                     _k_tok_thread_base,
                     _c_tok_stride_dw,
                     _k_he_off_dw,
+                    qkhe_loop=_QKHELOOP,
                 )
 
                 tile_v_base = _compute_block_base_dw_i64(tile_phys_block, stride_v_block, _v_head_off)
@@ -1519,7 +1541,7 @@ def compile_pa_decode_sw(
                 )
                 _store_vmax_warp(tile_kv_seq_start, seq_end=tile_context_len)
                 return (
-                    _unflatten_k(tile_k_flat),
+                    _unflatten_k(tile_k_flat, qkhe_loop=_QKHELOOP),
                     tile_v_ops,
                     tile_kv_seq_start,
                     tile_context_len,
@@ -1538,6 +1560,7 @@ def compile_pa_decode_sw(
                 query_length=query_length,
                 query_group_size=query_group_size,
                 query_load_is_bf16=query_load_is_bf16,
+                q_lanes_per_head=_Q_LANES_PER_HEAD,
             )
             if const_expr(fuse_partitions):
                 tile_valid = fx.Int32(0) < visible_tile_count
@@ -1557,11 +1580,14 @@ def compile_pa_decode_sw(
                 rowid,
                 local_qhead_idx,
                 mtp_subgroup_idx=0,
+                head_size=_HEAD,
+                qkhe_loop=_QKHELOOP,
+                q_lanes_per_head=_Q_LANES_PER_HEAD,
             )
             if const_expr(fuse_partitions):
                 running_max = NEG_INF
                 running_sum = ZERO_F
-                outs = [arith.constant_vector(0.0, T.f32x4) for _ in range_constexpr(VHELOOP)]
+                outs = [arith.constant_vector(0.0, T.f32x4) for _ in range_constexpr(_VHELOOP)]
                 (
                     tile_k_ops,
                     tile_v_and_scales,
@@ -1592,7 +1618,7 @@ def compile_pa_decode_sw(
                 ) = _load_tile(prefetched_tile_metadata, prefetched_tile_scale_scalars)
                 causal_bound = context_len + fx.Int32(1 - query_length) + qi_val
                 seq_start = context_len - fx.Int32(query_length + sliding_window) + qi_val
-                outs = [arith.constant_vector(0.0, T.f32x4) for _ in range_constexpr(VHELOOP)]
+                outs = [arith.constant_vector(0.0, T.f32x4) for _ in range_constexpr(_VHELOOP)]
                 running_max, running_sum, outs = _process_block_split(
                     NEG_INF,
                     ZERO_F,

--- a/kernels/pa_metadata.py
+++ b/kernels/pa_metadata.py
@@ -1,0 +1,507 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+"""FlyDSL implementation of aiter's ``get_pa_metadata_v1`` worklist scheduler.
+
+This replaces the ``aiter.ops.attention.get_pa_metadata_v1`` C++/CUDA dependency
+(``module_pa_metadata.so``) with a FlyDSL device kernel, so paged-attention
+decode (``kernels/pa_decode_fp8.py``) can build its CU worklist without aiter.
+
+Scope — PA-decode-specialized port of
+``aiter/csrc/kernels/mla/metadata/v1_2_pa_device.cuh::kn_get_pa_metadata_v1_2``.
+The following invariants always hold for the PA decode use and are baked in:
+
+* ``kQoSplits == False`` — ``packed_qo_len = query_length * gqa`` is small
+  (<= ~32) so it never exceeds ``kPackedQoLenPerWg=128`` ⇒ ``num_qo_tiles = 1``,
+  ``qo_tile_size = query_length``.
+* uniform qo length across batches (``uni_seqlen_qo = query_length``).
+* causal, non-sparse (``topk = -1``), ``qk_batch_ratio = 1``,
+  ``num_splits = num_cu`` (``max_split_per_batch = -1``).
+
+All six outputs are produced as a faithful drop-in for the C++ kernel:
+``work_metadata_ptrs``, ``work_indptr``, ``work_info`` (8 fields),
+``reduce_indptr``, ``reduce_final_map`` and ``reduce_partial_map`` — each
+verified element-for-element against aiter. The caller consumes them directly
+(no post-hoc expansion).
+
+work_info layout (8 x int32 per work), matching ``PaWorkInfo``:
+  [0] batch_idx  [1] partial_qo_loc(-1 if no split)  [2] qo_start  [3] qo_end
+  [4] kv_start   [5] kv_end                          [6] kv_offset(=0)
+  [7] q_head_range = (qhead_end << 16) | (qhead_start & 0xFFFF)
+
+The kernel is launched single-thread (grid=block=(1,1,1)); the scheduler is a
+serial algorithm (warp reductions / lane-parallel fills in the original collapse
+to serial loops). It runs once per shape and the result is cached, so single-
+thread is the correct, simplest model.
+"""
+
+import functools
+
+import torch
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import scf
+from flydsl.expr import arith, buffer_ops, gpu, range_constexpr
+from flydsl.expr.typing import Int32, T
+from flydsl.runtime.device import get_rocm_arch
+
+from kernels.kernels_common import get_warp_size
+
+_WORK_INFO_FIELDS = 8
+
+
+def get_pa_metadata_info_v1(batch_size: int, num_head_k: int = 1, num_cu: int = None):
+    """Buffer sizes/dtypes, matching ``aiter.get_pa_metadata_info_v1``.
+
+    Returns (shape, dtype) tuples for:
+      work_metadata_ptrs, work_indptr, work_info_set,
+      reduce_indptr, reduce_final_map, reduce_partial_map.
+
+    ``num_cu`` overrides the worklist bin count (default = device CU count);
+    pass a multiple of the CU count to oversubscribe the persistent grid.
+    """
+    if num_cu is None:
+        gpu = torch.cuda.current_device()
+        num_cu = torch.cuda.get_device_properties(gpu).multi_processor_count
+    cu_num = num_cu
+
+    tile_cnt = batch_size
+    max_work = (tile_cnt + cu_num - 1) * num_head_k
+    max_split_tiles = min(batch_size + cu_num - 1, (cu_num - 1) * 2)
+
+    return (
+        ((2,), torch.uint64),  # work_metadata_ptrs
+        ((cu_num + 1,), torch.int32),  # work_indptr
+        ((max_work, _WORK_INFO_FIELDS), torch.int32),  # work_info_set
+        ((tile_cnt + 1,), torch.int32),  # reduce_indptr
+        ((tile_cnt, 2), torch.int32),  # reduce_final_map
+        ((max_split_tiles,), torch.int32),  # reduce_partial_map
+    )
+
+
+def _is_pow2(x: int) -> bool:
+    return x > 0 and (x & (x - 1)) == 0
+
+
+@functools.lru_cache(maxsize=256)
+def compile_pa_metadata_v1(
+    *,
+    num_cu: int,
+    num_heads_k: int,
+    gqa: int,
+    kv_granularity: int,
+    query_length: int,
+    warp_size: int,
+):
+    """Compile the FlyDSL worklist scheduler for a fixed device/shape config.
+
+    ``num_batches`` stays a runtime kernel argument; everything else is baked.
+
+    Launched as a single warp (``grid=block=(warp_size,1,1)``), matching aiter's
+    ``<<<grid, warp_size, ...>>>``: Phase-1 (per-batch block counts + sum) is
+    warp-parallel (lane-strided + warp reduce), while the serial CU x batch
+    scheduler runs uniformly on all lanes — exactly as the original, whose
+    work_indptr / work_info writes are not lane-guarded (benign same-value
+    races). The original's lane-divided / lane-0-guarded work is only for the
+    reduce_* maps, which the caller recomputes and we therefore omit.
+    """
+    assert _is_pow2(kv_granularity), "kv_granularity must be power of 2"
+    assert num_cu % num_heads_k == 0, "num_cu must be divisible by num_heads_k"
+    num_splits_per_khead = num_cu // num_heads_k
+    # warp-reduce shuffle offsets: warp_size/2, ..., 1
+    _shuffle_offsets = []
+    _o = warp_size // 2
+    while _o >= 1:
+        _shuffle_offsets.append(_o)
+        _o //= 2
+
+    @flyc.kernel(known_block_size=(warp_size, 1, 1))
+    def pa_metadata_v1_kernel(
+        seqlens_qo_indptr_ptr: fx.Tensor,  # [num_batches + 1] i32 (cumulative qo seqlens)
+        pages_kv_indptr_ptr: fx.Tensor,  # [num_batches + 1] i32 (cumulative pages)
+        context_lens_ptr: fx.Tensor,  # [num_batches] i32
+        work_indptr_ptr: fx.Tensor,  # [num_cu + 1] i32   (output)
+        work_info_ptr: fx.Tensor,  # [max_work * 8] i32 (output, flattened)
+        reduce_indptr_ptr: fx.Tensor,  # [num_batches + 1] i32 (output)
+        reduce_final_map_ptr: fx.Tensor,  # [num_batches * 2] i32 (output, flattened)
+        reduce_partial_map_ptr: fx.Tensor,  # [max_split_tiles] i32 (output)
+        num_batches: Int32,
+    ):
+        i32 = T.i32
+        sq_rsrc = buffer_ops.create_buffer_resource(seqlens_qo_indptr_ptr, max_size=True)
+        ctx_rsrc = buffer_ops.create_buffer_resource(context_lens_ptr, max_size=True)
+        wi_rsrc = buffer_ops.create_buffer_resource(work_indptr_ptr, max_size=True)
+        winfo_rsrc = buffer_ops.create_buffer_resource(work_info_ptr, max_size=True)
+        rip_rsrc = buffer_ops.create_buffer_resource(reduce_indptr_ptr, max_size=True)
+        rfm_rsrc = buffer_ops.create_buffer_resource(reduce_final_map_ptr, max_size=True)
+        rpm_rsrc = buffer_ops.create_buffer_resource(reduce_partial_map_ptr, max_size=True)
+        # pages_kv_indptr_ptr is accepted for signature compat but unused: the
+        # work unit is a `partition_size`-token partition, so both the load
+        # balance and the kv ranges are counted as ceil(context_len/kv_gran)
+        # partitions (kv_granularity == partition_size). This matches the
+        # original kernel's kLdsBatchInfo=true path where curr_kv_pages is the
+        # per-batch num_blocks, not the pages_kv_indptr delta.
+
+        c0 = fx.Int32(0)
+        c1 = fx.Int32(1)
+        c_qlen = fx.Int32(query_length)
+        c_nb = num_batches  # Int32 runtime
+        c_nspk = fx.Int32(num_splits_per_khead)
+        c_numcu = fx.Int32(num_cu)
+        c_ws = fx.Int32(warp_size)
+        c_kvg = fx.Int32(kv_granularity)
+        lane = fx.Int32(gpu.thread_id("x"))
+
+        def _load(rsrc, off):
+            return fx.Int32(buffer_ops.buffer_load(rsrc, fx.Int32(off).ir_value(), vec_width=1, dtype=i32))
+
+        def _num_part(batch_idx):
+            # number of partition_size-token partitions for this batch =
+            # ceil(context_len[batch_idx] / kv_granularity)
+            ctxv = _load(ctx_rsrc, batch_idx)
+            return fx.Int32(arith.ceildivui(ctxv.ir_value(), c_kvg.ir_value()))
+
+        def _store(rsrc, off, val):
+            # NOTE: no masked stores — masked buffer_store sets OOB offset
+            # (0x7FFFFFFF) expecting HW bounds-check to drop it, but our
+            # max_size resources disable bounds-checking, so a masked store
+            # faults. All stores here are unconditional + overwrite-safe.
+            buffer_ops.buffer_store(fx.Int32(val).ir_value(), rsrc, fx.Int32(off).ir_value())
+
+        def _sel(cond_b, a, b):
+            return fx.Int32(arith.select(cond_b.ir_value(), fx.Int32(a).ir_value(), fx.Int32(b).ir_value()))
+
+        # work_indptr[0] = 0 ; reduce_indptr[0] = 0
+        _store(wi_rsrc, 0, 0)
+        _store(rip_rsrc, 0, 0)
+
+        # ---- Phase 1: sum_blocks = Sum_b ceil(context_lens[b] / kv_granularity) ----
+        # (causal + uniform + tiny qo  =>  effective_kv == context_lens[b])
+        # warp-parallel: each lane sums batches {lane, lane+ws, lane+2ws, ...},
+        # then a warp reduce-add gives the total in every lane (matches aiter).
+        wl1 = scf.WhileOp([i32, i32], [lane.ir_value(), c0.ir_value()])
+        cb1 = ir.Block.create_at_start(wl1.before, [i32, i32])
+        bb1 = ir.Block.create_at_start(wl1.after, [i32, i32])
+        with ir.InsertionPoint(cb1):
+            b = fx.Int32(cb1.arguments[0])
+            scf.ConditionOp((b < c_nb).ir_value(), list(cb1.arguments))
+        with ir.InsertionPoint(bb1):
+            b = fx.Int32(bb1.arguments[0])
+            s = fx.Int32(bb1.arguments[1])
+            nblk = _num_part(b)
+            scf.YieldOp([(b + c_ws).ir_value(), (s + nblk).ir_value()])
+        sum_blocks = fx.Int32(wl1.results[1])
+        for sh in _shuffle_offsets:
+            sum_blocks = sum_blocks + sum_blocks.shuffle_xor(arith.constant(sh, type=i32), c_ws.ir_value())
+
+        average = fx.Int32(arith.divui(sum_blocks.ir_value(), c_nspk.ir_value()))
+        reminder = fx.Int32(arith.remui(sum_blocks.ir_value(), c_nspk.ir_value()))
+
+        def _remain_for_cid(cid_val):
+            # remain = average + (1 if (cid % num_splits_per_khead) < reminder else 0)
+            mod = fx.Int32(arith.remui(cid_val.ir_value(), c_nspk.ir_value()))
+            return average + _sel(mod < reminder, 1, 0)
+
+        # ---- Phase 2: per khead, flattened CU x batch scheduler ----
+        # cid and num_works persist across kheads; the rest reset per khead.
+        cid = c0
+        num_works = c0
+
+        for khead in range_constexpr(num_heads_k):
+            qh_start = khead * gqa
+            qh_end = (khead + 1) * gqa
+            qhr_const = (qh_end << 16) | (qh_start & 0xFFFF)  # python int constant
+
+            kvend0 = _num_part(c0)  # partitions in batch 0 (cumulative kv end)
+            remain0 = _remain_for_cid(cid)
+
+            # State vector (11 i32):
+            #  0 cid, 1 batch, 2 kvblk, 3 nsplit, 4 num_works,
+            #  5 pidx, 6 kvbeg, 7 kvend, 8 remain,
+            #  9 last_reduce_indptr (lri), 10 global_reduce_tile_idx (grt)
+            # cid + num_works persist across kheads; lri + grt reset per khead
+            # (matches the original, which overwrites reduce_* per khead).
+            init = [
+                cid.ir_value(), c0.ir_value(), c0.ir_value(), c0.ir_value(),
+                num_works.ir_value(), c0.ir_value(), c0.ir_value(), kvend0.ir_value(),
+                remain0.ir_value(), c0.ir_value(), c0.ir_value(),
+            ]
+            wl = scf.WhileOp([i32] * 11, init)
+            cbk = ir.Block.create_at_start(wl.before, [i32] * 11)
+            bbk = ir.Block.create_at_start(wl.after, [i32] * 11)
+
+            with ir.InsertionPoint(cbk):
+                s_cid = fx.Int32(cbk.arguments[0])
+                s_batch = fx.Int32(cbk.arguments[1])
+                cond = (s_cid < c_numcu) & (s_batch < c_nb)
+                scf.ConditionOp(cond.ir_value(), list(cbk.arguments))
+
+            with ir.InsertionPoint(bbk):
+                a = bbk.arguments
+                cid_ = fx.Int32(a[0])
+                batch_ = fx.Int32(a[1])
+                kvblk_ = fx.Int32(a[2])
+                nsplit_ = fx.Int32(a[3])
+                nworks_ = fx.Int32(a[4])
+                pidx_ = fx.Int32(a[5])
+                kvbeg_ = fx.Int32(a[6])
+                kvend_ = fx.Int32(a[7])
+                remain_ = fx.Int32(a[8])
+                lri_ = fx.Int32(a[9])
+                grt_ = fx.Int32(a[10])
+
+                pages = kvend_ - kvbeg_
+                remain_kv = pages - kvblk_
+                do_finish = remain_ >= remain_kv  # fx bool
+
+                # qo_start/qo_end from seqlens_qo_indptr (the QoState array path,
+                # matching C++). batch_ < num_batches in the loop, so batch_+1 <=
+                # num_batches indexes the valid last element (no OOB). For uniform
+                # qo (sq = arange*query_length) this equals query_length*batch.
+                qo_start = _load(sq_rsrc, batch_)
+                qo_end = _load(sq_rsrc, batch_ + c1)
+                kv_start = kvbeg_ + kvblk_  # same for both branches
+
+                # ---- finish branch (CU completes this batch) ----
+                f_kv_end = kvend_  # min(kv_start + remain_kv, kvend_) == kvend_
+                nsplit_pos = nsplit_ > c0
+                f_ploc = _sel(nsplit_pos, pidx_, -1)
+                f_pidx2 = _sel(nsplit_pos, pidx_ + c_qlen, pidx_)
+                f_nworks2 = nworks_ + c1
+                f_remain2 = remain_ - remain_kv
+                f_batch2 = batch_ + c1
+                # next batch kv window (in partition units). max_size buffer rsrc
+                # disables HW bounds checking, so clamp the index before loading
+                # context_lens (f_batch2 can equal num_batches → OOB on last batch;
+                # the result is unused after the loop exits anyway).
+                nb_in_range = f_batch2 < c_nb
+                safe_idx = _sel(nb_in_range, f_batch2, 0)
+                f_new_pages = _sel(nb_in_range, _num_part(safe_idx), 0)
+                f_kvbeg2 = kvend_
+                f_kvend2 = kvend_ + f_new_pages
+
+                # ---- split branch (CU does a partial; close cid) ----
+                s_emit = remain_ > c0
+                s_kv_end_raw = kv_start + remain_
+                s_kv_end = _sel(s_kv_end_raw < kvend_, s_kv_end_raw, kvend_)
+                s_nworks2 = _sel(s_emit, nworks_ + c1, nworks_)
+                s_pidx2 = _sel(s_emit, pidx_ + c_qlen, pidx_)
+                s_kvblk2 = _sel(s_emit, kvblk_ + remain_, kvblk_)
+                s_nsplit2 = _sel(s_emit, nsplit_ + c1, nsplit_)
+                s_cid2 = cid_ + c1
+                s_remain2 = _remain_for_cid(s_cid2)
+
+                # ---- emit work entry at slot nworks_ ----
+                # Overwrite-safe: if this step does not emit, nworks_ is unchanged
+                # so the slot is reused by the next emit (or lies beyond valid_work).
+                w_ploc = _sel(do_finish, f_ploc, pidx_)
+                w_kv_end = _sel(do_finish, f_kv_end, s_kv_end)
+                base = nworks_ * fx.Int32(_WORK_INFO_FIELDS)
+                _store(winfo_rsrc, base + fx.Int32(0), batch_)
+                _store(winfo_rsrc, base + fx.Int32(1), w_ploc)
+                _store(winfo_rsrc, base + fx.Int32(2), qo_start)
+                _store(winfo_rsrc, base + fx.Int32(3), qo_end)
+                _store(winfo_rsrc, base + fx.Int32(4), kv_start)
+                _store(winfo_rsrc, base + fx.Int32(5), w_kv_end)
+                _store(winfo_rsrc, base + fx.Int32(6), c0)
+                _store(winfo_rsrc, base + fx.Int32(7), fx.Int32(qhr_const))
+
+                # ---- reduce maps: only when finishing a SPLIT batch (nsplit>0) ----
+                # This batch was split across (nsplit_+1) CUs and this CU finishes
+                # it, forming one reduce group. Faithful to the C++ kernel
+                # (kQoSplits=False path).
+                do_reduce = do_finish & nsplit_pos
+                num_splits = nsplit_ + c1
+                # reduce_indptr[grt+1] = lri + num_splits ; reduce_final_map[grt] =
+                # (qo_start, qo_end). Unconditional + overwrite-safe (same argument
+                # as work_indptr: grt only advances on do_reduce, so non-do_reduce
+                # writes to grt+1 are overwritten by the next do_reduce or the tail;
+                # reduce_final_map[grt*2..] beyond the final grt is never read).
+                _store(rip_rsrc, grt_ + c1, lri_ + num_splits)
+                _store(rfm_rsrc, grt_ * fx.Int32(2), qo_start)
+                _store(rfm_rsrc, grt_ * fx.Int32(2) + c1, qo_end)
+                # reduce_partial_map[lri + s] = pidx - (nsplit - s)*qlen, s in [0,num_splits)
+                # nested loop runs num_splits times when do_reduce, else 0 times.
+                rcount = _sel(do_reduce, num_splits, 0)
+                wlr = scf.WhileOp([i32], [c0.ir_value()])
+                cbr = ir.Block.create_at_start(wlr.before, [i32])
+                bbr = ir.Block.create_at_start(wlr.after, [i32])
+                with ir.InsertionPoint(cbr):
+                    sidx = fx.Int32(cbr.arguments[0])
+                    scf.ConditionOp((sidx < rcount).ir_value(), list(cbr.arguments))
+                with ir.InsertionPoint(bbr):
+                    sidx = fx.Int32(bbr.arguments[0])
+                    val = pidx_ - (nsplit_ - sidx) * c_qlen
+                    _store(rpm_rsrc, lri_ + sidx, val)
+                    scf.YieldOp([(sidx + c1).ir_value()])
+                n_lri = lri_ + _sel(do_reduce, num_splits, 0)
+                n_grt = grt_ + _sel(do_reduce, 1, 0)
+
+                # ---- new state via select(do_finish, finish, split) ----
+                n_cid = _sel(do_finish, cid_, s_cid2)
+                n_batch = _sel(do_finish, f_batch2, batch_)
+                n_kvblk = _sel(do_finish, 0, s_kvblk2)
+                n_nsplit = _sel(do_finish, 0, s_nsplit2)
+                n_nworks = _sel(do_finish, f_nworks2, s_nworks2)
+                n_pidx = _sel(do_finish, f_pidx2, s_pidx2)
+                n_kvbeg = _sel(do_finish, f_kvbeg2, kvbeg_)
+                n_kvend = _sel(do_finish, f_kvend2, kvend_)
+                n_remain = _sel(do_finish, f_remain2, s_remain2)
+
+                # ---- work_indptr[cid_+1] = n_nworks (unconditional, overwrite-safe) ----
+                # In the finish branch cid_ does not advance, so repeated writes to
+                # work_indptr[cid_+1] keep updating until the cid closes; the last
+                # write (before cid advances in the split branch, or loop exit) holds
+                # the correct running num_works for that cid. cid_+1 <= num_cu (loop
+                # guard cid_ < num_cu) so the index is always in-bounds.
+                _store(wi_rsrc, cid_ + c1, n_nworks)
+
+                scf.YieldOp([
+                    n_cid.ir_value(), n_batch.ir_value(), n_kvblk.ir_value(), n_nsplit.ir_value(),
+                    n_nworks.ir_value(), n_pidx.ir_value(), n_kvbeg.ir_value(), n_kvend.ir_value(),
+                    n_remain.ir_value(), n_lri.ir_value(), n_grt.ir_value(),
+                ])
+
+            cid = fx.Int32(wl.results[0])
+            num_works = fx.Int32(wl.results[4])
+            last_reduce_indptr = fx.Int32(wl.results[9])
+            global_reduce_tile_idx = fx.Int32(wl.results[10])
+
+            # ---- post-khead close: advance cid past the last processed cid so
+            # the next khead (and the tail) start fresh. The loop already wrote
+            # work_indptr[last_cid+1]=num_works on its final iteration, so no
+            # store is needed here — only the cid advance.
+            in_range = cid < c_numcu
+            cid = _sel(in_range, cid + c1, cid)
+
+        # ---- tail: work_indptr[i] = num_works for i in [cid, num_cu] ----
+        wlt = scf.WhileOp([i32], [cid.ir_value()])
+        cbt = ir.Block.create_at_start(wlt.before, [i32])
+        bbt = ir.Block.create_at_start(wlt.after, [i32])
+        with ir.InsertionPoint(cbt):
+            it = fx.Int32(cbt.arguments[0])
+            scf.ConditionOp((it <= c_numcu).ir_value(), list(cbt.arguments))
+        with ir.InsertionPoint(bbt):
+            it = fx.Int32(bbt.arguments[0])
+            _store(wi_rsrc, it, num_works)
+            scf.YieldOp([(it + c1).ir_value()])
+
+        # ---- tail: reduce_indptr[i] = last_reduce_indptr for i in [grt, num_batches] ----
+        # (reduce_indptr has num_batches+1 entries; uses the final khead's grt/lri,
+        # matching the original which resets grt per khead and fills the tail once.)
+        c_rip_size = c_nb + c1  # reduce_indptr length = num_batches + 1
+        wlr2 = scf.WhileOp([i32], [global_reduce_tile_idx.ir_value()])
+        cbr2 = ir.Block.create_at_start(wlr2.before, [i32])
+        bbr2 = ir.Block.create_at_start(wlr2.after, [i32])
+        with ir.InsertionPoint(cbr2):
+            it = fx.Int32(cbr2.arguments[0])
+            scf.ConditionOp((it < c_rip_size).ir_value(), list(cbr2.arguments))
+        with ir.InsertionPoint(bbr2):
+            it = fx.Int32(bbr2.arguments[0])
+            _store(rip_rsrc, it, last_reduce_indptr)
+            scf.YieldOp([(it + c1).ir_value()])
+
+    @flyc.jit
+    def launch_pa_metadata_v1(
+        seqlens_qo_indptr: fx.Tensor,
+        pages_kv_indptr: fx.Tensor,
+        context_lens: fx.Tensor,
+        work_indptr: fx.Tensor,
+        work_info: fx.Tensor,
+        reduce_indptr: fx.Tensor,
+        reduce_final_map: fx.Tensor,
+        reduce_partial_map: fx.Tensor,
+        num_batches: Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        pa_metadata_v1_kernel(
+            seqlens_qo_indptr,
+            pages_kv_indptr,
+            context_lens,
+            work_indptr,
+            work_info,
+            reduce_indptr,
+            reduce_final_map,
+            reduce_partial_map,
+            num_batches,
+        ).launch(grid=(1, 1, 1), block=(warp_size, 1, 1), stream=stream)
+
+    return {"kernel": pa_metadata_v1_kernel, "launch": launch_pa_metadata_v1}
+
+
+def get_pa_metadata_v1(
+    seqlens_qo_indptr: torch.Tensor,
+    pages_kv_indptr: torch.Tensor,
+    context_lens: torch.Tensor,
+    num_heads_per_head_k: int,
+    num_heads_k: int,
+    is_causal: bool,
+    work_metadata_ptrs: torch.Tensor,
+    work_indptr: torch.Tensor,
+    work_info: torch.Tensor,
+    reduce_indptr: torch.Tensor,
+    reduce_final_map: torch.Tensor,
+    reduce_partial_map: torch.Tensor,
+    kv_granularity: int = 16,
+    block_size: int = 16,
+    max_seqlen_qo: int = -1,
+    uni_seqlen_qo: int = -1,
+    fast_mode: bool = True,
+    topk: int = -1,
+    max_split_per_batch: int = -1,
+    num_cu: int = None,
+) -> None:
+    """Drop-in replacement for ``aiter.ops.attention.get_pa_metadata_v1``.
+
+    PA-decode-specialized: requires causal, non-sparse, uniform qo. Fills
+    ``work_indptr`` and ``work_info`` in-place; ``reduce_*`` are left untouched
+    (the caller recomputes them from work_indptr/work_info).
+
+    ``num_cu`` overrides the worklist bin count (default = device CU count);
+    pass a multiple of the CU count to oversubscribe the persistent grid.
+    """
+    assert is_causal, "FlyDSL pa_metadata only supports causal"
+    assert topk == -1, "FlyDSL pa_metadata does not support sparse (topk)"
+    assert uni_seqlen_qo >= 1, "FlyDSL pa_metadata requires uniform qo length"
+
+    dev = pages_kv_indptr.device
+    if num_cu is None:
+        num_cu = torch.cuda.get_device_properties(dev).multi_processor_count
+    num_batches = context_lens.shape[0]
+    query_length = uni_seqlen_qo
+    warp_size = get_warp_size(get_rocm_arch())
+
+    compiled = compile_pa_metadata_v1(
+        num_cu=num_cu,
+        num_heads_k=num_heads_k,
+        gqa=num_heads_per_head_k,
+        kv_granularity=kv_granularity,
+        query_length=query_length,
+        warp_size=warp_size,
+    )
+
+    # work_metadata_ptrs[0/1] = device addresses of work_indptr / work_info,
+    # matching the C++ kernel (which writes them in-kernel via reinterpret_cast).
+    # These are exactly the tensors' data_ptr() values, so writing them host-side
+    # produces identical bytes.
+    if work_metadata_ptrs is not None and work_metadata_ptrs.numel() >= 2:
+        work_metadata_ptrs[0] = work_indptr.data_ptr()
+        work_metadata_ptrs[1] = work_info.data_ptr()
+
+    # work_info [max_work, 8] and reduce_final_map [num_batches, 2] are written
+    # flattened by the kernel.
+    work_info_flat = work_info.view(-1)
+    reduce_final_map_flat = reduce_final_map.view(-1)
+
+    compiled["launch"](
+        seqlens_qo_indptr,
+        pages_kv_indptr,
+        context_lens,
+        work_indptr,
+        work_info_flat,
+        reduce_indptr,
+        reduce_final_map_flat,
+        reduce_partial_map,
+        num_batches,
+    )

--- a/kernels/pa_metadata.py
+++ b/kernels/pa_metadata.py
@@ -223,9 +223,17 @@ def compile_pa_metadata_v1(
             # cid + num_works persist across kheads; lri + grt reset per khead
             # (matches the original, which overwrites reduce_* per khead).
             init = [
-                cid.ir_value(), c0.ir_value(), c0.ir_value(), c0.ir_value(),
-                num_works.ir_value(), c0.ir_value(), c0.ir_value(), kvend0.ir_value(),
-                remain0.ir_value(), c0.ir_value(), c0.ir_value(),
+                cid.ir_value(),
+                c0.ir_value(),
+                c0.ir_value(),
+                c0.ir_value(),
+                num_works.ir_value(),
+                c0.ir_value(),
+                c0.ir_value(),
+                kvend0.ir_value(),
+                remain0.ir_value(),
+                c0.ir_value(),
+                c0.ir_value(),
             ]
             wl = scf.WhileOp([i32] * 11, init)
             cbk = ir.Block.create_at_start(wl.before, [i32] * 11)
@@ -357,11 +365,21 @@ def compile_pa_metadata_v1(
                 # guard cid_ < num_cu) so the index is always in-bounds.
                 _store(wi_rsrc, cid_ + c1, n_nworks)
 
-                scf.YieldOp([
-                    n_cid.ir_value(), n_batch.ir_value(), n_kvblk.ir_value(), n_nsplit.ir_value(),
-                    n_nworks.ir_value(), n_pidx.ir_value(), n_kvbeg.ir_value(), n_kvend.ir_value(),
-                    n_remain.ir_value(), n_lri.ir_value(), n_grt.ir_value(),
-                ])
+                scf.YieldOp(
+                    [
+                        n_cid.ir_value(),
+                        n_batch.ir_value(),
+                        n_kvblk.ir_value(),
+                        n_nsplit.ir_value(),
+                        n_nworks.ir_value(),
+                        n_pidx.ir_value(),
+                        n_kvbeg.ir_value(),
+                        n_kvend.ir_value(),
+                        n_remain.ir_value(),
+                        n_lri.ir_value(),
+                        n_grt.ir_value(),
+                    ]
+                )
 
             cid = fx.Int32(wl.results[0])
             num_works = fx.Int32(wl.results[4])

--- a/kernels/pa_metadata.py
+++ b/kernels/pa_metadata.py
@@ -45,7 +45,6 @@ from flydsl._mlir.dialects import scf
 from flydsl.expr import arith, buffer_ops, gpu, range_constexpr
 from flydsl.expr.typing import Int32, T
 from flydsl.runtime.device import get_rocm_arch
-
 from kernels.kernels_common import get_warp_size
 
 _WORK_INFO_FIELDS = 8

--- a/tests/kernels/test_pa.py
+++ b/tests/kernels/test_pa.py
@@ -43,7 +43,7 @@ try:
         get_pa_metadata as flydsl_get_pa_metadata,
     )
     from kernels.pa_decode_fp8 import (
-        get_sw_ps_max_context_partition_num,
+        get_recommended_splits,
     )
     from kernels.pa_decode_fp8 import (
         pa_decode_ps_launch as flydsl_ps_launch,
@@ -487,7 +487,7 @@ def get_gluon_partition_count(
     query_length: int = 1,
 ) -> int:
     if sliding_window > 0:
-        return get_sw_ps_max_context_partition_num(
+        return get_recommended_splits(
             sliding_window,
             context_partition_size,
             query_length,
@@ -659,10 +659,6 @@ def run_pa_decode_ps_test(
         raise RuntimeError("FlyDSL `pa_decode_ps_launch` is not available.")
     if compute_type != aiter.dtypes.fp8:
         raise ValueError("This PS-only harness only keeps fp8 cases.")
-    if block_size != 1024:
-        raise ValueError("This PS-only harness only keeps block_size=1024 cases.")
-    if head_size != 128:
-        raise ValueError("This PS-only harness only keeps head_size=128 cases.")
     results: Dict[str, Union[float, int, str, bool, Tuple[int, int]]] = {
         "compute_type": dtype_to_name(compute_type),
         "quant_mode": quant_mode,
@@ -853,7 +849,7 @@ def run_pa_decode_ps_test(
     ps_value_scale: torch.Tensor = value_scale_original
     flydsl_ps_output = torch.empty_like(reference_output)
 
-    max_context_partition_num = get_sw_ps_max_context_partition_num(
+    max_context_partition_num = get_recommended_splits(
         sliding_window,
         context_partition_size,
         query_length,
@@ -1232,8 +1228,8 @@ def sliding_window_accuracy_test() -> None:
     BATCH_SIZE_OPTIONS = [128]
     TRANS_V_OPTIONS = [True]
     KV_VARLEN_OPTIONS = [True]
-    BLOCK_SIZE_OPTIONS = [1024]
-    SLIDING_WINDOW_OPTIONS = [0, 128, 1023]
+    BLOCK_SIZE_OPTIONS = [16, 1024]
+    SLIDING_WINDOW_OPTIONS = [0]
     parse_arg_and_run_test(output_tag="ps_sliding_window_accuracy")
 
 


### PR DESCRIPTION
Port the FlyDSL-native PA worklist/reduce-map scheduler (kernels/pa_metadata.py) and its matching persistent FP8 decode kernel from the pa_update_metadata line onto latest main. This replaces the runtime dependency on aiter's get_pa_metadata_v1 / get_pa_metadata_info_v1 (cloned unpinned from aiter HEAD in CI), which drifted and produced uninitialized garbage output in the PS decode path. pa_reduce_v1 is still sourced from aiter.

Files:
- kernels/pa_metadata.py: new, FlyDSL impl of get_pa_metadata_v1/_info_v1
- kernels/pa_decode_fp8.py: native 256-token partition layout (partition_indptr, num_cu oversubscription); no _expand_pa_metadata_for_block_splits
- kernels/pa_decode_swa.py: matching sliding-window decode/reduce
- tests/kernels/test_pa.py: align harness with new launch signatures

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
