### PR TITLE
Pass num_kv_splits to mla_reduce_v1 / pa_reduce_v1

### DIFF
--- a/kernels/pa_decode_fp8.py
+++ b/kernels/pa_decode_fp8.py
@@ -3195,6 +3195,7 @@ def pa_decode_ps_launch(
         metadata["reduce_final_map"],
         metadata["reduce_partial_map"],
         query_length,  # max_qlen
+        0,  # num_kv_splits: splits are data-driven via reduce_* maps
         output,
         None,
     )

--- a/tests/kernels/test_mla_decode.py
+++ b/tests/kernels/test_mla_decode.py
@@ -329,6 +329,7 @@ def run_single(
             reduce_final_map,
             reduce_partial_map,
             max_seqlen_qo,
+            max_split_per_batch,
             out_asm,
             None,
         )
@@ -347,6 +348,7 @@ def run_single(
             reduce_final_map,
             reduce_partial_map,
             max_seqlen_qo,
+            max_split_per_batch,
             out_tensor,
             None,
         )


### PR DESCRIPTION
aiter added a num_kv_splits parameter (between max_seqlen_q and final_output) to mla_reduce_v1 and its pa_reduce_v1 wrapper. Update the call sites to match the new signature:

- test_mla_decode.py: pass max_split_per_batch (the split count already used for get_mla_metadata_info_v1).
- pa_decode_fp8.py: pass 0 (paged-attention reduce is data-driven via the reduce_* metadata maps, matching aiter's own pa_persistent_fwd).

Fixes 8 MI325 CI failures (6 in test_mla_decode, 2 in test_pa).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
