### PR TITLE
[FMHA] gfx950 dualwave SWP forward kernel: split-K, varlen, arbitrary seq_len (+ gfx942 fallback fix)

### DIFF
--- a/kernels/flash_attn_generic.py
+++ b/kernels/flash_attn_generic.py
@@ -88,6 +88,8 @@ def build_flash_attn_func_module_primary(
     daz=True,
     path_tag="auto",
     num_kv_heads=None,
+    cu_seqlens_q=None,
+    cu_seqlens_kv=None,
     dualwave_swp_lazy_rescale=True,
     dualwave_swp_setprio=True,
     dualwave_swp_debug_lazy_counts=False,
@@ -111,11 +113,22 @@ def build_flash_attn_func_module_primary(
     K_SUB_N = 32
     WARP_SIZE = 64
 
+    # ── seq_len support ────────────────────────────────────────────────────
+    # Both variants now handle arbitrary seq_len:
+    #   * generic fallback: partial last q-tile via Q-load/O-store bounds, and
+    #     partial last kv-tile via per-(batch) num_records-bounded DMA loads /
+    #     clamped non-DMA loads + causal / non-causal padding masks.
+    #   * DUALWAVE_SWP fast path (built below): now handles any seq_len >= 1
+    #     (the pipeline floors its tile count at the 4-tile minimum; extra tiles
+    #     read 0 via the num_records bound and are masked out).
+    _DUALWAVE_MIN_SEQ = 1
+
     # ── DUALWAVE_SWP fast path (gfx950 D=128 bf16/f16) ──
     # Built when:
     #   * outermost call (block_m is None)
     #   * head_dim == 128, dtype in (bf16, f16), gpu_arch startswith "gfx950"
-    # Runtime dispatch additionally requires seq_len >= 384 and seq_len % 256 == 0.
+    # Runtime dispatch additionally requires seq_len >= 384 (any alignment; the
+    # DUALWAVE_SWP kernel handles non-256/64-aligned seq_len internally).
     _dualwave_swp_launch = None
     if block_m is None and head_dim == 128 and dtype_str in ("bf16", "f16") and gpu_arch.startswith("gfx950"):
         try:
@@ -133,34 +146,86 @@ def build_flash_attn_func_module_primary(
                 dualwave_swp_setprio=dualwave_swp_setprio,
                 dualwave_swp_debug_lazy_counts=dualwave_swp_debug_lazy_counts,
                 dualwave_swp_enable_stagger=dualwave_swp_enable_stagger,
+                # QKV varlen (packed cu_seqlens). Non-None cu_seqlens_q -> build the
+                # varlen kernel variant; the runtime tensors are captured here and
+                # forwarded into the dualwave launch by _wrap_with_dualwave_swp below.
+                varlen=(cu_seqlens_q is not None),
             )
         except Exception as _dualwave_swp_err:
             import sys
 
             print(
-                f"[flash_attn_func] OPUS path build failed, falling back: {_dualwave_swp_err}",
+                f"[flash_attn_func] DUALWAVE_SWP path build failed, falling back: {_dualwave_swp_err}",
                 file=sys.stderr,
             )
             _dualwave_swp_launch = None
 
+    def _extract_seq_len(args, kwargs):
+        """Return the launch-time seq_len as int, or None if not statically known."""
+        S = args[5] if len(args) > 5 else kwargs.get("seq_len", None)
+        try:
+            return int(S)
+        except (TypeError, ValueError):
+            return None
+
+    def _guard_seqlen(_dispatched):
+        """Reject seq_len values the kernel cannot compute correctly.
+
+        Both variants now handle arbitrary seq_len: the DUALWAVE_SWP fast path
+        for seq_len >= 384, and the generic fallback for any seq_len (partial
+        last q-tile via Q/O bounds, partial last kv-tile via bounded/clamped KV
+        loads + causal / non-causal padding masks). So the only constraint left
+        is seq_len >= 1. A symbolic / non-int seq_len is let through.
+        """
+
+        def _guarded(*args, **kwargs):
+            S_int = _extract_seq_len(args, kwargs)
+            if S_int is not None and S_int < 1:
+                raise ValueError(f"flash_attn_func: seq_len must be >= 1, got {S_int}.")
+            return _dispatched(*args, **kwargs)
+
+        if hasattr(_dispatched, "compile"):
+            _guarded.compile = _dispatched.compile
+        return _guarded
+
     def _wrap_with_dualwave_swp(_fallback):
-        """Return a dispatcher that routes eligible runtime shapes to OPUS."""
+        """Route eligible runtime shapes to DUALWAVE_SWP, then apply the seq_len
+        guard (only at the outermost, user-facing build; inner recursive builds
+        carry ``block_m`` set and are guarded by their parent)."""
+        if cu_seqlens_q is not None and _dualwave_swp_launch is None:
+            raise ValueError(
+                "QKV varlen (cu_seqlens) is only supported on the gfx950 DUALWAVE_SWP "
+                "path (head_dim=128, dtype bf16/f16, gpu_arch gfx950)"
+            )
         if _dualwave_swp_launch is None:
-            return _fallback
+            dispatched = _fallback
+        else:
 
-        def _dualwave_swp_dispatch(*args, **kwargs):
-            S = args[5] if len(args) > 5 else kwargs.get("seq_len", 0)
-            try:
-                S_int = int(S)
-            except (TypeError, ValueError):
-                S_int = 0
-            if S_int >= 384 and S_int % 256 == 0:
-                return _dualwave_swp_launch(*args, **kwargs)
-            return _fallback(*args, **kwargs)
+            def _dualwave_swp_dispatch(*args, **kwargs):
+                # The DUALWAVE_SWP kernel handles non-aligned seq_len (partial
+                # last q-block + partial/odd kv-tile count) the same way the
+                # reference asm does, so the only constraint is the software-
+                # pipeline depth minimum (>= 384). seq_len need NOT be a
+                # multiple of 256/64 for this path.
+                S_int = _extract_seq_len(args, kwargs)
+                if S_int is not None and S_int >= _DUALWAVE_MIN_SEQ:
+                    # Varlen: forward the cu_seqlens captured at build time (S here
+                    # is max_seqlen, which sizes grid_y; per-batch ranges come from
+                    # cu_seqlens inside the kernel).
+                    if cu_seqlens_q is not None:
+                        return _dualwave_swp_launch(
+                            *args, cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_kv, **kwargs
+                        )
+                    return _dualwave_swp_launch(*args, **kwargs)
+                return _fallback(*args, **kwargs)
 
-        if hasattr(_fallback, "compile"):
-            _dualwave_swp_dispatch.compile = _fallback.compile
-        return _dualwave_swp_dispatch
+            if hasattr(_fallback, "compile"):
+                _dualwave_swp_dispatch.compile = _fallback.compile
+            dispatched = _dualwave_swp_dispatch
+
+        if block_m is None:
+            return _guard_seqlen(dispatched)
+        return dispatched
 
     # Auto tile selection: for H>=32, build both M=128 and M=256 variants
     # and dispatch at runtime based on B*S.
@@ -340,10 +405,8 @@ def build_flash_attn_func_module_primary(
         elem_dtype = dtype_to_elem_type(dtype_str)
         elem_type = elem_dtype.ir_type
         compute_type = fx.Float32.ir_type
-        q_ptr = _extract_aligned_pointer(Q)
         k_ptr = _extract_aligned_pointer(K)
         v_ptr = _extract_aligned_pointer(V)
-        o_ptr = _extract_aligned_pointer(O)
 
         # All FP operations use aggressive fast-math (no NaN/Inf checks, reassociation).
         # The unsafe_fp_math/fast_fp_math builder params control LLVM-level attributes only.
@@ -457,6 +520,14 @@ def build_flash_attn_func_module_primary(
             token = batch_idx * seq_len_v + token_idx
             return token * STRIDE_TOKEN_KV + kv_head_idx * HEAD_DIM + col
 
+        def _kv_row_clamp(row_idx):
+            # Non-DMA KV loads use raw pointers (no hardware bounds), so clamp the
+            # global KV row to the last valid token; partial-tile lanes then read a
+            # duplicated in-bounds row whose contribution the score-side causal /
+            # padding mask discards. (The DMA path is bounded by num_records.)
+            last = seq_len_v - fx.Index(1)
+            return fx.Index(ArithValue(row_idx < seq_len_v).select(row_idx, last))
+
         def _load_global_half_vec(ptr, base_idx, vec_elems: int):
             gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=elem_type)
             return _pointer_load(Vec.make_type(vec_elems, elem_dtype), gep)
@@ -519,7 +590,7 @@ def build_flash_attn_func_module_primary(
             k_base = k_buf_base(buf_id)
             for batch in range_constexpr(NUM_BATCHES_KV):
                 row_offset = batch * ROWS_PER_BATCH_LOAD
-                row_idx = tile_start + load_row_in_batch + row_offset
+                row_idx = _kv_row_clamp(tile_start + load_row_in_batch + row_offset)
                 if const_expr(KV_NEEDS_GUARD):
                     row_valid = load_row_in_batch < fx.Index(BLOCK_N)
                     if row_valid:
@@ -556,7 +627,7 @@ def build_flash_attn_func_module_primary(
             v_base = v_buf_base(buf_id)
             for batch in range_constexpr(NUM_BATCHES_KV):
                 row_offset = batch * ROWS_PER_BATCH_LOAD
-                row_idx = tile_start + load_row_in_batch + row_offset
+                row_idx = _kv_row_clamp(tile_start + load_row_in_batch + row_offset)
                 if const_expr(KV_NEEDS_GUARD):
                     row_valid = load_row_in_batch < fx.Index(BLOCK_N)
                     if row_valid:
@@ -575,7 +646,7 @@ def build_flash_attn_func_module_primary(
             vecs = []
             for batch in range_constexpr(NUM_BATCHES_KV):
                 row_offset = batch * ROWS_PER_BATCH_LOAD
-                row_idx = tile_start + load_row_in_batch + row_offset
+                row_idx = _kv_row_clamp(tile_start + load_row_in_batch + row_offset)
                 g_idx = global_idx_kv(row_idx, load_col_base)
                 vecs.append(load_global_f16xN(v_ptr, g_idx))
             return vecs
@@ -594,9 +665,21 @@ def build_flash_attn_func_module_primary(
                     lds_row = load_row_in_batch + row_offset
                     _v_store_to_lds(v_base, lds_row, vecs[batch])
 
+        # Per-(batch) byte bounds: rows >= seq_len read past this batch's region,
+        # so a bounded num_records makes the hardware return 0 on OOB loads and
+        # drop OOB stores (arbitrary-seqlen safe, no fault). Equivalent to
+        # max_size for an aligned seq_len, so the aligned hot path is unchanged.
+        # Same num_records trick as the hand-asm / DUALWAVE_SWP kernel
+        # (flash_attn_gfx950.py), used here for the K/V DMA loads, the Q-load,
+        # and the O-store -- so no per-lane q_in_bounds select / O-store predicate.
+        _kv_nrec_bytes = _raw((batch_idx + fx.Index(1)) * seq_len_v * fx.Index(STRIDE_TOKEN_KV * 2))
+        _q_nrec_bytes = _raw((batch_idx + fx.Index(1)) * seq_len_v * fx.Index(STRIDE_TOKEN_Q * 2))
+        q_rsrc = buffer_ops.create_buffer_resource(Q, max_size=False, num_records_bytes=_q_nrec_bytes)
+        o_rsrc = buffer_ops.create_buffer_resource(O, max_size=False, num_records_bytes=_q_nrec_bytes)
+
         # ---- DMA loading for K (buffer_load_dwordx4 ... lds) ----
         if const_expr(ENABLE_DMA):
-            k_rsrc = buffer_ops.create_buffer_resource(K, max_size=True)
+            k_rsrc = buffer_ops.create_buffer_resource(K, max_size=False, num_records_bytes=_kv_nrec_bytes)
             DMA_BYTES = 16  # buffer_load_dwordx4 = 16 bytes per lane
             DMA_BATCH_BYTES = BLOCK_SIZE * DMA_BYTES
             K_TILE_BYTES = BLOCK_N * K_STRIDE * 2
@@ -651,7 +734,7 @@ def build_flash_attn_func_module_primary(
 
         # ---- DMA loading for V (buffer_load_dwordx4 ... lds) ----
         if const_expr(ENABLE_DMA):
-            v_rsrc = buffer_ops.create_buffer_resource(V, max_size=True)
+            v_rsrc = buffer_ops.create_buffer_resource(V, max_size=False, num_records_bytes=_kv_nrec_bytes)
             V_TILE_BYTES = BLOCK_N * V_STRIDE * 2
             NUM_DMA_V = V_TILE_BYTES // DMA_BATCH_BYTES
             LANES_PER_V_ROW = HEAD_DIM * 2 // DMA_BYTES
@@ -691,17 +774,16 @@ def build_flash_attn_func_module_primary(
 
         # ---- Preload Q^T B-operand packs once (register-resident) ----
         # B operand uses j = lane_mod_32, k-subblock = lane_div_32*MFMA_LANE_K.
+        # Q is loaded through the num_records-bounded q_rsrc, so an out-of-bounds
+        # row (q_row >= seq_len, partial last q-tile) reads 0 from hardware -- no
+        # q_in_bounds select / row clamp needed (DUALWAVE_SWP-style boundary).
         q_row = q_start + wave_q_offset + lane_mod_32
         q_row_i32 = fx.Int32(q_row)
-        q_in_bounds = q_row < seq_len_v
-        q_row_safe = fx.Index(ArithValue(q_in_bounds).select(q_row, fx.Index(0)))
-        c_zero_mfma_pack = Vec.filled(MFMA_LANE_K, 0.0, elem_dtype).ir_value()
         q_b_packs = []
         for ks in range_constexpr(K_STEPS_QK):
             q_col = fx.Index(ks * K_STEP_QK) + lane_div_32 * MFMA_LANE_K
-            g_idx = global_idx_q(q_row_safe, q_col)
-            raw = load_global_mfma_pack(q_ptr, g_idx)
-            q_b_packs.append(ArithValue(q_in_bounds).select(raw, c_zero_mfma_pack))
+            g_idx = global_idx_q(q_row, q_col)
+            q_b_packs.append(buffer_ops.buffer_load(q_rsrc, g_idx, vec_width=MFMA_LANE_K, dtype=elem_dtype))
 
         # ---- Constants ----
         c_neg_inf = fx.Float32(float("-inf"))
@@ -997,6 +1079,24 @@ def build_flash_attn_func_module_primary(
                         s_raw_hi_14,
                         s_raw_hi_15,
                     ]
+                else:
+                    # Non-causal KV padding mask: set keys whose absolute column
+                    # index >= seq_len to -inf, so bounded/clamped out-of-bounds
+                    # KV (which reads 0 on the DMA path or a duplicated row on the
+                    # non-DMA path) does not leak into the softmax. (Causal already
+                    # masks these columns via the kv_col > q_row test above.) The
+                    # element->column layout mirrors the causal masking above:
+                    # lo col = kv_start + lane_div_32*4 + ((r//4)*8 + r%4); hi = +K_SUB_N.
+                    kv_start_i32 = fx.Int32(kv_start)
+                    lane_off_i32 = fx.Int32(lane_div_32) * fx.Int32(4)
+                    seq_len_i32 = fx.Int32(seq_len_v)
+                    for r in range_constexpr(16):
+                        _off = (r // 4) * 8 + (r % 4)
+                        kv_col = kv_start_i32 + lane_off_i32 + fx.Int32(_off)
+                        s_raw_lo[r] = ArithValue(kv_col >= seq_len_i32).select(c_neg_inf, s_raw_lo[r])
+                        s_raw_hi[r] = ArithValue(kv_col + fx.Int32(K_SUB_N) >= seq_len_i32).select(
+                            c_neg_inf, s_raw_hi[r]
+                        )
 
                 local_max = s_raw_lo[0]
                 for r in range_constexpr(15):
@@ -1211,24 +1311,58 @@ def build_flash_attn_func_module_primary(
                     _yield_args.append(_cur_buf_id)
             loop_results = yield _yield_args
 
-        # ---- Normalize and store O (skip OOB rows for partial Q tiles) ----
+        # ---- Normalize and store O (128-bit buffer_store_dwordx4) ----
+        # Ported from flash_attn_gfx950.py: pack 4 f32 -> 2 packed-16bit dwords
+        # (cvt_pk_bf16_f32 / RNE trunc), then permlane32_swap fuses each lane's
+        # 4 cols with its half-wave partner's 4 cols so one store covers 8
+        # contiguous cols -> 4 dwordx4 per wave per d_chunk instead of 16 scalar
+        # stores. O is num_records-bounded (o_rsrc), so OOB rows of a partial
+        # last q-tile are dropped by hardware -- no per-lane predicate needed.
         l_final = loop_results[1]
         o_finals = [loop_results[2 + dc] for dc in range_constexpr(D_CHUNKS)]
 
         inv_l = rocdl.rcp(T.f32, l_final)
         inv_l_vec = Vec.from_elements([inv_l], fx.Float32).broadcast_to(16)
+        v_o = [Vec(o_finals[dc]) * inv_l_vec for dc in range_constexpr(D_CHUNKS)]
 
-        if q_in_bounds:
-            for dc in range_constexpr(D_CHUNKS):
-                o_norm_vec = Vec(o_finals[dc]) * inv_l_vec
-                for r in range_constexpr(16):
-                    o_val = Vec(o_norm_vec)[r]
-                    o_f16 = fx.Float32(o_val).to(elem_dtype)
+        pair_i32_ty = ir.Type.parse("!llvm.struct<(i32, i32)>")
+        is_hi_half = ArithValue(lane_div_32 != fx.Index(0))
 
-                    d_row_rel = lane_div_32 * 4 + (r // 4) * 8 + (r % 4)
-                    d_col = fx.Index(dc * D_CHUNK) + d_row_rel
-                    o_global = global_idx_q(q_row, d_col)
-                    _store_global_half(o_ptr, o_global, o_f16)
+        def _o_pack_2dw(dc, store_group):
+            # 4 f32 outputs -> 2 packed-16bit dwords (lo = cols 0,1; hi = cols 2,3).
+            r_base = store_group * 4
+            if const_expr(dtype_str == "bf16"):
+                lo = rocdl.cvt_pk_bf16_f32(Vec(v_o[dc])[r_base], Vec(v_o[dc])[r_base + 1])
+                hi = rocdl.cvt_pk_bf16_f32(Vec(v_o[dc])[r_base + 2], Vec(v_o[dc])[r_base + 3])
+                return lo, hi
+            o_f16 = [fx.Float32(Vec(v_o[dc])[r_base + i]).to(elem_dtype) for i in range_constexpr(4)]
+            pack = Vec.from_elements(o_f16, elem_dtype).bitcast(fx.Int32)
+            return _raw(pack[0]), _raw(pack[1])
+
+        def _swap_halves(dw):
+            # permlane32_swap(a,b) -> (a.lo|b.lo, a.hi|b.hi); with a=b=dw the
+            # partner dword dw[lane^32] is result[1] on low lanes, [0] on high.
+            swapped = rocdl.permlane32_swap(pair_i32_ty, _raw(dw), _raw(dw), False, False)
+            lo_res = llvm.extractvalue(T.i32, swapped, [0])
+            hi_res = llvm.extractvalue(T.i32, swapped, [1])
+            return is_hi_half.select(lo_res, hi_res)
+
+        for dc in range_constexpr(D_CHUNKS):
+            for g in range_constexpr(2):
+                d0_a, d1_a = _o_pack_2dw(dc, 2 * g)
+                d0_b, d1_b = _o_pack_2dw(dc, 2 * g + 1)
+                # low lanes: own group-2g cols 0-3 ++ partner's cols 4-7;
+                # high lanes: partner's group-(2g+1) cols 0-3 ++ own cols 4-7.
+                y0_a, y1_a = _swap_halves(d0_a), _swap_halves(d1_a)
+                y0_b, y1_b = _swap_halves(d0_b), _swap_halves(d1_b)
+                w0 = is_hi_half.select(y0_b, _raw(d0_a))
+                w1 = is_hi_half.select(y1_b, _raw(d1_a))
+                w2 = is_hi_half.select(_raw(d0_b), y0_a)
+                w3 = is_hi_half.select(_raw(d1_b), y1_a)
+                o_pack = Vec.from_elements([fx.Int32(w0), fx.Int32(w1), fx.Int32(w2), fx.Int32(w3)], fx.Int32)
+                d_col = fx.Index(dc * D_CHUNK) + (fx.Index(2 * g) + lane_div_32) * fx.Index(8)
+                o_global = global_idx_q(q_row, d_col)
+                buffer_ops.buffer_store(o_pack, o_rsrc, o_global * fx.Index(2), offset_is_bytes=True)
 
     @flyc.jit
     def launch_flash_attn_generic(

--- a/kernels/flash_attn_generic.py
+++ b/kernels/flash_attn_generic.py
@@ -130,7 +130,16 @@ def build_flash_attn_func_module_primary(
     # Runtime dispatch additionally requires seq_len >= 384 (any alignment; the
     # DUALWAVE_SWP kernel handles non-256/64-aligned seq_len internally).
     _dualwave_swp_launch = None
-    if block_m is None and head_dim == 128 and dtype_str in ("bf16", "f16") and gpu_arch.startswith("gfx950"):
+    # FLYDSL_DISABLE_DUALWAVE_SWP=1 forces the generic fallback even on gfx950 D=128
+    # bf16/f16 (used to exercise/validate the generic kernel on gfx950 hardware).
+    _dualwave_swp_disabled = os.environ.get("FLYDSL_DISABLE_DUALWAVE_SWP", "0") == "1"
+    if (
+        block_m is None
+        and head_dim == 128
+        and dtype_str in ("bf16", "f16")
+        and gpu_arch.startswith("gfx950")
+        and not _dualwave_swp_disabled
+    ):
         try:
             from kernels.flash_attn_gfx950 import build_flash_attn_dualwave_swp_module
 
@@ -320,6 +329,14 @@ def build_flash_attn_func_module_primary(
 
     # MFMA32 K-dimension: 16 on gfx950+ (CDNA4) for both GEMMs.
     USE_K16 = gpu_arch.startswith("gfx950")
+
+    # 128-bit permlane-fused O-store needs gfx950: it uses permlane32_swap AND
+    # cvt_pk_bf16_f32, both of which are gfx950 (CDNA4) only -- on gfx942 the LLVM
+    # backend cannot select them ("Cannot select intrinsic llvm.amdgcn.permlane32.swap").
+    # gfx942 falls back to a per-lane dwordx2 store using .to(elem_dtype) (arch-correct
+    # bf16/f16 conversion). FLYDSL_GENERIC_OSTORE_SCALAR=1 forces the scalar path so the
+    # gfx942 store can be validated on gfx950 hardware.
+    USE_PERMLANE_OSTORE = gpu_arch.startswith("gfx950") and os.environ.get("FLYDSL_GENERIC_OSTORE_SCALAR", "0") != "1"
     K_STEP_QK = 16 if USE_K16 else 8
     K_STEPS_QK = head_dim // K_STEP_QK
     D_CHUNK = 32
@@ -1325,44 +1342,61 @@ def build_flash_attn_func_module_primary(
         inv_l_vec = Vec.from_elements([inv_l], fx.Float32).broadcast_to(16)
         v_o = [Vec(o_finals[dc]) * inv_l_vec for dc in range_constexpr(D_CHUNKS)]
 
-        pair_i32_ty = ir.Type.parse("!llvm.struct<(i32, i32)>")
-        is_hi_half = ArithValue(lane_div_32 != fx.Index(0))
+        if const_expr(USE_PERMLANE_OSTORE):
+            # gfx950: 128-bit permlane-fused store (cvt_pk_bf16_f32 + permlane32_swap).
+            pair_i32_ty = ir.Type.parse("!llvm.struct<(i32, i32)>")
+            is_hi_half = ArithValue(lane_div_32 != fx.Index(0))
 
-        def _o_pack_2dw(dc, store_group):
-            # 4 f32 outputs -> 2 packed-16bit dwords (lo = cols 0,1; hi = cols 2,3).
-            r_base = store_group * 4
-            if const_expr(dtype_str == "bf16"):
-                lo = rocdl.cvt_pk_bf16_f32(Vec(v_o[dc])[r_base], Vec(v_o[dc])[r_base + 1])
-                hi = rocdl.cvt_pk_bf16_f32(Vec(v_o[dc])[r_base + 2], Vec(v_o[dc])[r_base + 3])
-                return lo, hi
-            o_f16 = [fx.Float32(Vec(v_o[dc])[r_base + i]).to(elem_dtype) for i in range_constexpr(4)]
-            pack = Vec.from_elements(o_f16, elem_dtype).bitcast(fx.Int32)
-            return _raw(pack[0]), _raw(pack[1])
+            def _o_pack_2dw(dc, store_group):
+                # 4 f32 outputs -> 2 packed-16bit dwords (lo = cols 0,1; hi = cols 2,3).
+                r_base = store_group * 4
+                if const_expr(dtype_str == "bf16"):
+                    lo = rocdl.cvt_pk_bf16_f32(Vec(v_o[dc])[r_base], Vec(v_o[dc])[r_base + 1])
+                    hi = rocdl.cvt_pk_bf16_f32(Vec(v_o[dc])[r_base + 2], Vec(v_o[dc])[r_base + 3])
+                    return lo, hi
+                o_f16 = [fx.Float32(Vec(v_o[dc])[r_base + i]).to(elem_dtype) for i in range_constexpr(4)]
+                pack = Vec.from_elements(o_f16, elem_dtype).bitcast(fx.Int32)
+                return _raw(pack[0]), _raw(pack[1])
 
-        def _swap_halves(dw):
-            # permlane32_swap(a,b) -> (a.lo|b.lo, a.hi|b.hi); with a=b=dw the
-            # partner dword dw[lane^32] is result[1] on low lanes, [0] on high.
-            swapped = rocdl.permlane32_swap(pair_i32_ty, _raw(dw), _raw(dw), False, False)
-            lo_res = llvm.extractvalue(T.i32, swapped, [0])
-            hi_res = llvm.extractvalue(T.i32, swapped, [1])
-            return is_hi_half.select(lo_res, hi_res)
+            def _swap_halves(dw):
+                # permlane32_swap(a,b) -> (a.lo|b.lo, a.hi|b.hi); with a=b=dw the
+                # partner dword dw[lane^32] is result[1] on low lanes, [0] on high.
+                swapped = rocdl.permlane32_swap(pair_i32_ty, _raw(dw), _raw(dw), False, False)
+                lo_res = llvm.extractvalue(T.i32, swapped, [0])
+                hi_res = llvm.extractvalue(T.i32, swapped, [1])
+                return is_hi_half.select(lo_res, hi_res)
 
-        for dc in range_constexpr(D_CHUNKS):
-            for g in range_constexpr(2):
-                d0_a, d1_a = _o_pack_2dw(dc, 2 * g)
-                d0_b, d1_b = _o_pack_2dw(dc, 2 * g + 1)
-                # low lanes: own group-2g cols 0-3 ++ partner's cols 4-7;
-                # high lanes: partner's group-(2g+1) cols 0-3 ++ own cols 4-7.
-                y0_a, y1_a = _swap_halves(d0_a), _swap_halves(d1_a)
-                y0_b, y1_b = _swap_halves(d0_b), _swap_halves(d1_b)
-                w0 = is_hi_half.select(y0_b, _raw(d0_a))
-                w1 = is_hi_half.select(y1_b, _raw(d1_a))
-                w2 = is_hi_half.select(_raw(d0_b), y0_a)
-                w3 = is_hi_half.select(_raw(d1_b), y1_a)
-                o_pack = Vec.from_elements([fx.Int32(w0), fx.Int32(w1), fx.Int32(w2), fx.Int32(w3)], fx.Int32)
-                d_col = fx.Index(dc * D_CHUNK) + (fx.Index(2 * g) + lane_div_32) * fx.Index(8)
-                o_global = global_idx_q(q_row, d_col)
-                buffer_ops.buffer_store(o_pack, o_rsrc, o_global * fx.Index(2), offset_is_bytes=True)
+            for dc in range_constexpr(D_CHUNKS):
+                for g in range_constexpr(2):
+                    d0_a, d1_a = _o_pack_2dw(dc, 2 * g)
+                    d0_b, d1_b = _o_pack_2dw(dc, 2 * g + 1)
+                    # low lanes: own group-2g cols 0-3 ++ partner's cols 4-7;
+                    # high lanes: partner's group-(2g+1) cols 0-3 ++ own cols 4-7.
+                    y0_a, y1_a = _swap_halves(d0_a), _swap_halves(d1_a)
+                    y0_b, y1_b = _swap_halves(d0_b), _swap_halves(d1_b)
+                    w0 = is_hi_half.select(y0_b, _raw(d0_a))
+                    w1 = is_hi_half.select(y1_b, _raw(d1_a))
+                    w2 = is_hi_half.select(_raw(d0_b), y0_a)
+                    w3 = is_hi_half.select(_raw(d1_b), y1_a)
+                    o_pack = Vec.from_elements([fx.Int32(w0), fx.Int32(w1), fx.Int32(w2), fx.Int32(w3)], fx.Int32)
+                    d_col = fx.Index(dc * D_CHUNK) + (fx.Index(2 * g) + lane_div_32) * fx.Index(8)
+                    o_global = global_idx_q(q_row, d_col)
+                    buffer_ops.buffer_store(o_pack, o_rsrc, o_global * fx.Index(2), offset_is_bytes=True)
+        else:
+            # gfx942 (CDNA3) fallback: no permlane32_swap / cvt_pk_bf16_f32. Each lane
+            # stores its own 16 output cols as 4 dwordx2 groups (4 contiguous cols each),
+            # packed via .to(elem_dtype) (arch-correct bf16/f16 conversion). Same column
+            # map as the per-element store: d_col = dc*D_CHUNK + lane_div_32*4 + 8*grp + r.
+            # O is num_records-bounded (o_rsrc) -> OOB rows of a partial last q-tile drop.
+            for dc in range_constexpr(D_CHUNKS):
+                for grp in range_constexpr(4):
+                    r0 = grp * 4
+                    o_f16 = [fx.Float32(Vec(v_o[dc])[r0 + i]).to(elem_dtype) for i in range_constexpr(4)]
+                    pack = Vec.from_elements(o_f16, elem_dtype).bitcast(fx.Int32)
+                    o2 = Vec.from_elements([_raw(pack[0]), _raw(pack[1])], fx.Int32)
+                    d_col = fx.Index(dc * D_CHUNK) + lane_div_32 * fx.Index(4) + fx.Index(grp * 8)
+                    o_global = global_idx_q(q_row, d_col)
+                    buffer_ops.buffer_store(o2, o_rsrc, o_global * fx.Index(2), offset_is_bytes=True)
 
     @flyc.jit
     def launch_flash_attn_generic(

--- a/kernels/flash_attn_gfx950.py
+++ b/kernels/flash_attn_gfx950.py
@@ -7,15 +7,20 @@ The gfx950 fast path of FlyDSL flash attention: same math as the generic
 ``flash_attn_generic.py`` BLOCK_M=256 path, but with a hand-built software
 pipeline and two-wave-group time-multiplexing instead of the compiler schedule.
 Dispatched only when gpu_arch >= gfx950, head_dim == 128, dtype in (bf16, fp16),
-and (at runtime) seq_len % 256 == 0 and seq_len >= 384.
+and (at runtime) seq_len >= 384. seq_len need NOT be a multiple of 256/64: a
+partial last q-block and a partial/odd kv-tile count are handled the same way as
+the hand-written reference asm (num_records bound on Q/K/V/O, tile count rounded
+up to even, and a kv padding-mask on the non-causal path).
 """
 
+import contextlib
 import math as host_math
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import fly, llvm, vector
+from flydsl._mlir.dialects import scf as _scf
 from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl
 from flydsl.expr import math as fmath
@@ -24,7 +29,7 @@ from flydsl.expr.typing import Vector as Vec
 from flydsl.expr.utils.arith import ArithValue
 from flydsl.expr.utils.arith import _to_raw as _raw
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
-from kernels.kernels_common import dtype_to_elem_type
+from kernels.kernels_common import _if_then, dtype_to_elem_type
 
 _LOG2E = host_math.log2(host_math.e)
 # s_waitcnt bitfield encoding
@@ -73,6 +78,16 @@ def _lds_alias_scope_array(names):
     return ir.Attribute.parse(f"[{', '.join(attrs)}]")
 
 
+def dualwave_splitk_workspace_elems(batch_size, num_heads, seq_len, num_kv_splits, head_dim=128):
+    """fp32 elements needed for the split-K workspace: O_partial + Mrow + Lrow.
+
+    O_partial is stored as kernel-native 16-bit (bf16/fp16), two columns per
+    fp32 slot; Mrow/Lrow stay fp32.
+    """
+    rows = batch_size * num_kv_splits * num_heads * seq_len
+    return rows * (head_dim // 2) + 2 * rows
+
+
 def build_flash_attn_dualwave_swp_module(
     num_heads,
     head_dim,
@@ -85,8 +100,16 @@ def build_flash_attn_dualwave_swp_module(
     dualwave_swp_setprio=True,
     dualwave_swp_debug_lazy_counts=False,
     dualwave_swp_enable_stagger=True,
+    num_kv_splits=1,
+    varlen=False,
 ):
-    """Build an DUALWAVE_SWP flash_attn launcher for D=128 bf16/f16 on gfx950."""
+    """Build an DUALWAVE_SWP flash_attn launcher for D=128 bf16/f16 on gfx950.
+
+    ``varlen`` builds the QKV variable-length (packed) variant: Q/O are
+    ``[total_q, H, D]``, K/V are ``[total_kv, H_kv, D]``, and per-batch token
+    ranges come from cumulative ``cu_seqlens_q`` / ``cu_seqlens_kv`` (int32
+    ``[B+1]``) passed at launch. Per batch ``seqlen_q == seqlen_kv`` (self-attn).
+    With ``varlen=False`` the dense path is unchanged (byte-identical codegen)."""
     gpu_arch = get_hip_arch()
 
     if not gpu_arch.startswith("gfx950"):
@@ -99,6 +122,9 @@ def build_flash_attn_dualwave_swp_module(
     if num_kv_heads is None:
         num_kv_heads = num_heads
     assert num_heads % num_kv_heads == 0
+    NUM_KV_SPLITS = int(num_kv_splits)
+    assert NUM_KV_SPLITS >= 1
+    SPLITK = NUM_KV_SPLITS > 1
 
     # ──────────────────────────── Tile constants ────────────────────────────
     # Match existing flash_attn_generic BLOCK_M=256 path for layout compatibility.
@@ -188,6 +214,9 @@ def build_flash_attn_dualwave_swp_module(
     DUALWAVE_SWP_SETPRIO = bool(dualwave_swp_setprio)
     DUALWAVE_SWP_DEBUG_LAZY_COUNTS = bool(dualwave_swp_debug_lazy_counts)
     DUALWAVE_SWP_ENABLE_STAGGER = bool(dualwave_swp_enable_stagger)
+    VARLEN = bool(varlen)
+    if VARLEN and num_kv_splits and int(num_kv_splits) > 1:
+        raise ValueError("varlen is not supported together with num_kv_splits > 1")
 
     @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
     def flash_attn_dualwave_swp_gfx950_kernel(
@@ -196,6 +225,8 @@ def build_flash_attn_dualwave_swp_module(
         V: fx.Tensor,
         O: fx.Tensor,  # noqa: E741
         DebugCounts: fx.Tensor,
+        CuSeqQ: fx.Tensor,
+        CuSeqKv: fx.Tensor,
         seq_len: fx.Int32,
         stride_q_n: fx.Int32,
         stride_kv_n: fx.Int32,
@@ -234,7 +265,12 @@ def build_flash_attn_dualwave_swp_module(
 
         h_idx = fx.Index(gpu.block_idx.x)
         q_block_idx = fx.Index(gpu.block_idx.y)
-        batch_idx = fx.Index(gpu.block_idx.z)
+        if const_expr(SPLITK):
+            bz_idx = fx.Index(gpu.block_idx.z)
+            batch_idx = bz_idx // NUM_KV_SPLITS
+            split_idx = bz_idx % NUM_KV_SPLITS
+        else:
+            batch_idx = fx.Index(gpu.block_idx.z)
         tid = fx.Index(gpu.thread_idx.x)
 
         wave_id = tid // WARP_SIZE
@@ -242,13 +278,13 @@ def build_flash_attn_dualwave_swp_module(
         lane_mod_32 = lane % 32
         lane_div_32 = lane // 32
 
-        _tid_i32 = arith.index_cast(T.i32, _raw(tid))
+        _tid_i32 = _raw(fx.Int32(tid))
         _wave_id_uni_i32 = rocdl.readfirstlane(
             T.i32,
-            arith.divsi(_tid_i32, arith.constant(WARP_SIZE, type=T.i32)),
+            arith.divsi(_tid_i32, _raw(fx.Int32(WARP_SIZE))),
         )
-        _stagger_i32 = arith.divsi(_wave_id_uni_i32, arith.constant(4, type=T.i32))
-        wave_id_uni = fx.Index(arith.index_cast(T.index, _wave_id_uni_i32))
+        _stagger_i32 = arith.divsi(_wave_id_uni_i32, _raw(fx.Int32(4)))
+        wave_id_uni = fx.Index(_wave_id_uni_i32)
 
         wave_q_offset = wave_id * ROWS_PER_WAVE
         q_start = q_block_idx * BLOCK_M
@@ -258,8 +294,42 @@ def build_flash_attn_dualwave_swp_module(
         q_head_idx = h_kv_idx * GQA_GROUP_SIZE + group_id
         kv_head_idx = h_kv_idx
 
-        q_gmem_elem_offset = (batch_idx * seq_len_v + q_start) * stride_q_n_v + q_head_idx * HEAD_DIM
-        kv_gmem_elem_offset = batch_idx * seq_len_v * stride_kv_n_v + kv_head_idx * HEAD_DIM
+        # Per-batch token ranges. Dense: batch_idx*seq_len .. (batch_idx+1)*seq_len
+        # (every batch the same seq_len, regular stride). Varlen: read the cumulative
+        # cu_seqlens_q / cu_seqlens_kv (int32 [B+1]) so this batch's Q rows are the
+        # packed range [cu_q[z], cu_q[z+1]) and its KV rows [cu_k[z], cu_k[z+1]).
+        # q_tok_base / kv_tok_base replace `batch_idx*seq_len` in every address; the
+        # _end values bound num_records; seqlen_q/kv drive the OOB skip + masks/tiles.
+        if const_expr(VARLEN):
+            # cu_seqlens read through the element-indexed Layout API + a 32-bit copy
+            # atom (same idiom as Q/K/V/O views), not a raw buffer resource.
+            _cuq_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(CuSeqQ), fx.make_layout(1, 1))
+            _cuk_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(CuSeqKv), fx.make_layout(1, 1))
+            _cu_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Int32)
+            _cu_v1i32 = Vec.make_type(1, fx.Int32)
+
+            def _cu_load(div, idx):
+                v = fly.copy_atom_call_ssa([_cu_v1i32], _cu_atom, fx.slice(div, (None, fx.Int32(idx))))
+                return fx.Index(Vec(v, (1,), fx.Int32)[0])
+
+            q_tok_base = _cu_load(_cuq_div, batch_idx)
+            q_tok_end = _cu_load(_cuq_div, batch_idx + fx.Index(1))
+            kv_tok_base = _cu_load(_cuk_div, batch_idx)
+            kv_tok_end = _cu_load(_cuk_div, batch_idx + fx.Index(1))
+            seqlen_q_v = q_tok_end - q_tok_base
+            seqlen_kv_v = kv_tok_end - kv_tok_base
+            seqlen_kv_i32 = fx.Int32(seqlen_kv_v)
+        else:
+            q_tok_base = batch_idx * seq_len_v
+            kv_tok_base = batch_idx * seq_len_v
+            q_tok_end = (batch_idx + fx.Index(1)) * seq_len_v
+            kv_tok_end = (batch_idx + fx.Index(1)) * seq_len_v
+            seqlen_q_v = seq_len_v
+            seqlen_kv_v = seq_len_v
+            seqlen_kv_i32 = seq_len
+
+        q_gmem_elem_offset = (q_tok_base + q_start) * stride_q_n_v + q_head_idx * HEAD_DIM
+        kv_gmem_elem_offset = kv_tok_base * stride_kv_n_v + kv_head_idx * HEAD_DIM
 
         DMA_BYTES = 16
         NUM_DMA_K = SMEM_D_RPT
@@ -268,15 +338,49 @@ def build_flash_attn_dualwave_swp_module(
         # Copy atoms + flat (element-indexed) buffer-tensor views for Q/K/V/O,
         # built once as straight-line SSA dominating the loop so the load/store
         # helpers below are plain functions.
-        q_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(Q), fx.make_layout(1, 1))
-        k_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(K), fx.make_layout(1, 1))
-        v_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(V), fx.make_layout(1, 1))
-        o_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(O), fx.make_layout(1, 1))
+        #
+        # Non-aligned seqlen support (copied from the hand-asm num_records bound):
+        # bound num_records to the END of THIS batch's region (= asm's
+        # num_records = seq_len*stride). A partial last q-block or a partial/extra
+        # kv-tile then reads rows with absolute index >= seq_len at a byte offset
+        # >= num_records, so hardware OOB returns 0 on loads and drops the OOB
+        # O-stores -- no fault, no corruption. For aligned seqlen every access is
+        # in-bounds, so results are unchanged.
+        # (raw index ir.Value; make_buffer_tensor's Int64() coercion accepts a raw
+        # index value and emits the index->i64 cast, but not the fx.Index wrapper.)
+        q_nrec_bytes = _raw(q_tok_end * stride_q_n_v * BF16_BYTES)
+        kv_nrec_bytes = _raw(kv_tok_end * stride_kv_n_v * BF16_BYTES)
+        q_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(Q, num_records_bytes=q_nrec_bytes), fx.make_layout(1, 1))
+        k_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(K, num_records_bytes=kv_nrec_bytes), fx.make_layout(1, 1))
+        v_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(V, num_records_bytes=kv_nrec_bytes), fx.make_layout(1, 1))
+        o_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(O, num_records_bytes=q_nrec_bytes), fx.make_layout(1, 1))
         _load_atom_128 = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Int32)
         _store_atom_64 = fx.make_copy_atom(fx.rocdl.BufferCopy64b(), fx.Int32)
+        _store_atom_128 = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Int32)
         _dma_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), 128)
         _o_store_reg = fx.make_rmem_tensor(fx.make_layout(2, 1), fx.Int32)
+        _o_store_reg_128 = fx.make_rmem_tensor(fx.make_layout(4, 1), fx.Int32)
         _lds_ptr_ty = fx.PointerType.get(elem_dtype.ir_type, 2, DMA_BYTES)
+        if const_expr(SPLITK):
+            # Split-K workspace (fp32-elem indexed), passed via the DebugCounts slot:
+            # [O_partial: Z*H*S*D/2 packed 16-bit pairs][Mrow: Z*H*S][Lrow: Z*H*S],
+            # Z = batch*splits. O_partial holds kernel-native bf16/fp16, 2 cols/dword.
+            ws_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(DebugCounts), fx.make_layout(1, 1))
+            _store_atom_32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Int32)
+            _ws_store_reg_32 = fx.make_rmem_tensor(fx.make_layout(1, 1), fx.Int32)
+            _ws_store_reg_128 = fx.make_rmem_tensor(fx.make_layout(4, 1), fx.Int32)
+
+        def _ws_store_f32(f32_val, elem_index):
+            """32-bit f32 register->global store into the split-K workspace."""
+            pack = Vec.from_elements([fx.Float32(f32_val)], fx.Float32).bitcast(fx.Int32)
+            fx.memref_store_vec(pack, _ws_store_reg_32)
+            fx.copy(_store_atom_32, _ws_store_reg_32, fx.slice(ws_div, (None, fx.Int32(elem_index))))
+
+        def _ws_store_quad_i32(dwords, elem_index):
+            """128-bit i32x4 register->global store (buffer_store_dwordx4) into the split-K workspace."""
+            pack = Vec.from_elements([fx.Int32(v) for v in dwords], fx.Int32)
+            fx.memref_store_vec(pack, _ws_store_reg_128)
+            fx.copy(_store_atom_128, _ws_store_reg_128, fx.slice(ws_div, (None, fx.Int32(elem_index))))
 
         def _buffer_load_128(elem_index):
             """128-bit global->register load (buffer_load_dwordx4) from Q."""
@@ -298,6 +402,11 @@ def build_flash_attn_dualwave_swp_module(
             """64-bit register->global store (buffer_store_dwordx2) into O."""
             fx.memref_store_vec(pack_i32_vec, _o_store_reg)
             fx.copy(_store_atom_64, _o_store_reg, fx.slice(o_div, (None, fx.Int32(elem_index))))
+
+        def _buffer_store_128(pack_i32_vec, elem_index):
+            """128-bit register->global store (buffer_store_dwordx4) into O."""
+            fx.memref_store_vec(pack_i32_vec, _o_store_reg_128)
+            fx.copy(_store_atom_128, _o_store_reg_128, fx.slice(o_div, (None, fx.Int32(elem_index))))
 
         lane_in_warp = tid % WARP_SIZE
         n_in_warp = lane_in_warp // VEC_KV
@@ -323,13 +432,51 @@ def build_flash_attn_dualwave_swp_module(
         v32f32_type = Vec.make_type(PV_K_STEPS * 2 * 8, fx.Float32)
 
         kv_tile_size = BLOCK_N
-        num_kv_tiles = (seq_len_v + kv_tile_size - 1) // kv_tile_size
+        num_kv_tiles = (seqlen_kv_v + kv_tile_size - 1) // kv_tile_size
         if const_expr(CAUSAL):
             q_block_end = q_start + BLOCK_M
             causal_num_tiles = (q_block_end + kv_tile_size - 1) // kv_tile_size
             max_num_tiles = fx.Index(ArithValue(causal_num_tiles < num_kv_tiles).select(causal_num_tiles, num_kv_tiles))
         else:
             max_num_tiles = num_kv_tiles
+        # Non-aligned kv support: the prologue + 2-tile-unrolled loop + 3-tile
+        # drain pipeline requires an EVEN tile count (max_num_tiles = 4 + 2*iters).
+        # ceil(seq_len/64) can be odd when seq_len is not a multiple of 64, so
+        # round up to even. The single extra tile is fully out of range (its keys
+        # have absolute index >= seq_len), so it reads 0 (num_records bound) and
+        # is masked to -inf (causal mask, or the seq padding-mask below in the
+        # non-causal path) -- contributing nothing to the softmax. Aligned sizes
+        # are already a multiple of 4, so this is a no-op for them. Done before
+        # the split-K chunking so each split inherits an even total.
+        # (No fx.Index(...) wrap: Index arithmetic already yields an index whose
+        # backing value is an ArithValue, as required by scf.range's stop.)
+        max_num_tiles = ((max_num_tiles + fx.Index(1)) // fx.Index(2)) * fx.Index(2)
+        # seq_len >= 1 support: the prologue(1) + 2-tile loop + 3-tile drain
+        # pipeline needs at least 4 tiles. For a tiny seq_len (< ~192) ceil/round
+        # can give 2, so floor the tile count at 4. The extra tiles are entirely
+        # out of range (keys >= seq_len) -> read 0 (num_records bound) and are
+        # masked (causal mask / non-causal seq padding mask), contributing
+        # nothing. seq_len that already yields >= 4 tiles is unaffected.
+        max_num_tiles = fx.Index(ArithValue(max_num_tiles < fx.Index(4)).select(fx.Index(4), max_num_tiles))
+
+        # Split-K tile range [split_t0, split_t_end). chunk is EVEN (preserves
+        # the K-buffer parity: K buf = tile % 2 fixed in prologue/loop) and at
+        # least 6. The pipeline needs >= 4 tiles, so a tail of < 4 tiles is
+        # folded into the previous split and the splits past it run empty.
+        if const_expr(SPLITK):
+            chunk = ((max_num_tiles + (NUM_KV_SPLITS - 1)) // NUM_KV_SPLITS + 1) // 2 * 2
+            chunk = fx.Index(ArithValue(chunk < fx.Index(6)).select(fx.Index(6), chunk))
+            split_t0 = split_idx * chunk
+            split_t_end = split_t0 + chunk
+            split_t_end = fx.Index(ArithValue(split_t_end < max_num_tiles).select(split_t_end, max_num_tiles))
+            split_t_end = fx.Index(
+                ArithValue(max_num_tiles - split_t_end < fx.Index(4)).select(max_num_tiles, split_t_end)
+            )
+            # written as a no-underflow compare: index subtraction wraps
+            split_nonempty = split_t0 + fx.Index(4) <= max_num_tiles
+        else:
+            split_t0 = 0
+            split_t_end = max_num_tiles
 
         urk_base_per_lane = (
             (lane_mod_32 % 8) * SMEM_K_LINE_STRIDE + (lane_mod_32 // 8) * D_128B_SIZE + lane_div_32 * VEC_KV
@@ -382,7 +529,7 @@ def build_flash_attn_dualwave_swp_module(
             return _ds_read_tr16_b64_imm(v4f16_type, addr_i32, imm_bytes)
 
         def _global_idx_q(token_idx, col):
-            token = batch_idx * seq_len_v + token_idx
+            token = q_tok_base + token_idx
             return token * stride_q_n_v + q_head_idx * HEAD_DIM + col
 
         def _concat_vectors(lhs, rhs):
@@ -768,6 +915,44 @@ def build_flash_attn_dualwave_swp_module(
                 s_hi = Vec.from_elements([_raw(v) for v in hi_list], fx.Float32).ir_value()
             return s_lo, s_hi
 
+        def _seq_pad_mask_inplace(v_s_lists, tile_idx):
+            """KV padding mask for a non-64-aligned kv length (asm seq-mask): set
+            any score whose ABSOLUTE key column >= seq_len to -inf.
+
+            The element->column map is identical to the causal mask: for s_lo
+            element r the absolute key column is
+                kv_tile_start + lane_div_32*4 + thr_r,    thr_r = (r//4)*8 + (r%4)
+            and s_hi (n_strip=1) adds W_N=32. We keep iff col < seq_len.
+            """
+            s_lo, s_hi = v_s_lists
+            kv_tile_start = tile_idx * BLOCK_N
+            col_base = fx.Int32(kv_tile_start) + fx.Int32(lane_div_32) * fx.Int32(4)
+            for r in range_constexpr(16):
+                thr = (r // 4) * 8 + (r % 4)
+                col_lo = col_base + fx.Int32(thr)
+                col_hi = col_lo + fx.Int32(32)
+                s_lo[r] = ArithValue(col_lo < seqlen_kv_i32).select(s_lo[r], c_neg_inf)
+                s_hi[r] = ArithValue(col_hi < seqlen_kv_i32).select(s_hi[r], c_neg_inf)
+
+        @flyc.jit
+        def _seq_pad_mask_if_needed(v_s, tile_idx=fx.Index(0)):
+            """Non-causal kv padding: mask keys with absolute column >= seq_len.
+
+            Gated so it is a no-op unless this tile reaches past seq_len, so
+            aligned kv is unaffected. Mirrors ``_causal_mask_prologue_if_needed``
+            exactly (same return shape) so the downstream row-max / sub-row consume
+            it identically. In split-K, tile_idx is the absolute tile index, so
+            only the last split's last tiles trigger it.
+            """
+            s_lo, s_hi = v_s
+            kv_tile_end = (tile_idx + fx.Index(1)) * BLOCK_N
+            if fx.Int32(kv_tile_end) > seqlen_kv_i32:
+                lo_list, hi_list = _v_s_vec_to_lists(v_s)
+                _seq_pad_mask_inplace((lo_list, hi_list), tile_idx)
+                s_lo = Vec.from_elements([_raw(v) for v in lo_list], fx.Float32).ir_value()
+                s_hi = Vec.from_elements([_raw(v) for v in hi_list], fx.Float32).ir_value()
+            return s_lo, s_hi
+
         def _attn_row_max(v_s):
             s_lo, s_hi = v_s
             m = c_neg_inf
@@ -872,7 +1057,7 @@ def build_flash_attn_dualwave_swp_module(
         @flyc.jit
         def _debug_count_lazy_branch(all_below):
             if const_expr(DUALWAVE_SWP_DEBUG_LAZY_COUNTS):
-                if fx.Int32(arith.index_cast(T.i32, _raw(lane))) == fx.Int32(0):
+                if fx.Int32(lane) == fx.Int32(0):
                     if fx.Boolean(all_below):
                         _debug_atomic_inc_lazy_count(0)
                     else:
@@ -924,77 +1109,270 @@ def build_flash_attn_dualwave_swp_module(
                 m_out = _anchor_scalar_f32(m_tile_max)
             return ([o0, o1, o2, o3], m_out, l_out, _v_vec32_to_p(vp_out))
 
-        # Prologue: load K tile 0 -> LDS buf0, wait, and sync the workgroup.
-        _async_load_k(0, 0)
-        rocdl.s_waitcnt(0)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-
-        # Load this wave's Q rows and pre-scale by the 1/sqrt(D) softmax
-        q_row_in_block = wave_q_offset + lane_mod_32
-        q_start_pos_i32 = fx.Int32(q_start + wave_id_uni * ROWS_PER_WAVE)
-        q_row = q_start + q_row_in_block
-        q_row_i32 = fx.Int32(q_row)
-        q_all_bf16 = _load_q_all(q_row_in_block)
-        q_all_scaled_bf16 = _scale_q_all(q_all_bf16)
-
-        # Pipeline ahead: prefetch K tile1 (buf1) + V tile0 (buf0) as background
-        _async_load_k(BLOCK_N, 1)
-        _async_load_v(0, 0)
-        v_k = _async_load_k_from_lds_to_vgpr(0, urk_base_per_lane)
-        rocdl.sched_barrier(0)
-        rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
-        _waitcnt_vm_n(NUM_DMA_V)
-
-        # OPEN the wave-group phase shift: one extra s_barrier on group B
-        if const_expr(DUALWAVE_SWP_ENABLE_STAGGER):
-            _stagger_extra_barrier_if_one()  # group B: +1 s_barrier -> open the shift
+        # Split-K: empty splits (fewer than 4 tiles to do) skip the whole
+        # pipeline and only write zeros below; non-splitk traces no guard.
+        # Varlen: grid_y is sized for max_seqlen, so a q-block past THIS batch's
+        # seqlen_q has no rows to compute -- skip the whole pipeline (the condition
+        # is uniform across the WG, so the workgroup barriers inside stay balanced).
+        # VARLEN and SPLITK are mutually exclusive, so they share the one guard.
+        if const_expr(SPLITK):
+            _split_if = _scf.IfOp(_raw(split_nonempty))
+            _split_guard = _if_then(_split_if)
+        elif const_expr(VARLEN):
+            _split_guard = _if_then(_scf.IfOp(_raw(ArithValue(q_start < seqlen_q_v))))
         else:
+            _split_guard = contextlib.nullcontext()
+        with _split_guard:
+            # Prologue: load K tile split_t0 -> LDS buf0, wait, and sync the workgroup.
+            _async_load_k(split_t0 * BLOCK_N, 0)
+            rocdl.s_waitcnt(0)
             rocdl.sched_barrier(0)
             rocdl.s_barrier()
 
-        # Prologue scores + first softmax pass for KV tile 0
-        v_s_0 = _mma0(v_k)
-        rocdl.sched_barrier(0)
-        if const_expr(CAUSAL):
-            v_s_0 = _causal_mask_prologue_if_needed(v_s_0)
-        else:
-            v_s_0 = _v_s_vec_to_lists(v_s_0)
-        m_row_pro = _attn_row_max(v_s_0)
-        v_s_0 = _attn_sub_row(v_s_0, m_row_pro)
-        v_p_0 = _attn_exp2_slice(v_s_0, 0, 16)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
+            # Load this wave's Q rows and pre-scale by the 1/sqrt(D) softmax
+            q_row_in_block = wave_q_offset + lane_mod_32
+            q_start_pos_i32 = fx.Int32(q_start + wave_id_uni * ROWS_PER_WAVE)
+            q_row = q_start + q_row_in_block
+            q_row_i32 = fx.Int32(q_row)
+            q_all_bf16 = _load_q_all(q_row_in_block)
+            q_all_scaled_bf16 = _scale_q_all(q_all_bf16)
 
-        # Prefetch K tile 2 into buf0, keeping the K double-buffer one step ahead
-        _async_load_k((2 * BLOCK_N), 0)
+            # Pipeline ahead: prefetch K tile1 (buf1) + V tile0 (buf0) as background
+            _async_load_k((split_t0 + 1) * BLOCK_N, 1)
+            _async_load_v(split_t0 * BLOCK_N, 0)
+            v_k = _async_load_k_from_lds_to_vgpr(0, urk_base_per_lane)
+            rocdl.sched_barrier(0)
+            rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
+            _waitcnt_vm_n(NUM_DMA_V)
 
-        # Loop-carried state (scf.for init args): m_row, l_row(=0), D_CHUNKS zero
-        l_row_init = c_zero_f
-        init_args = [m_row_pro, l_row_init]
-        for _ in range_constexpr(D_CHUNKS):
-            init_args.append(c_zero_v16f32)
-        init_args.append(_v_pair_to_vec32(v_p_0))
+            # OPEN the wave-group phase shift: one extra s_barrier on group B
+            if const_expr(DUALWAVE_SWP_ENABLE_STAGGER):
+                _stagger_extra_barrier_if_one()  # group B: +1 s_barrier -> open the shift
+            else:
+                rocdl.sched_barrier(0)
+                rocdl.s_barrier()
 
-        # ============================= Main loop =============================
-        # Software-pipelined inner loop
-        loop_results = init_args
-        for j, loop_args in range(
-            fx.Index(3),
-            max_num_tiles - fx.Index(1),
-            fx.Index(2),
-            init=init_args,
-        ):
-            m_row = loop_args[0]
-            l_row = loop_args[1]
-            v_o = [loop_args[2 + i] for i in range_constexpr(D_CHUNKS)]
-            v_p_0 = _v_vec32_to_pair(loop_args[2 + D_CHUNKS])
-            j_idx = j
+            # Prologue scores + first softmax pass for KV tile 0
+            v_s_0 = _mma0(v_k)
+            rocdl.sched_barrier(0)
+            if const_expr(CAUSAL):
+                if const_expr(SPLITK):
+                    v_s_0 = _causal_mask_prologue_if_needed(v_s_0, split_t0, (split_t0 + 1) * BLOCK_N)
+                else:
+                    v_s_0 = _causal_mask_prologue_if_needed(v_s_0)
+            else:
+                # Non-causal KV padding mask for the PROLOGUE tile too: for a tiny
+                # seq_len the only real tile is tile 0 (prologue), so its keys with
+                # absolute column >= seq_len must be masked here (the epilogue mask
+                # only covers the last 3 tiles). Gated inside _seq_pad_mask_if_needed
+                # -> a no-op once tile 0 is full (seq_len >= BLOCK_N), so larger
+                # seq_len is unaffected and the hot loop is untouched.
+                if const_expr(SPLITK):
+                    v_s_0 = _seq_pad_mask_if_needed(v_s_0, split_t0)
+                else:
+                    v_s_0 = _seq_pad_mask_if_needed(v_s_0)
+            m_row_pro = _attn_row_max(v_s_0)
+            v_s_0 = _attn_sub_row(v_s_0, m_row_pro)
+            v_p_0 = _attn_exp2_slice(v_s_0, 0, 16)
+            rocdl.sched_barrier(0)
+            rocdl.s_barrier()
+            rocdl.sched_barrier(0)
 
-            # Cluster 0 (memory): prefetch next V (buf1), read resident K from LDS
-            # (v_k) for MMA0, wait + sync.
-            _async_load_v((j_idx - 2) * BLOCK_N, 1)
+            # Prefetch K tile 2 into buf0, keeping the K double-buffer one step ahead
+            _async_load_k((split_t0 + 2) * BLOCK_N, 0)
+
+            # Loop-carried state (scf.for init args): m_row, l_row(=0), D_CHUNKS zero
+            l_row_init = c_zero_f
+            init_args = [m_row_pro, l_row_init]
+            for _ in range_constexpr(D_CHUNKS):
+                init_args.append(c_zero_v16f32)
+            init_args.append(_v_pair_to_vec32(v_p_0))
+
+            # ============================= Main loop =============================
+            # Software-pipelined inner loop
+            if const_expr(SPLITK):
+                loop_lb = split_t0 + 3
+            else:
+                loop_lb = fx.Index(3)
+            loop_results = init_args
+            for j, loop_args in range(
+                loop_lb,
+                split_t_end - fx.Index(1),
+                fx.Index(2),
+                init=init_args,
+            ):
+                m_row = loop_args[0]
+                l_row = loop_args[1]
+                v_o = [loop_args[2 + i] for i in range_constexpr(D_CHUNKS)]
+                v_p_0 = _v_vec32_to_pair(loop_args[2 + D_CHUNKS])
+                j_idx = j
+
+                # Cluster 0 (memory): prefetch next V (buf1), read resident K from LDS
+                # (v_k) for MMA0, wait + sync.
+                _async_load_v((j_idx - 2) * BLOCK_N, 1)
+                v_k = _async_load_k_from_lds_to_vgpr(1, urk_base_per_lane)
+                rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(NUM_DMA_K + NUM_DMA_V)
+                rocdl.sched_barrier(0)
+                rocdl.s_barrier()
+                rocdl.sched_barrier(0)
+
+                # Cluster 1 (compute): MMA0 -> v_s_1; finish v_p_0's 2nd-half exp2,
+                # sum into l_row, cast to bf16 for P*V.
+                v_s_1 = _mma0(v_k)
+                v_p_0 = _attn_exp2_slice(v_p_0, 16, 16)
+                tile_sum_a = _attn_sum(v_p_0)
+                l_row = _fadd(l_row, tile_sum_a)
+                v_p_0 = _cast_p(v_p_0)
+                v_p_0 = _anchor_v_p(v_p_0)
+                _sched_barrier_exp_pairs(6, 3, 1)
+                _sched_barrier_pairs(10, 5, 1)
+                rocdl.sched_barrier(0)
+                rocdl.s_barrier()
+                rocdl.sched_barrier(0)
+
+                # Cluster 2 (memory): prefetch next K (buf1), read this tile's V from
+                # LDS (v_v) for P*V, wait + sync.
+                _async_load_k(j_idx * BLOCK_N, 1)
+                v_v = _read_v_packs_for_buf(0, urv_base_per_lane)
+                rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(NUM_DMA_K + NUM_DMA_V)
+                rocdl.sched_barrier(0)
+                rocdl.s_barrier()
+                rocdl.sched_barrier(0)
+
+                # Cluster 3 (compute): first P*V step + row max of v_s_1, lazy
+                # rescale, remaining 3 P*V steps, sub row + 1st-half exp2 of v_s_1.
+                if const_expr(DUALWAVE_SWP_SETPRIO):
+                    rocdl.s_setprio(1)
+                v_o = _mma1_step_k(0, v_p_0, v_v, v_o)
+                v_s_1 = _v_s_vec_to_lists(v_s_1)
+                m_tile_max_a = _attn_row_max(v_s_1)
+
+                _sched_barrier_pairs(4, 6, 2)
+
+                if const_expr(DUALWAVE_SWP_LAZY_RESCALE):
+                    v_o, m_row, l_row, v_p_0 = _lazy_rescale_o(v_o, m_row, l_row, m_tile_max_a, v_p_0)
+                else:
+                    m_new_a = _fmax(m_row, m_tile_max_a)
+                    corr_a = rocdl.exp2(T.f32, _raw(_fsub(m_row, m_new_a)))
+                    _scale_o(v_o, corr_a)
+                    v_o = _anchor_v_o(v_o)
+                    v_p_0 = _scale_v_p(v_p_0, corr_a)
+                    l_row = _fmul(l_row, corr_a)
+                    m_row = m_new_a
+                v_o = _mma1_step_k(1, v_p_0, v_v, v_o)
+                v_o = _mma1_step_k(2, v_p_0, v_v, v_o)
+                v_o = _mma1_step_k(3, v_p_0, v_v, v_o)
+                v_s_1 = _attn_sub_row(v_s_1, m_row)
+                v_p_1 = _attn_exp2_slice(v_s_1, 0, 16)
+
+                _sched_barrier_pairs(6, 6, 2)
+                # IGroupLP hint (group 2): 6 MFMA each paired with 3 EXP/TRANS (mask
+                # 0x400) so the new softmax exp2 stays near its MFMA window.
+                _sched_barrier_exp_pairs(6, 3, 2)
+                if const_expr(DUALWAVE_SWP_SETPRIO):
+                    rocdl.s_setprio(0)
+                # sched_barrier(0): compiler scheduling fence (mask 0 = nothing
+                # crosses), pinning s_setprio(0) and the closing s_barrier at the
+                # cluster boundary. Emits no ISA; the real sync is s_barrier().
+                rocdl.sched_barrier(0)
+                rocdl.s_barrier()
+                rocdl.sched_barrier(0)
+
+                # Cluster 4 (memory, mirror of C0): prefetch V (buf0), read K from
+                # buf0 into v_k, wait + sync.
+                _async_load_v((j_idx - 1) * BLOCK_N, 0)
+                v_k = _async_load_k_from_lds_to_vgpr(0, urk_base_per_lane)
+                rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(NUM_DMA_K + NUM_DMA_V)
+                rocdl.sched_barrier(0)
+                rocdl.s_barrier()
+                rocdl.sched_barrier(0)
+
+                # Cluster 5 (compute, mirror of C1): MMA0 -> v_s_0; finish v_p_1's
+                # 2nd-half exp2, sum into l_row, cast to bf16.
+                v_s_0 = _mma0(v_k)
+                v_p_1 = _attn_exp2_slice(v_p_1, 16, 16)
+                tile_sum_b = _attn_sum(v_p_1)
+                l_row = _fadd(l_row, tile_sum_b)
+                v_p_1 = _cast_p(v_p_1)
+                v_p_1 = _anchor_v_p(v_p_1)
+                _sched_barrier_exp_pairs(6, 3, 3)
+                _sched_barrier_pairs(10, 5, 3)
+                rocdl.sched_barrier(0)
+                rocdl.s_barrier()
+                rocdl.sched_barrier(0)
+
+                # Cluster 6 (memory): prefetch next K (buf0), read V packs (buf1),
+                # apply causal mask to v_s_0 (if causal), wait + sync.
+                _async_load_k((j_idx + 1) * BLOCK_N, 0)
+                v_packs_b = _read_v_packs_for_buf(1, urv_base_per_lane)
+                if const_expr(CAUSAL):
+                    v_s_0 = _causal_mask_prologue_if_needed(
+                        v_s_0,
+                        j_idx - 1,
+                        j_idx * BLOCK_N,
+                    )
+                else:
+                    v_s_0 = _v_s_vec_to_lists(v_s_0)
+                rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(NUM_DMA_K + NUM_DMA_V)
+                rocdl.sched_barrier(0)
+                rocdl.s_barrier()
+                rocdl.sched_barrier(0)
+
+                # Cluster 7 (compute, mirror of C3 for v_p_1/v_s_0): closes the iter,
+                # yield_args carries (m_row, l_row, v_o, packed v_p_0) to the next.
+                if const_expr(DUALWAVE_SWP_SETPRIO):
+                    rocdl.s_setprio(1)
+                v_v = v_packs_b
+                v_o = _mma1_step_k(0, v_p_1, v_v, v_o)
+                m_tile_max_b = _attn_row_max(v_s_0)
+                _sched_barrier_pairs(4, 6, 4)
+
+                if const_expr(DUALWAVE_SWP_LAZY_RESCALE):
+                    v_o, m_row, l_row, v_p_1 = _lazy_rescale_o(v_o, m_row, l_row, m_tile_max_b, v_p_1)
+                else:
+                    m_new_b = _fmax(m_row, m_tile_max_b)
+                    corr_b = rocdl.exp2(T.f32, _raw(_fsub(m_row, m_new_b)))
+                    _scale_o(v_o, corr_b)
+                    v_o = _anchor_v_o(v_o)
+                    v_p_1 = _scale_v_p(v_p_1, corr_b)
+                    l_row = _fmul(l_row, corr_b)
+                    m_row = m_new_b
+                v_v = v_packs_b
+                v_o = _mma1_step_k(1, v_p_1, v_v, v_o)
+                v_o = _mma1_step_k(2, v_p_1, v_v, v_o)
+                v_o = _mma1_step_k(3, v_p_1, v_v, v_o)
+                v_s_0 = _attn_sub_row(v_s_0, m_row)
+                v_p_0 = _attn_exp2_slice(v_s_0, 0, 16)
+                _sched_barrier_pairs(6, 5, 4)
+                _sched_barrier_exp_pairs(6, 3, 4)
+                if const_expr(DUALWAVE_SWP_SETPRIO):
+                    rocdl.s_setprio(0)
+                rocdl.sched_barrier(0)
+                rocdl.s_barrier()
+                rocdl.sched_barrier(0)
+
+                yield_args = [m_row, l_row] + v_o + [_v_pair_to_vec32(v_p_0)]
+                loop_results = yield yield_args
+
+            # Epilogue: drain the pipeline for the final tiles the loop left in
+            # flight. Mirrors the main-loop clusters but with no further
+            # prefetch-ahead. Unpack the loop-carried state:
+            m_row = loop_results[0]
+            l_row = loop_results[1]
+            v_o = [loop_results[2 + i] for i in range_constexpr(D_CHUNKS)]
+            v_p_0 = _v_vec32_to_pair(loop_results[2 + D_CHUNKS])
+
+            # Tile indices for the last three tiles handled by the epilogue.
+            max_m3 = split_t_end - 3
+            max_m2 = split_t_end - 2
+            max_m1 = split_t_end - 1
+
+            # Epilogue C0 (memory): prefetch V max_m3 (buf1), read K from buf1, sync.
+            _async_load_v(max_m3 * BLOCK_N, 1)
             v_k = _async_load_k_from_lds_to_vgpr(1, urk_base_per_lane)
             rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
             _waitcnt_vm_n(NUM_DMA_K + NUM_DMA_V)
@@ -1002,72 +1380,60 @@ def build_flash_attn_dualwave_swp_module(
             rocdl.s_barrier()
             rocdl.sched_barrier(0)
 
-            # Cluster 1 (compute): MMA0 -> v_s_1; finish v_p_0's 2nd-half exp2,
-            # sum into l_row, cast to bf16 for P*V.
+            # Epilogue C1 (compute): MMA0 -> v_s_1; finish v_p_0 softmax (like C1).
             v_s_1 = _mma0(v_k)
             v_p_0 = _attn_exp2_slice(v_p_0, 16, 16)
-            tile_sum_a = _attn_sum(v_p_0)
-            l_row = _fadd(l_row, tile_sum_a)
+            tile_sum_e1 = _attn_sum(v_p_0)
+            l_row = _fadd(l_row, tile_sum_e1)
             v_p_0 = _cast_p(v_p_0)
             v_p_0 = _anchor_v_p(v_p_0)
-            _sched_barrier_exp_pairs(6, 3, 1)
-            _sched_barrier_pairs(10, 5, 1)
+            _sched_barrier_exp_pairs(6, 3, 5)
+            _sched_barrier_pairs(10, 5, 5)
             rocdl.sched_barrier(0)
             rocdl.s_barrier()
             rocdl.sched_barrier(0)
 
-            # Cluster 2 (memory): prefetch next K (buf1), read this tile's V from
-            # LDS (v_v) for P*V, wait + sync.
-            _async_load_k(j_idx * BLOCK_N, 1)
-            v_v = _read_v_packs_for_buf(0, urv_base_per_lane)
+            # Epilogue C2 (memory): prefetch K max_m1, read V packs (buf0), causal mask v_s_1, sync.
+            _async_load_k(max_m1 * BLOCK_N, 1)
+            v_packs_e3 = _read_v_packs_for_buf(0, urv_base_per_lane)
+            if const_expr(CAUSAL):
+                v_s_1 = _causal_mask_prologue_if_needed(
+                    v_s_1,
+                    max_m3,
+                    max_m2 * BLOCK_N,
+                )
+            else:
+                v_s_1 = _seq_pad_mask_if_needed(v_s_1, max_m3)
             rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
             _waitcnt_vm_n(NUM_DMA_K + NUM_DMA_V)
             rocdl.sched_barrier(0)
             rocdl.s_barrier()
             rocdl.sched_barrier(0)
 
-            # Cluster 3 (compute): first P*V step + row max of v_s_1, lazy
-            # rescale, remaining 3 P*V steps, sub row + 1st-half exp2 of v_s_1.
+            # Epilogue C3 (compute): full P*V + unconditional rescale
             if const_expr(DUALWAVE_SWP_SETPRIO):
                 rocdl.s_setprio(1)
-            v_o = _mma1_step_k(0, v_p_0, v_v, v_o)
-            v_s_1 = _v_s_vec_to_lists(v_s_1)
-            m_tile_max_a = _attn_row_max(v_s_1)
-
-            _sched_barrier_pairs(4, 6, 2)
-
-            if const_expr(DUALWAVE_SWP_LAZY_RESCALE):
-                v_o, m_row, l_row, v_p_0 = _lazy_rescale_o(v_o, m_row, l_row, m_tile_max_a, v_p_0)
-            else:
-                m_new_a = _fmax(m_row, m_tile_max_a)
-                corr_a = rocdl.exp2(T.f32, _raw(_fsub(m_row, m_new_a)))
-                _scale_o(v_o, corr_a)
-                v_o = _anchor_v_o(v_o)
-                v_p_0 = _scale_v_p(v_p_0, corr_a)
-                l_row = _fmul(l_row, corr_a)
-                m_row = m_new_a
-            v_o = _mma1_step_k(1, v_p_0, v_v, v_o)
-            v_o = _mma1_step_k(2, v_p_0, v_v, v_o)
-            v_o = _mma1_step_k(3, v_p_0, v_v, v_o)
-            v_s_1 = _attn_sub_row(v_s_1, m_row)
+            v_o = _mma1(v_p_0, v_packs_e3, v_o)
+            m_tile_max_e3 = _attn_row_max(v_s_1)
+            row_max_e3 = _fmax(m_row, m_tile_max_e3)
+            rescale_e3 = rocdl.exp2(T.f32, _raw(_fsub(m_row, row_max_e3)))
+            m_row = row_max_e3
+            v_s_1 = _attn_sub_row(v_s_1, row_max_e3)
             v_p_1 = _attn_exp2_slice(v_s_1, 0, 16)
+            _sched_barrier_pairs(10, 5, 6)
+            _sched_barrier_exp_pairs(6, 3, 6)
+            rocdl.sched_barrier(0)
+            _scale_o(v_o, rescale_e3)
+            v_o = _anchor_v_o(v_o)
 
-            _sched_barrier_pairs(6, 6, 2)
-            # IGroupLP hint (group 2): 6 MFMA each paired with 3 EXP/TRANS (mask
-            # 0x400) so the new softmax exp2 stays near its MFMA window.
-            _sched_barrier_exp_pairs(6, 3, 2)
             if const_expr(DUALWAVE_SWP_SETPRIO):
                 rocdl.s_setprio(0)
-            # sched_barrier(0): compiler scheduling fence (mask 0 = nothing
-            # crosses), pinning s_setprio(0) and the closing s_barrier at the
-            # cluster boundary. Emits no ISA; the real sync is s_barrier().
             rocdl.sched_barrier(0)
             rocdl.s_barrier()
             rocdl.sched_barrier(0)
 
-            # Cluster 4 (memory, mirror of C0): prefetch V (buf0), read K from
-            # buf0 into v_k, wait + sync.
-            _async_load_v((j_idx - 1) * BLOCK_N, 0)
+            # Epilogue C4 (memory): prefetch V max_m2 (buf0), read K from buf0, sync.
+            _async_load_v(max_m2 * BLOCK_N, 0)
             v_k = _async_load_k_from_lds_to_vgpr(0, urk_base_per_lane)
             rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
             _waitcnt_vm_n(NUM_DMA_K + NUM_DMA_V)
@@ -1075,302 +1441,157 @@ def build_flash_attn_dualwave_swp_module(
             rocdl.s_barrier()
             rocdl.sched_barrier(0)
 
-            # Cluster 5 (compute, mirror of C1): MMA0 -> v_s_0; finish v_p_1's
-            # 2nd-half exp2, sum into l_row, cast to bf16.
+            # Epilogue C5 (compute): MMA0 -> v_s_0; fold rescale_e3 into l_row, finish
+            # v_p_1 softmax.
             v_s_0 = _mma0(v_k)
+            l_row = _fmul(l_row, rescale_e3)
             v_p_1 = _attn_exp2_slice(v_p_1, 16, 16)
-            tile_sum_b = _attn_sum(v_p_1)
-            l_row = _fadd(l_row, tile_sum_b)
+            tile_sum_e5 = _attn_sum(v_p_1)
+            l_row = _fadd(l_row, tile_sum_e5)
             v_p_1 = _cast_p(v_p_1)
             v_p_1 = _anchor_v_p(v_p_1)
-            _sched_barrier_exp_pairs(6, 3, 3)
-            _sched_barrier_pairs(10, 5, 3)
+            _sched_barrier_exp_pairs(6, 3, 7)
+            _sched_barrier_pairs(10, 5, 7)
             rocdl.sched_barrier(0)
             rocdl.s_barrier()
             rocdl.sched_barrier(0)
 
-            # Cluster 6 (memory): prefetch next K (buf0), read V packs (buf1),
-            # apply causal mask to v_s_0 (if causal), wait + sync.
-            _async_load_k((j_idx + 1) * BLOCK_N, 0)
-            v_packs_b = _read_v_packs_for_buf(1, urv_base_per_lane)
+            # Epilogue C6 (memory): read V packs (buf1), causal mask v_s_0, sync.
+            v_packs_e7 = _read_v_packs_for_buf(1, urv_base_per_lane)
             if const_expr(CAUSAL):
                 v_s_0 = _causal_mask_prologue_if_needed(
                     v_s_0,
-                    j_idx - 1,
-                    j_idx * BLOCK_N,
+                    max_m2,
+                    max_m1 * BLOCK_N,
                 )
             else:
-                v_s_0 = _v_s_vec_to_lists(v_s_0)
+                v_s_0 = _seq_pad_mask_if_needed(v_s_0, max_m2)
             rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
-            _waitcnt_vm_n(NUM_DMA_K + NUM_DMA_V)
+            _waitcnt_vm_n(NUM_DMA_V)
             rocdl.sched_barrier(0)
             rocdl.s_barrier()
             rocdl.sched_barrier(0)
 
-            # Cluster 7 (compute, mirror of C3 for v_p_1/v_s_0): closes the iter,
-            # yield_args carries (m_row, l_row, v_o, packed v_p_0) to the next.
+            # Epilogue C7 (compute, mirror of C3): full P*V + unconditional rescale.
             if const_expr(DUALWAVE_SWP_SETPRIO):
                 rocdl.s_setprio(1)
-            v_v = v_packs_b
-            v_o = _mma1_step_k(0, v_p_1, v_v, v_o)
-            m_tile_max_b = _attn_row_max(v_s_0)
-            _sched_barrier_pairs(4, 6, 4)
-
-            if const_expr(DUALWAVE_SWP_LAZY_RESCALE):
-                v_o, m_row, l_row, v_p_1 = _lazy_rescale_o(v_o, m_row, l_row, m_tile_max_b, v_p_1)
-            else:
-                m_new_b = _fmax(m_row, m_tile_max_b)
-                corr_b = rocdl.exp2(T.f32, _raw(_fsub(m_row, m_new_b)))
-                _scale_o(v_o, corr_b)
-                v_o = _anchor_v_o(v_o)
-                v_p_1 = _scale_v_p(v_p_1, corr_b)
-                l_row = _fmul(l_row, corr_b)
-                m_row = m_new_b
-            v_v = v_packs_b
-            v_o = _mma1_step_k(1, v_p_1, v_v, v_o)
-            v_o = _mma1_step_k(2, v_p_1, v_v, v_o)
-            v_o = _mma1_step_k(3, v_p_1, v_v, v_o)
-            v_s_0 = _attn_sub_row(v_s_0, m_row)
+            v_o = _mma1(v_p_1, v_packs_e7, v_o)
+            m_tile_max_e7 = _attn_row_max(v_s_0)
+            row_max_e7 = _fmax(m_row, m_tile_max_e7)
+            rescale_e7 = rocdl.exp2(T.f32, _raw(_fsub(m_row, row_max_e7)))
+            m_row = row_max_e7
+            v_s_0 = _attn_sub_row(v_s_0, row_max_e7)
             v_p_0 = _attn_exp2_slice(v_s_0, 0, 16)
-            _sched_barrier_pairs(6, 5, 4)
-            _sched_barrier_exp_pairs(6, 3, 4)
+            _sched_barrier_pairs(10, 5, 8)
+            _sched_barrier_exp_pairs(6, 3, 8)
+            rocdl.sched_barrier(0)
+            _scale_o(v_o, rescale_e7)
+            v_o = _anchor_v_o(v_o)
             if const_expr(DUALWAVE_SWP_SETPRIO):
                 rocdl.s_setprio(0)
             rocdl.sched_barrier(0)
             rocdl.s_barrier()
             rocdl.sched_barrier(0)
 
-            yield_args = [m_row, l_row] + v_o + [_v_pair_to_vec32(v_p_0)]
-            loop_results = yield yield_args
-
-        # Epilogue: drain the pipeline for the final tiles the loop left in
-        # flight. Mirrors the main-loop clusters but with no further
-        # prefetch-ahead. Unpack the loop-carried state:
-        m_row = loop_results[0]
-        l_row = loop_results[1]
-        v_o = [loop_results[2 + i] for i in range_constexpr(D_CHUNKS)]
-        v_p_0 = _v_vec32_to_pair(loop_results[2 + D_CHUNKS])
-
-        # Tile indices for the last three tiles handled by the epilogue.
-        max_m3 = max_num_tiles - 3
-        max_m2 = max_num_tiles - 2
-        max_m1 = max_num_tiles - 1
-
-        # Epilogue C0 (memory): prefetch V max_m3 (buf1), read K from buf1, sync.
-        _async_load_v(max_m3 * BLOCK_N, 1)
-        v_k = _async_load_k_from_lds_to_vgpr(1, urk_base_per_lane)
-        rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
-        _waitcnt_vm_n(NUM_DMA_K + NUM_DMA_V)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C1 (compute): MMA0 -> v_s_1; finish v_p_0 softmax (like C1).
-        v_s_1 = _mma0(v_k)
-        v_p_0 = _attn_exp2_slice(v_p_0, 16, 16)
-        tile_sum_e1 = _attn_sum(v_p_0)
-        l_row = _fadd(l_row, tile_sum_e1)
-        v_p_0 = _cast_p(v_p_0)
-        v_p_0 = _anchor_v_p(v_p_0)
-        _sched_barrier_exp_pairs(6, 3, 5)
-        _sched_barrier_pairs(10, 5, 5)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C2 (memory): prefetch K max_m1, read V packs (buf0), causal mask v_s_1, sync.
-        _async_load_k(max_m1 * BLOCK_N, 1)
-        v_packs_e3 = _read_v_packs_for_buf(0, urv_base_per_lane)
-        if const_expr(CAUSAL):
-            v_s_1 = _causal_mask_prologue_if_needed(
-                v_s_1,
-                max_m3,
-                max_m2 * BLOCK_N,
-            )
-        else:
-            v_s_1 = _v_s_vec_to_lists(v_s_1)
-        rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
-        _waitcnt_vm_n(NUM_DMA_K + NUM_DMA_V)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C3 (compute): full P*V + unconditional rescale
-        if const_expr(DUALWAVE_SWP_SETPRIO):
-            rocdl.s_setprio(1)
-        v_o = _mma1(v_p_0, v_packs_e3, v_o)
-        m_tile_max_e3 = _attn_row_max(v_s_1)
-        row_max_e3 = _fmax(m_row, m_tile_max_e3)
-        rescale_e3 = rocdl.exp2(T.f32, _raw(_fsub(m_row, row_max_e3)))
-        m_row = row_max_e3
-        v_s_1 = _attn_sub_row(v_s_1, row_max_e3)
-        v_p_1 = _attn_exp2_slice(v_s_1, 0, 16)
-        _sched_barrier_pairs(10, 5, 6)
-        _sched_barrier_exp_pairs(6, 3, 6)
-        rocdl.sched_barrier(0)
-        _scale_o(v_o, rescale_e3)
-        v_o = _anchor_v_o(v_o)
-
-        if const_expr(DUALWAVE_SWP_SETPRIO):
-            rocdl.s_setprio(0)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C4 (memory): prefetch V max_m2 (buf0), read K from buf0, sync.
-        _async_load_v(max_m2 * BLOCK_N, 0)
-        v_k = _async_load_k_from_lds_to_vgpr(0, urk_base_per_lane)
-        rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
-        _waitcnt_vm_n(NUM_DMA_K + NUM_DMA_V)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C5 (compute): MMA0 -> v_s_0; fold rescale_e3 into l_row, finish
-        # v_p_1 softmax.
-        v_s_0 = _mma0(v_k)
-        l_row = _fmul(l_row, rescale_e3)
-        v_p_1 = _attn_exp2_slice(v_p_1, 16, 16)
-        tile_sum_e5 = _attn_sum(v_p_1)
-        l_row = _fadd(l_row, tile_sum_e5)
-        v_p_1 = _cast_p(v_p_1)
-        v_p_1 = _anchor_v_p(v_p_1)
-        _sched_barrier_exp_pairs(6, 3, 7)
-        _sched_barrier_pairs(10, 5, 7)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C6 (memory): read V packs (buf1), causal mask v_s_0, sync.
-        v_packs_e7 = _read_v_packs_for_buf(1, urv_base_per_lane)
-        if const_expr(CAUSAL):
-            v_s_0 = _causal_mask_prologue_if_needed(
-                v_s_0,
-                max_m2,
-                max_m1 * BLOCK_N,
-            )
-        else:
-            v_s_0 = _v_s_vec_to_lists(v_s_0)
-        rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
-        _waitcnt_vm_n(NUM_DMA_V)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C7 (compute, mirror of C3): full P*V + unconditional rescale.
-        if const_expr(DUALWAVE_SWP_SETPRIO):
-            rocdl.s_setprio(1)
-        v_o = _mma1(v_p_1, v_packs_e7, v_o)
-        m_tile_max_e7 = _attn_row_max(v_s_0)
-        row_max_e7 = _fmax(m_row, m_tile_max_e7)
-        rescale_e7 = rocdl.exp2(T.f32, _raw(_fsub(m_row, row_max_e7)))
-        m_row = row_max_e7
-        v_s_0 = _attn_sub_row(v_s_0, row_max_e7)
-        v_p_0 = _attn_exp2_slice(v_s_0, 0, 16)
-        _sched_barrier_pairs(10, 5, 8)
-        _sched_barrier_exp_pairs(6, 3, 8)
-        rocdl.sched_barrier(0)
-        _scale_o(v_o, rescale_e7)
-        v_o = _anchor_v_o(v_o)
-        if const_expr(DUALWAVE_SWP_SETPRIO):
-            rocdl.s_setprio(0)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C8 (memory): prefetch V max_m1 (buf1), read K from buf1, sync.
-        _async_load_v(max_m1 * BLOCK_N, 1)
-        v_k = _async_load_k_from_lds_to_vgpr(1, urk_base_per_lane)
-        rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
-        _waitcnt_vm_n(NUM_DMA_V)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C9 (compute): MMA0 -> v_s_1 (last tile); fold rescale_e7 into
-        # l_row, finish v_p_0 softmax.
-        v_s_1 = _mma0(v_k)
-        l_row = _fmul(l_row, rescale_e7)
-        v_p_0 = _attn_exp2_slice(v_p_0, 16, 16)
-        tile_sum_e9 = _attn_sum(v_p_0)
-        l_row = _fadd(l_row, tile_sum_e9)
-        v_p_0 = _cast_p(v_p_0)
-        v_p_0 = _anchor_v_p(v_p_0)
-        _sched_barrier_exp_pairs(6, 3, 9)
-        _sched_barrier_pairs(10, 5, 9)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C10 (memory): read last V packs (buf0), causal mask v_s_1,
-        # drain all DMAs (vmcnt 0), sync.
-        v_packs_e11 = _read_v_packs_for_buf(0, urv_base_per_lane)
-        if const_expr(CAUSAL):
-            v_s_1 = _causal_mask_prologue_if_needed(
-                v_s_1,
-                max_m1,
-                max_num_tiles * BLOCK_N,
-            )
-        else:
-            v_s_1 = _v_s_vec_to_lists(v_s_1)
-        rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
-        _waitcnt_vm_n(0)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C11 (compute): full P*V + rescale for v_p_0, then complete the
-        # last tile's softmax in-place (both exp2 halves, sum, cast) since no
-        # further pass follows.
-        v_o = _mma1(v_p_0, v_packs_e11, v_o)
-        m_tile_max_e11 = _attn_row_max(v_s_1)
-        row_max_e11 = _fmax(m_row, m_tile_max_e11)
-        rescale_e11 = rocdl.exp2(T.f32, _raw(_fsub(m_row, row_max_e11)))
-        m_row = row_max_e11
-        v_s_1 = _attn_sub_row(v_s_1, row_max_e11)
-        v_p_1 = _attn_exp2_slice(v_s_1, 0, 16)
-        _sched_barrier_pairs(9, 6, 10)
-        _sched_barrier_exp_pairs(7, 3, 10)
-        rocdl.sched_barrier(0)
-        v_p_1 = _attn_exp2_slice(v_p_1, 16, 16)
-        l_row = _fmul(l_row, rescale_e11)
-        tile_sum_e11 = _attn_sum(v_p_1)
-        l_row = _fadd(l_row, tile_sum_e11)
-        v_p_1 = _cast_p(v_p_1)
-        v_p_1 = _anchor_v_p(v_p_1)
-        rocdl.sched_barrier(0)
-        _scale_o(v_o, rescale_e11)
-        v_o = _anchor_v_o(v_o)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C12 (memory): read the final V packs for the closing P*V.
-        v_packs_e13 = _read_v_packs_for_buf(1, urv_base_per_lane)
-        rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-        rocdl.sched_barrier(0)
-
-        # Epilogue C13 (compute): final P*V -> v_o holds the unnormalized output.
-        v_o = _mma1(v_p_1, v_packs_e13, v_o)
-
-        # Normalize O by the softmax denominator (guarded so a zero l_row yields
-        # 0 instead of nan).
-        inv_l_rcp = rocdl.rcp(T.f32, _raw(l_row))
-        inv_l = ArithValue(fx.Float32(l_row) > c_zero_f).select(inv_l_rcp, c_zero_f)
-        _scale_o(v_o, inv_l)
-
-        # CLOSE the phase shift: one extra s_barrier on group A (complement of
-        # the prologue's group-B barrier) realigns the two groups before the
-        # store. Disabled -> one plain barrier.
-        if const_expr(DUALWAVE_SWP_ENABLE_STAGGER):
-            _stagger_extra_barrier_if_zero()  # group A: +1 s_barrier -> close the shift
-        else:
+            # Epilogue C8 (memory): prefetch V max_m1 (buf1), read K from buf1, sync.
+            _async_load_v(max_m1 * BLOCK_N, 1)
+            v_k = _async_load_k_from_lds_to_vgpr(1, urk_base_per_lane)
+            rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
+            _waitcnt_vm_n(NUM_DMA_V)
+            rocdl.sched_barrier(0)
             rocdl.s_barrier()
+            rocdl.sched_barrier(0)
 
-        # Store O back to global memory.
-        for dc in range_constexpr(D_CHUNKS):
-            for store_group in range_constexpr(4):
+            # Epilogue C9 (compute): MMA0 -> v_s_1 (last tile); fold rescale_e7 into
+            # l_row, finish v_p_0 softmax.
+            v_s_1 = _mma0(v_k)
+            l_row = _fmul(l_row, rescale_e7)
+            v_p_0 = _attn_exp2_slice(v_p_0, 16, 16)
+            tile_sum_e9 = _attn_sum(v_p_0)
+            l_row = _fadd(l_row, tile_sum_e9)
+            v_p_0 = _cast_p(v_p_0)
+            v_p_0 = _anchor_v_p(v_p_0)
+            _sched_barrier_exp_pairs(6, 3, 9)
+            _sched_barrier_pairs(10, 5, 9)
+            rocdl.sched_barrier(0)
+            rocdl.s_barrier()
+            rocdl.sched_barrier(0)
+
+            # Epilogue C10 (memory): read last V packs (buf0), causal mask v_s_1,
+            # drain all DMAs (vmcnt 0), sync.
+            v_packs_e11 = _read_v_packs_for_buf(0, urv_base_per_lane)
+            if const_expr(CAUSAL):
+                v_s_1 = _causal_mask_prologue_if_needed(
+                    v_s_1,
+                    max_m1,
+                    split_t_end * BLOCK_N,
+                )
+            else:
+                v_s_1 = _seq_pad_mask_if_needed(v_s_1, max_m1)
+            rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
+            _waitcnt_vm_n(0)
+            rocdl.sched_barrier(0)
+            rocdl.s_barrier()
+            rocdl.sched_barrier(0)
+
+            # Epilogue C11 (compute): full P*V + rescale for v_p_0, then complete the
+            # last tile's softmax in-place (both exp2 halves, sum, cast) since no
+            # further pass follows.
+            v_o = _mma1(v_p_0, v_packs_e11, v_o)
+            m_tile_max_e11 = _attn_row_max(v_s_1)
+            row_max_e11 = _fmax(m_row, m_tile_max_e11)
+            rescale_e11 = rocdl.exp2(T.f32, _raw(_fsub(m_row, row_max_e11)))
+            m_row = row_max_e11
+            v_s_1 = _attn_sub_row(v_s_1, row_max_e11)
+            v_p_1 = _attn_exp2_slice(v_s_1, 0, 16)
+            _sched_barrier_pairs(9, 6, 10)
+            _sched_barrier_exp_pairs(7, 3, 10)
+            rocdl.sched_barrier(0)
+            v_p_1 = _attn_exp2_slice(v_p_1, 16, 16)
+            l_row = _fmul(l_row, rescale_e11)
+            tile_sum_e11 = _attn_sum(v_p_1)
+            l_row = _fadd(l_row, tile_sum_e11)
+            v_p_1 = _cast_p(v_p_1)
+            v_p_1 = _anchor_v_p(v_p_1)
+            rocdl.sched_barrier(0)
+            _scale_o(v_o, rescale_e11)
+            v_o = _anchor_v_o(v_o)
+            rocdl.s_barrier()
+            rocdl.sched_barrier(0)
+
+            # Epilogue C12 (memory): read the final V packs for the closing P*V.
+            v_packs_e13 = _read_v_packs_for_buf(1, urv_base_per_lane)
+            rocdl.s_waitcnt(_LGKMCNT_0_ONLY)
+            rocdl.sched_barrier(0)
+            rocdl.s_barrier()
+            rocdl.sched_barrier(0)
+
+            # Epilogue C13 (compute): final P*V -> v_o holds the unnormalized output.
+            v_o = _mma1(v_p_1, v_packs_e13, v_o)
+
+            # Normalize O by the softmax denominator (guarded so a zero l_row
+            # yields 0 instead of nan). Split-K also normalizes before the 16-bit
+            # pack (keeps |O_partial| ~ |V| so the mantissa is fully used); the
+            # combine kernel re-weights by w_s * l_s.
+            inv_l_rcp = rocdl.rcp(T.f32, _raw(l_row))
+            inv_l = ArithValue(fx.Float32(l_row) > c_zero_f).select(inv_l_rcp, c_zero_f)
+            _scale_o(v_o, inv_l)
+
+            # CLOSE the phase shift: one extra s_barrier on group A (complement of
+            # the prologue's group-B barrier) realigns the two groups before the
+            # store. Disabled -> one plain barrier.
+            if const_expr(DUALWAVE_SWP_ENABLE_STAGGER):
+                _stagger_extra_barrier_if_zero()  # group A: +1 s_barrier -> close the shift
+            else:
+                rocdl.s_barrier()
+
+            # Store O back to global memory, 128b per store: a lane fuses its own
+            # 4-col half with its half-wave partner's 4 cols (permlane32_swap), so a
+            # store_group pair covers 8 contiguous cols -> 8 dwordx4 per wave
+            # instead of 16 dwordx2.
+            pair_i32_ty = ir.Type.parse("!llvm.struct<(i32, i32)>")
+
+            def _o_pack_2dw(dc, store_group):
                 r_base = store_group * 4
                 # Pack 4 f32 outputs -> 2 packed-16bit dwords (lo, hi).
                 if const_expr(dtype_str == "bf16"):
@@ -1382,18 +1603,217 @@ def build_flash_attn_dualwave_swp_module(
                         Vec(v_o[dc])[r_base + 2],
                         Vec(v_o[dc])[r_base + 3],
                     )
-                    o_pack = Vec.from_elements([lo, hi], fx.Int32)
-                else:
-                    # fp16: trunc 4 f32 -> 4 f16 (RNE), view as 2 dwords.
-                    o_f16 = []
-                    for i in range_constexpr(4):
-                        o_f16.append(fx.Float32(Vec(v_o[dc])[r_base + i]).to(elem_dtype))
-                    o_pack = Vec.from_elements(o_f16, elem_dtype).bitcast(fx.Int32)
-                # Map this lane's MFMA output to (row, head_dim col).
-                d_row_rel = lane_div_32 * 4 + store_group * 8
-                d_col = (dc * D_CHUNK) + d_row_rel
-                o_global = _global_idx_q(q_row, d_col)
-                _buffer_store_64(o_pack, o_global)
+                    return lo, hi
+                # fp16: trunc 4 f32 -> 4 f16 (RNE), view as 2 dwords.
+                o_f16 = []
+                for i in range_constexpr(4):
+                    o_f16.append(fx.Float32(Vec(v_o[dc])[r_base + i]).to(elem_dtype))
+                pack = Vec.from_elements(o_f16, elem_dtype).bitcast(fx.Int32)
+                return _raw(pack[0]), _raw(pack[1])
+
+            is_hi_half = ArithValue(lane_div_32 != fx.Index(0))
+
+            def _swap_halves(dw):
+                # permlane32_swap(a,b) -> (a.lo|b.lo, a.hi|b.hi); with a=b=dw the
+                # partner dword dw[lane^32] is result[1] on low lanes, [0] on high.
+                swapped = rocdl.permlane32_swap(pair_i32_ty, _raw(dw), _raw(dw), False, False)
+                lo_res = llvm.extractvalue(T.i32, swapped, [0])
+                hi_res = llvm.extractvalue(T.i32, swapped, [1])
+                return is_hi_half.select(lo_res, hi_res)
+
+            if const_expr(not SPLITK):
+                for dc in range_constexpr(D_CHUNKS):
+                    for g in range_constexpr(2):
+                        d0_a, d1_a = _o_pack_2dw(dc, 2 * g)
+                        d0_b, d1_b = _o_pack_2dw(dc, 2 * g + 1)
+                        # low lanes: own group-2g cols 0-3 ++ partner's cols 4-7;
+                        # high lanes: partner's group-(2g+1) cols 0-3 ++ own cols 4-7.
+                        y0_a, y1_a = _swap_halves(d0_a), _swap_halves(d1_a)
+                        y0_b, y1_b = _swap_halves(d0_b), _swap_halves(d1_b)
+                        w0 = is_hi_half.select(y0_b, _raw(d0_a))
+                        w1 = is_hi_half.select(y1_b, _raw(d1_a))
+                        w2 = is_hi_half.select(_raw(d0_b), y0_a)
+                        w3 = is_hi_half.select(_raw(d1_b), y1_a)
+                        o_pack = Vec.from_elements([fx.Int32(w0), fx.Int32(w1), fx.Int32(w2), fx.Int32(w3)], fx.Int32)
+                        d_col = (dc * D_CHUNK) + (2 * g + lane_div_32) * 8
+                        o_global = _global_idx_q(q_row, d_col)
+                        _buffer_store_128(o_pack, o_global)
+            else:
+                # Split-K: store the normalized v_o into O_partial as kernel-native
+                # 16-bit (2 cols/dword, same permlane32_swap fuse as the splits==1
+                # path -> 8 cols/lane per dwordx4) plus this row's fp32 (m_row, l_row).
+                split_z = batch_idx * NUM_KV_SPLITS + split_idx
+                o_part_row_base = ((split_z * NUM_HEADS_Q + q_head_idx) * seq_len_v + q_row) * (HEAD_DIM // 2)
+                grid_z = fx.Index(gpu.grid_dim.z)
+                mrow_base = grid_z * NUM_HEADS_Q * seq_len_v * (HEAD_DIM // 2)
+                lrow_base = mrow_base + grid_z * NUM_HEADS_Q * seq_len_v
+                ml_row_idx = (split_z * NUM_HEADS_Q + q_head_idx) * seq_len_v + q_row
+                # Non-aligned seqlen: the workspace is indexed directly by q_row and
+                # (unlike O) cannot be num_records-bounded (a single flat buffer for
+                # all splits/heads), so an OOB row q_row >= seq_len would corrupt a
+                # neighbour's slot. Guard the writes by q_row < seq_len; the combine
+                # kernel only reads rows s < seq_len, so skipped rows are never read.
+                # lane and lane+32 share lane%32 -> share q_row, so the half-wave
+                # permlane32_swap fuse below is applied with both partners equally
+                # active/inactive. For aligned seqlen the guard is always true.
+                _if_qrow = _scf.IfOp(_raw(ArithValue(q_row < seq_len_v)))
+                with _if_then(_if_qrow):
+                    for dc in range_constexpr(D_CHUNKS):
+                        for g in range_constexpr(2):
+                            d0_a, d1_a = _o_pack_2dw(dc, 2 * g)
+                            d0_b, d1_b = _o_pack_2dw(dc, 2 * g + 1)
+                            y0_a, y1_a = _swap_halves(d0_a), _swap_halves(d1_a)
+                            y0_b, y1_b = _swap_halves(d0_b), _swap_halves(d1_b)
+                            w0 = is_hi_half.select(y0_b, _raw(d0_a))
+                            w1 = is_hi_half.select(y1_b, _raw(d1_a))
+                            w2 = is_hi_half.select(_raw(d0_b), y0_a)
+                            w3 = is_hi_half.select(_raw(d1_b), y1_a)
+                            dw_col = dc * (D_CHUNK // 2) + (2 * g + lane_div_32) * 4
+                            _ws_store_quad_i32([w0, w1, w2, w3], o_part_row_base + dw_col)
+                    # one value per q row; both half-waves hold the same reduced m/l
+                    _if_ml = _scf.IfOp(_raw(lane < fx.Index(32)))
+                    with _if_then(_if_ml):
+                        _ws_store_f32(m_row, mrow_base + ml_row_idx)
+                        _ws_store_f32(l_row, lrow_base + ml_row_idx)
+
+        if const_expr(SPLITK):
+            # Empty split: zero O_partial for own q rows, l = 0, m = -1e30.
+            _empty_if = _scf.IfOp(_raw(max_num_tiles < split_t0 + fx.Index(4)))
+            with _if_then(_empty_if):
+                q_row_e = q_start + wave_q_offset + lane_mod_32
+                split_z_e = batch_idx * NUM_KV_SPLITS + split_idx
+                o_row_base_e = ((split_z_e * NUM_HEADS_Q + q_head_idx) * seq_len_v + q_row_e) * (HEAD_DIM // 2)
+                c_zero_i = fx.Int32(0)
+                grid_z_e = fx.Index(gpu.grid_dim.z)
+                mrow_base_e = grid_z_e * NUM_HEADS_Q * seq_len_v * (HEAD_DIM // 2)
+                lrow_base_e = mrow_base_e + grid_z_e * NUM_HEADS_Q * seq_len_v
+                ml_row_e = (split_z_e * NUM_HEADS_Q + q_head_idx) * seq_len_v + q_row_e
+                # Same q_row < seq_len guard as the main store: don't zero OOB rows
+                # of a partial last q-block (they'd overwrite a neighbour's slot).
+                _if_qrow_e = _scf.IfOp(_raw(ArithValue(q_row_e < seq_len_v)))
+                with _if_then(_if_qrow_e):
+                    for dc in range_constexpr(D_CHUNKS):
+                        for g in range_constexpr(2):
+                            dw_col = dc * (D_CHUNK // 2) + (2 * g + lane_div_32) * 4
+                            _ws_store_quad_i32([c_zero_i, c_zero_i, c_zero_i, c_zero_i], o_row_base_e + dw_col)
+                    _if_ml_e = _scf.IfOp(_raw(lane < fx.Index(32)))
+                    with _if_then(_if_ml_e):
+                        _ws_store_f32(fx.Float32(-1e30), mrow_base_e + ml_row_e)
+                        _ws_store_f32(c_zero_f, lrow_base_e + ml_row_e)
+
+    # Combine kernel: out = sum_s w_s * O_s / sum_s w_s * l_s, w_s = exp2(m_s - m_max).
+    # One wave row of 32 lanes covers a (b, h, s) row, 4 contiguous cols/lane.
+    COMBINE_BLOCK = 256
+    COMBINE_ROWS_PER_BLOCK = COMBINE_BLOCK // (HEAD_DIM // 4)  # 8
+
+    @flyc.kernel(known_block_size=[COMBINE_BLOCK, 1, 1])
+    def flash_attn_splitk_combine_kernel(
+        O: fx.Tensor,  # noqa: E741
+        WS: fx.Tensor,
+        batch_size: fx.Int32,
+        seq_len: fx.Int32,
+        stride_q_n: fx.Int32,
+    ):
+        elem_dtype = dtype_to_elem_type(dtype_str)
+        fm_fast = fx.arith.FastMathFlags.fast
+        seq_v = fx.Index(seq_len)
+        stride_v = fx.Index(stride_q_n)
+        bs_v = fx.Index(batch_size)
+        tid = fx.Index(gpu.thread_idx.x)
+        blk = fx.Index(gpu.block_idx.x)
+
+        row = blk * COMBINE_ROWS_PER_BLOCK + tid // 32
+        col = (tid % 32) * 4
+        hs = seq_v * NUM_HEADS_Q
+        b = row // hs
+        rem = row % hs
+        h = rem // seq_v
+        s = rem % seq_v
+
+        z_total = bs_v * NUM_KV_SPLITS
+        mrow_base = z_total * NUM_HEADS_Q * seq_v * (HEAD_DIM // 2)
+        lrow_base = mrow_base + z_total * NUM_HEADS_Q * seq_v
+        row0 = (b * NUM_KV_SPLITS * NUM_HEADS_Q + h) * seq_v + s
+        per_split_row = NUM_HEADS_Q * seq_v
+
+        ws_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(WS), fx.make_layout(1, 1))
+        o_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(O), fx.make_layout(1, 1))
+        _load_atom_64 = fx.make_copy_atom(fx.rocdl.BufferCopy64b(), fx.Int32)
+        _load_atom_32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Int32)
+        _store_atom_64 = fx.make_copy_atom(fx.rocdl.BufferCopy64b(), fx.Int32)
+        _o_store_reg = fx.make_rmem_tensor(fx.make_layout(2, 1), fx.Int32)
+        v2i32_type = Vec.make_type(2, fx.Int32)
+        v1i32_type = Vec.make_type(1, fx.Int32)
+
+        # m/l are f32 in the workspace; load them through the SAME element-indexed
+        # buffer-tensor view as O_partial (modern Layout API + copy atom), not a raw
+        # llvm global pointer.
+        def _ws_load_f32(elem_index):
+            i32 = fly.copy_atom_call_ssa([v1i32_type], _load_atom_32, fx.slice(ws_div, (None, fx.Int32(elem_index))))
+            return _raw(Vec(i32, (1,), fx.Int32).bitcast(fx.Float32)[0])
+
+        def _fadd(a, b):
+            return arith.addf(_raw(a), _raw(b), fastmath=fm_fast)
+
+        def _fmul(a, b):
+            return arith.mulf(_raw(a), _raw(b), fastmath=fm_fast)
+
+        def _fmax(a, b):
+            return arith.MaxNumFOp(_raw(a), _raw(b), fastmath=fm_fast).result
+
+        m_s = []
+        l_s = []
+        for i in range_constexpr(NUM_KV_SPLITS):
+            m_s.append(_ws_load_f32(mrow_base + row0 + i * per_split_row))
+            l_s.append(_ws_load_f32(lrow_base + row0 + i * per_split_row))
+        m_max = m_s[0]
+        for i in range_constexpr(NUM_KV_SPLITS - 1):
+            m_max = _fmax(m_max, m_s[i + 1])
+
+        den = _raw(fx.Float32(0.0))
+        acc = _raw(Vec.filled(4, 0.0, fx.Float32))
+        for i in range_constexpr(NUM_KV_SPLITS):
+            # Empty split (causal tail block): l == 0 and O_partial is zeroed, so it
+            # contributes nothing -- skip its O reads. The runtime `if` (its condition
+            # holds a call, so the AST rewriter lowers it to scf.if) reassigns the
+            # pre-existing acc/den so the update propagates out of the branch; the
+            # not-taken path keeps acc/den unchanged. One merged exit.
+            @flyc.jit
+            def _accum_split(acc, den):
+                if fx.Float32(l_s[i]) > fx.Float32(0.0):
+                    w = rocdl.exp2(T.f32, _raw(arith.subf(_raw(m_s[i]), _raw(m_max), fastmath=fm_fast)))
+                    wl = _fmul(w, l_s[i])
+                    den = _fadd(den, wl)
+                    # O_partial holds packed 16-bit normalized partials (2 cols/dword):
+                    # dwordx2 per lane, extend the 4 cols to f32, weight by w * l.
+                    o_idx = (row0 + i * per_split_row) * (HEAD_DIM // 2) + col // 2
+                    o2_i32 = fly.copy_atom_call_ssa(
+                        [v2i32_type], _load_atom_64, fx.slice(ws_div, (None, fx.Int32(o_idx)))
+                    )
+                    o4 = Vec(o2_i32, (2,), fx.Int32).bitcast(elem_dtype).to(fx.Float32)
+                    w4 = Vec.from_elements([fx.Float32(wl)], fx.Float32).broadcast_to(4)
+                    acc = _fadd(acc, _fmul(w4, o4))
+                return acc, den
+
+            acc, den = _accum_split(acc, den)
+
+        inv_rcp = rocdl.rcp(T.f32, den)
+        inv = ArithValue(fx.Float32(den) > fx.Float32(0.0)).select(inv_rcp, fx.Float32(0.0))
+        inv4 = Vec.from_elements([fx.Float32(inv)], fx.Float32).broadcast_to(4)
+        out4 = Vec(_fmul(acc, inv4), (4,), fx.Float32)
+        if const_expr(dtype_str == "bf16"):
+            lo = rocdl.cvt_pk_bf16_f32(out4[0], out4[1])
+            hi = rocdl.cvt_pk_bf16_f32(out4[2], out4[3])
+        else:
+            o_f16 = []
+            for i in range_constexpr(4):
+                o_f16.append(fx.Float32(out4[i]).to(elem_dtype))
+            pack = Vec.from_elements(o_f16, elem_dtype).bitcast(fx.Int32)
+            lo, hi = _raw(pack[0]), _raw(pack[1])
+        o_pack = Vec.from_elements([fx.Int32(lo), fx.Int32(hi)], fx.Int32)
+        o_global = (b * seq_v + s) * stride_v + h * HEAD_DIM + col
+        fx.memref_store_vec(o_pack, _o_store_reg)
+        fx.copy(_store_atom_64, _o_store_reg, fx.slice(o_div, (None, fx.Int32(o_global))))
 
     @flyc.jit
     def launch_flash_attn_dualwave_swp(
@@ -1402,6 +1822,8 @@ def build_flash_attn_dualwave_swp_module(
         V: fx.Tensor,
         O: fx.Tensor,  # noqa: E741
         DebugCounts: fx.Tensor,
+        CuSeqQ: fx.Tensor,
+        CuSeqKv: fx.Tensor,
         batch_size: fx.Int32,
         seq_len: fx.Int32,
         stride_q_n: fx.Int32,
@@ -1412,6 +1834,10 @@ def build_flash_attn_dualwave_swp_module(
         bs_idx = fx.Index(batch_size)
         sl_idx = fx.Index(seq_len)
         num_q_blocks = (sl_idx + BLOCK_M - 1) // BLOCK_M
+        if const_expr(SPLITK):
+            grid_z = bs_idx * NUM_KV_SPLITS
+        else:
+            grid_z = bs_idx
 
         passthrough_entries = (
             [
@@ -1428,6 +1854,8 @@ def build_flash_attn_dualwave_swp_module(
             V,
             O,
             DebugCounts,
+            CuSeqQ,
+            CuSeqKv,
             seq_len,
             stride_q_n,
             stride_kv_n,
@@ -1438,10 +1866,17 @@ def build_flash_attn_dualwave_swp_module(
                 "passthrough": passthrough_entries,
             },
         ).launch(
-            grid=(NUM_HEADS_Q, num_q_blocks, bs_idx),
+            grid=(NUM_HEADS_Q, num_q_blocks, grid_z),
             block=(BLOCK_SIZE, 1, 1),
             stream=stream,
         )
+        if const_expr(SPLITK):
+            combine_rows = bs_idx * NUM_HEADS_Q * sl_idx
+            flash_attn_splitk_combine_kernel(O, DebugCounts, batch_size, seq_len, stride_q_n).launch(
+                grid=(combine_rows // COMBINE_ROWS_PER_BLOCK, 1, 1),
+                block=(COMBINE_BLOCK, 1, 1),
+                stream=stream,
+            )
 
     _dualwave_swp_compile_hints = {
         "fast_fp_math": True,
@@ -1464,6 +1899,9 @@ def build_flash_attn_dualwave_swp_module(
         head_dim_runtime=None,
         debug_counts=None,
         *,
+        workspace=None,
+        cu_seqlens_q=None,
+        cu_seqlens_kv=None,
         stream=None,
     ):
         if stride_kv_n is None:
@@ -1472,15 +1910,48 @@ def build_flash_attn_dualwave_swp_module(
             stride_q_n = DEFAULT_STRIDE_Q_N
         if head_dim_runtime is None:
             head_dim_runtime = HEAD_DIM
+        if SPLITK:
+            if workspace is None:
+                raise ValueError("num_kv_splits > 1 requires a fp32 workspace (see dualwave_splitk_workspace_elems)")
+            debug_counts = workspace
         if debug_counts is None:
             debug_counts = O
+        # Dense launches still pass valid tensors for the (unused) cu_seqlens slots;
+        # the kernel only reads them under const_expr(VARLEN). Use O as a placeholder.
+        if cu_seqlens_q is None:
+            cu_seqlens_q = O
+        if cu_seqlens_kv is None:
+            cu_seqlens_kv = O
         with CompilationContext.compile_hints(_dualwave_swp_compile_hints):
             if stream is None:
                 return launch_flash_attn_dualwave_swp(
-                    Q, K, V, O, debug_counts, batch_size, seq_len, stride_q_n, stride_kv_n, head_dim_runtime
+                    Q,
+                    K,
+                    V,
+                    O,
+                    debug_counts,
+                    cu_seqlens_q,
+                    cu_seqlens_kv,
+                    batch_size,
+                    seq_len,
+                    stride_q_n,
+                    stride_kv_n,
+                    head_dim_runtime,
                 )
             return launch_flash_attn_dualwave_swp(
-                Q, K, V, O, debug_counts, batch_size, seq_len, stride_q_n, stride_kv_n, head_dim_runtime, stream=stream
+                Q,
+                K,
+                V,
+                O,
+                debug_counts,
+                cu_seqlens_q,
+                cu_seqlens_kv,
+                batch_size,
+                seq_len,
+                stride_q_n,
+                stride_kv_n,
+                head_dim_runtime,
+                stream=stream,
             )
 
     def _compile(
@@ -1495,6 +1966,9 @@ def build_flash_attn_dualwave_swp_module(
         head_dim_runtime=None,
         debug_counts=None,
         *,
+        workspace=None,
+        cu_seqlens_q=None,
+        cu_seqlens_kv=None,
         stream=None,
     ):
         if stride_kv_n is None:
@@ -1503,8 +1977,16 @@ def build_flash_attn_dualwave_swp_module(
             stride_q_n = DEFAULT_STRIDE_Q_N
         if head_dim_runtime is None:
             head_dim_runtime = HEAD_DIM
+        if SPLITK:
+            if workspace is None:
+                raise ValueError("num_kv_splits > 1 requires a fp32 workspace (see dualwave_splitk_workspace_elems)")
+            debug_counts = workspace
         if debug_counts is None:
             debug_counts = O
+        if cu_seqlens_q is None:
+            cu_seqlens_q = O
+        if cu_seqlens_kv is None:
+            cu_seqlens_kv = O
         with CompilationContext.compile_hints(_dualwave_swp_compile_hints):
             return flyc.compile(
                 launch_flash_attn_dualwave_swp,
@@ -1513,6 +1995,8 @@ def build_flash_attn_dualwave_swp_module(
                 V,
                 O,
                 debug_counts,
+                cu_seqlens_q,
+                cu_seqlens_kv,
                 batch_size,
                 seq_len,
                 stride_q_n,

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -35,6 +35,10 @@ if not torch.cuda.is_available():
 from kernels.flash_attn_generic import (  # noqa: E402
     build_flash_attn_func_module,
 )
+from kernels.flash_attn_gfx950 import (  # noqa: E402
+    build_flash_attn_dualwave_swp_module,
+    dualwave_splitk_workspace_elems,
+)
 from tests.test_common import run_perftest  # noqa: E402
 
 # Tensor initialization range (uniform distribution)
@@ -49,36 +53,68 @@ FLASH_ATTN_FUNC_KERNEL_CONFIG = {
     "dualwave_swp_enable_stagger": os.getenv("FLYDSL_DUALWAVE_SWP_STAGGER", "1") == "1",
 }
 
-# (batch, seq_len, num_heads, num_kv_heads, head_dim)
+# (batch, seq_len, num_heads, num_kv_heads, head_dim, num_kv_splits)
 # num_kv_heads == num_heads -> MHA; num_kv_heads < num_heads -> GQA/MQA.
+# num_kv_splits > 1 -> split-K path (gfx950 DUALWAVE_SWP only, seq_len >= 384, D=128).
 DEFAULT_CONFIGS = [
-    (8, 128, 64, 64, 128),
-    (8, 256, 64, 64, 128),
-    (8, 512, 64, 64, 128),
-    (1, 128, 64, 64, 128),
-    (1, 256, 64, 64, 128),
-    (1, 384, 64, 64, 128),
-    (1, 512, 64, 64, 128),
-    (1, 1024, 64, 64, 128),
-    (1, 2048, 64, 64, 128),
-    (1, 4096, 64, 64, 128),
-    (1, 8192, 64, 64, 128),
-    (4, 8192, 64, 64, 128),
-    (1, 2048, 32, 32, 128),
-    (1, 4096, 32, 32, 128),
-    (1, 8192, 32, 32, 128),
-    (8, 8192, 32, 32, 128),
-    (1, 2048, 16, 16, 128),
-    (1, 4096, 16, 16, 128),
-    (1, 8192, 16, 16, 128),
-    (16, 8192, 16, 16, 128),
-    (1, 2048, 8, 8, 128),
-    (1, 4096, 8, 8, 128),
-    (1, 8192, 8, 8, 128),
-    (32, 8192, 8, 8, 128),
-    (16, 8192, 64, 64, 128),
+    (8, 128, 64, 64, 128, 1),
+    (8, 256, 64, 64, 128, 1),
+    (8, 512, 64, 64, 128, 1),
+    (1, 128, 64, 64, 128, 1),
+    (1, 256, 64, 64, 128, 1),
+    (1, 384, 64, 64, 128, 1),
+    (1, 512, 64, 64, 128, 1),
+    (1, 1024, 64, 64, 128, 1),
+    (1, 2048, 64, 64, 128, 1),
+    (1, 4096, 64, 64, 128, 1),
+    (1, 8192, 64, 64, 128, 1),
+    (4, 8192, 64, 64, 128, 1),
+    (1, 2048, 32, 32, 128, 1),
+    (1, 4096, 32, 32, 128, 1),
+    (1, 8192, 32, 32, 128, 1),
+    (8, 8192, 32, 32, 128, 1),
+    (1, 2048, 16, 16, 128, 1),
+    (1, 4096, 16, 16, 128, 1),
+    (1, 8192, 16, 16, 128, 1),
+    (16, 8192, 16, 16, 128, 1),
+    (1, 2048, 8, 8, 128, 1),
+    (1, 4096, 8, 8, 128, 1),
+    (1, 8192, 8, 8, 128, 1),
+    (32, 8192, 8, 8, 128, 1),
+    (16, 8192, 64, 64, 128, 1),
     # GQA configs (num_kv_heads < num_heads).
-    (16, 8192, 64, 8, 128),
+    (16, 8192, 64, 8, 128, 1),
+    (2, 1024, 64, 64, 128, 1),
+    # (1, 98144, 3, 3, 128, 5),
+    # (1, 147216, 3, 3, 128, 5),
+    # (1, 196288, 3, 3, 128, 5),
+    # (1, 245360, 3, 3, 128, 5),
+    # (1, 294432, 3, 3, 128, 5),
+    # (1, 12268, 24, 24, 128, 1),
+    # (1, 18402, 24, 24, 128, 1),
+    # (1, 24536, 24, 24, 128, 1),
+    # (1, 30670, 24, 24, 128, 2),
+    # (1, 36804, 24, 24, 128, 2),
+    # (1, 64, 4, 4, 128, 1),
+    # (1, 30, 4, 4, 128, 1),
+    # (1, 1, 4, 4, 128, 1),
+    # (2, 7, 4, 4, 128, 1),
+    # (3, 31, 3, 3, 128, 1),
+    # (5, 33, 5, 5, 128, 1),
+    # (5, 63, 7, 7, 128, 1),
+    # (3, 65, 3, 3, 128, 1),
+]
+
+# QKV varlen test cases (packed cu_seqlens). Each entry is
+#   (per_batch_seqlens, num_heads, num_kv_heads, head_dim)
+# batch = len(per_batch_seqlens); per batch seqlen_q == seqlen_kv (self-attention).
+# Exercise uneven per-batch lengths, non-256/64-multiple lengths, seqlen<256, GQA.
+VARLEN_CONFIGS = [
+    # ([8192], 64, 64, 128),  # uneven; 128 -> partial last q-block; MHA
+    ([512, 256, 1024, 128], 64, 64, 128),  # uneven; 128 -> partial last q-block; MHA
+    ([300, 700, 500], 32, 32, 128),  # all non-256-multiples; partial q+kv tiles
+    ([1024, 1024], 64, 8, 128),  # even, GQA (num_kv_heads=8)
+    ([1, 3, 31, 33, 63, 65], 16, 16, 128),  # small (<256) + non-multiples; 4 batches
 ]
 
 
@@ -235,21 +271,72 @@ def run_config(
     dtype_str="f16",
     verbose=True,
     num_kv_heads=None,
+    varlen_seqlens=None,
 ):
     device = "cuda"
     results = {}
 
-    if seq_len % 128 != 0:
-        results["err"] = f"seq_len ({seq_len}) must be divisible by 128 for flash_attn_func"
-        return results
-    if head_dim % 32 != 0 or head_dim < 64:
-        results["err"] = f"head_dim ({head_dim}) must be >= 64 and divisible by 32"
-        return results
+    # ── flash_attn_func size / dtype / GPU-arch constraints ──────────────────
+    # Reject an unsupported config up-front by raising ValueError with a clear
+    # reason (mirrors the kernel's own guards in flash_attn_generic.py) instead
+    # of building a kernel that would assert, read KV out-of-bounds, or return
+    # garbage. The sweep callers wrap run_config in try/except, so the raise is
+    # surfaced as an ERROR row.
     if num_kv_heads is None:
         num_kv_heads = num_heads
+
+    # 1) GPU architecture. MFMA32 + the LDS-transpose paths need CDNA3 (gfx942)
+    #    or CDNA4 (gfx950); the DUALWAVE_SWP fast path is gfx950-only.
+    try:
+        gpu_arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
+    except Exception:
+        gpu_arch = ""
+    if not (gpu_arch.startswith("gfx942") or gpu_arch.startswith("gfx950")):
+        raise ValueError(
+            f"unsupported GPU arch '{gpu_arch or 'unknown'}': flash_attn_func requires "
+            f"CDNA3 (gfx942) or CDNA4 (gfx950)"
+        )
+
+    # 2) dtype: only f16 / bf16.
+    if dtype_str not in ("f16", "bf16"):
+        raise ValueError(f"dtype_str ('{dtype_str}') must be 'f16' or 'bf16'")
+
+    # 3) head_dim: a multiple of 32 and >= 64 (the DUALWAVE_SWP fast path further
+    #    needs exactly 128; other head_dims simply run the generic path).
+    if head_dim % 32 != 0 or head_dim < 64:
+        raise ValueError(f"head_dim ({head_dim}) must be >= 64 and a multiple of 32")
+
+    # 4) GQA/MQA head divisibility.
     if num_heads % num_kv_heads != 0:
-        results["err"] = f"num_heads ({num_heads}) must be divisible by num_kv_heads ({num_kv_heads})"
-        return results
+        raise ValueError(f"num_heads ({num_heads}) must be divisible by num_kv_heads ({num_kv_heads})")
+
+    # 5) seq_len: arbitrary length is supported (the DUALWAVE_SWP fast path for
+    #    seq_len >= 384, the generic fallback for any seq_len -- partial last
+    #    q-tile via Q/O bounds, partial last kv-tile via bounded/clamped KV loads
+    #    + causal / non-causal padding masks). Only seq_len >= 1 is required.
+    if seq_len < 1:
+        raise ValueError(f"seq_len ({seq_len}) must be >= 1")
+
+    # ── QKV varlen (packed cu_seqlens) ───────────────────────────────────────
+    # When varlen_seqlens is given, this batch is packed: Q/O are [total_tok, H, D],
+    # K/V are [total_tok, H_kv, D], per-batch token ranges come from the cumulative
+    # cu_seqlens (int32 [B+1]) passed to the build call. Per batch seqlen_q==seqlen_kv.
+    varlen = varlen_seqlens is not None
+    if varlen:
+        _vl = [int(s) for s in varlen_seqlens]
+        if len(_vl) < 1 or any(s < 1 for s in _vl):
+            raise ValueError(f"varlen_seqlens must be a non-empty list of positive ints, got {varlen_seqlens}")
+        batch = len(_vl)
+        seq_len = max(_vl)
+        _cu = [0]
+        for s in _vl:
+            _cu.append(_cu[-1] + s)
+        total_tok = _cu[-1]
+        cu_seqlens_q = torch.tensor(_cu, dtype=torch.int32, device=device)
+        cu_seqlens_kv = cu_seqlens_q  # self-attn: q==kv per batch
+    else:
+        cu_seqlens_q = None
+        cu_seqlens_kv = None
 
     try:
         exe = build_flash_attn_func_module(
@@ -260,6 +347,8 @@ def run_config(
             waves_per_eu=FLASH_ATTN_FUNC_KERNEL_CONFIG["waves_per_eu"],
             daz=FLASH_ATTN_FUNC_KERNEL_CONFIG.get("daz", False),
             num_kv_heads=num_kv_heads,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_kv=cu_seqlens_kv,
             dualwave_swp_lazy_rescale=FLASH_ATTN_FUNC_KERNEL_CONFIG["dualwave_swp_lazy_rescale"],
             dualwave_swp_setprio=FLASH_ATTN_FUNC_KERNEL_CONFIG["dualwave_swp_setprio"],
             dualwave_swp_debug_lazy_counts=FLASH_ATTN_FUNC_KERNEL_CONFIG["dualwave_swp_debug_lazy_counts"],
@@ -275,24 +364,32 @@ def run_config(
     B, S, H, D = batch, seq_len, num_heads, head_dim
     H_KV = num_kv_heads
     setup_seed(seed)
-    q_4d = torch.empty(B, S, H, D, dtype=dtype, device=device).uniform_(*UNIFORM_RANGE)
-    k_4d = torch.empty(B, S, H_KV, D, dtype=dtype, device=device).uniform_(*UNIFORM_RANGE)
-    v_4d = torch.empty(B, S, H_KV, D, dtype=dtype, device=device).uniform_(*UNIFORM_RANGE)
-    trigger_lazy_else = os.getenv("FLYDSL_DUALWAVE_SWP_TRIGGER_LAZY_ELSE", "0") == "1"
     debug_lazy_counts = FLASH_ATTN_FUNC_KERNEL_CONFIG["dualwave_swp_debug_lazy_counts"]
-    if trigger_lazy_else:
-        q_4d.fill_(1.0)
-        k_4d.zero_()
-        if S >= 128:
-            k_4d[:, 64:128, :, :].fill_(80.0)
-        print(
-            "[DUALWAVE_SWP_LAZY_ELSE_DEBUG] constructed Q=1, K tile0=0, " "K tile1=80 to force row_max - m_row > 8",
-            flush=True,
-        )
-
-    q_flat = q_4d.contiguous().view(-1)
-    k_flat = k_4d.contiguous().view(-1)
-    v_flat = v_4d.contiguous().view(-1)
+    if varlen:
+        # Packed [total_tok, H/H_kv, D]; reference slices each batch out by cu_seqlens.
+        q_3d = torch.empty(total_tok, H, D, dtype=dtype, device=device).uniform_(*UNIFORM_RANGE)
+        k_3d = torch.empty(total_tok, H_KV, D, dtype=dtype, device=device).uniform_(*UNIFORM_RANGE)
+        v_3d = torch.empty(total_tok, H_KV, D, dtype=dtype, device=device).uniform_(*UNIFORM_RANGE)
+        q_flat = q_3d.contiguous().view(-1)
+        k_flat = k_3d.contiguous().view(-1)
+        v_flat = v_3d.contiguous().view(-1)
+    else:
+        q_4d = torch.empty(B, S, H, D, dtype=dtype, device=device).uniform_(*UNIFORM_RANGE)
+        k_4d = torch.empty(B, S, H_KV, D, dtype=dtype, device=device).uniform_(*UNIFORM_RANGE)
+        v_4d = torch.empty(B, S, H_KV, D, dtype=dtype, device=device).uniform_(*UNIFORM_RANGE)
+        trigger_lazy_else = os.getenv("FLYDSL_DUALWAVE_SWP_TRIGGER_LAZY_ELSE", "0") == "1"
+        if trigger_lazy_else:
+            q_4d.fill_(1.0)
+            k_4d.zero_()
+            if S >= 128:
+                k_4d[:, 64:128, :, :].fill_(80.0)
+            print(
+                "[DUALWAVE_SWP_LAZY_ELSE_DEBUG] constructed Q=1, K tile0=0, " "K tile1=80 to force row_max - m_row > 8",
+                flush=True,
+            )
+        q_flat = q_4d.contiguous().view(-1)
+        k_flat = k_4d.contiguous().view(-1)
+        v_flat = v_4d.contiguous().view(-1)
     o_flat = torch.zeros_like(q_flat)
     debug_counts = torch.zeros(2, dtype=torch.float32, device=device) if debug_lazy_counts else None
 
@@ -322,8 +419,20 @@ def run_config(
             flush=True,
         )
 
-    ref_4d = pytorch_ref_attention(q_4d.float(), k_4d.float(), v_4d.float(), causal=causal).to(dtype)
-    ref_flat = ref_4d.contiguous().view(-1)
+    if varlen:
+        # Per-batch reference: SDPA on each unpacked [seqlen_b] slice -> packed buffer.
+        ref_3d = torch.empty(total_tok, H, D, dtype=dtype, device=device)
+        for _b in range(batch):
+            s0, s1 = _cu[_b], _cu[_b + 1]
+            qb = q_3d[s0:s1].unsqueeze(0).float()
+            kb = k_3d[s0:s1].unsqueeze(0).float()
+            vb = v_3d[s0:s1].unsqueeze(0).float()
+            rb = pytorch_ref_attention(qb, kb, vb, causal=causal).to(dtype)
+            ref_3d[s0:s1] = rb.squeeze(0)
+        ref_flat = ref_3d.contiguous().view(-1)
+    else:
+        ref_4d = pytorch_ref_attention(q_4d.float(), k_4d.float(), v_4d.float(), causal=causal).to(dtype)
+        ref_flat = ref_4d.contiguous().view(-1)
 
     o_f32 = o_flat.float()
     ref_f32 = ref_flat.float()
@@ -363,6 +472,156 @@ def run_config(
 
         # Warm up ROCTracer/torch.profiler itself so the measured run_perftest
         # below is not biased by first-profiler-session setup overhead.
+        with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+            profile_memory=False,
+            with_stack=False,
+            with_modules=True,
+        ):
+            for _ in range(10):
+                kernel_fn()
+            torch.cuda.synchronize()
+
+        _, us = run_perftest(kernel_fn, num_iters=iters, num_warmup=warmup)
+        if varlen:
+            # Sum per-batch FLOPs (each batch attends only within its own seqlen).
+            flops = sum(4.0 * sb * (sb / 2.0 if causal else float(sb)) * D * H for sb in _vl)
+        else:
+            s_eff = S / 2.0 if causal else float(S)
+            flops = 4.0 * S * s_eff * D * H * B
+        tflops = flops / (us * 1e-6) / 1e12
+        results["us"] = us
+        results["tflops"] = tflops
+    except Exception as e:
+        results["bench_err"] = str(e)
+
+    return results
+
+
+def run_splitk_config(
+    batch,
+    seq_len,
+    num_heads,
+    head_dim,
+    dtype,
+    causal,
+    warmup,
+    iters,
+    seed=DEFAULT_SEED,
+    dtype_str="bf16",
+    verbose=True,
+    num_kv_heads=None,
+    num_kv_splits=2,
+):
+    """Run the gfx950 DUALWAVE_SWP kernel in split-K mode (num_kv_splits > 1).
+
+    Drives ``build_flash_attn_dualwave_swp_module(num_kv_splits=...)`` directly
+    (the generic flash_attn_func dispatch does not plumb split-K) with the
+    required fp32 workspace, then validates the combined output vs torch SDPA.
+    Returns a run_config-compatible result dict (max_err / min_cos / passed /
+    us / tflops) so it prints through the same summary table.
+    """
+    device = "cuda"
+    results = {}
+
+    if int(num_kv_splits) < 2:
+        results["err"] = f"run_splitk_config requires num_kv_splits >= 2, got {num_kv_splits}"
+        return results
+    # Not-applicable shapes are SKIPPED (not failed) so a default-config sweep with
+    # --num_kv_splits N quietly skips D!=128 / non-bf16,f16 / seq_len<384 configs.
+    if head_dim != 128 or dtype_str not in ("bf16", "f16") or seq_len < 384:
+        return {"skip": True}
+    if num_kv_heads is None:
+        num_kv_heads = num_heads
+    if num_heads % num_kv_heads != 0:
+        results["err"] = f"num_heads ({num_heads}) must be divisible by num_kv_heads ({num_kv_heads})"
+        return results
+
+    # The split-K workspace is a single buffer-tensor addressed with a 32-bit
+    # num_records (bytes). When batch*splits*heads*seq is large enough that the
+    # fp32 workspace exceeds 4 GiB, high m/l offsets fall past the descriptor and
+    # get OOB-dropped -> wrong combine. Split-K targets SMALL grids anyway, so
+    # SKIP (not fail) any shape whose workspace would overflow 32-bit addressing.
+    ws_elems = dualwave_splitk_workspace_elems(batch, num_heads, seq_len, int(num_kv_splits), head_dim=head_dim)
+    if ws_elems * 4 >= 0xFFFFFFFF:
+        return {"skip": True}
+
+    try:
+        exe = build_flash_attn_dualwave_swp_module(
+            num_heads=num_heads,
+            head_dim=head_dim,
+            causal=causal,
+            dtype_str=dtype_str,
+            waves_per_eu=FLASH_ATTN_FUNC_KERNEL_CONFIG["waves_per_eu"],
+            daz=FLASH_ATTN_FUNC_KERNEL_CONFIG.get("daz", False),
+            num_kv_heads=num_kv_heads,
+            dualwave_swp_lazy_rescale=FLASH_ATTN_FUNC_KERNEL_CONFIG["dualwave_swp_lazy_rescale"],
+            dualwave_swp_setprio=FLASH_ATTN_FUNC_KERNEL_CONFIG["dualwave_swp_setprio"],
+            dualwave_swp_debug_lazy_counts=False,
+            dualwave_swp_enable_stagger=FLASH_ATTN_FUNC_KERNEL_CONFIG["dualwave_swp_enable_stagger"],
+            num_kv_splits=int(num_kv_splits),
+        )
+    except Exception as e:
+        results["err"] = f"build: {e}"
+        import traceback
+
+        traceback.print_exc()
+        return results
+
+    B, S, H, D = batch, seq_len, num_heads, head_dim
+    H_KV = num_kv_heads
+    setup_seed(seed)
+    q_4d = torch.empty(B, S, H, D, dtype=dtype, device=device).uniform_(*UNIFORM_RANGE)
+    k_4d = torch.empty(B, S, H_KV, D, dtype=dtype, device=device).uniform_(*UNIFORM_RANGE)
+    v_4d = torch.empty(B, S, H_KV, D, dtype=dtype, device=device).uniform_(*UNIFORM_RANGE)
+
+    q_flat = q_4d.contiguous().view(-1)
+    k_flat = k_4d.contiguous().view(-1)
+    v_flat = v_4d.contiguous().view(-1)
+    o_flat = torch.zeros_like(q_flat)
+    workspace = torch.zeros(ws_elems, dtype=torch.float32, device=device)
+
+    try:
+        exe(q_flat, k_flat, v_flat, o_flat, B, S, workspace=workspace)
+        torch.cuda.synchronize()
+    except Exception as e:
+        results["err"] = f"exec: {e}"
+        import traceback
+
+        traceback.print_exc()
+        return results
+
+    ref_4d = pytorch_ref_attention(q_4d.float(), k_4d.float(), v_4d.float(), causal=causal).to(dtype)
+    ref_flat = ref_4d.contiguous().view(-1)
+
+    o_f32 = o_flat.float()
+    ref_f32 = ref_flat.float()
+    max_err = (o_f32 - ref_f32).abs().max().item()
+    mean_err = (o_f32 - ref_f32).abs().mean().item()
+    cos_sim = F.cosine_similarity(o_f32.reshape(-1, D), ref_f32.reshape(-1, D), dim=1)
+    min_cos = cos_sim.min().item()
+    results["max_err"] = max_err
+    results["mean_err"] = mean_err
+    results["min_cos"] = min_cos
+    results["passed"] = max_err < 1e-2 and min_cos > 0.99
+
+    if verbose:
+        tag = f"B={B} S={S} H={H} D={D} splits={num_kv_splits}"
+        result_md5 = compute_md5(o_flat)
+        ref_md5 = compute_md5(ref_flat)
+        print(f"  [{tag}] result_md5 = {result_md5}")
+        print(f"  [{tag}] ref_md5    = {ref_md5}")
+        print(f"  [{tag}] --- compare_arrays ---")
+        compare_arrays(
+            o_flat.to(torch.float32).detach().cpu().numpy(),
+            ref_flat.to(torch.float32).detach().cpu().numpy(),
+        )
+
+    try:
+
+        def kernel_fn():
+            exe(q_flat, k_flat, v_flat, o_flat, B, S, workspace=workspace)
+
         with torch.profiler.profile(
             activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
             profile_memory=False,
@@ -602,6 +861,7 @@ def _write_cmp_csv(csv_path, data_rows, avg_rows):
         "D",
         "dtype",
         "causal",
+        "kv_sp",
         "FlyDSL_Time(us)",
         "FlyDSL_TFLOPS",
         "FlyDSL_MaxErr",
@@ -650,8 +910,8 @@ def _write_cmp_csv(csv_path, data_rows, avg_rows):
             else:
                 label, fa, ca, aa = avg_row
                 cmp_overrides = None
-            # label + 6 empty cfg columns (S, H, Hkv, D, dtype, causal)
-            w.writerow([label, "", "", "", "", "", ""] + _metrics(fa, ca, aa, cmp_overrides))
+            # label + 7 empty cfg columns (S, H, Hkv, D, dtype, causal, kv_sp)
+            w.writerow([label, "", "", "", "", "", "", ""] + _metrics(fa, ca, aa, cmp_overrides))
 
 
 def _write_normal_csv(csv_path, data_rows, avg_rows):
@@ -664,6 +924,7 @@ def _write_normal_csv(csv_path, data_rows, avg_rows):
         "D",
         "dtype",
         "causal",
+        "kv_sp",
         "Path",
         "Status",
         "MaxErr",
@@ -687,10 +948,11 @@ def _write_normal_csv(csv_path, data_rows, avg_rows):
                 ]
             )
         for label, avg in avg_rows:
-            # label + 7 empty (S, H, Hkv, D, dtype, causal, Path) + Status + 4 metrics
+            # label + 8 empty (S, H, Hkv, D, dtype, causal, kv_sp, Path) + Status + 4 metrics
             w.writerow(
                 [
                     label,
+                    "",
                     "",
                     "",
                     "",
@@ -742,7 +1004,7 @@ def _avg_cmp_values(rows, fly_idx, other_idx):
 
 
 def _tag_group(cfg):
-    """Extract (dtype_key, causal_tag) from config tuple (B, S, H, Hkv, D, dtype, causal)."""
+    """Extract (dtype_key, causal_tag) from config tuple (B, S, H, Hkv, D, dtype, causal, kv_sp)."""
     return cfg[5], cfg[6]
 
 
@@ -774,15 +1036,15 @@ def _print_grouped_avgs(rows, tag_fn, print_avg_fn):
                 print_avg_fn(f"AVG ({ct})", subset)
 
 
-_CFG_HDR = f"{'B':>4s} {'S':>6s} {'H':>4s} {'Hkv':>4s} {'D':>4s} " f"{'dtype':>5s} {'causal':>8s}"
+_CFG_HDR = f"{'B':>4s} {'S':>6s} {'H':>4s} {'Hkv':>4s} {'D':>4s} {'dtype':>5s} {'causal':>8s} {'kv_sp':>5s}"
 _CFG_W = len(_CFG_HDR)
 _PATH_W = 20
 
 
 def _fmt_cfg(cfg):
-    """Format config tuple (B, S, H, Hkv, D, dtype, causal) as fixed-width columns."""
-    B, S, H, Hkv, D, dt, cs = cfg
-    return f"{B:>4d} {S:>6d} {H:>4d} {Hkv:>4d} {D:>4d} {dt:>5s} {cs:>8s}"
+    """Format config tuple (B, S, H, Hkv, D, dtype, causal, kv_sp) as fixed-width columns."""
+    B, S, H, Hkv, D, dt, cs, ksp = cfg
+    return f"{B:>4d} {S:>6d} {H:>4d} {Hkv:>4d} {D:>4d} {dt:>5s} {cs:>8s} {ksp:>5d}"
 
 
 def _fmt_normal_row(cfg, path, status, r):
@@ -792,9 +1054,71 @@ def _fmt_normal_row(cfg, path, status, r):
     prefix = f"{cfg_s}{path_s}"
     if "err" in r:
         return f"{prefix} | {'ERROR':>6s} | {r['err'][:60]}"
+    if r.get("skip"):
+        return f"{prefix} | {'SKIP':>6s} | n/a"
     us_s = f"{r['us']:>10.1f}" if "us" in r else "       N/A"
     tf_s = f"{r['tflops']:>9.1f}" if "tflops" in r else "      N/A"
     return f"{prefix} | {status:>6s} | " f"{r['max_err']:>8.2e} {r['min_cos']:>8.5f} | " f"{us_s} {tf_s}"
+
+
+def _run_varlen_section(args, dtypes_to_test, causals_to_test, dtype_map):
+    """Self-contained QKV varlen test/bench: the FlyDSL packed cu_seqlens path vs a
+    per-batch SDPA reference (computed inside run_config). One row per
+    (dtype, causal, VARLEN_CONFIG). Returns True if all rows passed."""
+    if not VARLEN_CONFIGS:
+        return True
+    print("=" * 130)
+    print("QKV varlen (packed cu_seqlens): FlyDSL vs per-batch SDPA reference")
+    print("=" * 130)
+    hdr = (
+        f"  {'seqlens':<28} {'B':>3} {'H':>4} {'Hkv':>4} {'D':>4} {'dtype':>6} "
+        f"{'causal':>8} | {'Time(us)':>10} {'TFLOPS':>8} {'MaxErr':>9} {'status':>7}"
+    )
+    print(hdr)
+    print("  " + "-" * (len(hdr) - 2))
+    all_ok = True
+    for dtype_key in dtypes_to_test:
+        dtype, dtype_str = dtype_map[dtype_key]
+        for causal in causals_to_test:
+            for seqlens, nh, nh_kv, hd in VARLEN_CONFIGS:
+                nh_kv_eff = args.num_kv_heads if args.num_kv_heads is not None else nh_kv
+                ctag = "causal" if causal else "nocausal"
+                sl_str = str(seqlens)
+                if len(sl_str) > 28:
+                    sl_str = sl_str[:25] + "..."
+                pre = f"  {sl_str:<28} {len(seqlens):>3} {nh:>4} {nh_kv_eff:>4} {hd:>4} {dtype_key:>6} {ctag:>8} |"
+                try:
+                    r = run_config(
+                        len(seqlens),
+                        max(seqlens),
+                        nh,
+                        hd,
+                        dtype,
+                        causal,
+                        warmup=args.warmup,
+                        iters=args.iters,
+                        seed=args.seed,
+                        dtype_str=dtype_str,
+                        verbose=False,
+                        num_kv_heads=nh_kv_eff,
+                        varlen_seqlens=seqlens,
+                    )
+                except Exception as e:
+                    print(f"{pre} RAISED: {e}")
+                    all_ok = False
+                    continue
+                if "err" in r:
+                    print(f"{pre} ERR: {r['err']}")
+                    all_ok = False
+                    continue
+                us = r.get("us", float("nan"))
+                tf = r.get("tflops", float("nan"))
+                me = r.get("max_err", float("nan"))
+                passed = bool(r.get("passed", False))
+                all_ok = all_ok and passed
+                print(f"{pre} {us:>10.1f} {tf:>8.1f} {me:>9.2e} {('PASS' if passed else 'FAIL'):>7}")
+    print("=" * 130)
+    return all_ok
 
 
 def main():
@@ -809,6 +1133,13 @@ def main():
         help="KV head count for GQA/MQA. Default = num_heads (MHA). " "Requires num_heads %% num_kv_heads == 0.",
     )
     parser.add_argument("--head_dim", type=int, default=None)
+    parser.add_argument(
+        "--num_kv_splits",
+        type=int,
+        default=1,
+        help="Split-K factor for the gfx950 DUALWAVE_SWP kernel. >1 runs the split-K "
+        "path (+combine kernel) via run_splitk_config; D=128 bf16/f16, seq_len >= 384.",
+    )
     causal_group = parser.add_mutually_exclusive_group()
     causal_group.add_argument("--causal", action="store_true", dest="causal")
     causal_group.add_argument("--no-causal", action="store_false", dest="causal")
@@ -848,6 +1179,7 @@ def main():
                 nh_single,
                 args.num_kv_heads if args.num_kv_heads is not None else nh_single,
                 args.head_dim or 128,
+                args.num_kv_splits,
             )
         ]
     else:
@@ -861,6 +1193,11 @@ def main():
         print("=" * 130)
         print(f"FlyDSL vs aiter_ck vs aiter_asm  ({causal_desc}, {dtype_desc})")
         print(f"GPU: {torch.cuda.get_device_name(0)}")
+        if args.num_kv_splits > 1:
+            print(
+                f"  FlyDSL column: split-K path (num_kv_splits={args.num_kv_splits}); "
+                f"D!=128 / non-bf16,f16 / seq_len<384 / ws>4GiB configs SKIP"
+            )
         print(f"  FlyDSL opts: {FLASH_ATTN_FUNC_KERNEL_CONFIG}")
         print("  aiter_ck: bf16+fp16, aiter_asm: bf16 only")
         print("=" * 130)
@@ -870,27 +1207,49 @@ def main():
         for dtype_key in dtypes_to_test:
             dtype, dtype_str = dtype_map[dtype_key]
             for causal in causals_to_test:
-                for batch, seq_len, nh, nh_kv_default, hd in configs:
+                for batch, seq_len, nh, nh_kv_default, hd, cfg_kv_splits in configs:
                     causal_tag = "causal" if causal else "nocausal"
-                    # CLI --num_kv_heads (if set) overrides the per-config default.
+                    # CLI --num_kv_heads / --num_kv_splits (if set) override the per-config default.
                     nh_kv = args.num_kv_heads if args.num_kv_heads is not None else nh_kv_default
-                    cfg = (batch, seq_len, nh, nh_kv, hd, dtype_key, causal_tag)
+                    kv_splits = args.num_kv_splits if args.num_kv_splits > 1 else cfg_kv_splits
+                    cfg = (batch, seq_len, nh, nh_kv, hd, dtype_key, causal_tag, kv_splits)
                     print(f"  {_fmt_cfg(cfg)} ...", flush=True)
 
-                    fly_r = run_config(
-                        batch,
-                        seq_len,
-                        nh,
-                        hd,
-                        dtype,
-                        causal,
-                        warmup=args.warmup,
-                        iters=args.iters,
-                        seed=args.seed,
-                        dtype_str=dtype_str,
-                        verbose=False,
-                        num_kv_heads=nh_kv,
-                    )
+                    try:
+                        if kv_splits > 1:
+                            fly_r = run_splitk_config(
+                                batch,
+                                seq_len,
+                                nh,
+                                hd,
+                                dtype,
+                                causal,
+                                warmup=args.warmup,
+                                iters=args.iters,
+                                seed=args.seed,
+                                dtype_str=dtype_str,
+                                verbose=False,
+                                num_kv_heads=nh_kv,
+                                num_kv_splits=kv_splits,
+                            )
+                        else:
+                            fly_r = run_config(
+                                batch,
+                                seq_len,
+                                nh,
+                                hd,
+                                dtype,
+                                causal,
+                                warmup=args.warmup,
+                                iters=args.iters,
+                                seed=args.seed,
+                                dtype_str=dtype_str,
+                                verbose=False,
+                                num_kv_heads=nh_kv,
+                            )
+                    except Exception as _fly_err:
+                        print(f"    [FlyDSL unsupported] {_fmt_cfg(cfg)}: {_fly_err}", flush=True)
+                        fly_r = {"err": str(_fly_err)}
                     ck_r = run_aiter_bench(
                         batch,
                         seq_len,
@@ -973,6 +1332,9 @@ def main():
         _write_cmp_csv(csv_path, rows, cmp_avg_rows)
         print(f"Results saved to: {csv_path}")
 
+        if configs is DEFAULT_CONFIGS:
+            _run_varlen_section(args, dtypes_to_test, causals_to_test, dtype_map)
+
     else:
         # ---- Normal FlyDSL test mode ----
         print("=" * 130)
@@ -993,30 +1355,52 @@ def main():
         for dtype_key in dtypes_to_test:
             dtype, dtype_str = dtype_map[dtype_key]
             for causal in causals_to_test:
-                for batch, seq_len, nh, nh_kv_default, hd in configs:
+                for batch, seq_len, nh, nh_kv_default, hd, cfg_kv_splits in configs:
                     causal_tag = "causal" if causal else "nocausal"
-                    # CLI --num_kv_heads (if set) overrides the per-config default.
+                    # CLI --num_kv_heads / --num_kv_splits (if set) override the per-config default.
                     nh_kv = args.num_kv_heads if args.num_kv_heads is not None else nh_kv_default
-                    cfg = (batch, seq_len, nh, nh_kv, hd, dtype_key, causal_tag)
+                    kv_splits = args.num_kv_splits if args.num_kv_splits > 1 else cfg_kv_splits
+                    cfg = (batch, seq_len, nh, nh_kv, hd, dtype_key, causal_tag, kv_splits)
                     try:
-                        r = run_config(
-                            batch,
-                            seq_len,
-                            nh,
-                            hd,
-                            dtype,
-                            causal,
-                            warmup=args.warmup,
-                            iters=args.iters,
-                            seed=args.seed,
-                            dtype_str=dtype_str,
-                            num_kv_heads=nh_kv,
-                        )
+                        if kv_splits > 1:
+                            r = run_splitk_config(
+                                batch,
+                                seq_len,
+                                nh,
+                                hd,
+                                dtype,
+                                causal,
+                                warmup=args.warmup,
+                                iters=args.iters,
+                                seed=args.seed,
+                                dtype_str=dtype_str,
+                                num_kv_heads=nh_kv,
+                                num_kv_splits=kv_splits,
+                            )
+                        else:
+                            r = run_config(
+                                batch,
+                                seq_len,
+                                nh,
+                                hd,
+                                dtype,
+                                causal,
+                                warmup=args.warmup,
+                                iters=args.iters,
+                                seed=args.seed,
+                                dtype_str=dtype_str,
+                                num_kv_heads=nh_kv,
+                            )
                         path = ""
                         if "err" in r:
+                            print(f"    [FlyDSL unsupported] {_fmt_cfg(cfg)}: {r['err']}", flush=True)
                             print(_fmt_normal_row(cfg, path, "ERROR", r))
                             all_passed = False
                             rows.append((cfg, path, "ERROR", r))
+                            continue
+                        if r.get("skip"):
+                            print(_fmt_normal_row(cfg, path, "SKIP", r))
+                            rows.append((cfg, path, "SKIP", r))
                             continue
 
                         status = "PASS" if r["passed"] else "FAIL"
@@ -1025,6 +1409,7 @@ def main():
                         print(_fmt_normal_row(cfg, path, status, r))
                         rows.append((cfg, path, status, r))
                     except Exception as e:
+                        print(f"    [FlyDSL unsupported] {_fmt_cfg(cfg)}: {e}", flush=True)
                         print(_fmt_normal_row(cfg, "", "ERROR", {"err": str(e)}))
                         all_passed = False
                         rows.append((cfg, "", "ERROR", {"err": str(e)}))
@@ -1053,7 +1438,12 @@ def main():
         csv_path = f"fmha_perf_{_gpu_short_name()}.csv"
         _write_normal_csv(csv_path, rows, normal_avg_rows)
         print(f"Results saved to: {csv_path}")
-        if all_passed:
+
+        varlen_ok = True
+        if configs is DEFAULT_CONFIGS:
+            varlen_ok = _run_varlen_section(args, dtypes_to_test, causals_to_test, dtype_map)
+
+        if all_passed and varlen_ok:
             print("All tests PASSED")
         else:
             print("Some tests FAILED")


### PR DESCRIPTION
## Motivation

The current `main` flash-attention forward path on gfx950 (CDNA4 / MI355X) leaves
performance on the table and does not support split-K, packed-QKV variable length
(`cu_seqlens`), or arbitrary `seq_len`. This PR adds a new hand-scheduled gfx950
**dualwave software-pipelined** (`DUALWAVE_SWP`) FMHA forward kernel and extends the
generic fallback so both paths handle arbitrary `seq_len >= 1`, while keeping gfx942
(CDNA3) working.

> This branch also absorbs the changes from **ROCm/FlyDSL#670** (`num_kv_splits` plumbed
> into `mla_reduce_v1` / `pa_reduce_v1`).

## Technical Details

- **`flash_attn_dualwave_swp_gfx950_kernel`** (D=128, bf16/f16): 8-wave two-group
  ping-pong software pipeline (prologue + 2-tile loop + drain), lazy O-rescale,
  `s_setprio` scheduling, `num_records`-bounded OOB loads/stores, and a 128-bit
  `buffer_store_dwordx4` O-store (`cvt_pk_bf16_f32` + `permlane32_swap`).
- **Split-K** (`num_kv_splits`) + a split-K combine kernel.
- **QKV varlen**: packed `[total_tok, H, D]` Q/O and `[total_kv, H_kv, D]` K/V driven by
  cumulative `cu_seqlens_q` / `cu_seqlens_kv` (int32 `[B+1]`); per-batch token ranges,
  bounds, masks; threaded through `build_flash_attn_func_module(..., cu_seqlens_q=, cu_seqlens_kv=)`.
- **Arbitrary `seq_len >= 1`** on both the dualwave fast path and the generic fallback
  (partial last q-tile via Q/O `num_records` bounds; partial last kv-tile via
  bounded/clamped KV loads + causal / non-causal padding masks).
- **gfx942 (CDNA3) fix**: the generic fallback's 128-bit permlane O-store uses
  `permlane32_swap` + `cvt_pk_bf16_f32`, both gfx950-only. They are now gated behind
  gfx950; gfx942 uses a per-lane `dwordx2` scalar store packed via `.to(elem_dtype)`
  (arch-correct conversion). This fixes the gfx942 crash
  `LLVM ERROR: Cannot select intrinsic llvm.amdgcn.permlane32.swap`.
- Dispatch / seq_len-guard / varlen-routing updates in `flash_attn_generic.py`;
  new target ops in `python/flydsl/expr/rocdl.py`; docs + skills updates.

## Test Plan

```
python tests/kernels/test_flash_attn_fwd.py --iters 100 --compare
```
- 27 configs (`DEFAULT_CONFIGS`) × {causal, non-causal} × {bf16, fp16} on MI355X (gfx950),
  comparing FlyDSL vs `aiter_ck` / `aiter_asm`, correctness vs PyTorch SDPA (`MaxErr`).
- QKV varlen self-attention configs validated vs per-batch SDPA.
- Same sweep run on the `main` branch FMHA for a performance comparison.

**Environment:** AMD Instinct MI355X (gfx950), ROCm 7.1.0, HIP 7.1.25424, rocprofv3 1.0.0.

## Test Result

- All configs **PASS** (bf16 `MaxErr ~3.9e-3`, fp16 `MaxErr ~1e-4`).
- **Performance: refine_fmha vs main** (FlyDSL TFLOPS, same shapes on MI355X / gfx950). Full per-config data is in the two CSV attachments below.

**Highlights**
- Dense regime (`splits=1`, `seq_len >= 384`): geomean ~**1.04x** faster than main.
- **Split-K** (`num_kv_splits`, small heads / long seq) gives large gains over main: `B1 S8192 H2` split-K=4 = **641 vs 252 TFLOPS (2.55x)**; `B1 S4096 H2` 2.42x; `B1 S2048 H4` split-K=4 1.88x; `B1 S8192 H4` split-K=2 1.50x.
- Short/medium-seq MHA: `S256`-`S512 H64` up to 1.36x; `B2 S1024 H64` up to 1.12x; `B8 S1024 H32` ~1.05x.

**Configs where refine_fmha is >5% faster than main** (48 of 144 compared; the remaining shapes are within +/-5%, i.e. on par):

| B | S | H | Hkv | dtype | causal | splits | main TFLOPS | refine TFLOPS | speedup |
|---|---|---|---|---|---|---|---|---|---|
| 1 | 8192 | 2 | 2 | bf16 | causal | 4 | 252 | 641 | 2.55x |
| 1 | 8192 | 2 | 2 | fp16 | causal | 4 | 253 | 614 | 2.42x |
| 1 | 4096 | 2 | 2 | bf16 | causal | 4 | 117 | 283 | 2.42x |
| 1 | 4096 | 2 | 2 | fp16 | causal | 4 | 118 | 279 | 2.37x |
| 1 | 4096 | 2 | 2 | fp16 | nocausal | 4 | 235 | 533 | 2.27x |
| 1 | 4096 | 2 | 2 | bf16 | nocausal | 4 | 234 | 531 | 2.27x |
| 1 | 8192 | 2 | 2 | bf16 | nocausal | 4 | 494 | 1018 | 2.06x |
| 1 | 8192 | 2 | 2 | fp16 | nocausal | 4 | 491 | 957 | 1.95x |
| 1 | 2048 | 4 | 4 | bf16 | causal | 4 | 102 | 191 | 1.88x |
| 1 | 2048 | 4 | 4 | fp16 | causal | 4 | 103 | 190 | 1.85x |
| 1 | 2048 | 4 | 4 | bf16 | nocausal | 4 | 205 | 357 | 1.74x |
| 1 | 2048 | 4 | 4 | fp16 | nocausal | 4 | 205 | 356 | 1.73x |
| 1 | 8192 | 4 | 4 | bf16 | causal | 2 | 482 | 726 | 1.50x |
| 1 | 8192 | 4 | 4 | fp16 | causal | 2 | 482 | 701 | 1.45x |
| 8 | 256 | 64 | 64 | bf16 | nocausal | 1 | 391 | 530 | 1.36x |
| 1 | 384 | 64 | 64 | bf16 | nocausal | 1 | 241 | 315 | 1.31x |
| 1 | 384 | 64 | 64 | bf16 | causal | 1 | 134 | 171 | 1.28x |
| 8 | 256 | 64 | 64 | fp16 | nocausal | 1 | 400 | 508 | 1.27x |
| 1 | 8192 | 4 | 4 | bf16 | nocausal | 2 | 888 | 1114 | 1.25x |
| 1 | 384 | 64 | 64 | fp16 | nocausal | 1 | 249 | 309 | 1.24x |
| 1 | 256 | 64 | 64 | bf16 | nocausal | 1 | 142 | 177 | 1.24x |
| 1 | 8192 | 4 | 4 | fp16 | nocausal | 2 | 854 | 1058 | 1.24x |
| 1 | 384 | 64 | 64 | fp16 | causal | 1 | 139 | 167 | 1.20x |
| 8 | 512 | 64 | 64 | bf16 | causal | 1 | 432 | 516 | 1.19x |
| 8 | 512 | 64 | 64 | fp16 | causal | 1 | 422 | 497 | 1.18x |
| 8 | 256 | 64 | 64 | bf16 | causal | 1 | 224 | 260 | 1.16x |
| 1 | 256 | 64 | 64 | fp16 | nocausal | 1 | 149 | 172 | 1.16x |
| 1 | 256 | 64 | 64 | bf16 | causal | 1 | 76 | 87 | 1.14x |
| 2 | 1024 | 64 | 64 | bf16 | nocausal | 1 | 900 | 1007 | 1.12x |
| 8 | 512 | 64 | 64 | bf16 | nocausal | 1 | 728 | 810 | 1.11x |
| 8 | 512 | 64 | 64 | fp16 | nocausal | 1 | 704 | 779 | 1.11x |
| 8 | 256 | 64 | 64 | fp16 | causal | 1 | 229 | 253 | 1.10x |
| 2 | 1024 | 64 | 64 | fp16 | nocausal | 1 | 866 | 956 | 1.10x |
| 1 | 512 | 64 | 64 | bf16 | causal | 1 | 217 | 239 | 1.10x |
| 1 | 512 | 64 | 64 | bf16 | nocausal | 1 | 442 | 483 | 1.09x |
| 2 | 1024 | 64 | 64 | fp16 | causal | 1 | 581 | 634 | 1.09x |
| 1 | 4096 | 8 | 8 | fp16 | nocausal | 1 | 773 | 835 | 1.08x |
| 2 | 1024 | 64 | 64 | bf16 | causal | 1 | 597 | 641 | 1.07x |
| 1 | 512 | 64 | 64 | fp16 | causal | 1 | 221 | 238 | 1.07x |
| 1 | 2048 | 64 | 64 | bf16 | causal | 1 | 788 | 842 | 1.07x |
| 1 | 1024 | 64 | 64 | fp16 | causal | 1 | 528 | 561 | 1.06x |
| 1 | 1024 | 64 | 64 | bf16 | causal | 1 | 533 | 563 | 1.06x |
| 8 | 1024 | 32 | 32 | bf16 | nocausal | 1 | 950 | 1003 | 1.06x |
| 1 | 1024 | 64 | 64 | bf16 | nocausal | 1 | 907 | 957 | 1.06x |
| 8 | 1024 | 32 | 32 | fp16 | nocausal | 1 | 894 | 942 | 1.05x |
| 8 | 1024 | 32 | 32 | fp16 | causal | 1 | 600 | 632 | 1.05x |
| 8 | 1024 | 32 | 32 | bf16 | causal | 1 | 612 | 645 | 1.05x |
| 1 | 2048 | 4 | 4 | fp16 | nocausal | 1 | 205 | 216 | 1.05x |


### Full per-config CSV data

Full sweep (FlyDSL vs aiter_ck / aiter_asm, bf16/fp16 x causal/non-causal). CSVs attached below:

**refine_fmha sweep** (`fmha_perf_compare_MI355X.refine_fmha.csv`):
[fmha_perf_compare_MI355X.refine_fmha.csv](https://github.com/user-attachments/files/28965564/fmha_perf_compare_MI355X.refine_fmha.csv)

**main sweep** (`fmha_perf_compare_MI355X.main.csv`):
[fmha_perf_compare_MI355X.main.csv](https://github.com/user-attachments/files/28965579/fmha_perf_compare_MI355X.main.csv)

## Submission Checklist

- [x] Code formatted with `black` (line-length 120) and `ruff check` clean.
- [x] Correctness + performance verified on gfx950 (MI355X).
- [x] gfx942 (CDNA3) generic fallback builds/runs (no gfx950-only intrinsics on that path).
- [ ] CI green.
