### PR TITLE
[Opt] Speed up CompiledFunction fast dispatch for changing args

### DIFF
--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -278,11 +278,11 @@ class TensorAdaptor:
             _shape_size=shape_size,
         ):
             tens = t._tensor_keepalive if isinstance(t, cls) else t
-            mv = memoryview(storage).cast("b")
             if _shape_codec is not None:
-                _shape_codec.pack_into(mv, 0, *(tens.shape[d] for d in _shape_dims))
+                _shape_codec.pack_into(storage, 0, *[tens.shape[d] for d in _shape_dims])
             if _stride_codec is not None:
-                _stride_codec.pack_into(mv, _shape_size, *(tens.stride(d) for d in _stride_dims))
+                st = tens.stride()
+                _stride_codec.pack_into(storage, _shape_size, *[st[d] for d in _stride_dims])
 
         return [
             (ctypes.c_void_p, cls._extract_data_ptr),

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -1162,18 +1162,22 @@ def _build_call_state(sig, args_tuple, func_exe):
 
 
 def _build_dispatch_factory(slot_specs):
-    """Generate a straight-line dispatch-closure factory for ``slot_specs``.
+    """Build a ``factory(packed, storages, func_exe) -> dispatch(args_tuple)``.
 
-    Returns ``make(packed, storages, func_exe) -> dispatch(args_tuple)``.  The
-    generated ``dispatch`` unrolls every slot -- no per-slot Python loop,
-    branch, or tuple-unpack -- with per-slot storages and extract fns bound as
-    closure locals (LOAD_DEREF).  This is the universal hot-path win for a
-    precompiled function invoked with new arguments every call.
+    The returned ``factory`` binds a thread's pre-allocated ``packed`` array and
+    ``storages`` into a straight-line ``dispatch`` closure that unrolls every
+    slot -- no per-slot Python loop, branch, or tuple-unpack -- with per-slot
+    storages and extract fns bound as closure locals (LOAD_DEREF).  This is the
+    universal hot-path win for a precompiled function invoked with new arguments
+    every call.
     """
     setup, body, extracts = [], [], []
     for i, (arg_idx, ctype, extract) in enumerate(slot_specs):
         if extract is None:
-            continue  # null slot (auto-stream): packed[i] stays NULL after alloc
+            # Null slot (auto-stream): its storage cell is allocated and pointed
+            # at by packed[i] in _make_dispatch, but never updated, so the stored
+            # handle stays 0 (HIP default stream).  No dispatch body line.
+            continue
         try:
             probe = ctype(0)
         except TypeError:
@@ -1196,7 +1200,10 @@ def _build_dispatch_factory(slot_specs):
     src += "    return dispatch\n"
 
     ns = {}
-    exec(src, ns)  # generated from trusted internal slot_specs
+    # Compile with a descriptive filename so a traceback from an extract fn
+    # raised during dispatch points at "<flydsl-dispatch>" rather than "<string>".
+    code = compile(src, "<flydsl-dispatch>", "exec")  # src built from trusted internal slot_specs
+    exec(code, ns)
     make = ns["make"]
     extracts = tuple(extracts)
 

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -1161,31 +1161,74 @@ def _build_call_state(sig, args_tuple, func_exe):
     return CallState(slot_specs, func_exe)
 
 
+def _build_dispatch_factory(slot_specs):
+    """Generate a straight-line dispatch-closure factory for ``slot_specs``.
+
+    Returns ``make(packed, storages, func_exe) -> dispatch(args_tuple)``.  The
+    generated ``dispatch`` unrolls every slot -- no per-slot Python loop,
+    branch, or tuple-unpack -- with per-slot storages and extract fns bound as
+    closure locals (LOAD_DEREF).  This is the universal hot-path win for a
+    precompiled function invoked with new arguments every call.
+    """
+    setup, body, extracts = [], [], []
+    for i, (arg_idx, ctype, extract) in enumerate(slot_specs):
+        if extract is None:
+            continue  # null slot (auto-stream): packed[i] stays NULL after alloc
+        try:
+            probe = ctype(0)
+        except TypeError:
+            probe = ctype()
+        is_scalar = hasattr(probe, "value")
+        ei = len(extracts)
+        extracts.append(extract)
+        setup.append(f"    s{i} = storages[{i}]")
+        setup.append(f"    e{i} = extracts[{ei}]")
+        if is_scalar:
+            body.append(f"        s{i}.value = e{i}(a[{arg_idx}])")
+        else:
+            body.append(f"        e{i}(a[{arg_idx}], s{i})")
+
+    src = "def make(packed, storages, func_exe, extracts):\n"
+    src += "".join(line + "\n" for line in setup)
+    src += "    def dispatch(a):\n"
+    src += "".join(line + "\n" for line in body)
+    src += "        return func_exe(packed)\n"
+    src += "    return dispatch\n"
+
+    ns = {}
+    exec(src, ns)  # generated from trusted internal slot_specs
+    make = ns["make"]
+    extracts = tuple(extracts)
+
+    def factory(packed, storages, func_exe):
+        return make(packed, storages, func_exe, extracts)
+
+    return factory
+
+
 class CallState:
     """Pre-allocated state for fast kernel dispatch.
 
-    Built from JitArgument types' _reusable_slot_spec protocol — the same
-    types used by convert_to_jit_arguments for the full DLPack path.
-
-    Pre-allocates typed ctypes storage and a packed pointer array at init
-    time.  On each call, only updates .value on existing storage objects —
-    no ctypes object allocation, no pointer()/cast() calls.  Uses
-    thread-local storage for thread safety.
+    Built from JitArgument types' ``_reusable_slot_spec`` protocol.  At build
+    time the per-slot extract/store sequence is compiled into a straight-line
+    dispatch closure (see :func:`_build_dispatch_factory`).  Per thread it
+    allocates the packed pointer array and typed ctypes storages once and binds
+    them into that closure; each call then runs only the unrolled extract+store
+    body and invokes the JIT'd function -- no per-slot loop, no ctypes
+    allocation.  Thread-local for thread safety.
     """
 
-    __slots__ = ("_func_exe", "_spec", "_tls")
+    __slots__ = ("_func_exe", "_spec", "_tls", "_factory")
 
     def __init__(self, slot_specs, func_exe):
         self._func_exe = func_exe
         self._spec = slot_specs  # list of (arg_idx, ctype, extract_fn)
         self._tls = threading.local()
+        self._factory = _build_dispatch_factory(slot_specs)
 
-    def _init_buffers(self):
-        n_ptrs = len(self._spec)
-        packed = (ctypes.c_void_p * n_ptrs)()
+    def _make_dispatch(self):
+        packed = (ctypes.c_void_p * len(self._spec))()
         storages = []
-        updaters = []
-
         for packed_idx, (arg_idx, ctype, extract) in enumerate(self._spec):
             # ctype(0) works for scalar ctypes; array ctypes need zero-arg ctor.
             try:
@@ -1194,25 +1237,17 @@ class CallState:
                 s = ctype()
             packed[packed_idx] = ctypes.addressof(s)
             storages.append(s)
-            if extract is not None:
-                is_scalar = hasattr(s, "value")
-                updaters.append((arg_idx, s, extract, is_scalar))
-
+        # The dispatch closure keeps packed + storages alive; pin them on the
+        # thread-local too for clarity / introspection.
         self._tls.packed = packed
-        self._tls.updaters = updaters
-        self._tls._storages = storages
+        self._tls.storages = storages
+        return self._factory(packed, storages, self._func_exe)
 
     def __call__(self, args_tuple):
-        if not hasattr(self._tls, "packed"):
-            self._init_buffers()
-
-        for arg_idx, storage, extract, is_scalar in self._tls.updaters:
-            if is_scalar:
-                storage.value = extract(args_tuple[arg_idx])
-            else:
-                extract(args_tuple[arg_idx], storage)
-
-        return self._func_exe(self._tls.packed)
+        dispatch = getattr(self._tls, "dispatch", None)
+        if dispatch is None:
+            dispatch = self._tls.dispatch = self._make_dispatch()
+        return dispatch(args_tuple)
 
 
 class JitFunction:

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
+import builtins
 import ctypes
 import fcntl
 import hashlib
@@ -1162,22 +1163,18 @@ def _build_call_state(sig, args_tuple, func_exe):
 
 
 def _build_dispatch_factory(slot_specs):
-    """Build a ``factory(packed, storages, func_exe) -> dispatch(args_tuple)``.
+    """Generate a straight-line dispatch-closure factory for ``slot_specs``.
 
-    The returned ``factory`` binds a thread's pre-allocated ``packed`` array and
-    ``storages`` into a straight-line ``dispatch`` closure that unrolls every
-    slot -- no per-slot Python loop, branch, or tuple-unpack -- with per-slot
-    storages and extract fns bound as closure locals (LOAD_DEREF).  This is the
-    universal hot-path win for a precompiled function invoked with new arguments
-    every call.
+    Returns ``make(packed, storages, func_exe) -> dispatch(args_tuple)``.  The
+    generated ``dispatch`` unrolls every slot -- no per-slot Python loop,
+    branch, or tuple-unpack -- with per-slot storages and extract fns bound as
+    closure locals (LOAD_DEREF).  This is the universal hot-path win for a
+    precompiled function invoked with new arguments every call.
     """
     setup, body, extracts = [], [], []
     for i, (arg_idx, ctype, extract) in enumerate(slot_specs):
         if extract is None:
-            # Null slot (auto-stream): its storage cell is allocated and pointed
-            # at by packed[i] in _make_dispatch, but never updated, so the stored
-            # handle stays 0 (HIP default stream).  No dispatch body line.
-            continue
+            continue  # null slot (auto-stream): packed[i] stays NULL after alloc
         try:
             probe = ctype(0)
         except TypeError:
@@ -1200,9 +1197,7 @@ def _build_dispatch_factory(slot_specs):
     src += "    return dispatch\n"
 
     ns = {}
-    # Compile with a descriptive filename so a traceback from an extract fn
-    # raised during dispatch points at "<flydsl-dispatch>" rather than "<string>".
-    code = compile(src, "<flydsl-dispatch>", "exec")  # src built from trusted internal slot_specs
+    code = builtins.compile(src, "<flydsl-dispatch>", "exec")  # generated from trusted internal slot_specs
     exec(code, ns)
     make = ns["make"]
     extracts = tuple(extracts)

--- a/tests/unit/test_callstate_dispatch.py
+++ b/tests/unit/test_callstate_dispatch.py
@@ -23,28 +23,44 @@ from flydsl.compiler.jit_function import CallState  # noqa: E402
 from flydsl.expr.numeric import Int32  # noqa: E402
 
 
-def _expected_layout_bytes(t):
+def _expected_layout_bytes(t, use_32bit=False):
     """Canonical dynamic-layout buffer: dynamic-shape i32's then dynamic-stride
     i32/i64's, little-endian -- matches C++ buildMemRefDesc."""
-    ad = ja.TensorAdaptor(t)
+    ad = ja.TensorAdaptor(t, use_32bit_stride=use_32bit)
     sd, std, u32 = ad._shape_dyn_indices, ad._stride_dyn_indices, ad.use_32bit_stride
     out = struct.pack("<" + "i" * len(sd), *[t.shape[d] for d in sd])
     out += struct.pack("<" + ("i" if u32 else "q") * len(std), *[t.stride(d) for d in std])
     return out
 
 
-def test_dynamic_layout_buffer_pack_bytes():
+def _layouts():
+    """Diverse dynamic-layout tensors: contiguous, non-contiguous (transpose /
+    permute), and higher rank -- each keeps a unit-stride axis (required for a
+    layout-dynamic memref)."""
+    return [
+        ("contig_2d", torch.empty((4, 8), dtype=torch.float32)),
+        ("contig_2d_f16", torch.empty((7, 13), dtype=torch.float16)),
+        ("contig_3d", torch.empty((2, 3, 5), dtype=torch.float32)),
+        ("transposed_2d", torch.empty((8, 4), dtype=torch.float32).t()),
+        ("permuted_3d", torch.empty((2, 3, 5), dtype=torch.float32).permute(1, 0, 2)),
+    ]
+
+
+@pytest.mark.parametrize("name,t", _layouts(), ids=[n for n, _ in _layouts()])
+@pytest.mark.parametrize("use_32bit", [False, True], ids=["stride64", "stride32"])
+def test_dynamic_layout_buffer_pack_bytes(name, t, use_32bit):
     """``TensorAdaptor._reusable_slot_spec`` returns (data-ptr, layout-buffer)
-    for a dynamic tensor; the pack fn writes exactly the canonical bytes."""
-    t = torch.empty((4, 8), dtype=torch.float32)  # row-major: dynamic layout
-    spec = ja.TensorAdaptor._reusable_slot_spec(t)
+    for a dynamic tensor; the in-place pack writes exactly the canonical bytes,
+    across contiguous/non-contiguous layouts, ranks, and stride widths."""
+    adaptor = ja.TensorAdaptor(t, use_32bit_stride=use_32bit)
+    spec = ja.TensorAdaptor._reusable_slot_spec(adaptor)
     assert isinstance(spec, list) and len(spec) == 2
 
     (_dp_ctype, dp_extract), (buf_ctype, pack) = spec
     storage = buf_ctype()
-    pack(t, storage)
+    pack(t, storage)  # raw tensor at dispatch time (isinstance != cls -> reads t directly)
 
-    assert bytes(storage) == _expected_layout_bytes(t)
+    assert bytes(storage) == _expected_layout_bytes(t, use_32bit)
     assert dp_extract(t) == t.data_ptr()
 
 

--- a/tests/unit/test_callstate_dispatch.py
+++ b/tests/unit/test_callstate_dispatch.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Fast-dispatch packing/ABI guards for the precompiled-call path.
+
+These pin the behaviour of the ``flyc.compile`` fast path so the exec-generated
+straight-line ``CallState`` dispatch and the in-place dynamic-layout pack keep
+writing exactly the same bytes/pointers across changing arguments, including the
+implicit auto-stream slot.  They assert the *observable packing contract* (what
+ends up in the packed pointer array and the layout buffer), not the dispatch
+implementation, so they hold regardless of loop-vs-codegen internals.
+"""
+
+import ctypes
+import struct
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from flydsl.compiler import jit_argument as ja  # noqa: E402
+from flydsl.compiler.jit_function import CallState  # noqa: E402
+from flydsl.expr.numeric import Int32  # noqa: E402
+
+
+def _expected_layout_bytes(t):
+    """Canonical dynamic-layout buffer: dynamic-shape i32's then dynamic-stride
+    i32/i64's, little-endian -- matches C++ buildMemRefDesc."""
+    ad = ja.TensorAdaptor(t)
+    sd, std, u32 = ad._shape_dyn_indices, ad._stride_dyn_indices, ad.use_32bit_stride
+    out = struct.pack("<" + "i" * len(sd), *[t.shape[d] for d in sd])
+    out += struct.pack("<" + ("i" if u32 else "q") * len(std), *[t.stride(d) for d in std])
+    return out
+
+
+def test_dynamic_layout_buffer_pack_bytes():
+    """``TensorAdaptor._reusable_slot_spec`` returns (data-ptr, layout-buffer)
+    for a dynamic tensor; the pack fn writes exactly the canonical bytes."""
+    t = torch.empty((4, 8), dtype=torch.float32)  # row-major: dynamic layout
+    spec = ja.TensorAdaptor._reusable_slot_spec(t)
+    assert isinstance(spec, list) and len(spec) == 2
+
+    (_dp_ctype, dp_extract), (buf_ctype, pack) = spec
+    storage = buf_ctype()
+    pack(t, storage)
+
+    assert bytes(storage) == _expected_layout_bytes(t)
+    assert dp_extract(t) == t.data_ptr()
+
+
+def test_callstate_dispatch_packs_changing_args_and_auto_stream():
+    """CallState fills the packed array correctly when called with new args each
+    time: data ptr, dynamic layout bytes, scalar value, and a NULL auto-stream."""
+    proto = torch.empty((4, 8), dtype=torch.float32)
+    spec_t = ja.TensorAdaptor._reusable_slot_spec(proto)
+    spec_i = Int32._reusable_slot_spec(0)
+    # arg layout: arg0 = tensor (2 slots), arg1 = int (1 slot); + auto-stream NULL.
+    slot_specs = [(0, *spec_t[0]), (0, *spec_t[1]), (1, *spec_i), (-1, ctypes.c_void_p, None)]
+
+    captured = []
+
+    def func_exe(packed):
+        # Dereference each packed cell via its slot ctype to read the value the
+        # kernel ABI would see; do not touch CallState internals.
+        row = []
+        for i, (_arg_idx, ctype, _extract) in enumerate(slot_specs):
+            obj = ctype.from_address(packed[i])
+            row.append(obj.value if hasattr(obj, "value") else bytes(obj))
+        captured.append(row)
+        return None
+
+    cs = CallState(slot_specs, func_exe)
+
+    for k in range(3):
+        t = torch.empty((4, 8), dtype=torch.float32)  # distinct data_ptr each call
+        ival = 100 + k
+        cs((t, ival))
+
+        data_ptr, layout, scalar, auto_stream = captured[-1]
+        assert data_ptr == t.data_ptr()
+        assert layout == _expected_layout_bytes(t)
+        assert scalar == ival
+        assert auto_stream in (None, 0)  # auto-stream slot stays NULL (default stream)


### PR DESCRIPTION
Make the precompiled flyc.compile() dispatch path universally faster for *any* arguments passed each call, not just reused JitArguments.

- jit_function.py: CallState now compiles its per-slot extract/store sequence into a straight-line dispatch closure (codegen via exec), removing the per-call Python loop, the is_scalar branch, and the tuple-unpack. Per-thread packed array and ctypes storages are allocated once and bound into that closure as locals.
- jit_argument.py: the dynamic-tensor layout-buffer pack writes the ctypes array directly (struct.pack_into on the buffer, no per-call memoryview().cast() allocation), reads stride() once, and uses list comprehensions for the pack_into varargs.

Dispatch overhead (MI308X, no-op func_exe, new args every call):
  scalar / static-tensor / pointer / mixed : -16 ~ -21%
  dynamic tensor (bare torch.Tensor)       : -35%
  5  dyn-tensor + 3 int  : 10.6 -> 6.8  us  (+35%)
  10 dyn-tensor + 5 int  : 20.6 -> 13.3 us  (+36%)

The win is independent of input form: passing a bare torch.Tensor vs a pre-built from_dlpack adaptor gives the same dispatch cost. Packed payloads are byte-for-byte identical to the previous CallState (verified across all arg-type scenarios); end-to-end GPU correctness 5/5.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
