### PR TITLE
[Bugfix] Drop arch env vars from the JIT cache key (fix AOT cache misses)

### DIFF
--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -114,17 +114,6 @@ _NOT_IN_BASELINE = object()
 # Environment variables that influence code generation *independently of the
 # resolved GPUTarget*. Their current values enter the hot cache key so
 # cross-process / cross-config artifacts don't collide.
-#
-# Arch selectors (ARCH / FLYDSL_GPU_ARCH / HSA_OVERRIDE_GFX_VERSION) are
-# deliberately NOT listed here. Their only effect is to pick the target arch,
-# which is already folded into the key via ("_target_", GPUTarget). Listing them
-# would (a) double-count arch and (b) make the key depend on *how* arch was
-# supplied -- env-injected during CPU/AOT pre-compilation vs device-detected at
-# GPU runtime. detect_target() normalizes both paths to the same GPUTarget, so a
-# cache built on a (GPU-less) build host with ARCH=gfx950 would otherwise never
-# be hit at runtime, where those env vars are unset and arch comes from the
-# device. Dropping the raw env vars loses no key precision: any arch change still
-# changes ("_target_", ...).
 _CACHE_INVALIDATING_ENV_VARS = (
     "FLYDSL_COMPILE_OPT_LEVEL",
     "FLYDSL_COMPILE_BACKEND",

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -111,15 +111,24 @@ def _create_mlir_context(*, load_dialects=True):
 _NOT_IN_BASELINE = object()
 
 
-# Environment variables that influence code generation. Their current values
-# enter the hot cache key so cross-process / cross-config artifacts don't collide.
+# Environment variables that influence code generation *independently of the
+# resolved GPUTarget*. Their current values enter the hot cache key so
+# cross-process / cross-config artifacts don't collide.
+#
+# Arch selectors (ARCH / FLYDSL_GPU_ARCH / HSA_OVERRIDE_GFX_VERSION) are
+# deliberately NOT listed here. Their only effect is to pick the target arch,
+# which is already folded into the key via ("_target_", GPUTarget). Listing them
+# would (a) double-count arch and (b) make the key depend on *how* arch was
+# supplied -- env-injected during CPU/AOT pre-compilation vs device-detected at
+# GPU runtime. detect_target() normalizes both paths to the same GPUTarget, so a
+# cache built on a (GPU-less) build host with ARCH=gfx950 would otherwise never
+# be hit at runtime, where those env vars are unset and arch comes from the
+# device. Dropping the raw env vars loses no key precision: any arch change still
+# changes ("_target_", ...).
 _CACHE_INVALIDATING_ENV_VARS = (
     "FLYDSL_COMPILE_OPT_LEVEL",
     "FLYDSL_COMPILE_BACKEND",
     "FLYDSL_COMPILE_LLVM_DIR",
-    "ARCH",
-    "FLYDSL_GPU_ARCH",
-    "HSA_OVERRIDE_GFX_VERSION",
     "FLYDSL_DEBUG_ENABLE_DEBUG_INFO",
     "FLYDSL_EXTRA_SOURCE_DIRS",
 )


### PR DESCRIPTION
## Motivation

After #597 hardened the JIT cache key to fold whitelisted code-gen env vars into the key, **AOT-precompiled-then-shipped caches stopped being hit at runtime**. This surfaces downstream in aiter as `RuntimeError: AOT cache miss` for FlyDSL MoE kernels under its strict `check_aot_cache=True` tests (the cache dir is present with the right `manager_key`, but the inner key never matches).

## Root cause

`_cache_invalidating_env_values()` folds these arch selectors into the key: `ARCH`, `FLYDSL_GPU_ARCH`, `HSA_OVERRIDE_GFX_VERSION`. Their **only** effect is to pick the target arch — which is already in the key via `("_target_", GPUTarget)`.

The arch can be supplied two ways, and `detect_target()` normalizes both to the *same* `GPUTarget`:
- **AOT pre-compilation** runs on a GPU-less build host and injects `ARCH=gfx950` / `FLYDSL_GPU_ARCH=gfx950` via env.
- **Runtime** has those env vars unset; arch comes from device detection.

So the resolved `("_target_", GPUTarget(arch="gfx950", ...))` is identical in both, but the raw `("_env_", (... "ARCH"="gfx950"/"" ...))` segment **diverges** (`"gfx950"` at build vs `""` at runtime) → cache key mismatch → guaranteed miss for any shipped AOT cache.

## Fix

Drop the three arch selectors from `_CACHE_INVALIDATING_ENV_VARS`. No key precision is lost — any arch change still changes `("_target_", ...)`. Genuine code-gen knobs (`FLYDSL_COMPILE_OPT_LEVEL`, `FLYDSL_COMPILE_BACKEND`, `FLYDSL_COMPILE_LLVM_DIR`, `FLYDSL_DEBUG_ENABLE_DEBUG_INFO`, `FLYDSL_EXTRA_SOURCE_DIRS`) stay in the key.

## Tests

Existing cache-key tests are unaffected:
- `test_compile_hints.py::test_different_arch_gives_different_key` asserts the change flows through `("_target_", ...)` (it resets `_sig` and checks `t1.arch != t2.arch`) — still holds, since ARCH still feeds `detect_target()`.
- `test_jit_cache_key_completeness.py` env-drift tests use `FLYDSL_COMPILE_OPT_LEVEL` (retained).

## Follow-up note

`FLYDSL_COMPILE_LLVM_DIR` / `FLYDSL_EXTRA_SOURCE_DIRS` are path-like and could similarly diverge build-vs-runtime for shipped AOT caches; they're kept here because their *contents* can affect codegen. A more robust long-term approach would key on their *effect* (e.g. resolved LLVM version / source content hash) rather than the raw path string. Out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)