### PR TITLE
Bump FlyDSL version to 0.2.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.join(_project_root, "python"))
 project = "FlyDSL"
 copyright = "2024-2026, Advanced Micro Devices, Inc."
 author = "AMD"
-release = "0.1.8"
+release = "0.2.0"
 
 # -- General configuration ---------------------------------------------------
 extensions = [

--- a/python/flydsl/__init__.py
+++ b/python/flydsl/__init__.py
@@ -2,6 +2,6 @@
 # Copyright (c) 2025 FlyDSL Project Contributors
 # ruff: noqa: I001
 
-__version__ = "0.1.9"
+__version__ = "0.2.0"
 
 from .autotune import Config as Config, autotune as autotune  # noqa: E402


### PR DESCRIPTION
## Summary
- Update the FlyDSL package base version to 0.2.0.
- Sync the Sphinx documentation release version to 0.2.0.

## Test plan
- `PYTHONPATH=/data/felix/FlyDSL-bump-0.2.0/python python3 -c "import flydsl; print(flydsl.__version__)"`
- Cursor linter diagnostics for `python/flydsl/__init__.py` and `docs/conf.py`


Made with [Cursor](https://cursor.com)