### PR TITLE
[Docs] Point the README quick-check at the GEMM correctness test

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ pip install pytest pandas
 pip install torch --index-url https://download.pytorch.org/whl/rocm7.2
 
 # Run GEMM correctness tests (fast, ~15s)
-bash scripts/run_tests.sh
+python -m pytest tests/kernels/test_preshuffle_gemm.py -m "not large_shape"
 
 # Run performance benchmarks
 bash scripts/run_benchmark.sh


### PR DESCRIPTION
## Summary

The README "Run tests" section labels `bash scripts/run_tests.sh` as a quick post-install check:

```bash
# Run GEMM correctness tests (fast, ~15s)
bash scripts/run_tests.sh
```

But `run_tests.sh` runs the **entire** test suite, which takes many minutes — the "~15s GEMM correctness" label is inaccurate and misleads contributors validating a fresh build. This PR points the line at the actual GEMM correctness test, which runs the real GPU path in ~10s and matches the original intent of the comment.

Closes #646

## Findings

- **`run_tests.sh` runs the full suite**, in three phases: `pytest` over `tests/kernels|unit|system|python/examples` (**3118 tests** selected with the default `-m "not large_shape"`), then all standalone `examples/`
  scripts, then every `tests/mlir/**/*.mlir` FileCheck test.
- **Timings rule out ~15s for the full suite:** a full run did not complete within a 300s cap; `tests/kernels/test_allreduce.py` alone (8-GPU accuracy tests, `@pytest.mark.multi_gpu`) did not finish 6 parametrizations in 150s on an 8-GPU host. Those multi-GPU tests auto-skip on <4 GPUs but run (and dominate) on larger hosts.
- **The label is stale, but ~15s was once right for GEMM:** `git blame` traces the comment to the v0.1 PR (#164), when the suite was small. The targeted GEMM correctness test still runs in ~10s today, so keeping the comment and swapping the command restores its accuracy.

## Change (one line)

Replace `bash scripts/run_tests.sh` with the GEMM correctness test:

```bash
# Run GEMM correctness tests (fast, ~15s)
python -m pytest tests/kernels/test_preshuffle_gemm.py -m "not large_shape"
```

## Verification

```
$ python -m pytest tests/kernels/test_preshuffle_gemm.py -m "not large_shape" 43 passed, 4 skipped, 76 deselected in 9.19s
```
