### PR TITLE
[Bugfix] rmsnorm: annotate known_block_size on large-M small-N path

### DIFF
--- a/kernels/rmsnorm_kernel.py
+++ b/kernels/rmsnorm_kernel.py
@@ -304,7 +304,7 @@ def _build_rmsnorm_large_m_small_n_module(M: int, N: int, dtype_str: str):
     BLOCK_THREADS_SPECIAL = BLOCK_M * THREADS_PER_ROW
     elem_bits = 32 if dtype_str == "f32" else 16
 
-    @flyc.kernel
+    @flyc.kernel(known_block_size=[BLOCK_THREADS_SPECIAL, 1, 1])
     def rmsnorm_large_m_small_n_kernel(
         Input: fx.Tensor,
         Gamma: fx.Tensor,


### PR DESCRIPTION
Fixes #614.

## Problem

The large-M small-N rmsnorm path (`M > 8192 and N <= 2048`) launches blocks of `BLOCK_M * THREADS_PER_ROW` = **1024** threads (`N<=512`) or **512** threads (`N=1536`), but the kernel is decorated with a bare `@flyc.kernel`. Without `known_block_size`, the AMDGPU backend keeps its default max flat workgroup size of 256, so the launch aborts:

```
ValueError: launch block size 1024x1x1 = 1024 threads exceeds the AMDGPU
default max_flat_workgroup_size of 256.
```

This crashes rmsnorm on real shapes — DeepSeek-R1 (`N=512`, `N=1536`) and Qwen3 per-head q/k-norm (`N=128`) at large prefill token counts.

## Fix

Add `known_block_size=[BLOCK_THREADS_SPECIAL, 1, 1]` to the kernel decorator — the same idiom every other >256-thread kernel in `kernels/` uses (`fp8_gemm_8wave`, `flash_attn_func`, `hgemm_splitk`, `custom_all_reduce_kernel`, ...). One line; preserves the path's intended block size.

```diff
-    @flyc.kernel
+    @flyc.kernel(known_block_size=[BLOCK_THREADS_SPECIAL, 1, 1])
     def rmsnorm_large_m_small_n_kernel(
```

## Verification (MI350X / gfx950, ROCm 7.2, `FLYDSL_RUNTIME_ENABLE_CACHE=0`)

| M | N | path | result | max\|err\| vs fp32 ref (bf16) |
|---|---|---|---|---|
| 16384 | 128 | special | compiles + runs | 0.0147 |
| 16384 | 512 | special | compiles + runs | 0.0149 |
| 16384 | 1536 | special | compiles + runs | 0.0155 |
| 32768 | 128 | special | compiles + runs | 0.0139 |
| 16384 | 2048 | special | compiles + runs | 0.0156 |
| 16384 | 4096 | fast (control) | unchanged | 0.0156 |
| 32768 | 8192 | fast (control) | unchanged | 0.0156 |

All previously-crashing shapes now run and match the fp32 reference within bf16 tolerance; fast-vectorized and generic paths are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)