### PR TITLE
Keep failing checkouts off git-cache rewrites

### DIFF
--- a/.github/workflows/flydsl-atom-integration.yaml
+++ b/.github/workflows/flydsl-atom-integration.yaml
@@ -55,10 +55,17 @@ jobs:
 
     env:
       CONTAINER_NAME: flydsl_atom_${{ strategy.job-index }}
+      # Keep checkout independent of runner-local git-cache rewrites.
+      GIT_CONFIG_GLOBAL: /dev/null
+      GIT_CONFIG_NOSYSTEM: "1"
 
     steps:
       - name: Checkout FlyDSL utility scripts
         uses: actions/checkout@v4
+        env:
+          # Keep checkout independent of runner-local git-cache rewrites.
+          GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
+          GIT_CONFIG_NOSYSTEM: "1"
         with:
           sparse-checkout: |
             scripts/install_awscli.sh
@@ -66,6 +73,10 @@ jobs:
 
       - name: Checkout upstream ATOM repo
         uses: actions/checkout@v4
+        env:
+          # Keep checkout independent of runner-local git-cache rewrites.
+          GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
+          GIT_CONFIG_NOSYSTEM: "1"
         with:
           repository: ${{ env.ATOM_REPOSITORY }}
           ref: ${{ env.ATOM_REF }}

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -10,6 +10,11 @@ on:
 
 jobs:
   test:
+    env:
+      # Some self-hosted runners configure a GitHub -> git-cache URL rewrite.
+      # If that cache is unavailable, checkout fails before the tests start.
+      GIT_CONFIG_GLOBAL: /dev/null
+      GIT_CONFIG_NOSYSTEM: "1"
     strategy:
       matrix:
         runners: ['linux-flydsl-mi325-1', 'linux-flydsl-mi355-1']
@@ -20,6 +25,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        env:
+          # Keep checkout independent of runner-local git-cache rewrites.
+          GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
+          GIT_CONFIG_NOSYSTEM: "1"
         with:
           path: flydsl
 


### PR DESCRIPTION
## Summary
- Isolate the Test Wheels checkout from runner-local GitHub-to-git-cache URL rewrites; this is the path that failed in the PyPI publish run.
- Apply the same protection to the ATOM nightly checkout, which is also currently failing at checkout with the same git-cache connection error.
- Leave wheel build and unrelated integration workflows unchanged.

## Test plan
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- Cursor linter diagnostics for `test-whl.yaml` and `flydsl-atom-integration.yaml`