### PR TITLE
[Kernel] Add W4A6 (MXFP6 A x MXFP4 B) support to preshuffle GEMM

### DIFF
--- a/kernels/preshuffle_gemm.py
+++ b/kernels/preshuffle_gemm.py
@@ -154,20 +154,25 @@ def compile_preshuffle_gemm_a8(
             dsrd_preload = computed_dsrd
         if dvmem_preload < 0:
             dvmem_preload = computed_dvmem
-    if in_dtype not in ("fp8", "int8", "int4", "fp16", "bf16", "fp4"):
-        raise ValueError("in_dtype must be one of ('fp8','int8','int4','fp16','bf16','fp4'), " f"got {in_dtype!r}")
+    if in_dtype not in ("fp8", "int8", "int4", "fp16", "bf16", "fp4", "fp6"):
+        raise ValueError(f"in_dtype must be one of ('fp8','int8','int4','fp16','bf16','fp4','fp6'), got {in_dtype!r}")
     if out_dtype not in ("fp16", "bf16"):
         raise ValueError(f"out_dtype must be 'fp16' or 'bf16', got {out_dtype!r}")
     _out_is_bf16 = out_dtype == "bf16"
     is_fp4 = in_dtype == "fp4"
+    # "fp6" = MXFP6 (E2M3) A x MXFP4 (E2M1) B. A is stored FP8-padded: 32 B per
+    # K=32 chunk (24 B packed FP6 + 8 B zero pad, ignored by the cbsz=2 MFMA).
+    # B and the per-32 E8M0 scales are identical to the is_fp4_or_fp6 path.
+    is_fp6 = in_dtype == "fp6"
+    is_fp4_or_fp6 = is_fp4 or is_fp6
     is_int4 = in_dtype == "int4"
     is_int8 = (in_dtype == "int8") or is_int4
     is_f16 = in_dtype == "fp16"
     is_bf16 = in_dtype == "bf16"
     is_f16_or_bf16 = is_f16 or is_bf16
-    elem_bytes = 1 if (in_dtype in ("fp8", "int8", "int4", "fp4")) else 2
+    elem_bytes = 1 if (in_dtype in ("fp8", "int8", "int4", "fp4", "fp6")) else 2
     a_elem_vec_pack = 2 if is_fp4 else 1
-    b_elem_vec_pack = 2 if is_fp4 else 1
+    b_elem_vec_pack = 2 if is_fp4_or_fp6 else 1
 
     KERNEL_NAME = (
         f"preshuffle_gemm_{in_dtype}_{out_dtype}"
@@ -187,6 +192,8 @@ def compile_preshuffle_gemm_a8(
         KERNEL_NAME += f"_xcd{xcd_swizzle}"
 
     tile_k_bytes = int(tile_k) * int(elem_bytes)
+    # fp6 needs 32 B per lane per K=32 chunk (FP8-padded); fp4/fp8 use 16 B.
+    a_per_lane_kpack_bytes = 32 if is_fp6 else 16
 
     if (tile_k_bytes % 64) != 0:
         raise ValueError(
@@ -194,7 +201,8 @@ def compile_preshuffle_gemm_a8(
             f"(tile_k={tile_k}, elem_bytes={elem_bytes})"
         )
 
-    _min_k_unroll = tile_k_bytes // a_elem_vec_pack // 64
+    _lane_group_bytes = 4 * a_per_lane_kpack_bytes  # 64 for fp4/fp8, 128 for fp6
+    _min_k_unroll = tile_k_bytes // a_elem_vec_pack // _lane_group_bytes
     if is_fp4 and _min_k_unroll < 2 and int(tile_k) != 128:
         raise ValueError(
             f"FP4 requires tile_k=128 or tile_k >= {64 * 2 * a_elem_vec_pack} "
@@ -256,7 +264,7 @@ def compile_preshuffle_gemm_a8(
             return fx.Float16
         if is_bf16:
             return fx.BFloat16
-        if is_fp4:
+        if is_fp4_or_fp6:
             return fx.Int8
         return fx.Int8 if is_int8 else _fp8_dtype()
 
@@ -268,7 +276,7 @@ def compile_preshuffle_gemm_a8(
             return Vec.make_type(8, fx.Float16)
         if is_bf16:
             return Vec.make_type(8, fx.BFloat16)
-        if is_fp4:
+        if is_fp4_or_fp6:
             return Vec.make_type(16, fx.Int8)
         return Vec.make_type(16, fx.Int8 if is_int8 else _fp8_dtype())
 
@@ -422,7 +430,7 @@ def compile_preshuffle_gemm_a8(
         _c_nrec = fx.Int64(c_m * c_n * 2)
         a_rsrc = buffer_ops.create_buffer_resource(arg_a, max_size=False, num_records_bytes=_a_nrec)
         c_rsrc = buffer_ops.create_buffer_resource(arg_c, max_size=False, num_records_bytes=_c_nrec)
-        _needs_per_token_scale = not is_f16_or_bf16 and not is_fp4
+        _needs_per_token_scale = not is_f16_or_bf16 and not is_fp4_or_fp6
         scale_a_rsrc = None if (is_f16_or_bf16) else buffer_ops.create_buffer_resource(arg_scale_a, max_size=False)
 
         # ---- Bias buffer resource (for fused epilogue) ----
@@ -451,12 +459,12 @@ def compile_preshuffle_gemm_a8(
         lane_mod_16 = fx.get(coord_lane16, 1)
 
         row_a_lds = lane_mod_16
-        kpack_elems = 16 if elem_bytes == 1 else 8
+        kpack_elems = a_per_lane_kpack_bytes if elem_bytes == 1 else 8
         col_offset_base = lane_div_16 * kpack_elems
         col_offset_base_bytes = col_offset_base if elem_bytes == 1 else col_offset_base * elem_bytes
 
         m_repeat = tile_m // 16
-        k_unroll = tile_k_bytes // a_elem_vec_pack // 64
+        k_unroll = tile_k_bytes // a_elem_vec_pack // _lane_group_bytes
 
         num_waves = 4
         n_per_wave = tile_n // num_waves
@@ -772,9 +780,9 @@ def compile_preshuffle_gemm_a8(
         _fp4_tilek128 = False
 
         def load_fp4_scale_chunk(_base_k):
-            raise RuntimeError("load_fp4_scale_chunk called when is_fp4=False")
+            raise RuntimeError("load_fp4_scale_chunk called when is_fp4_or_fp6=False")
 
-        if const_expr(is_fp4):
+        if const_expr(is_fp4_or_fp6):
             _fp4_pack_M_outer = 2
             _fp4_pack_N_outer = 2
             _fp4_pack_K_outer = 2
@@ -867,13 +875,14 @@ def compile_preshuffle_gemm_a8(
                 mfma_res_ty = Vec.make_type(4, fx.Float32)
                 c0_i64 = fx.Int64(0)
 
-                _fp4_cbsz = 4 if is_fp4 else 0
-                _fp4_blgp = 4 if is_fp4 else 0
-                _fp4_pack_M = 2 if is_fp4 else 1
-                _fp4_pack_N = 2 if is_fp4 else 1
-                _fp4_pack_K = 2 if is_fp4 else 1
+                # fp4: cbsz=4 (E2M1); fp6: cbsz=2 (E2M3). B is MXFP4 -> blgp=4.
+                _fp4_cbsz = 2 if is_fp6 else (4 if is_fp4 else 0)
+                _fp4_blgp = 4 if is_fp4_or_fp6 else 0
+                _fp4_pack_M = 2 if is_fp4_or_fp6 else 1
+                _fp4_pack_N = 2 if is_fp4_or_fp6 else 1
+                _fp4_pack_K = 2 if is_fp4_or_fp6 else 1
                 _quant_block_size = 32
-                _K1 = K // (_quant_block_size * 4 * _fp4_pack_K) if is_fp4 else 1
+                _K1 = K // (_quant_block_size * 4 * _fp4_pack_K) if is_fp4_or_fp6 else 1
                 _k_unroll_packed = k_unroll // _fp4_pack_K
                 _m_repeat_packed = m_repeat // _fp4_pack_M
                 _num_acc_n_packed = num_acc_n // _fp4_pack_N
@@ -881,7 +890,7 @@ def compile_preshuffle_gemm_a8(
                 def pack_i64x4_to_i32x8(x0, x1, x2, x3):
                     return Vec.from_elements([x0, x1, x2, x3], fx.Int64).bitcast(fx.Int32)
 
-                if const_expr(is_fp4):
+                if const_expr(is_fp4_or_fp6):
                     _fp4_a_sc, _fp4_b_sc = fp4_scales if fp4_scales else ([], [])
                     ku128_iters = 1 if _fp4_tilek128 else _k_unroll_packed
                     ikxdl_iters = 1 if _fp4_tilek128 else _fp4_pack_K
@@ -906,11 +915,22 @@ def compile_preshuffle_gemm_a8(
                                         curr_row_a_lds = row_a_lds + (mi_idx * 16)
                                         a0 = fx.Int64(0).ir_value()
                                         a1 = fx.Int64(0).ir_value()
-                                        if const_expr((a0_prefetch is not None) and (k_idx == 0) and (mi_idx == 0)):
+                                        if const_expr(
+                                            (a0_prefetch is not None)
+                                            and (k_idx == 0)
+                                            and (mi_idx == 0)
+                                            and (not is_fp6)
+                                        ):
                                             a0, a1 = a0_prefetch
                                         else:
                                             a0, a1 = lds_load_packs_k64(curr_row_a_lds, col_base, lds_buffer)
-                                        a128 = pack_i64x4_to_i32x8(a0, a1, c0_i64, c0_i64)
+                                        if const_expr(is_fp6):
+                                            # fp6: pull the 2nd 16 B chunk to complete the 32 B padded
+                                            # slot; upper 8 B is FP6 padding (cbsz=2 ignores it) -> discard.
+                                            a2, _ = lds_load_packs_k64(curr_row_a_lds, col_base + 16, lds_buffer)
+                                            a128 = pack_i64x4_to_i32x8(a0, a1, a2, c0_i64)
+                                        else:
+                                            a128 = pack_i64x4_to_i32x8(a0, a1, c0_i64, c0_i64)
                                         for inxdl in range_constexpr(_fp4_pack_N):
                                             ni_idx = ni_p * _fp4_pack_N + inxdl
                                             b0 = b_packs0[ni_idx]
@@ -1033,7 +1053,7 @@ def compile_preshuffle_gemm_a8(
         def store_output(final_accs, scales):
             s_b_vals = []
             s_a_vecs = []
-            if const_expr(not (is_f16_or_bf16 or is_fp4)):
+            if const_expr(not (is_f16_or_bf16 or is_fp4_or_fp6)):
                 s_b_vals = scales["s_b_vals"]
                 s_a_vecs = scales["s_a_vecs"]
 
@@ -1064,7 +1084,7 @@ def compile_preshuffle_gemm_a8(
                         val = Vec(acc)[ii]
                         if const_expr(is_int8):
                             val = fx.Float32(val)
-                        if const_expr(is_f16_or_bf16 or is_fp4):
+                        if const_expr(is_f16_or_bf16 or is_fp4_or_fp6):
                             val_s = val
                         elif const_expr(_needs_per_token_scale):
                             val_s = (val * s_a) * s_b_vals[ni]
@@ -1126,7 +1146,7 @@ def compile_preshuffle_gemm_a8(
                     val = Vec(acc)[ii]
                     if const_expr(is_int8):
                         val = fx.Float32(val)
-                    if const_expr(is_f16_or_bf16 or is_fp4):
+                    if const_expr(is_f16_or_bf16 or is_fp4_or_fp6):
                         val_s = val
                     elif const_expr(_needs_per_token_scale):
                         val_s = (val * s_a) * s_b_vals[ni]
@@ -1287,7 +1307,7 @@ def compile_preshuffle_gemm_a8(
                 if const_expr(dswr_tail > mfma_total):
                     dswr_tail = mfma_total
                 num_gmem_loads = num_b_loads + num_a_async_loads
-                if const_expr(is_fp4 and tile_k != 128):
+                if const_expr(is_fp4_or_fp6 and tile_k != 128):
                     num_fp4_scale_k_groups = 1 if int(tile_k) == 128 else (k_unroll // 2)
                     num_a_scale_loads = num_fp4_scale_k_groups * (m_repeat // 2)
                     num_b_scale_loads = num_fp4_scale_k_groups * (num_acc_n // 2)
@@ -1370,7 +1390,7 @@ def compile_preshuffle_gemm_a8(
         n_fp4_asc = 0
         n_fp4_bsc = 0
 
-        if const_expr(is_fp4):
+        if const_expr(is_fp4_or_fp6):
             n_fp4_asc = _k_unroll_packed_outer * _m_repeat_packed_outer
             n_fp4_bsc = _k_unroll_packed_outer * _num_acc_n_packed_outer
 
@@ -1416,7 +1436,7 @@ def compile_preshuffle_gemm_a8(
             gpu,
             prefetch_a0_pack,
             load_fp4_scale_chunk,
-            is_fp4,
+            is_fp4_or_fp6,
             rocdl,
             _pack_state,
             _flatten_b_tile,
@@ -1434,7 +1454,7 @@ def compile_preshuffle_gemm_a8(
                 n_accs_v=n_accs,
                 n_btile_v=n_btile,
                 n_a0pf_v=n_a0pf,
-                is_fp4_v=is_fp4,
+                is_fp4_v=is_fp4_or_fp6,
                 n_fp4_asc_v=n_fp4_asc,
                 n_fp4_bsc_v=n_fp4_bsc,
             )
@@ -1473,7 +1493,7 @@ def compile_preshuffle_gemm_a8(
                 )
 
                 next_k2 = k_iv + (tile_k * 2)
-                _sc_ping = load_fp4_scale_chunk(next_k2) if is_fp4 else None
+                _sc_ping = load_fp4_scale_chunk(next_k2) if is_fp4_or_fp6 else None
                 rocdl.sched_barrier(0)
                 if const_expr(use_async_copy):
                     prefetch_a_to_lds(
@@ -1510,7 +1530,7 @@ def compile_preshuffle_gemm_a8(
                     _flatten_b_tile(b_tile_pong_new),
                     a0_prefetch_pong_new,
                     _sc_ping,
-                    is_fp4_v=is_fp4,
+                    is_fp4_v=is_fp4_or_fp6,
                 )
 
             next_k1 = k_iv + tile_k
@@ -1523,7 +1543,7 @@ def compile_preshuffle_gemm_a8(
                 )
             else:
                 a_tile = prefetch_a_tile(next_k1)
-            _sc_ping = load_fp4_scale_chunk(k_iv + fx.Index(tile_k)) if is_fp4 else None
+            _sc_ping = load_fp4_scale_chunk(k_iv + fx.Index(tile_k)) if is_fp4_or_fp6 else None
             b_tile_ping = prefetch_b_tile(next_k1)
             accs_in, _ = compute_tile(
                 accs_in,
@@ -1554,7 +1574,7 @@ def compile_preshuffle_gemm_a8(
                 )
             else:
                 a_tile = prefetch_a_tile(next_k2)
-            _sc_pong = load_fp4_scale_chunk(k_iv + (tile_k * 2)) if is_fp4 else None
+            _sc_pong = load_fp4_scale_chunk(k_iv + (tile_k * 2)) if is_fp4_or_fp6 else None
             b_tile_pong_new = prefetch_b_tile(next_k2)
             accs_in, _ = compute_tile(
                 accs_in,
@@ -1580,7 +1600,7 @@ def compile_preshuffle_gemm_a8(
                 _flatten_b_tile(b_tile_pong_new),
                 a0_prefetch_pong_new,
                 _sc_pong,
-                is_fp4_v=is_fp4,
+                is_fp4_v=is_fp4_or_fp6,
             )
 
         if const_expr(lds_stage == 2):
@@ -1613,7 +1633,7 @@ def compile_preshuffle_gemm_a8(
                 row_a_lds_v=row_a_lds,
                 col_offset_base_bytes_v=col_offset_base_bytes,
             )
-            fp4_scales0 = load_fp4_scale_chunk(fx.Index(0)) if is_fp4 else None
+            fp4_scales0 = load_fp4_scale_chunk(fx.Index(0)) if is_fp4_or_fp6 else None
 
             final_accs = 1
             scales = 1
@@ -1626,7 +1646,7 @@ def compile_preshuffle_gemm_a8(
                         _flatten_b_tile(b_tile0),
                         a0_prefetch_pong,
                         fp4_scales0,
-                        is_fp4_v=is_fp4,
+                        is_fp4_v=is_fp4_or_fp6,
                     )
                     results = init_state
                     for iv, inner in range(0, c_k_main, tile_k * 2, init=init_state):
@@ -1652,7 +1672,7 @@ def compile_preshuffle_gemm_a8(
                             gpu=gpu,
                             prefetch_a0_pack=prefetch_a0_pack,
                             load_fp4_scale_chunk=load_fp4_scale_chunk,
-                            is_fp4=is_fp4,
+                            is_fp4_or_fp6=is_fp4_or_fp6,
                             rocdl=rocdl,
                             _pack_state=_pack_state,
                             _flatten_b_tile=_flatten_b_tile,
@@ -1670,7 +1690,7 @@ def compile_preshuffle_gemm_a8(
                         n_accs_v=n_accs,
                         n_btile_v=n_btile,
                         n_a0pf_v=n_a0pf,
-                        is_fp4_v=is_fp4,
+                        is_fp4_v=is_fp4_or_fp6,
                         n_fp4_asc_v=n_fp4_asc,
                         n_fp4_bsc_v=n_fp4_bsc,
                     )
@@ -1679,7 +1699,7 @@ def compile_preshuffle_gemm_a8(
                         accs,
                         b_tile_pong_final,
                         lds_a_pong,
-                        is_last_tile=not is_fp4,
+                        is_last_tile=not is_fp4_or_fp6,
                         a0_prefetch=a0pf,
                         fp4_scales=fp4_scales_final,
                         fp4_scale_half=0,
@@ -1691,7 +1711,7 @@ def compile_preshuffle_gemm_a8(
                         _flatten_b_tile(b_tile0),
                         a0_prefetch_pong,
                         fp4_scales0,
-                        is_fp4_v=is_fp4,
+                        is_fp4_v=is_fp4_or_fp6,
                     )
                     results = init_state
                     for iv, inner in range(0, c_k_stop, tile_k * 2, init=init_state):
@@ -1717,7 +1737,7 @@ def compile_preshuffle_gemm_a8(
                             gpu=gpu,
                             prefetch_a0_pack=prefetch_a0_pack,
                             load_fp4_scale_chunk=load_fp4_scale_chunk,
-                            is_fp4=is_fp4,
+                            is_fp4_or_fp6=is_fp4_or_fp6,
                             rocdl=rocdl,
                             _pack_state=_pack_state,
                             _flatten_b_tile=_flatten_b_tile,
@@ -1735,7 +1755,7 @@ def compile_preshuffle_gemm_a8(
                         n_accs_v=n_accs,
                         n_btile_v=n_btile,
                         n_a0pf_v=n_a0pf,
-                        is_fp4_v=is_fp4,
+                        is_fp4_v=is_fp4_or_fp6,
                         n_fp4_asc_v=n_fp4_asc,
                         n_fp4_bsc_v=n_fp4_bsc,
                     )
@@ -1774,7 +1794,7 @@ def compile_preshuffle_gemm_a8(
                         accs,
                         b_tile_ping,
                         lds_a_ping,
-                        is_last_tile=not is_fp4,
+                        is_last_tile=not is_fp4_or_fp6,
                         a0_prefetch=a0_prefetch_ping,
                         fp4_scales=fp4_scales_ep,
                         fp4_scale_half=1,
@@ -1786,7 +1806,7 @@ def compile_preshuffle_gemm_a8(
                     _flatten_b_tile(b_tile0),
                     a0_prefetch_pong,
                     fp4_scales0,
-                    is_fp4_v=is_fp4,
+                    is_fp4_v=is_fp4_or_fp6,
                 )
                 results = init_state
                 for iv, inner in range(0, c_k_main, tile_k * 2, init=init_state):
@@ -1812,7 +1832,7 @@ def compile_preshuffle_gemm_a8(
                         gpu=gpu,
                         prefetch_a0_pack=prefetch_a0_pack,
                         load_fp4_scale_chunk=load_fp4_scale_chunk,
-                        is_fp4=is_fp4,
+                        is_fp4_or_fp6=is_fp4_or_fp6,
                         rocdl=rocdl,
                         _pack_state=_pack_state,
                         _flatten_b_tile=_flatten_b_tile,
@@ -1830,7 +1850,7 @@ def compile_preshuffle_gemm_a8(
                     n_accs_v=n_accs,
                     n_btile_v=n_btile,
                     n_a0pf_v=n_a0pf,
-                    is_fp4_v=is_fp4,
+                    is_fp4_v=is_fp4_or_fp6,
                     n_fp4_asc_v=n_fp4_asc,
                     n_fp4_bsc_v=n_fp4_bsc,
                 )
@@ -1839,7 +1859,7 @@ def compile_preshuffle_gemm_a8(
                     accs,
                     b_tile_pong_final,
                     lds_a_pong,
-                    is_last_tile=not is_fp4,
+                    is_last_tile=not is_fp4_or_fp6,
                     a0_prefetch=a0pf,
                     fp4_scales=fp4_scales_final,
                 )
@@ -1850,7 +1870,7 @@ def compile_preshuffle_gemm_a8(
                     _flatten_b_tile(b_tile0),
                     a0_prefetch_pong,
                     fp4_scales0,
-                    is_fp4_v=is_fp4,
+                    is_fp4_v=is_fp4_or_fp6,
                 )
                 results = init_state
                 for iv, inner in range(0, c_k_stop, tile_k * 2, init=init_state):
@@ -1876,7 +1896,7 @@ def compile_preshuffle_gemm_a8(
                         gpu=gpu,
                         prefetch_a0_pack=prefetch_a0_pack,
                         load_fp4_scale_chunk=load_fp4_scale_chunk,
-                        is_fp4=is_fp4,
+                        is_fp4_or_fp6=is_fp4_or_fp6,
                         rocdl=rocdl,
                         _pack_state=_pack_state,
                         _flatten_b_tile=_flatten_b_tile,
@@ -1894,7 +1914,7 @@ def compile_preshuffle_gemm_a8(
                     n_accs_v=n_accs,
                     n_btile_v=n_btile,
                     n_a0pf_v=n_a0pf,
-                    is_fp4_v=is_fp4,
+                    is_fp4_v=is_fp4_or_fp6,
                     n_fp4_asc_v=n_fp4_asc,
                     n_fp4_bsc_v=n_fp4_bsc,
                 )
@@ -1911,7 +1931,7 @@ def compile_preshuffle_gemm_a8(
                     )
                 else:
                     a_regs_ping = prefetch_a_tile(last_k)
-                _sc_last = load_fp4_scale_chunk(last_k) if is_fp4 else None
+                _sc_last = load_fp4_scale_chunk(last_k) if is_fp4_or_fp6 else None
                 accs, _ = compute_tile(
                     accs,
                     b_tile_pong_ep,
@@ -1934,7 +1954,7 @@ def compile_preshuffle_gemm_a8(
                     accs,
                     b_tile_ping,
                     lds_a_ping,
-                    is_last_tile=not is_fp4,
+                    is_last_tile=not is_fp4_or_fp6,
                     a0_prefetch=a0_prefetch_ping,
                     fp4_scales=_sc_last,
                 )
@@ -1954,7 +1974,9 @@ def compile_preshuffle_gemm_a8(
 
                 next_k = iv + tile_k
                 a_next, b_next = prefetch_ab_tile(next_k)
-                _fp4_sc = load_fp4_scales(iv // fx.Index(tile_k) * fx.Index(_fp4_scale_k_stride)) if is_fp4 else None
+                _fp4_sc = (
+                    load_fp4_scales(iv // fx.Index(tile_k) * fx.Index(_fp4_scale_k_stride)) if is_fp4_or_fp6 else None
+                )
                 accs_in, _ = compute_tile(accs_in, b_tile_in, lds_a_pong, fp4_scales=_fp4_sc)
                 gpu.barrier()
                 store_a_tile_to_lds(a_next, lds_a_pong)
@@ -1965,12 +1987,14 @@ def compile_preshuffle_gemm_a8(
 
             accs_final = list(results[:n_accs])
             bt_final = _unflatten_b_tile(list(results[n_accs:]))
-            _last_fp4_sc = load_fp4_scales(fx.Index((K - tile_k) // tile_k * _fp4_scale_k_stride)) if is_fp4 else None
+            _last_fp4_sc = (
+                load_fp4_scales(fx.Index((K - tile_k) // tile_k * _fp4_scale_k_stride)) if is_fp4_or_fp6 else None
+            )
             final_accs, scales = compute_tile(
                 accs_final,
                 bt_final,
                 lds_a_pong,
-                is_last_tile=not is_fp4,
+                is_last_tile=not is_fp4_or_fp6,
                 fp4_scales=_last_fp4_sc,
             )
             store_output(final_accs, scales)
@@ -2061,4 +2085,49 @@ def compile_preshuffle_gemm_w4(
     return inner
 
 
-__all__ = ["compile_preshuffle_gemm_a8", "compile_preshuffle_gemm_w4"]
+def compile_preshuffle_gemm_a6w4(
+    *,
+    M: int = 0,
+    N: int = 0,
+    K: int,
+    tile_m: int,
+    tile_n: int,
+    tile_k: int,
+    out_dtype: str = "bf16",
+    lds_stage: int = 2,
+    use_cshuffle_epilog: bool = False,
+    waves_per_eu: int = None,
+    use_async_copy: bool = False,
+    dsrd_preload: int = 2,
+    dvmem_preload: int = 2,
+    xcd_swizzle: int = 0,
+):
+    """MXFP6 (E2M3) A x MXFP4 (E2M1) B preshuffle GEMM.
+
+    A storage: FP8-padded packed FP6 -- 32 B per K=32 row chunk (24 B of
+    bit-packed FP6 codes + 8 B zero pad, ignored by the cbsz=2 MFMA). B and
+    the per-32-element E8M0 scales are identical to compile_preshuffle_gemm_w4.
+    Delegates to compile_preshuffle_gemm_a8 with in_dtype="fp6".
+    """
+    if str(get_hip_arch()) != "gfx950":
+        raise RuntimeError(f"FP6/FP4 GEMM requires gfx950, got {get_hip_arch()}")
+    return compile_preshuffle_gemm_a8(
+        M=M,
+        N=N,
+        K=K,
+        tile_m=tile_m,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        in_dtype="fp6",
+        lds_stage=lds_stage,
+        out_dtype=out_dtype,
+        use_cshuffle_epilog=use_cshuffle_epilog,
+        waves_per_eu=waves_per_eu,
+        use_async_copy=use_async_copy,
+        dsrd_preload=dsrd_preload,
+        dvmem_preload=dvmem_preload,
+        xcd_swizzle=xcd_swizzle,
+    )
+
+
+__all__ = ["compile_preshuffle_gemm_a8", "compile_preshuffle_gemm_w4", "compile_preshuffle_gemm_a6w4"]

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -144,6 +144,16 @@ GEMM_FP4_SHAPES_ASYNC='
 8192,8192,8192,128,256,256,2
 '
 
+# FP6FP4 GEMM shapes (MXFP6 A x MXFP4 B; requires --wfp6, gfx950 only):
+# "M,N,K,tile_m,tile_n,tile_k". Same shapes as GEMM_FP4_SHAPES so fp6fp4 and
+# fp4 line up 1:1.
+GEMM_FP6FP4_SHAPES='
+8192,8192,8192,64,128,256
+8192,8192,8192,64,256,256
+8192,8192,8192,128,256,256
+8192,8192,8192,128,256,128
+'
+
 # MoE shapes: "tokens,model_dim,inter_dim,experts,topk,tile_m,tile_n,tile_k,tile_n2,tile_k2"
 MOE_SHAPES='
 32768,8192,8192,16,4,64,128,128,256,128
@@ -958,6 +968,52 @@ if [ "${RUN_PRESHUFFLE_GEMM}" -eq 1 ] && [ "${IS_CDNA}" = "true" ]; then
         FAIL_COUNT=$((FAIL_COUNT + 1))
         echo "gemm fp4 async failed. Log: ${log}" >&2
         _show_fail_log "${log}" "gemm_fp4_async"
+      fi
+    fi
+  done
+
+  # FP6FP4 GEMM (MXFP6 A x MXFP4 B, gfx950 only)
+  for shape in $GEMM_FP6FP4_SHAPES; do
+    [ -z "$shape" ] && continue
+    oldIFS=$IFS
+    IFS=,
+    # shellcheck disable=SC2086 # intentional word-splitting on IFS=,
+    set -- $shape
+    IFS=$oldIFS
+    M=$1; N=$2; K=$3; tile_m=$4; tile_n=$5; tile_k=$6
+    dtype="fp6fp4"
+    log="${BENCH_LOG_DIR}/preshuffle_gemm_${M}x${N}x${K}_${dtype}_t${tile_m}x${tile_n}x${tile_k}.log"
+    if python3 tests/kernels/test_preshuffle_gemm.py \
+      --wfp6 \
+      --in_dtype fp6 \
+      --num_warmup 10 \
+      --num_iters 100 \
+      -M "$M" \
+      -N "$N" \
+      -K "$K" \
+      --tile_m "$tile_m" \
+      --tile_n "$tile_n" \
+      --tile_k "$tile_k" >"${log}" 2>&1; then
+      # Check if test was skipped due to architecture
+      if grep -q "Skipping FP6\|Skipped" "${log}"; then
+        gemm_shape_tag="${M}x${N}x${K}_tile${tile_m}x${tile_n}x${tile_k}"
+        _emit_row "gemm" "${gemm_shape_tag}" "${dtype}" "skip" "skip"
+      else
+        SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+        gemm_shape_tag="${M}x${N}x${K}_tile${tile_m}x${tile_n}x${tile_k}"
+        row="$(_py_parse_and_emit gemm "${gemm_shape_tag}" "${dtype}" "${log}")"
+        set -- $row
+        _emit_row "$1" "$2" "$3" "$4" "$5"
+      fi
+    else
+      # Skip gracefully on unsupported architectures or missing features
+      if grep -q "gfx950\|invalid choice\|Skipped\|not supported" "${log}" 2>/dev/null; then
+        gemm_shape_tag="${M}x${N}x${K}_tile${tile_m}x${tile_n}x${tile_k}"
+        _emit_row "gemm" "${gemm_shape_tag}" "${dtype}" "skip" "skip"
+      else
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        echo "gemm fp6 failed. Log: ${log}" >&2
+        _show_fail_log "${log}" "gemm_fp6"
       fi
     fi
   done

--- a/tests/kernels/test_preshuffle_gemm.py
+++ b/tests/kernels/test_preshuffle_gemm.py
@@ -29,7 +29,11 @@ if _PYFLYDSL_SRC not in sys.path:
     sys.path.insert(0, _PYFLYDSL_SRC)
 
 from flydsl.runtime.device import get_rocm_arch  # noqa: E402
-from kernels.preshuffle_gemm import compile_preshuffle_gemm_a8, compile_preshuffle_gemm_w4  # noqa: E402
+from kernels.preshuffle_gemm import (  # noqa: E402
+    compile_preshuffle_gemm_a6w4,
+    compile_preshuffle_gemm_a8,
+    compile_preshuffle_gemm_w4,
+)
 from tests.kernels.utils import fp4_utils  # noqa: E402
 from tests.test_common import run_perftest, verify_output  # noqa: E402
 from tests.utils import pertoken_quant, shuffle_weight  # noqa: E402
@@ -442,11 +446,143 @@ def test_mfma_w4_flyc_preshuffle(
     print(f"[flyc] Throughput: {us:.1f} us, {tflops:.2f} TFLOPS, BW: {tbps:.3f} TB/s")
 
 
+@pytest.mark.parametrize("out_dtype", ["bf16", "fp16"])
+@pytest.mark.parametrize(
+    "M, N, K, tile_m, tile_n, tile_k",
+    [
+        (64, 8192, 8192, 64, 128, 128),
+        (32, 8192, 8192, 32, 128, 256),
+        pytest.param(128, 8192, 8192, 64, 128, 256, marks=pytest.mark.large_shape),
+        pytest.param(1024, 8192, 8192, 64, 256, 256, marks=pytest.mark.large_shape),
+        pytest.param(256, 4096, 14336, 128, 256, 256, marks=pytest.mark.large_shape),
+    ],
+)
+def test_mfma_a6w4_flyc_preshuffle(
+    out_dtype,
+    M,
+    N,
+    K,
+    tile_m,
+    tile_n,
+    tile_k,
+    *,
+    lds_stage: int = DEFAULT_LDS_STAGE,
+    bench_iters: int = DEFAULT_BENCH_ITERS,
+    bench_warmup: int = DEFAULT_BENCH_WARMUP,
+    use_cshuffle_epilog: bool = False,
+    waves_per_eu: int = 0,
+    use_async_copy: bool = False,
+    dsrd_preload: int = 2,
+    dvmem_preload: int = 2,
+):
+    """W4A6: MXFP6 (E2M3) A x MXFP4 (E2M1) B preshuffle GEMM - gfx950 only."""
+    if get_rocm_arch() != "gfx950":
+        pytest.skip(f"FP6/FP4 GEMM requires gfx950, got {get_rocm_arch()}")
+
+    print("=" * 80)
+    print(f"MFMA W4A6 (MXFP6 A x MXFP4 B) GEMM Test (Tile: {tile_m}x{tile_n}x{tile_k})")
+    print("=" * 80)
+
+    _wpe = int(waves_per_eu) if waves_per_eu else 0
+    _wpe = None if _wpe <= 0 else _wpe
+    launch_fn = compile_preshuffle_gemm_a6w4(
+        M=M,
+        N=N,
+        K=K,
+        tile_m=tile_m,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        out_dtype=out_dtype,
+        lds_stage=lds_stage,
+        use_cshuffle_epilog=bool(use_cshuffle_epilog),
+        waves_per_eu=_wpe,
+        use_async_copy=bool(use_async_copy),
+        dsrd_preload=int(dsrd_preload),
+        dvmem_preload=int(dvmem_preload),
+    )
+    print(f"Compiled (lds_stage={lds_stage}, async_copy={use_async_copy}, waves_per_eu={_wpe})")
+
+    device = torch.device("cuda")
+    M_align_32 = (M + 31) // 32 * 32
+    N_align_32 = (N + 31) // 32 * 32
+
+    a_fp32 = torch.randn(M, K, device=device, dtype=torch.float32)
+    b_fp32 = torch.randn(N, K, device=device, dtype=torch.float32)
+    a_fp32_padded = torch.zeros(M_align_32, K, device=device, dtype=torch.float32)
+    b_fp32_padded = torch.zeros(N_align_32, K, device=device, dtype=torch.float32)
+    a_fp32_padded[:M] = a_fp32
+    b_fp32_padded[:N] = b_fp32
+
+    # A: MXFP6 (E2M3), FP8-padded packed codes (row-major); scale shuffled.
+    a_pad, scale_a_orig, a_unpacked = fp4_utils.per_1x32_f6_quant(a_fp32_padded)
+    a_codes = a_pad[:M]
+    a_unpacked = a_unpacked[:M]
+    scale_a = fp4_utils.shuffle_scale_w4(scale_a_orig, 1, False)
+
+    # B: MXFP4 (E2M1), identical to the w4 path.
+    b_q, scale_b, _ = fp4_utils.per_1x32_f4_quant(b_fp32_padded)
+    b_q = b_q[:N]
+    b_shuffled = fp4_utils.shuffle_weight_w4(b_q, 16, False, False)
+    scale_b_shuffled = fp4_utils.shuffle_scale_w4(scale_b, 1, False)
+
+    # Reference: dequant(A) @ dequant(B).T in fp32.
+    a_deq = fp4_utils.fp6_e2m3_to_f32(a_unpacked) * fp4_utils.e8m0_to_f32(scale_a_orig[:M].repeat_interleave(32, dim=1))
+    b_deq = fp4_utils.mxfp4_to_f32(b_q) * fp4_utils.e8m0_to_f32(scale_b[:N].repeat_interleave(32, dim=1))
+    c_ref = torch.mm(a_deq, b_deq.T).to(torch.float32)
+
+    torch_out_dtype = torch.bfloat16 if out_dtype == "bf16" else torch.float16
+    c_out = torch.zeros((M, N), dtype=torch_out_dtype, device=device)
+    _dummy_bias = torch.empty(0, dtype=torch.bfloat16, device=device)
+
+    def _to_bytes(t):
+        return t if t.dtype in (torch.uint8, torch.int8) else t.view(torch.uint8)
+
+    def _a6w4_args(c, a, b, sa, sb):
+        return (
+            c.contiguous().view(-1),
+            _to_bytes(a).contiguous().view(-1),
+            _to_bytes(b).contiguous().view(-1),
+            _to_bytes(sa).contiguous().view(-1),
+            _to_bytes(sb).contiguous().view(-1),
+            _dummy_bias,
+            M,
+            N,
+            torch.cuda.current_stream(),
+        )
+
+    compiled_fn = flyc.compile(launch_fn, *_a6w4_args(c_out, a_codes, b_shuffled, scale_a, scale_b_shuffled))
+
+    def launch_kernel(c, a, b, sa, sb):
+        compiled_fn(*_a6w4_args(c, a, b, sa, sb))
+
+    _, us = run_perftest(
+        launch_kernel,
+        c_out,
+        a_codes,
+        b_shuffled,
+        scale_a,
+        scale_b_shuffled,
+        num_iters=max(2, int(bench_iters)),
+        num_warmup=int(bench_warmup),
+    )
+    torch.cuda.synchronize()
+
+    assert verify_output(c_out.to(torch.float32), c_ref, rtol=0.1, atol=0.1)
+
+    # A is 1 B/code FP8-padded (32 B/K-chunk); B is 0.5 B/code MXFP4.
+    bytes_moved = M * K + (N * K) // 2 + (M * N) * 2 + (M + N) * (K // 32)
+    tflops = (2 * M * N * K) / (us / 1e6) / 1e12
+    tbps = bytes_moved / 1e12 / (us / 1e6)
+    print(f"[flyc] W4A6 Throughput: {us:.1f} us, {tflops:.2f} TFLOPS, BW: {tbps:.3f} TB/s")
+
+
 if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Preshuffle GEMM benchmark")
-    parser.add_argument("--in_dtype", type=str, default="fp8", choices=["fp8", "int8", "int4", "fp16", "bf16", "fp4"])
+    parser.add_argument(
+        "--in_dtype", type=str, default="fp8", choices=["fp8", "int8", "int4", "fp16", "bf16", "fp4", "fp6"]
+    )
     parser.add_argument(
         "--out_dtype", type=str, default="bf16", choices=["fp16", "bf16"], help="Output dtype (default: bf16)."
     )
@@ -471,12 +607,35 @@ if __name__ == "__main__":
     parser.add_argument(
         "--wfp4", action="store_true", default=False, help="Run weight-fp4 (MXFP4) preshuffle GEMM test."
     )
+    parser.add_argument(
+        "--wfp6", action="store_true", default=False, help="Run W4A6 (MXFP6 A x MXFP4 B) preshuffle GEMM test."
+    )
     args = parser.parse_args()
     torch.set_default_device("cuda")
     try:
-        if not args.wfp4:
+        if args.wfp6:
+            test_mfma_a6w4_flyc_preshuffle(
+                args.out_dtype,
+                M=args.M,
+                N=args.N,
+                K=args.K,
+                tile_m=args.tile_m,
+                tile_n=args.tile_n,
+                tile_k=args.tile_k,
+                lds_stage=args.lds_stage,
+                bench_iters=args.num_iters,
+                bench_warmup=args.num_warmup,
+                use_cshuffle_epilog=bool(args.use_cshuffle_epilog),
+                waves_per_eu=int(args.waves_per_eu),
+                use_async_copy=bool(args.use_async_copy),
+                dsrd_preload=args.dsrd_preload,
+                dvmem_preload=args.dvmem_preload,
+            )
+        elif not args.wfp4:
             if args.in_dtype == "fp4":
                 raise ValueError("--in_dtype fp4 requires --wfp4")
+            if args.in_dtype == "fp6":
+                raise ValueError("--in_dtype fp6 requires --wfp6")
             test_mfma_a8_flyc_preshuffle(
                 args.in_dtype,
                 M=args.M,

--- a/tests/kernels/utils/fp4_utils.py
+++ b/tests/kernels/utils/fp4_utils.py
@@ -704,6 +704,72 @@ def per_1x32_f4_quant(x, scale=None, quant_dtype=fp4x2, shuffle=False):
     return y_fp4, scale.view(fp8_e8m0), y
 
 
+# MXFP6 (E2M3) helpers - A operand for the W4A6 preshuffle GEMM
+def pack_fp6_e2m3(x_unpacked: Tensor) -> Tensor:
+    """Pack uint8 (low 6 bits = E2M3) 4-at-a-time into 3 dense bytes.
+
+    Input (..., 4*G) uint8 -> output (..., 3*G) uint8 (little-endian groups:
+    b0 = e1[1:0]<<6 | e0, b1 = e2[3:0]<<4 | e1>>2, b2 = e3<<2 | e2>>4).
+    """
+    assert x_unpacked.dtype == torch.uint8 and x_unpacked.shape[-1] % 4 == 0
+    g = x_unpacked.unflatten(-1, (-1, 4)).to(torch.int32) & 0x3F
+    e0, e1, e2, e3 = g.unbind(dim=-1)
+    b0 = ((e1 & 0x03) << 6) | e0
+    b1 = ((e2 & 0x0F) << 4) | (e1 >> 2)
+    b2 = (e3 << 2) | (e2 >> 4)
+    out = torch.stack([b0, b1, b2], dim=-1).to(torch.uint8)
+    return out.reshape(*x_unpacked.shape[:-1], x_unpacked.shape[-1] // 4 * 3).contiguous()
+
+
+_FP6_E2M3_LUT: dict = {}
+
+
+def fp6_e2m3_to_f32(x_unpacked: Tensor) -> Tensor:
+    """Decode uint8 (low 6 bits = E2M3, 1 sign / 2 exp / 3 mant, bias 1) to fp32."""
+    dev = x_unpacked.device
+    lut = _FP6_E2M3_LUT.get(dev)
+    if lut is None:
+        vals = torch.empty(64, dtype=torch.float32)
+        for c in range(64):
+            sign = -1.0 if (c & 0x20) else 1.0
+            exp = (c >> 3) & 0x3
+            mant = c & 0x7
+            mag = (mant / 8.0) if exp == 0 else (2.0 ** (exp - 1)) * (1.0 + mant / 8.0)
+            vals[c] = sign * mag
+        lut = vals.to(dev)
+        _FP6_E2M3_LUT[dev] = lut
+    return lut[(x_unpacked & 0x3F).long()]
+
+
+def per_1x32_f6_quant(x):
+    """Per-1x32 MXFP6 (E2M3) quant of the A operand for compile_preshuffle_gemm_a6w4.
+
+    Returns:
+      a_pad:      (M, K) uint8 - FP8-padded packed FP6 (24 B codes + 8 B zero
+                  per K=32 chunk), the exact layout the kernel reads.
+      scale:      (M, K//32) e8m0 (unshuffled; caller applies shuffle_scale_w4).
+      a_unpacked: (M, K) uint8 - low-6-bit E2M3 codes (for the dequant reference).
+    """
+    block = 32
+    F6E2M3_MAX = 7.5
+    dtypeMax = 2.0 ** int(torch.log2(torch.tensor(F6E2M3_MAX, dtype=torch.float32)).item())
+    shape_original = x.shape
+    xb = x.view(-1, shape_original[-1]).reshape(-1, block)
+    max_abs = torch.amax(torch.abs(xb.float()), 1)
+    scale_e8m0 = f32_to_e8m0(max_abs / dtypeMax)
+    scale_f32 = e8m0_to_f32(scale_e8m0)
+    y = xb.float() / scale_f32.view(-1, 1)
+    codes = _f32_to_floatx_unpacked(y, 2, 3).to(torch.uint8)  # (.., 32) low6
+    a_unpacked = codes.view(*shape_original).contiguous()
+    M, K = a_unpacked.shape[0], a_unpacked.shape[-1]
+    packed = pack_fp6_e2m3(a_unpacked).view(M, K // 32, 24)
+    a_pad = torch.zeros(M, K // 32, 32, dtype=torch.uint8, device=x.device)
+    a_pad[:, :, :24] = packed
+    a_pad = a_pad.view(M, K)
+    scale = scale_e8m0.view(M, -1).view(torch.uint8)
+    return a_pad, scale, a_unpacked
+
+
 def preshuffle_b_16x16(b: Tensor, rows: int, cols: int) -> Tensor:
     """Preshuffle B data into 16x16 byte tiles for WMMA-friendly LDS loads.
 


### PR DESCRIPTION
## Motivation

Need a w4a6 matrix multiplication kernel for some cases

## Technical Details

Adds in_dtype="fp6" to compile_preshuffle_gemm_a8 and a thin compile_preshuffle_gemm_a6w4 wrapper. MXFP6 (E2M3) activations are stored FP8-padded (32 B per K=32 chunk: 24 B packed FP6 + 8 B zero pad, ignored by the cbsz=2 MFMA); B and the per-32 E8M0 scales are identical to the MXFP4 (w4) path. The shared FP4 logic is reused via is_fp4_or_fp6, so the fp4 path is behavior-identical (verified).

## Test Plan

Tests and benchmarks:
  - tests/kernels/test_preshuffle_gemm.py: test_mfma_a6w4_flyc_preshuffle
    (MXFP6 A x MXFP4 B vs an fp32 dequant ref, verify_output rtol/atol 0.1)
    plus run_perftest throughput, across 5 shapes x {bf16, fp16}; and a
    --wfp6 CLI path mirroring --wfp4.
  - tests/kernels/utils/fp4_utils.py: fp6 host helpers per_1x32_f6_quant,
    pack_fp6_e2m3, fp6_e2m3_to_f32.
  - scripts/run_benchmark.sh: GEMM_FP6FP4_SHAPES + an FP6FP4 (W4A6) bench
    loop (--wfp6), lined up 1:1 with the FP4 shapes.

## Test Result

Validated on MI355X (gfx950): fp6 rel_fro 0.0017 across M in {64,256} and K in {4096,14336}; fp4 w4 path unchanged (rel_fro 0.0017); ruff check/format clean on the added lines; pytest fp6 and fp4 cases pass.

Signed-off-by: Shreyas Atre <satre@amd.com>
Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>