### PR TITLE
[Docs] Onboarding notebooks (2/n): layout algebra

### DIFF
--- a/examples/notebooks/01_numeric_types.ipynb
+++ b/examples/notebooks/01_numeric_types.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9f1ad4fb",
+   "id": "159d14e9",
    "metadata": {},
    "source": [
     "<!-- SPDX-License-Identifier: Apache-2.0 -->\n",
@@ -10,30 +10,30 @@
     "\n",
     "# Numeric types\n",
     "\n",
-    "Every scalar you compute with in a FlyDSL kernel has a **DSL numeric type**.\n",
-    "These types are thin Python wrappers over MLIR scalar types: `fx.Int32` is `i32`,\n",
-    "`fx.Float32` is `f32`, `fx.BFloat16` is `bf16`, and so on. They carry the type\n",
-    "information FlyDSL needs to emit the right `arith` / `math` ops and to check casts.\n",
+    "Every scalar you compute with in a FlyDSL kernel has a **DSL numeric type** —\n",
+    "`fx.Int32`, `fx.Float32`, `fx.BFloat16`, and so on. The type fixes a value's\n",
+    "precision and signedness, decides how arithmetic and casts behave, and tells the\n",
+    "compiler what to emit.\n",
     "\n",
-    "This notebook covers the type families, how to construct and operate on values,\n",
-    "casts and promotion, and the difference between **compile-time** (`Constexpr`) and\n",
-    "**runtime** values."
+    "This notebook is about *using* these types: the families to pick from, how to\n",
+    "construct and compute with values, casts and promotion, and the difference between\n",
+    "**compile-time** (`Constexpr`) and **runtime** values. How a DSL type maps onto an\n",
+    "MLIR type underneath is implementation — it lives in an optional section at the end\n",
+    "(§6), so skip it if you just want to write kernels."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "119e540e",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "42e5acbc",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import torch\n",
+    "from wurlitzer import pipes\n",
     "\n",
     "import flydsl.compiler as flyc\n",
     "import flydsl.expr as fx\n",
-    "from wurlitzer import pipes\n",
     "\n",
     "\n",
     "def show_gpu_output(launcher, *args, **kwargs):\n",
@@ -48,63 +48,74 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c59421b",
+   "id": "be457121",
    "metadata": {},
    "source": [
     "## 1. The type families\n",
     "\n",
-    "| Family | DSL types | MLIR |\n",
+    "| Family | DSL types | When you reach for it |\n",
     "|---|---|---|\n",
-    "| Signed int | `Int4`, `Int8`, `Int16`, `Int32`, `Int64` | `i4 … i64` |\n",
-    "| Unsigned int | `Uint8`, `Uint16`, `Uint32`, `Uint64` | `ui8 … ui64` |\n",
-    "| Float | `Float16`, `BFloat16`, `Float32`, `Float64` | `f16`, `bf16`, `f32`, `f64` |\n",
-    "| FP8 / FP6 / FP4 | `Float8E5M2`, `Float8E4M3FN`, …, `Float6E2M3FN`, `Float4E2M1FN` | OCP low-precision |\n",
-    "| Special | `Boolean` (`i1`), `Index` (loop/index type) | |\n",
+    "| Signed int | `Int4`, `Int8`, `Int16`, `Int32`, `Int64` | indices, counters, masks |\n",
+    "| Unsigned int | `Uint8`, `Uint16`, `Uint32`, `Uint64` | bit math, addresses, packed lanes |\n",
+    "| Float | `Float16`, `BFloat16`, `Float32`, `Float64` | math and accumulators; `Float32` is the default |\n",
+    "| FP8 / FP6 / FP4 | `Float8E5M2`, `Float8E4M3FN`, …, `Float6E2M3FN`, `Float4E2M1FN` | low-precision matmul / copy operands on CDNA |\n",
+    "| Special | `Boolean`, `Index` | predicates; loop and index arithmetic |\n",
     "\n",
-    "Each type exposes its bit `.width` (no GPU needed to read it):"
+    "Pick by precision and signedness, the same way you would choose a C or `torch`\n",
+    "dtype. (The exact MLIR type each one lowers to is in §6 — you don't need it yet.)\n",
+    "\n",
+    "Each type exposes its bit `.width`, and this is pure metadata, so it reads at the\n",
+    "notebook top level with no GPU and no kernel:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3c91613",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "f351ca05",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "for t in [fx.Int8, fx.Int32, fx.Uint32, fx.Float16, fx.BFloat16,\n",
-    "          fx.Float32, fx.Float8E4M3FN, fx.Float4E2M1FN, fx.Boolean, fx.Index]:\n",
+    "for t in [\n",
+    "    fx.Int8,\n",
+    "    fx.Int32,\n",
+    "    fx.Uint32,\n",
+    "    fx.Float16,\n",
+    "    fx.BFloat16,\n",
+    "    fx.Float32,\n",
+    "    fx.Float8E4M3FN,\n",
+    "    fx.Float4E2M1FN,\n",
+    "    fx.Boolean,\n",
+    "    fx.Index,\n",
+    "]:\n",
     "    print(f\"{t.__name__:<14} width = {t.width}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d98d8567",
-   "metadata": {},
+   "id": "bb95e35d",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "## 2. Constructing and computing\n",
     "\n",
     "A value is created by calling the type: `fx.Int32(7)`, `fx.Float32(3.5)`.\n",
     "\n",
-    "Arithmetic on these values **emits MLIR**, so it has to happen *inside a traced\n",
-    "kernel* (there is no MLIR context at the notebook top level). We surface the\n",
-    "results with `fx.printf`.\n",
+    "Constructing and operating on values only works *inside a traced kernel* — there is\n",
+    "no compiler context at the notebook top level, so this all happens under\n",
+    "`@flyc.kernel` / `@flyc.jit`. We surface the results with `fx.printf`.\n",
     "\n",
-    "Operators map to the obvious MLIR ops: `+ - * // / %` → `arith.add/sub/mul/...`,\n",
-    "bitwise `& | ^ ~ << >>`, and comparisons `< <= > >= == !=` (which return a\n",
-    "`Boolean`). Two display quirks in `printf`: avoid a literal `%` in the format\n",
-    "string (the device `printf` consumes it), and a true `Boolean` prints as `-1`\n",
-    "(all bits of the `i1` set)."
+    "The usual operators work: `+ - * // / %`, bitwise `& | ^ ~ << >>`, and comparisons\n",
+    "`< <= > >= == !=` (which return a `Boolean`). Two `printf` quirks: avoid a literal\n",
+    "`%` in the format string (the device `printf` consumes it), and a true `Boolean`\n",
+    "prints as `-1` (all bits set)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90630369",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "aa8ed025",
+   "metadata": {},
    "outputs": [],
    "source": [
     "@flyc.kernel\n",
@@ -126,8 +137,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ebf0dd18",
-   "metadata": {},
+   "id": "2aa7b702",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "## 3. Casts and type promotion\n",
     "\n",
@@ -140,16 +153,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2b9c61c",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "99af03c9",
+   "metadata": {},
    "outputs": [],
    "source": [
     "@flyc.kernel\n",
     "def cast_demo():\n",
     "    i = fx.Int32(7)\n",
-    "    f = i.to(fx.Float32)                # explicit int -> float\n",
+    "    f = i.to(fx.Float32)  # explicit int -> float\n",
     "    g = fx.Float32(2.0)\n",
     "    fx.printf(\"f/g={}  sqrt(f)={}  exp2(g)={}\", f / g, fx.math.sqrt(f), fx.math.exp2(g))\n",
     "\n",
@@ -168,8 +179,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1757ec2d",
-   "metadata": {},
+   "id": "a744edb9",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "## 4. Compile-time (`Constexpr`) vs runtime values\n",
     "\n",
@@ -182,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae48217b",
+   "id": "9368a7be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b30b757b",
+   "id": "5cd73d59",
    "metadata": {},
    "source": [
     "## 5. Low-precision types\n",
@@ -214,8 +227,68 @@
     "first-class DSL types — you declare buffers and accumulators with them just like\n",
     "`Float32`. Their narrow mantissas trade accuracy for speed and memory bandwidth.\n",
     "The payoff shows up where data is *moved* and *multiplied* in low precision — the\n",
-    "copy atoms (next notebook) and the MMA atoms (the later layout/MMA series) — rather\n",
-    "than in scalar arithmetic, so we only introduce the type names here.\n",
+    "copy atoms (next notebook) and the MMA atoms (the later layout / MMA series) —\n",
+    "rather than in scalar arithmetic, so we only introduce the type names here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "502ec463",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 6. Under the hood — DSL type → MLIR (optional)\n",
+    "\n",
+    "Skip this if you only want to write kernels. But FlyDSL is an MLIR compiler, and\n",
+    "each DSL type is a thin handle over an **MLIR scalar type**: it knows that type and\n",
+    "emits the right `arith` / `math` ops for it. When you read an IR dump (`00_hello_flydsl`)\n",
+    "or chase a type error, this is the map:\n",
+    "\n",
+    "| DSL family | MLIR type |\n",
+    "|---|---|\n",
+    "| Signed int | `i4 … i64` |\n",
+    "| Unsigned int | `i8 … i64` (same signless `iN` — see below) |\n",
+    "| Float | `f16`, `bf16`, `f32`, `f64` |\n",
+    "| FP8 / FP6 / FP4 | `f8E4M3FN`, `f8E5M2`, …, `f6E2M3FN`, `f4E2M1FN` (OCP) |\n",
+    "| Special | `i1` (Boolean), `index` (Index) |\n",
+    "\n",
+    "The mapping is observable through a type's `.ir_type` — but only *inside* a trace,\n",
+    "because building an MLIR type needs a compiler context (the same reason arithmetic\n",
+    "had to live in a kernel back in §2). Notice the `print`s below run at *trace* time,\n",
+    "so their output lands here directly — no GPU, no `wurlitzer`.\n",
+    "\n",
+    "Watch `Uint32` and `Int32`: both report `i32`. MLIR integers are **signless** — the\n",
+    "bit width is in the type, but signedness is the DSL's job, applied by the op it\n",
+    "picks (`arith.divsi` vs `arith.divui`). That is also why the §1 table never spelled\n",
+    "out a `uN` type: there isn't one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa152d88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@flyc.jit\n",
+    "def show_ir_types():\n",
+    "    for t in (fx.Int32, fx.Uint32, fx.Float32, fx.BFloat16, fx.Float8E4M3FN, fx.Boolean, fx.Index):\n",
+    "        print(f\"{t.__name__:<14} width={t.width:<3} -> MLIR {t.ir_type}\")\n",
+    "    # types compose: four f32 packed into one vector value\n",
+    "    print(\"Vector.make_type(4, Float32) ->\", fx.Vector.make_type(4, fx.Float32))\n",
+    "\n",
+    "\n",
+    "show_ir_types()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3fdf680",
+   "metadata": {},
+   "source": [
+    "That `vector<4xf32>` is the shape a single thread carries when it moves or multiplies\n",
+    "several elements at once — which is exactly what the copy and layout notebooks build on.\n",
     "\n",
     "---\n",
     "**Next:** [`02_struct`](02_struct.ipynb) — bundling these scalars into aggregate\n",

--- a/examples/notebooks/01_numeric_types.ipynb
+++ b/examples/notebooks/01_numeric_types.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "09a109c1",
+   "id": "27518219",
    "metadata": {},
    "source": [
     "<!-- SPDX-License-Identifier: Apache-2.0 -->\n",
@@ -25,7 +25,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af3a5e2b",
+   "id": "3ea23665",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "107dc150",
+   "id": "f8ee13ed",
    "metadata": {},
    "source": [
     "## 1. The type families\n",
@@ -77,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6449c11d",
+   "id": "dfe05e7a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ad1323b",
+   "id": "676dd7e7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -120,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22d9392b",
+   "id": "96a01879",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "064ad9f1",
+   "id": "c18e7aa2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -159,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c879a845",
+   "id": "7a065e9b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8189ae17",
+   "id": "8a15cce1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -201,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fac2dcbd",
+   "id": "487cd0a2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +223,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70b42400",
+   "id": "1b0551d2",
    "metadata": {},
    "source": [
     "## 5. Low-precision types\n",
@@ -239,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a4af5d1",
+   "id": "751e74eb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -266,15 +266,16 @@
     "so their output lands here directly — no GPU, no `wurlitzer`.\n",
     "\n",
     "Watch `Uint32` and `Int32`: both report `i32`. MLIR integers are **signless** — the\n",
-    "bit width is in the type, but signedness is the DSL's job, applied by the op it\n",
-    "picks (`arith.divsi` vs `arith.divui`). That is also why the §1 table never spelled\n",
-    "out a `uN` type: there isn't one."
+    "type carries the bit width but no sign bit. Signedness rides on the *operation* instead\n",
+    "(signed divide is `arith.divsi`, unsigned is `arith.divui`), which is why `Int32` and\n",
+    "`Uint32` stay distinct DSL types even though they share one MLIR type — and why the §1\n",
+    "table never spelled out a `uN` type: there isn't one."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea20463d",
+   "id": "ec4117e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,11 +292,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e08e3faf",
+   "id": "831378a6",
    "metadata": {},
    "source": [
-    "That `vector<4xf32>` is the shape a single thread carries when it moves or multiplies\n",
-    "several elements at once — which is exactly what the copy and layout notebooks build on.\n",
+    "That `vector<4xf32>` is how a thread holds four `f32` values at once — the packing the\n",
+    "copy and layout notebooks lean on when a thread moves or multiplies several elements\n",
+    "together.\n",
     "\n",
     "---\n",
     "**Next:** [`02_struct`](02_struct.ipynb) — bundling these scalars into aggregate\n",

--- a/examples/notebooks/01_numeric_types.ipynb
+++ b/examples/notebooks/01_numeric_types.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "159d14e9",
+   "id": "09a109c1",
    "metadata": {},
    "source": [
     "<!-- SPDX-License-Identifier: Apache-2.0 -->\n",
@@ -25,10 +25,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42e5acbc",
+   "id": "af3a5e2b",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
+    "# §6 prints at trace time; disable the JIT disk cache so a warm-cache re-run still\n",
+    "# re-traces and re-prints (these kernels are tiny). Set before importing flydsl.\n",
+    "os.environ[\"FLYDSL_RUNTIME_ENABLE_CACHE\"] = \"0\"\n",
+    "\n",
     "import torch\n",
     "from wurlitzer import pipes\n",
     "\n",
@@ -48,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be457121",
+   "id": "107dc150",
    "metadata": {},
    "source": [
     "## 1. The type families\n",
@@ -71,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f351ca05",
+   "id": "6449c11d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb95e35d",
+   "id": "7ad1323b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -114,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa8ed025",
+   "id": "22d9392b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2aa7b702",
+   "id": "064ad9f1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -153,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99af03c9",
+   "id": "c879a845",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a744edb9",
+   "id": "8189ae17",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -195,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9368a7be",
+   "id": "fac2dcbd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +223,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5cd73d59",
+   "id": "70b42400",
    "metadata": {},
    "source": [
     "## 5. Low-precision types\n",
@@ -233,17 +239,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "502ec463",
+   "id": "7a4af5d1",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "source": [
     "## 6. Under the hood — DSL type → MLIR (optional)\n",
     "\n",
-    "Skip this if you only want to write kernels. But FlyDSL is an MLIR compiler, and\n",
-    "each DSL type is a thin handle over an **MLIR scalar type**: it knows that type and\n",
-    "emits the right `arith` / `math` ops for it. When you read an IR dump (`00_hello_flydsl`)\n",
-    "or chase a type error, this is the map:\n",
+    "Skip this if you only want to write kernels — you will rarely reach for it. But the\n",
+    "moment you dump IR (`00_hello_flydsl`) or read a type error, you hit MLIR type names\n",
+    "like `i32` / `f32` / `f8E4M3FN`, and this section is the map back to the DSL types you\n",
+    "wrote. Under the hood each DSL type is a thin handle over one **MLIR scalar type**: it\n",
+    "knows that type and emits the right `arith` / `math` ops for it.\n",
     "\n",
     "| DSL family | MLIR type |\n",
     "|---|---|\n",
@@ -267,7 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa152d88",
+   "id": "ea20463d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +291,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3fdf680",
+   "id": "e08e3faf",
    "metadata": {},
    "source": [
     "That `vector<4xf32>` is the shape a single thread carries when it moves or multiplies\n",

--- a/examples/notebooks/04_layout.ipynb
+++ b/examples/notebooks/04_layout.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "db5986ea",
+   "id": "1e7b4e02",
    "metadata": {},
    "source": [
     "<!-- SPDX-License-Identifier: Apache-2.0 -->\n",
@@ -26,7 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2207c4c1",
+   "id": "02263a0d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "580c6120",
+   "id": "14c82f04",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -55,13 +55,14 @@
     "stride `(8, 1)` — moving one row jumps 8 elements, moving one column jumps 1.\n",
     "\n",
     "A layout reports a handful of properties: `size` (number of coordinates), `cosize`\n",
-    "(span of the index image), `rank` (number of modes), and `depth` (nesting)."
+    "(how many distinct indices it produces), `rank` (number of modes), and `depth` (how\n",
+    "deeply the shape is nested)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e6e470f",
+   "id": "8c461728",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +80,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64608949",
+   "id": "a3a5c5bb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -95,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db769295",
+   "id": "a38d4df8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9487979f",
+   "id": "9a1b069e",
    "metadata": {},
    "source": [
     "The coordinate `(2, 3)` is the same logical position both times — only the stride\n",
@@ -123,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de97fdb4",
+   "id": "3ab175fb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -140,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c2494c5",
+   "id": "26ad955a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,7 +160,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa4f0048",
+   "id": "c360ce1e",
+   "metadata": {},
+   "source": [
+    "Read `(8, 8):(1, 8)` as **8 elements per tile** (first mode) × **8 tiles** (second\n",
+    "mode): `64 ÷ 8`. The stride `1` steps within a tile, `8` jumps to the next tile.\n",
+    "`fx.select(tiled, [0])` pulls out mode 0 — one tile's layout on its own."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da84ccde",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -168,15 +179,16 @@
     "\n",
     "A layout describes *positions*. A **tensor** attaches that layout to something:\n",
     "\n",
-    "- A **memref tensor** is a layout over **memory** — registers, LDS, or global. It\n",
-    "  has an element type, and reading it gives you *data*. This is what `make_rmem_tensor`\n",
-    "  and `rocdl.make_buffer_tensor` produce, and what the earlier notebooks copied.\n",
-    "- A **coord tensor** answers \"*which logical coordinate am I holding?*\". It is built\n",
-    "  on an **identity layout**, where `crd2idx` returns the coordinate itself (an\n",
-    "  `IntTuple`) instead of collapsing it to a flat address. There is no memory behind\n",
-    "  it — only the coordinates — which is exactly why it has **no element type**. Coord\n",
-    "  tensors are how a kernel tracks *which* logical element a thread owns, the basis for\n",
-    "  predication and indexing.\n",
+    "- A **memref tensor** is a layout over **memory** (a *memref* is MLIR's memory-backed\n",
+    "  tensor) — registers, LDS, or global. It has an element type, and reading it gives you\n",
+    "  *data*. This is what `make_rmem_tensor` and `rocdl.make_buffer_tensor` produce, and\n",
+    "  what the earlier notebooks copied.\n",
+    "- A **coord tensor** answers \"*which logical coordinate am I holding?*\". It is built on\n",
+    "  an **identity layout** — the layout analog of the identity function — where `crd2idx`\n",
+    "  returns the coordinate itself (an `IntTuple`) instead of collapsing it to a flat\n",
+    "  address. There is no memory behind it — only the coordinates — which is exactly why it\n",
+    "  has **no element type**. Coord tensors are how a kernel tracks *which* logical element\n",
+    "  a thread owns, the basis for predication and indexing.\n",
     "\n",
     "You partition both the same way; one yields data, the other the coordinates that go\n",
     "with it. The contrast below is the whole point: `crd2idx` collapses `(2, 3)` to the\n",
@@ -186,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd1be0a1",
+   "id": "14e8635a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +228,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "daec85b2",
+   "id": "8a156344",
+   "metadata": {},
+   "source": [
+    "Reading the coord-tensor repr `Tensor<(0,0), (4,8):(1E0,1E1)>`: `(0,0)` is its base\n",
+    "coordinate, `(4,8)` the shape, and `(1E0, 1E1)` the *basis* stride — FlyDSL's notation\n",
+    "for the identity stride that keeps each coordinate symbolic instead of flattening it.\n",
+    "The memref's plain `(8, 1)` stride, by contrast, is a real step into memory."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d4b280d",
    "metadata": {},
    "source": [
     "That is the entire vocabulary the next notebook tiles and visualizes: shapes and\n",

--- a/examples/notebooks/04_layout.ipynb
+++ b/examples/notebooks/04_layout.ipynb
@@ -1,0 +1,243 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "50327f71",
+   "metadata": {},
+   "source": [
+    "<!-- SPDX-License-Identifier: Apache-2.0 -->\n",
+    "<!-- Copyright (c) 2025 FlyDSL Project Contributors -->\n",
+    "\n",
+    "# Layout algebra\n",
+    "\n",
+    "A **layout** is a `(Shape, Stride)` pair, and it is a *function*: it maps a logical\n",
+    "coordinate to a linear index. That one idea is the spine of FlyDSL — every tiled\n",
+    "copy and every MMA in the earlier notebooks was really \"lay out the data, partition\n",
+    "it across threads, then move or multiply.\" Before we tile and swizzle (next\n",
+    "notebook), this one builds layouts, maps coordinates, cuts layouts into tiles, and\n",
+    "meets the two kinds of tensor.\n",
+    "\n",
+    "Everything here is **compile-time layout algebra**. We still wrap each cell in a\n",
+    "`@flyc.jit` because constructing a layout needs an MLIR context (the same reason\n",
+    "arithmetic lived inside a kernel in `01_numeric_types`), but nothing launches on the\n",
+    "GPU — the layout objects just print as readable values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e4f8887",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import flydsl.compiler as flyc\n",
+    "import flydsl.expr as fx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "136b274d",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 1. Shape, Stride, Layout\n",
+    "\n",
+    "The **shape** is the logical extent of each mode; the **stride** is how far you step\n",
+    "in linear memory per unit of that mode. A row-major 8×8 is shape `(8, 8)` with\n",
+    "stride `(8, 1)` — moving one row jumps 8 elements, moving one column jumps 1.\n",
+    "\n",
+    "A layout reports a handful of properties: `size` (number of coordinates), `cosize`\n",
+    "(span of the index image), `rank` (number of modes), and `depth` (nesting)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94c06ab1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@flyc.jit\n",
+    "def layout_basics():\n",
+    "    L = fx.make_layout((8, 8), (8, 1))\n",
+    "    print(\"layout      :\", L)\n",
+    "    print(\"shape/stride:\", fx.get_shape(L), \"/\", fx.get_stride(L))\n",
+    "    print(\"size/cosize :\", fx.size(L), \"/\", fx.cosize(L))\n",
+    "    print(\"rank/depth  :\", fx.rank(L), \"/\", fx.depth(L))\n",
+    "\n",
+    "\n",
+    "layout_basics()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "180559ae",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 2. Coordinates → indices\n",
+    "\n",
+    "`crd2idx` applies the layout: it takes a coordinate and returns the linear index.\n",
+    "The shape decides which coordinates are legal; the **stride** decides where each one\n",
+    "lands. So the *same* coordinate gives a *different* index under a row-major vs a\n",
+    "column-major layout — that difference is the whole point of carrying a stride."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68327fdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@flyc.jit\n",
+    "def coord_to_index():\n",
+    "    row = fx.make_layout((8, 8), (8, 1))  # row-major: stride (8, 1)\n",
+    "    col = fx.make_layout((8, 8), (1, 8))  # column-major: stride (1, 8)\n",
+    "    for c in [(0, 1), (1, 0), (2, 3)]:\n",
+    "        crd = fx.make_coord(*c)\n",
+    "        print(f\"coord {c}: row-major -> {fx.crd2idx(crd, row)}   column-major -> {fx.crd2idx(crd, col)}\")\n",
+    "\n",
+    "\n",
+    "coord_to_index()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a66f8e29",
+   "metadata": {},
+   "source": [
+    "Coordinate `(2, 3)` is index `2*8 + 3 = 19` row-major, but `2*1 + 3*8 = 26`\n",
+    "column-major. `idx2crd` is the inverse direction (index back to coordinate)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74bae49b",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 3. Tiling with `logical_divide`\n",
+    "\n",
+    "Real kernels never touch a whole tensor at once — they cut it into per-block and\n",
+    "per-thread tiles. `logical_divide` is the cut: it splits a layout by a *tiler*\n",
+    "layout, producing a hierarchical layout whose first mode is \"inside one tile\" and\n",
+    "whose second is \"which tile.\" This is exactly the move `01-vectorAdd` makes to hand\n",
+    "each thread its slice of a 64-element block."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e67d7b12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@flyc.jit\n",
+    "def tiling():\n",
+    "    flat = fx.make_layout(64, 1)  # 64 elements, contiguous\n",
+    "    tiled = fx.logical_divide(flat, fx.make_layout(8, 1))\n",
+    "    print(\"flat        :\", flat)\n",
+    "    print(\"divide by 8 :\", tiled, \"  (inner = 8 per tile, outer = 8 tiles)\")\n",
+    "    print(\"inner mode  :\", fx.select(tiled, [0]))  # one tile's layout\n",
+    "    print(\"rank        :\", fx.rank(tiled))\n",
+    "\n",
+    "\n",
+    "tiling()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60f74462",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 4. The two kinds of tensor — memref vs coord\n",
+    "\n",
+    "A layout describes *positions*. A **tensor** attaches that layout to something:\n",
+    "\n",
+    "- A **memref tensor** is a layout over **memory** — registers, LDS, or global. It\n",
+    "  has an element type, and reading it gives you *data*. This is what `make_rmem_tensor`\n",
+    "  and `rocdl.make_buffer_tensor` produce, and what the earlier notebooks copied.\n",
+    "- A **coord tensor** is a layout over **coordinates** — it has *no* element type, and\n",
+    "  \"reading\" a position gives you back its own logical coordinate. It is built on an\n",
+    "  **identity layout**, where `crd2idx` returns the coordinate unchanged instead of\n",
+    "  collapsing it to a flat address. Coord tensors are how a kernel knows *which*\n",
+    "  logical element a thread is holding — the basis for predication and indexing.\n",
+    "\n",
+    "You partition both the same way; one yields data, the other yields the coordinates\n",
+    "that go with it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7fc7d0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@flyc.jit\n",
+    "def two_tensors():\n",
+    "    # memref tensor: a layout over register memory, carries f32 data\n",
+    "    mem = fx.make_rmem_tensor(fx.make_layout((4, 8), (8, 1)), fx.Float32)\n",
+    "    print(\"memref tensor:\", mem, \"| element_type:\", mem.element_type)\n",
+    "\n",
+    "    # coord tensor: a layout over coordinates, built on an identity layout\n",
+    "    crd = fx.make_view(fx.make_coord(0, 0), fx.make_identity_layout((4, 8)))\n",
+    "    print(\"coord  tensor:\", crd)\n",
+    "    try:\n",
+    "        crd.element_type\n",
+    "    except TypeError as e:\n",
+    "        print(\"coord  tensor: element_type ->\", e)\n",
+    "\n",
+    "    # the difference is in the layout: ordinary collapses to an index, identity keeps the coordinate\n",
+    "    ordinary = fx.make_layout((4, 8), (8, 1))\n",
+    "    identity = fx.make_identity_layout((4, 8))\n",
+    "    c = fx.make_coord(2, 3)\n",
+    "    print(\"crd2idx (2,3): ordinary ->\", fx.crd2idx(c, ordinary), \"  identity ->\", fx.crd2idx(c, identity))\n",
+    "\n",
+    "\n",
+    "two_tensors()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "830a6c72",
+   "metadata": {},
+   "source": [
+    "That is the entire vocabulary the next notebook tiles and visualizes: shapes and\n",
+    "strides, coordinates and indices, `logical_divide` for tiling, and the two tensor\n",
+    "kinds you partition across threads.\n",
+    "\n",
+    "---\n",
+    "**Next:** [`05_tiled_copy_and_swizzle`](05_tiled_copy_and_swizzle.ipynb) — thread-value\n",
+    "layouts, partitioning, the swizzle trick for LDS, and drawing layouts with `print_typst`."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/04_layout.ipynb
+++ b/examples/notebooks/04_layout.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "50327f71",
+   "id": "db5986ea",
    "metadata": {},
    "source": [
     "<!-- SPDX-License-Identifier: Apache-2.0 -->\n",
@@ -26,17 +26,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e4f8887",
+   "id": "2207c4c1",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
+    "# These cells print at *trace* time. A warm JIT disk cache would skip the re-trace, and\n",
+    "# the prints would vanish on a re-run — so disable the disk cache (the kernels are tiny).\n",
+    "# Set before importing flydsl.\n",
+    "os.environ[\"FLYDSL_RUNTIME_ENABLE_CACHE\"] = \"0\"\n",
+    "\n",
     "import flydsl.compiler as flyc\n",
     "import flydsl.expr as fx"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "136b274d",
+   "id": "580c6120",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -54,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94c06ab1",
+   "id": "2e6e470f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +79,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "180559ae",
+   "id": "64608949",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -88,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68327fdb",
+   "id": "db769295",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,16 +113,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a66f8e29",
+   "id": "9487979f",
    "metadata": {},
    "source": [
-    "Coordinate `(2, 3)` is index `2*8 + 3 = 19` row-major, but `2*1 + 3*8 = 26`\n",
-    "column-major. `idx2crd` is the inverse direction (index back to coordinate)."
+    "The coordinate `(2, 3)` is the same logical position both times — only the stride\n",
+    "changes where it lands: `2*8 + 3 = 19` row-major, `2*1 + 3*8 = 26` column-major.\n",
+    "`idx2crd` is the inverse direction (index back to coordinate)."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "74bae49b",
+   "id": "de97fdb4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -132,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e67d7b12",
+   "id": "6c2494c5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60f74462",
+   "id": "fa4f0048",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -163,20 +171,22 @@
     "- A **memref tensor** is a layout over **memory** — registers, LDS, or global. It\n",
     "  has an element type, and reading it gives you *data*. This is what `make_rmem_tensor`\n",
     "  and `rocdl.make_buffer_tensor` produce, and what the earlier notebooks copied.\n",
-    "- A **coord tensor** is a layout over **coordinates** — it has *no* element type, and\n",
-    "  \"reading\" a position gives you back its own logical coordinate. It is built on an\n",
-    "  **identity layout**, where `crd2idx` returns the coordinate unchanged instead of\n",
-    "  collapsing it to a flat address. Coord tensors are how a kernel knows *which*\n",
-    "  logical element a thread is holding — the basis for predication and indexing.\n",
+    "- A **coord tensor** answers \"*which logical coordinate am I holding?*\". It is built\n",
+    "  on an **identity layout**, where `crd2idx` returns the coordinate itself (an\n",
+    "  `IntTuple`) instead of collapsing it to a flat address. There is no memory behind\n",
+    "  it — only the coordinates — which is exactly why it has **no element type**. Coord\n",
+    "  tensors are how a kernel tracks *which* logical element a thread owns, the basis for\n",
+    "  predication and indexing.\n",
     "\n",
-    "You partition both the same way; one yields data, the other yields the coordinates\n",
-    "that go with it."
+    "You partition both the same way; one yields data, the other the coordinates that go\n",
+    "with it. The contrast below is the whole point: `crd2idx` collapses `(2, 3)` to the\n",
+    "index `19` through the ordinary layout, but returns `(2, 3)` through the identity one."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7fc7d0b",
+   "id": "bd1be0a1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +216,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "830a6c72",
+   "id": "daec85b2",
    "metadata": {},
    "source": [
     "That is the entire vocabulary the next notebook tiles and visualizes: shapes and\n",

--- a/examples/notebooks/05_tiled_copy_and_swizzle.ipynb
+++ b/examples/notebooks/05_tiled_copy_and_swizzle.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3a935f5e",
+   "id": "fd22c642",
    "metadata": {},
    "source": [
     "<!-- SPDX-License-Identifier: Apache-2.0 -->\n",
@@ -21,7 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3faf9ae6",
+   "id": "2ac5df73",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa41e79b",
+   "id": "377e2b21",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -81,15 +81,15 @@
     "folds them into one **TV layout** (thread, value → offset in the tile) plus the tile\n",
     "shape it covers, and `make_tiled_copy` binds that to a copy atom.\n",
     "\n",
-    "Below, `thr` shape `(4, 1)` is 4 threads in a single row; `val` shape `(1, 8)` is 8\n",
-    "elements per thread in a row. Together they tile a `(4, 8)` region — 4 threads × 8\n",
-    "elements — which is the `tile (M, N)` the cell prints."
+    "Below, `thr` shape `(4, 1)` is 4 threads down dimension 0 (a 4×1 column); `val` shape\n",
+    "`(1, 8)` is 8 elements per thread along dimension 1 (a 1×8 row). Together they tile a\n",
+    "`(4, 8)` region — 4 threads × 8 elements — which is the `tile (M, N)` the cell prints."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8539718d",
+   "id": "b2fc666b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +111,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a83e386",
+   "id": "1e537718",
+   "metadata": {},
+   "source": [
+    "Read the printed `TV layout (4,8):(1,4)` as shape `(4, 8)` = (4 threads, 8 values each);\n",
+    "the stride then places `(thread t, value v)` in the tile — step `1` per thread, `4` per\n",
+    "value (one value-step hops past all 4 threads)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84d62730",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -120,11 +130,11 @@
     "\n",
     "`tiled.get_slice(tid)` gives one thread's view of the tiled copy; `partition_S` and\n",
     "`partition_D` then carve the source and destination tiles into that thread's slice.\n",
-    "Each partition is a **memref view** — a layout over the same memory, narrowed to the\n",
-    "elements this thread touches (the coordinate bookkeeping behind it is the coord-tensor\n",
-    "machinery from `04_layout`). The kernel below copies an `M×N` matrix tile-by-tile and\n",
-    "checks the result against the input; it also prints one thread's partitioned view at\n",
-    "trace time.\n",
+    "Each partition is a **memref view** — the same memory, but with a layout that maps only\n",
+    "the elements this thread copies (the per-thread coordinate bookkeeping is the\n",
+    "coord-tensor machinery from `04_layout`, which `partition_S/D` build for you). The\n",
+    "kernel below copies an `M×N` matrix tile-by-tile and checks the result against the\n",
+    "input; it also prints one thread's partitioned view at trace time.\n",
     "\n",
     "The device path here is AMD CDNA-specific — `rocdl.make_buffer_tensor` +\n",
     "`rocdl.BufferCopy128b`, the same atoms as `examples/02-tiledCopy.py`. The layout\n",
@@ -135,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92ac28b4",
+   "id": "8faddc78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +189,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "754ce5ac",
+   "id": "4c2ed959",
+   "metadata": {},
+   "source": [
+    "`copy correct: True` confirms the round-trip. The `per-thread source view` line printed\n",
+    "something like `Tensor<f32, buffer_desc, ((4,2),2,3):(…)>` — don't decode the nested\n",
+    "shape; the takeaway is just that it is *this thread's* slice of the same `f32` buffer\n",
+    "(`buffer_desc`), a view rather than freshly allocated memory."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe8dcfb5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -190,8 +211,10 @@
     "layout makes many of them hit the *same* bank on the same cycle — a bank conflict that\n",
     "serializes the access. A **swizzle** scrambles the address with a cheap XOR so those\n",
     "accesses spread across banks instead. `fx.SwizzleType.get(mask, base, shift)` describes\n",
-    "the scramble, and `make_composed_layout` stacks it on a base layout: a coordinate goes\n",
-    "through the base layout to an address, then the swizzle perturbs that address.\n",
+    "the scramble — the three numbers tune which address bits get XORed and by how much, knobs\n",
+    "you copy from a known-good config (the GEMM kernels) rather than derive by hand — and\n",
+    "`make_composed_layout` stacks it on a base layout: a coordinate goes through the base\n",
+    "layout to an address, then the swizzle perturbs that address.\n",
     "\n",
     "(There is a coordinate-space cousin, `coord_swizzle` — the same XOR applied to\n",
     "coordinates rather than byte addresses. The layout builder reaches for it internally\n",
@@ -202,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8626b8c4",
+   "id": "4a0123e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4a183bd",
+   "id": "f6bcda7c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -238,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "001dd538",
+   "id": "8a2f9c85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,18 +284,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c13b85d",
+   "id": "972e4c17",
    "metadata": {},
    "source": [
-    "An `8×8` layout, indices coloured by linear address — plain, then with the\n",
-    "`(3, 0, 3)` swizzle applied. The diagonal scramble in the second grid is the\n",
-    "bank-conflict fix:"
+    "An `8×8` layout, each cell shaded by its linear index — plain, then with the\n",
+    "`(3, 0, 3)` swizzle applied. The reshuffled shading in the second grid is the\n",
+    "bank-conflict fix made visible: cells that used to share an address bit now sit apart."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3021fa4d",
+   "id": "a381f4b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2434418",
+   "id": "0ea32742",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,17 +314,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97b06d14",
+   "id": "dce128fd",
    "metadata": {},
    "source": [
-    "And the tiled copy from §1 — each cell coloured by the thread that owns it, so you can\n",
-    "read off exactly which elements each of the four threads carries:"
+    "And the tiled copy from §1 — cells sharing a colour belong to the same thread, so each\n",
+    "colour block is one thread's 8 elements; you can read all four threads' slices straight\n",
+    "off the grid:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb0f2af6",
+   "id": "490dc3d4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb3e5c63",
+   "id": "5e640a42",
    "metadata": {},
    "source": [
     "That is the layout toolkit end to end: shapes and strides (`04`), tiling and the TV\n",

--- a/examples/notebooks/05_tiled_copy_and_swizzle.ipynb
+++ b/examples/notebooks/05_tiled_copy_and_swizzle.ipynb
@@ -1,0 +1,331 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4509f14e",
+   "metadata": {},
+   "source": [
+    "<!-- SPDX-License-Identifier: Apache-2.0 -->\n",
+    "<!-- Copyright (c) 2025 FlyDSL Project Contributors -->\n",
+    "\n",
+    "# Tiled copy and swizzle\n",
+    "\n",
+    "`04_layout` built layouts and cut them into tiles. This one spreads a tile across\n",
+    "threads — the **thread-value layout** and **tiled copy** — partitions it, applies the\n",
+    "**swizzle** trick that keeps LDS banks happy, and *draws* all of it with `print_typst`.\n",
+    "\n",
+    "As before, the layout algebra runs inside a `@flyc.jit` for the MLIR context; only\n",
+    "the copy capstone actually launches on the GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dead0823",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import tempfile\n",
+    "\n",
+    "import torch\n",
+    "from IPython.display import SVG, Code, display\n",
+    "\n",
+    "import flydsl.compiler as flyc\n",
+    "import flydsl.expr as fx\n",
+    "\n",
+    "try:\n",
+    "    import typst  # `pip install typst` — bundles the compiler\n",
+    "except ImportError:\n",
+    "    typst = None  # without it, diagrams fall back to raw source\n",
+    "\n",
+    "_TYP_DIR = tempfile.mkdtemp()\n",
+    "\n",
+    "\n",
+    "def render_typst(name):\n",
+    "    \"\"\"Show a Typst file written by print_typst: as an inline SVG when the `typst`\n",
+    "    package is available, otherwise as the raw Typst source.\"\"\"\n",
+    "    path = os.path.join(_TYP_DIR, name)\n",
+    "    if typst is None:\n",
+    "        display(Code(open(path).read(), language=\"typst\"))\n",
+    "        return\n",
+    "    out = typst.compile(path, format=\"svg\")\n",
+    "    if isinstance(out, list):  # one entry per page; our files have a single page\n",
+    "        out = out[0]\n",
+    "    if isinstance(out, (bytes, bytearray)):\n",
+    "        out = out.decode()\n",
+    "    display(SVG(out))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c23263c1",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 1. Thread-value layouts\n",
+    "\n",
+    "A copy hands a tile to a *team* of threads. Two layouts describe the split: a\n",
+    "**thread layout** (how the threads are arranged over the tile) and a **value layout**\n",
+    "(how many elements each thread carries, and where). `make_layout_tv` folds them into\n",
+    "one **TV layout** plus the tile shape it covers, and `make_tiled_copy` binds that to a\n",
+    "copy atom."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c0e37a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@flyc.jit\n",
+    "def tv_layout():\n",
+    "    thr = fx.make_layout((4, 1), (1, 1))  # 4 threads, laid out down the rows\n",
+    "    val = fx.make_layout((1, 8), (1, 1))  # each thread owns 8 columns\n",
+    "    tile_mn, tv = fx.make_layout_tv(thr, val)\n",
+    "    print(\"tile (M, N):\", tile_mn)  # the (4, 8) region one copy covers\n",
+    "    print(\"TV layout  :\", tv)  # (thread, value) -> offset in the tile\n",
+    "\n",
+    "    atom = fx.make_copy_atom(fx.UniversalCopy128b(), fx.Float32)\n",
+    "    tiled = fx.make_tiled_copy(atom, tv, tile_mn)\n",
+    "    print(\"tiled copy :\", tiled)\n",
+    "\n",
+    "\n",
+    "tv_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7239f22b",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 2. Partitioning, and a copy that runs\n",
+    "\n",
+    "`tiled.get_slice(tid)` gives one thread's view of the tiled copy; `partition_S` and\n",
+    "`partition_D` then carve the source and destination tiles into that thread's slice.\n",
+    "Each partition is a **memref view** — a layout over the same memory, narrowed to the\n",
+    "elements this thread touches (the coordinate bookkeeping behind it is the coord-tensor\n",
+    "machinery from `04_layout`). The kernel below copies an `M×N` matrix tile-by-tile and\n",
+    "checks the result against the input; it also prints one thread's partitioned view at\n",
+    "trace time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ce72c0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@flyc.kernel\n",
+    "def tiled_copy_kernel(A: fx.Tensor, B: fx.Tensor):\n",
+    "    tid = fx.thread_idx.x\n",
+    "    bid = fx.block_idx.x\n",
+    "    A = fx.rocdl.make_buffer_tensor(A)\n",
+    "    B = fx.rocdl.make_buffer_tensor(B)\n",
+    "    bA = fx.slice(fx.zipped_divide(A, (8, 24)), (None, bid))\n",
+    "    bB = fx.slice(fx.zipped_divide(B, (8, 24)), (None, bid))\n",
+    "\n",
+    "    thr = fx.make_layout((4, 1), (1, 1))\n",
+    "    val = fx.make_layout((1, 8), (1, 1))\n",
+    "    atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Float32)\n",
+    "    tile_mn, tv = fx.make_layout_tv(thr, val)\n",
+    "    tiled = fx.make_tiled_copy(atom, tv, tile_mn)\n",
+    "\n",
+    "    thr_copy = tiled.get_slice(tid)\n",
+    "    psrc = thr_copy.partition_S(bA)\n",
+    "    pdst = thr_copy.partition_D(bB)\n",
+    "    print(\"  per-thread source view:\", psrc)  # trace-time: prints once, during compile\n",
+    "\n",
+    "    frag = fx.make_fragment_like(psrc)\n",
+    "    fx.copy(atom, psrc, frag)\n",
+    "    fx.copy(atom, frag, pdst)\n",
+    "\n",
+    "\n",
+    "@flyc.jit\n",
+    "def run_copy(A: fx.Tensor, B: fx.Tensor, stream: fx.Stream = fx.Stream(None)):\n",
+    "    tiled_copy_kernel(A, B).launch(grid=(15, 1, 1), block=(4, 1, 1), stream=stream)\n",
+    "\n",
+    "\n",
+    "M, N = 8 * 3, 24 * 5\n",
+    "A = torch.arange(M * N, dtype=torch.float32).reshape(M, N).cuda()\n",
+    "B = torch.zeros(M, N, dtype=torch.float32).cuda()\n",
+    "run_copy(A, B, stream=torch.cuda.Stream())\n",
+    "torch.cuda.synchronize()\n",
+    "print(\"copy correct:\", bool(torch.allclose(A, B)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b86a7fd",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 3. Swizzle — keeping LDS banks happy\n",
+    "\n",
+    "When threads stage a tile through shared memory (LDS), a plain row-major layout makes\n",
+    "many of them hit the *same* bank on the same cycle — a bank conflict that serializes\n",
+    "the access. A **swizzle** scrambles the address with a cheap XOR so those accesses\n",
+    "spread across banks instead. `fx.SwizzleType.get(mask, base, shift)` describes the\n",
+    "scramble, and `make_composed_layout` stacks it on top of a base layout: a coordinate\n",
+    "goes through the base layout to an address, then the swizzle perturbs that address.\n",
+    "\n",
+    "(`coord_swizzle` is the coordinate-space cousin — the same XOR applied to coordinates\n",
+    "rather than byte addresses. The layout builder uses it internally; there is no public\n",
+    "constructor for it yet, so we only name it here.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df266539",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@flyc.jit\n",
+    "def swizzle():\n",
+    "    base = fx.make_ordered_layout((8, 8), (1, 0))\n",
+    "    swz = fx.make_composed_layout(fx.static(fx.SwizzleType.get(3, 0, 3)), base)\n",
+    "    print(\"base layout   :\", base)\n",
+    "    print(\"swizzle       :\", fx.SwizzleType.get(3, 0, 3))\n",
+    "    print(\"composed (swz):\", swz)\n",
+    "\n",
+    "\n",
+    "swizzle()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c722f8e9",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 4. Seeing it — `print_typst`\n",
+    "\n",
+    "Layouts, TV layouts, and swizzles are far easier to *see* than to read off a stride\n",
+    "tuple. `fx.utils.print_typst` writes a [Typst](https://typst.app) diagram of a layout,\n",
+    "a `TiledCopy`, or a composed swizzle; with `pip install typst` we compile that to SVG\n",
+    "and show it inline (without the package, the cell falls back to the raw Typst source).\n",
+    "The `print_typst` calls run inside the `@flyc.jit` (they need the layout's context);\n",
+    "the rendering happens afterwards on the host."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce1dd717",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@flyc.jit\n",
+    "def emit_diagrams():\n",
+    "    plain = fx.make_ordered_layout((8, 8), (1, 0))\n",
+    "    swz = fx.make_composed_layout(fx.static(fx.SwizzleType.get(3, 0, 3)), fx.make_ordered_layout((8, 8), (1, 0)))\n",
+    "    thr = fx.make_layout((4, 1), (1, 1))\n",
+    "    val = fx.make_layout((1, 8), (1, 1))\n",
+    "    tile_mn, tv = fx.make_layout_tv(thr, val)\n",
+    "    tiled = fx.make_tiled_copy(fx.make_copy_atom(fx.UniversalCopy128b(), fx.Float32), tv, tile_mn)\n",
+    "\n",
+    "    fx.utils.print_typst(plain, file=os.path.join(_TYP_DIR, \"plain.typ\"))\n",
+    "    fx.utils.print_typst(swz, file=os.path.join(_TYP_DIR, \"swizzle.typ\"))\n",
+    "    fx.utils.print_typst(tiled, file=os.path.join(_TYP_DIR, \"tiled_copy.typ\"))\n",
+    "\n",
+    "\n",
+    "emit_diagrams()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6912ece4",
+   "metadata": {},
+   "source": [
+    "An `8×8` layout, indices coloured by linear address — plain, then with the\n",
+    "`(3, 0, 3)` swizzle applied. The diagonal scramble in the second grid is the\n",
+    "bank-conflict fix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8760b967",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "render_typst(\"plain.typ\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39f5bd6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "render_typst(\"swizzle.typ\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3747aa0f",
+   "metadata": {},
+   "source": [
+    "And the tiled copy from §1 — each cell coloured by the thread that owns it, so you can\n",
+    "read off exactly which elements each of the four threads carries:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10fd9394",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "render_typst(\"tiled_copy.typ\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25505d29",
+   "metadata": {},
+   "source": [
+    "That is the layout toolkit end to end: shapes and strides (`04`), tiling and the TV\n",
+    "layout, partitioning into per-thread views, the swizzle that keeps LDS fast, and a way\n",
+    "to see all of it. It is the same machinery behind `examples/02-tiledCopy.py` and the\n",
+    "preshuffle GEMM.\n",
+    "\n",
+    "---\n",
+    "*End of the layout series for now. The MMA atoms — `make_mma_atom`, `make_tiled_mma`,\n",
+    "and the `gemm` op in `examples/03-tiledMma.py` — build directly on these pieces.*"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/05_tiled_copy_and_swizzle.ipynb
+++ b/examples/notebooks/05_tiled_copy_and_swizzle.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4509f14e",
+   "id": "3a935f5e",
    "metadata": {},
    "source": [
     "<!-- SPDX-License-Identifier: Apache-2.0 -->\n",
@@ -21,7 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dead0823",
+   "id": "3faf9ae6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -29,6 +29,12 @@
    "source": [
     "import os\n",
     "import tempfile\n",
+    "\n",
+    "# print_typst writes its .typ files as a trace-time side effect of @flyc.jit, and the\n",
+    "# layout cells print at trace time too. A warm JIT disk cache would skip the re-trace\n",
+    "# (and those side effects), so disable it — re-runs then always reproduce. Set before\n",
+    "# importing flydsl.\n",
+    "os.environ[\"FLYDSL_RUNTIME_ENABLE_CACHE\"] = \"0\"\n",
     "\n",
     "import torch\n",
     "from IPython.display import SVG, Code, display\n",
@@ -49,7 +55,8 @@
     "    package is available, otherwise as the raw Typst source.\"\"\"\n",
     "    path = os.path.join(_TYP_DIR, name)\n",
     "    if typst is None:\n",
-    "        display(Code(open(path).read(), language=\"typst\"))\n",
+    "        with open(path) as f:\n",
+    "            display(Code(f.read(), language=\"typst\"))\n",
     "        return\n",
     "    out = typst.compile(path, format=\"svg\")\n",
     "    if isinstance(out, list):  # one entry per page; our files have a single page\n",
@@ -61,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c23263c1",
+   "id": "aa41e79b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -69,16 +76,20 @@
     "## 1. Thread-value layouts\n",
     "\n",
     "A copy hands a tile to a *team* of threads. Two layouts describe the split: a\n",
-    "**thread layout** (how the threads are arranged over the tile) and a **value layout**\n",
-    "(how many elements each thread carries, and where). `make_layout_tv` folds them into\n",
-    "one **TV layout** plus the tile shape it covers, and `make_tiled_copy` binds that to a\n",
-    "copy atom."
+    "**thread layout** — the shape of the thread grid over the tile — and a **value\n",
+    "layout** — how many elements each thread carries, and in what shape. `make_layout_tv`\n",
+    "folds them into one **TV layout** (thread, value → offset in the tile) plus the tile\n",
+    "shape it covers, and `make_tiled_copy` binds that to a copy atom.\n",
+    "\n",
+    "Below, `thr` shape `(4, 1)` is 4 threads in a single row; `val` shape `(1, 8)` is 8\n",
+    "elements per thread in a row. Together they tile a `(4, 8)` region — 4 threads × 8\n",
+    "elements — which is the `tile (M, N)` the cell prints."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c0e37a4",
+   "id": "8539718d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7239f22b",
+   "id": "0a83e386",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -113,13 +124,18 @@
     "elements this thread touches (the coordinate bookkeeping behind it is the coord-tensor\n",
     "machinery from `04_layout`). The kernel below copies an `M×N` matrix tile-by-tile and\n",
     "checks the result against the input; it also prints one thread's partitioned view at\n",
-    "trace time."
+    "trace time.\n",
+    "\n",
+    "The device path here is AMD CDNA-specific — `rocdl.make_buffer_tensor` +\n",
+    "`rocdl.BufferCopy128b`, the same atoms as `examples/02-tiledCopy.py`. The layout\n",
+    "pieces (`make_layout_tv`, `make_tiled_copy`, `partition_S/D`) are arch-neutral; only\n",
+    "the copy atom and the buffer wrapper are CDNA."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ce72c0d",
+   "id": "92ac28b4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,29 +179,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b86a7fd",
+   "id": "754ce5ac",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "source": [
     "## 3. Swizzle — keeping LDS banks happy\n",
     "\n",
-    "When threads stage a tile through shared memory (LDS), a plain row-major layout makes\n",
-    "many of them hit the *same* bank on the same cycle — a bank conflict that serializes\n",
-    "the access. A **swizzle** scrambles the address with a cheap XOR so those accesses\n",
-    "spread across banks instead. `fx.SwizzleType.get(mask, base, shift)` describes the\n",
-    "scramble, and `make_composed_layout` stacks it on top of a base layout: a coordinate\n",
-    "goes through the base layout to an address, then the swizzle perturbs that address.\n",
+    "When threads stage a tile through shared memory (LDS, on AMD CDNA), a plain row-major\n",
+    "layout makes many of them hit the *same* bank on the same cycle — a bank conflict that\n",
+    "serializes the access. A **swizzle** scrambles the address with a cheap XOR so those\n",
+    "accesses spread across banks instead. `fx.SwizzleType.get(mask, base, shift)` describes\n",
+    "the scramble, and `make_composed_layout` stacks it on a base layout: a coordinate goes\n",
+    "through the base layout to an address, then the swizzle perturbs that address.\n",
     "\n",
-    "(`coord_swizzle` is the coordinate-space cousin — the same XOR applied to coordinates\n",
-    "rather than byte addresses. The layout builder uses it internally; there is no public\n",
-    "constructor for it yet, so we only name it here.)"
+    "(There is a coordinate-space cousin, `coord_swizzle` — the same XOR applied to\n",
+    "coordinates rather than byte addresses. The layout builder reaches for it internally\n",
+    "when it assembles a swizzled layout, so it stays an implementation detail you never\n",
+    "construct directly.)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df266539",
+   "id": "8626b8c4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +220,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c722f8e9",
+   "id": "f4a183bd",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -221,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce1dd717",
+   "id": "001dd538",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +261,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6912ece4",
+   "id": "1c13b85d",
    "metadata": {},
    "source": [
     "An `8×8` layout, indices coloured by linear address — plain, then with the\n",
@@ -255,7 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8760b967",
+   "id": "3021fa4d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39f5bd6b",
+   "id": "a2434418",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -274,7 +291,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3747aa0f",
+   "id": "97b06d14",
    "metadata": {},
    "source": [
     "And the tiled copy from §1 — each cell coloured by the thread that owns it, so you can\n",
@@ -284,7 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10fd9394",
+   "id": "fb0f2af6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25505d29",
+   "id": "eb3e5c63",
    "metadata": {},
    "source": [
     "That is the layout toolkit end to end: shapes and strides (`04`), tiling and the TV\n",

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -15,7 +15,7 @@ last.
 | 02 | [`02_struct.ipynb`](02_struct.ipynb) | `@fx.struct` aggregate value types and their memory layout |
 | 03 | [`03_universal_ops.ipynb`](03_universal_ops.ipynb) | target-agnostic `Universal*` atoms + a vector-add capstone |
 | 04 | [`04_layout.ipynb`](04_layout.ipynb) | layout algebra: shape/stride, `crd2idx`, `logical_divide`, memref vs coord tensors |
-| 05 | [`05_tiled_copy_and_swizzle.ipynb`](05_tiled_copy_and_swizzle.ipynb) | thread-value layouts, partitioning, the LDS swizzle, drawing layouts with `print_typst` |
+| 05 | [`05_tiled_copy_and_swizzle.ipynb`](05_tiled_copy_and_swizzle.ipynb) | thread-value layouts, partitioning, the LDS swizzle (AMD CDNA), drawing layouts with `print_typst` |
 
 ## API cheat-sheet
 
@@ -63,7 +63,7 @@ fx.make_composed_layout(fx.static(fx.SwizzleType.get(mask, base, shift)), base) 
 fx.utils.print_typst(layout_or_tiled_copy, file="x.typ")        # Typst diagram (render with the `typst` pkg)
 ```
 
-Three gotchas worth front-loading:
+A few gotchas worth front-loading:
 
 - `fx.printf` takes only bare `{}` (no `{:.2f}`); a literal `%` is consumed by the
   device printf (write `"mod"`); a true `Boolean` prints as `-1`.
@@ -71,6 +71,9 @@ Three gotchas worth front-loading:
   `with wurlitzer.pipes() as (out, _): launch(...); torch.cuda.synchronize()`, then `print(out.read())`.
 - `Constexpr` `fp8`/`bf16` math is not rounded until the value is materialized as its
   MLIR type; only `f16`/`f32`/`f64` fold at trace time.
+- The layout cells in `04`/`05` (and `01` §6) print at *trace* time, so those notebooks
+  set `FLYDSL_RUNTIME_ENABLE_CACHE=0`: a warm JIT disk cache would skip the re-trace, and
+  the trace-time prints (and `print_typst`'s diagram files) would vanish on a re-run.
 
 ## Running
 

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -3,9 +3,10 @@
 
 # FlyDSL onboarding notebooks
 
-An interactive, bottom-up introduction to the `flydsl.expr` foundation. Work through
-them in order — each builds on the last, and the series stops short of layout algebra
-(`make_layout`, `logical_divide`, tiled copy, MMA), which gets its own follow-up series.
+An interactive, bottom-up introduction to FlyDSL. Notebooks **00–03** cover the
+`flydsl.expr` foundation; **04–05** cover the **layout algebra** (`make_layout`,
+`logical_divide`, tiled copy, swizzle). Work through them in order — each builds on the
+last.
 
 | # | Notebook | Topic |
 |---|----------|-------|
@@ -13,13 +14,14 @@ them in order — each builds on the last, and the series stops short of layout 
 | 01 | [`01_numeric_types.ipynb`](01_numeric_types.ipynb) | scalar types: ints, floats, `bf16`/`fp8`, casts, `Constexpr` |
 | 02 | [`02_struct.ipynb`](02_struct.ipynb) | `@fx.struct` aggregate value types and their memory layout |
 | 03 | [`03_universal_ops.ipynb`](03_universal_ops.ipynb) | target-agnostic `Universal*` atoms + a vector-add capstone |
+| 04 | [`04_layout.ipynb`](04_layout.ipynb) | layout algebra: shape/stride, `crd2idx`, `logical_divide`, memref vs coord tensors |
+| 05 | [`05_tiled_copy_and_swizzle.ipynb`](05_tiled_copy_and_swizzle.ipynb) | thread-value layouts, partitioning, the LDS swizzle, drawing layouts with `print_typst` |
 
 ## API cheat-sheet
 
-The whole `flydsl.expr` foundation these notebooks cover, in one place — enough to
-write a kernel without reading the source. Layout ops (`make_layout`,
-`logical_divide`, tiled copy, MMA) are deliberately out of scope; they get their
-own series.
+The whole API these notebooks cover, in one place — enough to write a kernel without
+reading the source. The MMA atoms (`make_mma_atom`, `make_tiled_mma`, `gemm`) are the
+one piece left for later; `examples/03-tiledMma.py` is the worked reference.
 
 ```python
 # Kernel + launch (00)
@@ -44,6 +46,21 @@ fx.copy_atom_call(atom, src, dst)                                # copy src -> d
 rt = fx.make_rmem_tensor(fx.make_layout(1, 1), fx.Float32)       # per-thread register tensor
 fx.memref_load_vec(rt) / fx.memref_store_vec(val, rt)            # read / write a register tensor
 fx.arith.addf(a, b)                # explicit op on loaded values (`+` is for fx scalar values, not tensors)
+
+# Layout algebra (04) — runs inside a trace; nothing launches on the GPU
+L = fx.make_layout((8, 8), (8, 1))              # (shape, stride): a coord -> index function
+fx.crd2idx(fx.make_coord(2, 3), L)              # apply it; the stride decides where a coord lands
+fx.size(L) / fx.cosize(L) / fx.rank(L) / fx.get_shape(L) / fx.get_stride(L)
+fx.logical_divide(L, tiler)                     # cut a layout into (inside-a-tile, which-tile)
+fx.make_identity_layout(shape)                  # coords map to themselves -> the basis of a coord tensor
+fx.make_view(fx.make_coord(0, 0), id_layout)    # a coord tensor (has no element_type)
+
+# Tiled copy + swizzle + visualization (05)
+tile_mn, tv = fx.make_layout_tv(thr_layout, val_layout)         # threads x values -> a TV layout
+tiled = fx.make_tiled_copy(atom, tv, tile_mn)
+thr = tiled.get_slice(tid); thr.partition_S(src) / thr.partition_D(dst)   # per-thread memref views
+fx.make_composed_layout(fx.static(fx.SwizzleType.get(mask, base, shift)), base)   # LDS bank swizzle
+fx.utils.print_typst(layout_or_tiled_copy, file="x.typ")        # Typst diagram (render with the `typst` pkg)
 ```
 
 Three gotchas worth front-loading:
@@ -61,11 +78,13 @@ These notebooks execute kernels, so they need a built/installed FlyDSL and a ROC
 plus a couple of notebook tools:
 
 ```bash
-pip install jupyter wurlitzer
+pip install jupyter wurlitzer typst
 ```
 
 `wurlitzer` lets the notebooks show GPU `printf` output inline — Jupyter does not
-capture device stdout on its own. Then open them with Jupyter, or run headless:
+capture device stdout on its own. `typst` renders the layout diagrams in `05`
+(`print_typst`) to SVG inline; without it that notebook still runs and shows the raw
+Typst source instead. Then open them with Jupyter, or run headless:
 
 ```bash
 jupyter nbconvert --to notebook --execute --inplace examples/notebooks/*.ipynb

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -77,7 +77,8 @@ A few gotchas worth front-loading:
 
 ## Running
 
-These notebooks execute kernels, so they need a built/installed FlyDSL and a ROCm GPU,
+These notebooks execute kernels, so they need a built/installed FlyDSL (`pip install -e .`
+from the project root — see the root README for the build) on a ROCm GPU, with `torch`,
 plus a couple of notebook tools:
 
 ```bash
@@ -92,5 +93,9 @@ Typst source instead. Then open them with Jupyter, or run headless:
 ```bash
 jupyter nbconvert --to notebook --execute --inplace examples/notebooks/*.ipynb
 ```
+
+The notebooks ship without a pinned kernelspec, so `nbconvert` (and Jupyter) run them
+against your **active** Python environment — make sure `flydsl` imports there. Work
+through them in order; `00`–`03` are the foundation for `04`–`05`.
 
 Cell outputs are committed **cleared**; run the cells to populate them.


### PR DESCRIPTION
Picks up where #635 (1/n, expr foundation) left off — the layout half of the series, the part the earlier notebooks kept bumping into without ever explaining. Refs #573.

**04 — layout algebra.** A layout is `(shape, stride)`: a coordinate→index function. Build them, map coordinates (the same coord lands at a different index under row- vs column-major — which is the whole point of carrying a stride), tile with `logical_divide`, and meet the two tensor kinds: a *memref* tensor (a layout over memory — has data, has an element type) vs a *coord* tensor (a layout over coordinates, built on an identity layout where a coord maps to itself).

**05 — tiled copy and swizzle.** Thread-value layouts and `make_tiled_copy`, partitioning a tile into per-thread views, the XOR swizzle that keeps LDS banks conflict-free, and a `print_typst` showcase that renders layouts / swizzles / the TV grid to SVG inline. The copy capstone actually runs and checks against torch.

**01 polish.** The numeric-types notebook was smuggling MLIR into the DSL flow via an unexplained `MLIR` column. Split it: DSL programming up front, and an optional §6 that *explains and demonstrates* the type→MLIR mapping with `.ir_type`. Writing that caught a wrong row — unsigned ints don't map to `uN`. MLIR integers are signless, so `Uint32` and `Int32` are both `i32`, and signedness is carried by the op (`divsi` vs `divui`). §6 now teaches that instead.

All cells run-verified on MI350X (gfx950); outputs committed cleared. The `print_typst` rendering uses the `typst` pip package and degrades to raw Typst source without it.