### PR TITLE
[FMHA] trim kernel comments, drop FLYDSL_GENERIC_OSTORE_SCALAR env, add small-seq_len benchmark shapes

### DIFF
--- a/kernels/flash_attn_generic.py
+++ b/kernels/flash_attn_generic.py
@@ -113,22 +113,13 @@ def build_flash_attn_func_module_primary(
     K_SUB_N = 32
     WARP_SIZE = 64
 
-    # ── seq_len support ────────────────────────────────────────────────────
-    # Both variants now handle arbitrary seq_len:
-    #   * generic fallback: partial last q-tile via Q-load/O-store bounds, and
-    #     partial last kv-tile via per-(batch) num_records-bounded DMA loads /
-    #     clamped non-DMA loads + causal / non-causal padding masks.
-    #   * DUALWAVE_SWP fast path (built below): now handles any seq_len >= 1
-    #     (the pipeline floors its tile count at the 4-tile minimum; extra tiles
-    #     read 0 via the num_records bound and are masked out).
+    # Arbitrary seq_len: the generic fallback handles any length (partial q/kv tiles
+    # via num_records bounds + padding masks); the DUALWAVE_SWP fast path handles
+    # seq_len >= 1.
     _DUALWAVE_MIN_SEQ = 1
 
-    # ── DUALWAVE_SWP fast path (gfx950 D=128 bf16/f16) ──
-    # Built when:
-    #   * outermost call (block_m is None)
-    #   * head_dim == 128, dtype in (bf16, f16), gpu_arch startswith "gfx950"
-    # Runtime dispatch additionally requires seq_len >= 384 (any alignment; the
-    # DUALWAVE_SWP kernel handles non-256/64-aligned seq_len internally).
+    # DUALWAVE_SWP fast path (gfx950 D=128 bf16/f16): built for the outermost call;
+    # runtime dispatch needs seq_len >= 384 (any alignment, handled internally).
     _dualwave_swp_launch = None
     # FLYDSL_DISABLE_DUALWAVE_SWP=1 forces the generic fallback even on gfx950 D=128
     # bf16/f16 (used to exercise/validate the generic kernel on gfx950 hardware).
@@ -211,11 +202,9 @@ def build_flash_attn_func_module_primary(
         else:
 
             def _dualwave_swp_dispatch(*args, **kwargs):
-                # The DUALWAVE_SWP kernel handles non-aligned seq_len (partial
-                # last q-block + partial/odd kv-tile count) the same way the
-                # reference asm does, so the only constraint is the software-
-                # pipeline depth minimum (>= 384). seq_len need NOT be a
-                # multiple of 256/64 for this path.
+                # DUALWAVE_SWP handles non-aligned seq_len (partial last q-block +
+                # partial/odd kv-tile count) like the reference asm; only constraint
+                # is the pipeline depth minimum (seq_len >= 384).
                 S_int = _extract_seq_len(args, kwargs)
                 if S_int is not None and S_int >= _DUALWAVE_MIN_SEQ:
                     # Varlen: forward the cu_seqlens captured at build time (S here
@@ -330,13 +319,9 @@ def build_flash_attn_func_module_primary(
     # MFMA32 K-dimension: 16 on gfx950+ (CDNA4) for both GEMMs.
     USE_K16 = gpu_arch.startswith("gfx950")
 
-    # 128-bit permlane-fused O-store needs gfx950: it uses permlane32_swap AND
-    # cvt_pk_bf16_f32, both of which are gfx950 (CDNA4) only -- on gfx942 the LLVM
-    # backend cannot select them ("Cannot select intrinsic llvm.amdgcn.permlane32.swap").
-    # gfx942 falls back to a per-lane dwordx2 store using .to(elem_dtype) (arch-correct
-    # bf16/f16 conversion). FLYDSL_GENERIC_OSTORE_SCALAR=1 forces the scalar path so the
-    # gfx942 store can be validated on gfx950 hardware.
-    USE_PERMLANE_OSTORE = gpu_arch.startswith("gfx950") and os.environ.get("FLYDSL_GENERIC_OSTORE_SCALAR", "0") != "1"
+    # 128-bit permlane-fused O-store needs gfx950 (permlane32_swap + cvt_pk_bf16_f32,
+    # both CDNA4-only); gfx942 falls back to a per-lane dwordx2 store via .to(elem_dtype).
+    USE_PERMLANE_OSTORE = gpu_arch.startswith("gfx950")
     K_STEP_QK = 16 if USE_K16 else 8
     K_STEPS_QK = head_dim // K_STEP_QK
     D_CHUNK = 32
@@ -682,13 +667,9 @@ def build_flash_attn_func_module_primary(
                     lds_row = load_row_in_batch + row_offset
                     _v_store_to_lds(v_base, lds_row, vecs[batch])
 
-        # Per-(batch) byte bounds: rows >= seq_len read past this batch's region,
-        # so a bounded num_records makes the hardware return 0 on OOB loads and
-        # drop OOB stores (arbitrary-seqlen safe, no fault). Equivalent to
-        # max_size for an aligned seq_len, so the aligned hot path is unchanged.
-        # Same num_records trick as the hand-asm / DUALWAVE_SWP kernel
-        # (flash_attn_gfx950.py), used here for the K/V DMA loads, the Q-load,
-        # and the O-store -- so no per-lane q_in_bounds select / O-store predicate.
+        # Per-batch num_records bound: rows >= seq_len read/write past this batch's
+        # region, so OOB loads return 0 and OOB stores drop (arbitrary-seqlen safe;
+        # aligned hot path unchanged). Same asm trick, used for K/V/Q loads + O-store.
         _kv_nrec_bytes = _raw((batch_idx + fx.Index(1)) * seq_len_v * fx.Index(STRIDE_TOKEN_KV * 2))
         _q_nrec_bytes = _raw((batch_idx + fx.Index(1)) * seq_len_v * fx.Index(STRIDE_TOKEN_Q * 2))
         q_rsrc = buffer_ops.create_buffer_resource(Q, max_size=False, num_records_bytes=_q_nrec_bytes)
@@ -790,10 +771,8 @@ def build_flash_attn_func_module_primary(
                     )
 
         # ---- Preload Q^T B-operand packs once (register-resident) ----
-        # B operand uses j = lane_mod_32, k-subblock = lane_div_32*MFMA_LANE_K.
-        # Q is loaded through the num_records-bounded q_rsrc, so an out-of-bounds
-        # row (q_row >= seq_len, partial last q-tile) reads 0 from hardware -- no
-        # q_in_bounds select / row clamp needed (DUALWAVE_SWP-style boundary).
+        # B operand: j = lane_mod_32, k-subblock = lane_div_32*MFMA_LANE_K. Q is
+        # num_records-bounded (q_rsrc) so OOB rows read 0 -- no q_in_bounds select.
         q_row = q_start + wave_q_offset + lane_mod_32
         q_row_i32 = fx.Int32(q_row)
         q_b_packs = []
@@ -1097,13 +1076,10 @@ def build_flash_attn_func_module_primary(
                         s_raw_hi_15,
                     ]
                 else:
-                    # Non-causal KV padding mask: set keys whose absolute column
-                    # index >= seq_len to -inf, so bounded/clamped out-of-bounds
-                    # KV (which reads 0 on the DMA path or a duplicated row on the
-                    # non-DMA path) does not leak into the softmax. (Causal already
-                    # masks these columns via the kv_col > q_row test above.) The
-                    # element->column layout mirrors the causal masking above:
-                    # lo col = kv_start + lane_div_32*4 + ((r//4)*8 + r%4); hi = +K_SUB_N.
+                    # Non-causal KV padding mask: keys with absolute column >= seq_len
+                    # -> -inf, so OOB KV (0 or duplicated row) doesn't leak into softmax.
+                    # Col layout (mirrors causal): lo = kv_start + lane_div_32*4 +
+                    # ((r//4)*8 + r%4); hi = +K_SUB_N.
                     kv_start_i32 = fx.Int32(kv_start)
                     lane_off_i32 = fx.Int32(lane_div_32) * fx.Int32(4)
                     seq_len_i32 = fx.Int32(seq_len_v)
@@ -1329,12 +1305,9 @@ def build_flash_attn_func_module_primary(
             loop_results = yield _yield_args
 
         # ---- Normalize and store O (128-bit buffer_store_dwordx4) ----
-        # Ported from flash_attn_gfx950.py: pack 4 f32 -> 2 packed-16bit dwords
-        # (cvt_pk_bf16_f32 / RNE trunc), then permlane32_swap fuses each lane's
-        # 4 cols with its half-wave partner's 4 cols so one store covers 8
-        # contiguous cols -> 4 dwordx4 per wave per d_chunk instead of 16 scalar
-        # stores. O is num_records-bounded (o_rsrc), so OOB rows of a partial
-        # last q-tile are dropped by hardware -- no per-lane predicate needed.
+        # gfx950: pack 4 f32 -> 2 bf16 dwords (cvt_pk_bf16_f32), permlane32_swap fuses
+        # each lane's 4 cols with its half-wave partner's -> 8 cols/store. O is
+        # num_records-bounded (o_rsrc) -> partial-q-tile OOB rows drop.
         l_final = loop_results[1]
         o_finals = [loop_results[2 + dc] for dc in range_constexpr(D_CHUNKS)]
 
@@ -1383,11 +1356,9 @@ def build_flash_attn_func_module_primary(
                     o_global = global_idx_q(q_row, d_col)
                     buffer_ops.buffer_store(o_pack, o_rsrc, o_global * fx.Index(2), offset_is_bytes=True)
         else:
-            # gfx942 (CDNA3) fallback: no permlane32_swap / cvt_pk_bf16_f32. Each lane
-            # stores its own 16 output cols as 4 dwordx2 groups (4 contiguous cols each),
-            # packed via .to(elem_dtype) (arch-correct bf16/f16 conversion). Same column
-            # map as the per-element store: d_col = dc*D_CHUNK + lane_div_32*4 + 8*grp + r.
-            # O is num_records-bounded (o_rsrc) -> OOB rows of a partial last q-tile drop.
+            # gfx942 fallback (no permlane32_swap / cvt_pk_bf16_f32): each lane stores
+            # its 16 cols as 4 dwordx2 groups via .to(elem_dtype); col map d_col =
+            # dc*D_CHUNK + lane_div_32*4 + 8*grp + r. num_records bound drops OOB rows.
             for dc in range_constexpr(D_CHUNKS):
                 for grp in range_constexpr(4):
                     r0 = grp * 4

--- a/kernels/flash_attn_gfx950.py
+++ b/kernels/flash_attn_gfx950.py
@@ -294,12 +294,10 @@ def build_flash_attn_dualwave_swp_module(
         q_head_idx = h_kv_idx * GQA_GROUP_SIZE + group_id
         kv_head_idx = h_kv_idx
 
-        # Per-batch token ranges. Dense: batch_idx*seq_len .. (batch_idx+1)*seq_len
-        # (every batch the same seq_len, regular stride). Varlen: read the cumulative
-        # cu_seqlens_q / cu_seqlens_kv (int32 [B+1]) so this batch's Q rows are the
-        # packed range [cu_q[z], cu_q[z+1]) and its KV rows [cu_k[z], cu_k[z+1]).
-        # q_tok_base / kv_tok_base replace `batch_idx*seq_len` in every address; the
-        # _end values bound num_records; seqlen_q/kv drive the OOB skip + masks/tiles.
+        # Per-batch token ranges. Dense: batch_idx*seq_len. Varlen: read cumulative
+        # cu_seqlens_q / cu_seqlens_kv (int32 [B+1]) -> packed [cu[z], cu[z+1]).
+        # *_tok_base replace batch_idx*seq_len in addresses; *_tok_end bound
+        # num_records; seqlen_q/kv drive the OOB skip + masks/tiles.
         if const_expr(VARLEN):
             # cu_seqlens read through the element-indexed Layout API + a 32-bit copy
             # atom (same idiom as Q/K/V/O views), not a raw buffer resource.
@@ -335,19 +333,10 @@ def build_flash_attn_dualwave_swp_module(
         NUM_DMA_K = SMEM_D_RPT
         NUM_DMA_V = SMEM_D_RPT
 
-        # Copy atoms + flat (element-indexed) buffer-tensor views for Q/K/V/O,
-        # built once as straight-line SSA dominating the loop so the load/store
-        # helpers below are plain functions.
-        #
-        # Non-aligned seqlen support (copied from the hand-asm num_records bound):
-        # bound num_records to the END of THIS batch's region (= asm's
-        # num_records = seq_len*stride). A partial last q-block or a partial/extra
-        # kv-tile then reads rows with absolute index >= seq_len at a byte offset
-        # >= num_records, so hardware OOB returns 0 on loads and drops the OOB
-        # O-stores -- no fault, no corruption. For aligned seqlen every access is
-        # in-bounds, so results are unchanged.
-        # (raw index ir.Value; make_buffer_tensor's Int64() coercion accepts a raw
-        # index value and emits the index->i64 cast, but not the fx.Index wrapper.)
+        # Copy atoms + element-indexed buffer-tensor views for Q/K/V/O, built once as
+        # straight-line SSA dominating the loop. num_records is bound to the END of
+        # this batch's region so OOB rows (partial last q-block / extra kv-tile) read 0
+        # and OOB stores drop (no fault); aligned seqlen is fully in-bounds, unchanged.
         q_nrec_bytes = _raw(q_tok_end * stride_q_n_v * BF16_BYTES)
         kv_nrec_bytes = _raw(kv_tok_end * stride_kv_n_v * BF16_BYTES)
         q_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(Q, num_records_bytes=q_nrec_bytes), fx.make_layout(1, 1))
@@ -439,24 +428,13 @@ def build_flash_attn_dualwave_swp_module(
             max_num_tiles = fx.Index(ArithValue(causal_num_tiles < num_kv_tiles).select(causal_num_tiles, num_kv_tiles))
         else:
             max_num_tiles = num_kv_tiles
-        # Non-aligned kv support: the prologue + 2-tile-unrolled loop + 3-tile
-        # drain pipeline requires an EVEN tile count (max_num_tiles = 4 + 2*iters).
-        # ceil(seq_len/64) can be odd when seq_len is not a multiple of 64, so
-        # round up to even. The single extra tile is fully out of range (its keys
-        # have absolute index >= seq_len), so it reads 0 (num_records bound) and
-        # is masked to -inf (causal mask, or the seq padding-mask below in the
-        # non-causal path) -- contributing nothing to the softmax. Aligned sizes
-        # are already a multiple of 4, so this is a no-op for them. Done before
-        # the split-K chunking so each split inherits an even total.
-        # (No fx.Index(...) wrap: Index arithmetic already yields an index whose
-        # backing value is an ArithValue, as required by scf.range's stop.)
+        # Pipeline (prologue + 2-tile loop + 3-tile drain) needs an EVEN tile count,
+        # so round ceil(seq_len/64) up to even. The extra tile is out of range -> reads
+        # 0 (num_records) and is masked, contributing nothing; aligned sizes: no-op.
         max_num_tiles = ((max_num_tiles + fx.Index(1)) // fx.Index(2)) * fx.Index(2)
-        # seq_len >= 1 support: the prologue(1) + 2-tile loop + 3-tile drain
-        # pipeline needs at least 4 tiles. For a tiny seq_len (< ~192) ceil/round
-        # can give 2, so floor the tile count at 4. The extra tiles are entirely
-        # out of range (keys >= seq_len) -> read 0 (num_records bound) and are
-        # masked (causal mask / non-causal seq padding mask), contributing
-        # nothing. seq_len that already yields >= 4 tiles is unaffected.
+        # Pipeline needs >= 4 tiles; for tiny seq_len (< ~192) floor the count at 4.
+        # The extra tiles are out of range -> read 0 (num_records) and are masked,
+        # contributing nothing; seq_len already yielding >= 4 tiles is unaffected.
         max_num_tiles = fx.Index(ArithValue(max_num_tiles < fx.Index(4)).select(fx.Index(4), max_num_tiles))
 
         # Split-K tile range [split_t0, split_t_end). chunk is EVEN (preserves
@@ -1109,11 +1087,9 @@ def build_flash_attn_dualwave_swp_module(
                 m_out = _anchor_scalar_f32(m_tile_max)
             return ([o0, o1, o2, o3], m_out, l_out, _v_vec32_to_p(vp_out))
 
-        # Split-K: empty splits (fewer than 4 tiles to do) skip the whole
-        # pipeline and only write zeros below; non-splitk traces no guard.
-        # Varlen: grid_y is sized for max_seqlen, so a q-block past THIS batch's
-        # seqlen_q has no rows to compute -- skip the whole pipeline (the condition
-        # is uniform across the WG, so the workgroup barriers inside stay balanced).
+        # Split-K: empty splits (< 4 tiles) skip the pipeline, writing zeros below.
+        # Varlen: grid_y is sized for max_seqlen, so a q-block past this batch's
+        # seqlen_q has no rows -> skip (uniform across the WG, barriers stay balanced).
         # VARLEN and SPLITK are mutually exclusive, so they share the one guard.
         if const_expr(SPLITK):
             _split_if = _scf.IfOp(_raw(split_nonempty))
@@ -1161,12 +1137,9 @@ def build_flash_attn_dualwave_swp_module(
                 else:
                     v_s_0 = _causal_mask_prologue_if_needed(v_s_0)
             else:
-                # Non-causal KV padding mask for the PROLOGUE tile too: for a tiny
-                # seq_len the only real tile is tile 0 (prologue), so its keys with
-                # absolute column >= seq_len must be masked here (the epilogue mask
-                # only covers the last 3 tiles). Gated inside _seq_pad_mask_if_needed
-                # -> a no-op once tile 0 is full (seq_len >= BLOCK_N), so larger
-                # seq_len is unaffected and the hot loop is untouched.
+                # Non-causal padding mask for the prologue tile too: for tiny seq_len
+                # tile 0 is the only real tile, so its keys >= seq_len must be masked
+                # here. Gated -> no-op once tile 0 is full (seq_len >= BLOCK_N).
                 if const_expr(SPLITK):
                     v_s_0 = _seq_pad_mask_if_needed(v_s_0, split_t0)
                 else:
@@ -1648,14 +1621,10 @@ def build_flash_attn_dualwave_swp_module(
                 mrow_base = grid_z * NUM_HEADS_Q * seq_len_v * (HEAD_DIM // 2)
                 lrow_base = mrow_base + grid_z * NUM_HEADS_Q * seq_len_v
                 ml_row_idx = (split_z * NUM_HEADS_Q + q_head_idx) * seq_len_v + q_row
-                # Non-aligned seqlen: the workspace is indexed directly by q_row and
-                # (unlike O) cannot be num_records-bounded (a single flat buffer for
-                # all splits/heads), so an OOB row q_row >= seq_len would corrupt a
-                # neighbour's slot. Guard the writes by q_row < seq_len; the combine
-                # kernel only reads rows s < seq_len, so skipped rows are never read.
-                # lane and lane+32 share lane%32 -> share q_row, so the half-wave
-                # permlane32_swap fuse below is applied with both partners equally
-                # active/inactive. For aligned seqlen the guard is always true.
+                # The workspace is indexed directly by q_row and (unlike O) can't be
+                # num_records-bounded, so guard writes by q_row < seq_len (combine only
+                # reads s < seq_len). lane and lane+32 share q_row, so the half-wave
+                # permlane32_swap fuse applies to both equally; aligned: always true.
                 _if_qrow = _scf.IfOp(_raw(ArithValue(q_row < seq_len_v)))
                 with _if_then(_if_qrow):
                     for dc in range_constexpr(D_CHUNKS):
@@ -1773,11 +1742,9 @@ def build_flash_attn_dualwave_swp_module(
         den = _raw(fx.Float32(0.0))
         acc = _raw(Vec.filled(4, 0.0, fx.Float32))
         for i in range_constexpr(NUM_KV_SPLITS):
-            # Empty split (causal tail block): l == 0 and O_partial is zeroed, so it
-            # contributes nothing -- skip its O reads. The runtime `if` (its condition
-            # holds a call, so the AST rewriter lowers it to scf.if) reassigns the
-            # pre-existing acc/den so the update propagates out of the branch; the
-            # not-taken path keeps acc/den unchanged. One merged exit.
+            # Empty split (causal tail): l == 0 and O_partial is zeroed -> skip its O
+            # reads. The runtime `if` (call in cond -> scf.if) reassigns pre-existing
+            # acc/den so the update propagates; not-taken keeps them unchanged.
             @flyc.jit
             def _accum_split(acc, den):
                 if fx.Float32(l_s[i]) > fx.Float32(0.0):

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -77,6 +77,22 @@ DEFAULT_FLASH_ATTN_FUNC_SHAPES='
 16,8192,16,16,128,bf16,true
 4,8192,64,64,128,bf16,true
 4,8192,64,8,128,bf16,true
+1,64,4,4,128,bf16,true
+1,64,4,4,128,bf16,false
+1,30,4,4,128,bf16,true
+1,30,4,4,128,bf16,false
+1,1,4,4,128,bf16,true
+1,1,4,4,128,bf16,false
+2,7,4,4,128,bf16,true
+2,7,4,4,128,bf16,false
+3,31,3,3,128,bf16,true
+3,31,3,3,128,bf16,false
+5,33,5,5,128,bf16,true
+5,33,5,5,128,bf16,false
+5,63,7,7,128,bf16,true
+5,63,7,7,128,bf16,false
+3,65,3,3,128,bf16,true
+3,65,3,3,128,bf16,false
 '
 FLASH_ATTN_FUNC_SHAPES="${FLASH_ATTN_FUNC_SHAPES:-${DEFAULT_FLASH_ATTN_FUNC_SHAPES}}"
 # MLA decode shapes: "batch,ctx_len" (DeepSeek MLA, fp8 Q/KV, nh=128).


### PR DESCRIPTION
## Motivation

Follow-up to #683 (gfx950 dualwave SWP FMHA + gfx942 fallback). This PR cleans up the
FMHA kernels: trims the now-overly-verbose inline comments, drops the
`FLYDSL_GENERIC_OSTORE_SCALAR` test-only env override (no longer needed once the gfx942
fix landed), and adds small-seq_len FMHA benchmark shapes. No functional change to the
kernels.

## Technical Details

- `kernels/flash_attn_generic.py`, `kernels/flash_attn_gfx950.py`: condense long inline
  comments (now <= 5 lines each); no code-logic changes.
- `kernels/flash_attn_generic.py`: drop the `FLYDSL_GENERIC_OSTORE_SCALAR` env override —
  `USE_PERMLANE_OSTORE = gpu_arch.startswith("gfx950")`. It was a test-only hook to force
  the gfx942 scalar O-store on gfx950; the gfx942 store path itself is unchanged.
- `scripts/run_benchmark.sh`: add 8 small-seq_len FMHA shapes (bf16, causal + non-causal).

## Test Plan

```
python tests/kernels/test_flash_attn_fwd.py --iters 100 --compare
```
on MI355X (gfx950).

## Test Result

All configs PASS — bf16 `MaxErr <= 3.91e-3`, fp16 `<= ~1e-3`; varlen self-attention
configs PASS. Behavior is unchanged (comment / test-only-env / benchmark-shape edits
only). `black` + `ruff check` clean. (No perf comparison requested.)

## Submission Checklist

- [x] `black` + `ruff check` clean (line-length 120).
- [x] Accuracy verified on gfx950 (MI355X) — all configs PASS.
- [x] No functional change (comments / test-only env / benchmark shapes only).
- [ ] CI green.
