### PR TITLE
[Opt] Memoize JitArgument/DslType isinstance in JIT cache-key hot path

### DIFF
--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -22,7 +22,7 @@ from ..expr.typing import (
     Tensor,
     address_space_from_attr,
 )
-from .protocol import DslType, JitArgument
+from .protocol import DslType, JitArgument, is_dsl_type, is_jit_argument
 
 _RESOLVE_SIG_WARNED = set()
 
@@ -124,9 +124,9 @@ def convert_to_jit_arguments(
             constexpr_values[param_name] = value
             continue
 
-        is_jit_arg = isinstance(value, JitArgument)
-        is_dsl_type = isinstance(value, DslType)
-        if is_jit_arg and is_dsl_type:
+        is_jit_arg = is_jit_argument(value)
+        is_dsl = is_dsl_type(value)
+        if is_jit_arg and is_dsl:
             jit_arg = value
             dsl_type = type(value)
         elif is_jit_arg:

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -42,6 +42,7 @@ from .protocol import (
     cache_signature,
     construct_from_ir_values,
     get_ir_types,
+    is_jit_argument,
 )
 
 EXTRA_SOURCE_DIRS: List[str] = []
@@ -1414,7 +1415,7 @@ class JitFunction:
                     key_parts.append((name, arg))
                     continue
 
-            if isinstance(arg, JitArgument):
+            if is_jit_argument(arg):
                 jit_arg = arg
             elif isinstance(ann, type) and issubclass(ann, JitArgument):
                 jit_arg = ann(arg)

--- a/python/flydsl/compiler/protocol.py
+++ b/python/flydsl/compiler/protocol.py
@@ -35,6 +35,37 @@ class Storable(Protocol):
     def __poke_into_ptr__(cls, ptr: ir.Value, value) -> None: ...
 
 
+# ``isinstance(obj, <runtime_checkable Protocol>)`` is O(number of protocol
+# members) and costs several microseconds per call (the negative case is the
+# most expensive). Whether an object satisfies these structural protocols is a
+# pure function of ``type(obj)`` -- the protocol only checks for the presence of
+# methods, which every instance of a type shares -- so the result is memoized by
+# type. This keeps the per-argument JIT dispatch / cache-key hot path cheap
+# (~0.1us dict lookup) instead of re-running the structural check every launch.
+_JIT_ARGUMENT_BY_TYPE: dict = {}
+_DSL_TYPE_BY_TYPE: dict = {}
+
+
+def is_jit_argument(obj) -> bool:
+    """``isinstance(obj, JitArgument)`` memoized by ``type(obj)``."""
+    t = type(obj)
+    r = _JIT_ARGUMENT_BY_TYPE.get(t)
+    if r is None:
+        r = isinstance(obj, JitArgument)
+        _JIT_ARGUMENT_BY_TYPE[t] = r
+    return r
+
+
+def is_dsl_type(obj) -> bool:
+    """``isinstance(obj, DslType)`` memoized by ``type(obj)``."""
+    t = type(obj)
+    r = _DSL_TYPE_BY_TYPE.get(t)
+    if r is None:
+        r = isinstance(obj, DslType)
+        _DSL_TYPE_BY_TYPE[t] = r
+    return r
+
+
 def get_ir_types(obj) -> List[ir.Type]:
     if isinstance(obj, ir.Value):
         return [obj.type]


### PR DESCRIPTION
## Summary

PR #577 (*Promote cache_signature to a interface of JitArgument*) replaced the
cheap `hasattr(...)` duck-typing checks in the per-launch cache-key computation
with `isinstance(arg, JitArgument)` / `isinstance(value, DslType)` against
`@runtime_checkable` Protocols.

`isinstance` against a `runtime_checkable` Protocol is **O(number of protocol
members)** and costs several microseconds per call — the *negative* case is the
most expensive:

| check | cost |
|---|---|
| `isinstance(int, JitArgument)` (False) | ~8.0 us |
| `isinstance(torch.Stream, JitArgument)` (False) | ~7.7 us |
| `isinstance(adaptor, JitArgument)` (True) | ~3.6 us |
| `hasattr(x, "__get_c_pointers__")` | ~0.08 us |

Across all kernel arguments this regressed the `JitFunction.__call__`
warm-dispatch path from **~29 us to ~80 us** (and ~94 us with later cache-key
work layered on top). Profiling shows the `_resolve_and_make_cache_key` arg
loop alone went from ~4 us to ~58 us, dominated by these `isinstance` calls.

## Fix

Whether an object satisfies these structural protocols is a pure function of
`type(obj)` (the protocol only checks for the presence of methods, which every
instance of a type shares), so the result is safely memoized by type. Add
`is_jit_argument` / `is_dsl_type` helpers in `protocol.py` and use them in:
- `_resolve_and_make_cache_key` (`jit_function.py`)
- `convert_to_jit_arguments` (`jit_argument.py`)

## Results

- Warm `JitFunction` dispatch: **~94 us → ~60 us** (the #577 arg-loop cost drops
  back to ~7 us; remaining cost is `sig.bind` / globals-drift / runtime-pairing,
  unrelated to #577).
- `CompiledFunction` fast-dispatch path: unchanged (~8 us).
- **501 unit tests + 36 cache-key tests pass.** #597 / #586 / #624 cache-key
  completeness and correctness behavior is fully preserved (env-var drift,
  globals-drift detection, arch-env-var exclusion, cross-process collision
  protection all intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)