### PR TITLE
 [gfx1250] Add cluster launch support with TDM multicast bandwidth tests

### DIFF
--- a/lib/Runtime/ROCm/CMakeLists.txt
+++ b/lib/Runtime/ROCm/CMakeLists.txt
@@ -7,6 +7,17 @@ file(GLOB _rocm_paths LIST_DIRECTORIES true "/opt/rocm*")
 list(SORT _rocm_paths ORDER DESCENDING)
 find_package(hip REQUIRED CONFIG PATHS ${_rocm_paths})
 
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_LIBRARIES hip::host)
+check_cxx_source_compiles("
+    #include <hip/hip_runtime.h>
+    int main() {
+        hipLaunchAttributeID id = hipLaunchAttributeClusterDimension;
+        return 0;
+    }
+" HIP_HAS_CLUSTER_LAUNCH)
+unset(CMAKE_REQUIRED_LIBRARIES)
+
 add_library(FlyJitRuntime SHARED FlyRocmRuntimeWrappers.cpp)
 target_include_directories(FlyJitRuntime PRIVATE
   ${LLVM_INCLUDE_DIRS}
@@ -14,4 +25,7 @@ target_include_directories(FlyJitRuntime PRIVATE
 )
 target_compile_features(FlyJitRuntime PRIVATE cxx_std_17)
 target_link_libraries(FlyJitRuntime PRIVATE hip::host hip::amdhip64)
+if(HIP_HAS_CLUSTER_LAUNCH)
+  target_compile_definitions(FlyJitRuntime PRIVATE HIP_HAS_CLUSTER_LAUNCH)
+endif()
 set_target_properties(FlyJitRuntime PROPERTIES OUTPUT_NAME "fly_jit_runtime")

--- a/lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp
+++ b/lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp
@@ -96,8 +96,7 @@ extern "C" void mgpuLaunchClusterKernel(hipFunction_t function, intptr_t cluster
             "[mgpuLaunchClusterKernel] cluster=(%ld,%ld,%ld) requested but "
             "built against HIP_VERSION < 7.2; falling back to "
             "hipModuleLaunchKernel.\n",
-            static_cast<long>(clusterX), static_cast<long>(clusterY),
-            static_cast<long>(clusterZ));
+            static_cast<long>(clusterX), static_cast<long>(clusterY), static_cast<long>(clusterZ));
   }
   HIP_REPORT_IF_ERROR(hipModuleLaunchKernel(function, gridX, gridY, gridZ, blockX, blockY, blockZ,
                                             smem, stream, params, extra));

--- a/lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp
+++ b/lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp
@@ -68,7 +68,9 @@ extern "C" void mgpuLaunchClusterKernel(hipFunction_t function, intptr_t cluster
                                         intptr_t blockY, intptr_t blockZ, int32_t smem,
                                         hipStream_t stream, void **params, void **extra,
                                         size_t /*paramsCount*/) {
-#ifdef hipLaunchAttributeClusterDimension
+#if defined(HIP_VERSION) && (HIP_VERSION >= 70200000)
+  // ROCm 7.2+: hipLaunchAttributeClusterDimension is functional at runtime
+  // (SWDEV-567096). ROCm 7.0 has the API but cluster attrs are not implemented.
   hipLaunchAttribute attrs[1];
   attrs[0].id = hipLaunchAttributeClusterDimension;
   attrs[0].value.clusterDim.x = static_cast<unsigned>(clusterX);
@@ -87,37 +89,15 @@ extern "C" void mgpuLaunchClusterKernel(hipFunction_t function, intptr_t cluster
   config.attrs = attrs;
   config.numAttrs = 1;
 
-  hipError_t err = hipDrvLaunchKernelEx(&config, function, params, extra);
-  if (err == hipSuccess)
-    return;
-
-  const bool requestedRealCluster = (clusterX > 1) || (clusterY > 1) || (clusterZ > 1);
-  if (requestedRealCluster) {
-    fprintf(stderr,
-            "[mgpuLaunchClusterKernel] hipDrvLaunchKernelEx failed (err=%d) "
-            "for requested cluster=(%ld,%ld,%ld); not falling back to "
-            "hipModuleLaunchKernel.\n",
-            static_cast<int>(err), static_cast<long>(clusterX), static_cast<long>(clusterY),
-            static_cast<long>(clusterZ));
-    HIP_REPORT_IF_ERROR(err);
-    return;
-  }
-
-  fprintf(stderr,
-          "[mgpuLaunchClusterKernel] hipDrvLaunchKernelEx failed (err=%d) "
-          "for cluster=(1,1,1); falling back to hipModuleLaunchKernel.\n",
-          static_cast<int>(err));
-  HIP_REPORT_IF_ERROR(hipModuleLaunchKernel(function, gridX, gridY, gridZ, blockX, blockY, blockZ,
-                                            smem, stream, params, extra));
+  HIP_REPORT_IF_ERROR(hipDrvLaunchKernelEx(&config, function, params, extra));
 #else
-  // Cluster launch not supported by this HIP version; ignore cluster dims
-  // and fall back to regular kernel launch.
   if ((clusterX > 1) || (clusterY > 1) || (clusterZ > 1)) {
     fprintf(stderr,
             "[mgpuLaunchClusterKernel] cluster=(%ld,%ld,%ld) requested but "
-            "hipLaunchAttributeClusterDimension is not available in this HIP "
-            "version; falling back to hipModuleLaunchKernel.\n",
-            static_cast<long>(clusterX), static_cast<long>(clusterY), static_cast<long>(clusterZ));
+            "built against HIP_VERSION < 7.2; falling back to "
+            "hipModuleLaunchKernel.\n",
+            static_cast<long>(clusterX), static_cast<long>(clusterY),
+            static_cast<long>(clusterZ));
   }
   HIP_REPORT_IF_ERROR(hipModuleLaunchKernel(function, gridX, gridY, gridZ, blockX, blockY, blockZ,
                                             smem, stream, params, extra));

--- a/lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp
+++ b/lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp
@@ -68,9 +68,7 @@ extern "C" void mgpuLaunchClusterKernel(hipFunction_t function, intptr_t cluster
                                         intptr_t blockY, intptr_t blockZ, int32_t smem,
                                         hipStream_t stream, void **params, void **extra,
                                         size_t /*paramsCount*/) {
-#if defined(HIP_VERSION) && (HIP_VERSION >= 70200000)
-  // ROCm 7.2+: hipLaunchAttributeClusterDimension is functional at runtime
-  // (SWDEV-567096). ROCm 7.0 has the API but cluster attrs are not implemented.
+#ifdef HIP_HAS_CLUSTER_LAUNCH
   hipLaunchAttribute attrs[1];
   attrs[0].id = hipLaunchAttributeClusterDimension;
   attrs[0].value.clusterDim.x = static_cast<unsigned>(clusterX);
@@ -94,8 +92,8 @@ extern "C" void mgpuLaunchClusterKernel(hipFunction_t function, intptr_t cluster
   if ((clusterX > 1) || (clusterY > 1) || (clusterZ > 1)) {
     fprintf(stderr,
             "[mgpuLaunchClusterKernel] cluster=(%ld,%ld,%ld) requested but "
-            "built against HIP_VERSION < 7.2; falling back to "
-            "hipModuleLaunchKernel.\n",
+            "HIP does not support hipLaunchAttributeClusterDimension; "
+            "falling back to hipModuleLaunchKernel.\n",
             static_cast<long>(clusterX), static_cast<long>(clusterY), static_cast<long>(clusterZ));
   }
   HIP_REPORT_IF_ERROR(hipModuleLaunchKernel(function, gridX, gridY, gridZ, blockX, blockY, blockZ,

--- a/tests/perf/bench_tdm_bandwidth_gfx1250.py
+++ b/tests/perf/bench_tdm_bandwidth_gfx1250.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""TDM load bandwidth benchmark for gfx1250.
+
+Three modes:
+  --mode read-only : TDM loads only (no store). Measures peak TDM HBM read bandwidth.
+  --mode unique    : Each WG reads unique tiles + add + store. Measures raw HBM R/W bandwidth.
+  --mode multicast : GEMM-like shared tiles with cluster multicast. Measures
+                     multicast L2→LDS throughput amplification.
+
+Usage:
+    python tests/perf/bench_tdm_bandwidth_gfx1250.py                      # run all modes
+    python tests/perf/bench_tdm_bandwidth_gfx1250.py --mode read-only     # peak read BW only
+    python tests/perf/bench_tdm_bandwidth_gfx1250.py --mode unique        # R/W BW only
+    python tests/perf/bench_tdm_bandwidth_gfx1250.py --mode multicast     # multicast only
+"""
+
+import argparse
+import sys
+
+import torch
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, const_expr, gpu, range_constexpr, tdm_ops, vector
+from flydsl.expr.rocdl import cluster
+from flydsl.expr.typing import T
+from flydsl.runtime.device import get_rocm_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr, get_op_result_or_value
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TILE = 128
+BLOCK_DIM = 256
+WAVE_SIZE = 32
+NUM_WARPS = BLOCK_DIM // WAVE_SIZE
+VEC_WIDTH = 8
+ELEM_BYTES = 2  # bf16
+TILE_BYTES = TILE * TILE * ELEM_BYTES  # 32 KB
+ELEMS_PER_THREAD = (TILE * TILE) // BLOCK_DIM  # 64
+VECS_PER_THREAD = ELEMS_PER_THREAD // VEC_WIDTH  # 8
+
+
+# ---------------------------------------------------------------------------
+# Kernel: unique tiles per WG (mode=unique)
+# ---------------------------------------------------------------------------
+
+
+def _compile_tdm_unique_add(grid_m, grid_n):
+    """Each WG reads unique A/B tiles — no L2 reuse, all reads hit HBM."""
+    lds_a_offset = 0
+    lds_b_offset = ((TILE_BYTES + 127) // 128) * 128
+    total_lds = lds_b_offset + TILE_BYTES
+
+    smem_alloc = SmemAllocator(None, arch="gfx1250", global_sym_name="tdm_unique_add_smem")
+    smem_alloc.ptr = total_lds
+
+    tile_elems = TILE * TILE
+
+    @flyc.kernel
+    def tdm_unique_add_kernel(arg_a: fx.Tensor, arg_b: fx.Tensor, arg_c: fx.Tensor):
+        bx = gpu.block_id("x")
+        by = gpu.block_id("y")
+        tid = gpu.thread_id("x")
+
+        bid_idx = bx * arith.index(grid_n) + by
+        blk_row = bid_idx * arith.index(TILE)
+        k_base = arith.index(0)
+
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            smem_alloc.finalized = False
+            smem_alloc.finalize()
+        smem_base = smem_alloc.get_base()
+        bf16_ty = T.bf16
+        smem_a = SmemPtr(smem_base, lds_a_offset, bf16_ty, shape=(TILE * TILE,))
+        smem_b = SmemPtr(smem_base, lds_b_offset, bf16_ty, shape=(TILE * TILE,))
+        lds_a_memref = get_op_result_or_value(smem_a.get())
+        lds_b_memref = get_op_result_or_value(smem_b.get())
+
+        # A, B: (total_wgs * TILE, TILE), each WG reads unique rows
+        desc_a = tdm_ops.make_tensor_descriptor_2d(
+            global_ptr=arg_a,
+            lds_memref=lds_a_memref,
+            global_offset=(blk_row, k_base),
+            tensor_shape=(TILE, TILE),
+            strides=(TILE, 1),
+            tile_shape=(TILE, TILE),
+            elem_bytes=ELEM_BYTES,
+            num_warps=NUM_WARPS,
+            workgroup_mask=0,
+        )
+        desc_b = tdm_ops.make_tensor_descriptor_2d(
+            global_ptr=arg_b,
+            lds_memref=lds_b_memref,
+            global_offset=(blk_row, k_base),
+            tensor_shape=(TILE, TILE),
+            strides=(TILE, 1),
+            tile_shape=(TILE, TILE),
+            elem_bytes=ELEM_BYTES,
+            num_warps=NUM_WARPS,
+            workgroup_mask=0,
+        )
+
+        tdm_ops.tensor_load_2d(desc_a)
+        tdm_ops.tensor_load_2d(desc_b)
+        tdm_ops.tensor_wait(0)
+        gpu.barrier()
+
+        bid = fx.block_idx.x * grid_n + fx.block_idx.y
+        C = fx.rocdl.make_buffer_tensor(arg_c)
+        tC = fx.logical_divide(C, fx.make_layout(tile_elems, 1))
+        tC = fx.slice(tC, (None, bid))
+        tC = fx.logical_divide(tC, fx.make_layout(VEC_WIDTH, 1))
+        copyAtom = fx.make_copy_atom(fx.rocdl.BufferCopy(VEC_WIDTH * fx.BFloat16.width), fx.BFloat16)
+        rC = fx.make_rmem_tensor(VEC_WIDTH, fx.BFloat16)
+        vec_ty = T.vec(VEC_WIDTH, bf16_ty)
+        base_elem = tid * arith.index(ELEMS_PER_THREAD)
+        for v in range_constexpr(VECS_PER_THREAD):
+            elem_off = base_elem + arith.index(v * VEC_WIDTH)
+            va = vector.load_op(vec_ty, lds_a_memref, [elem_off])
+            vb = vector.load_op(vec_ty, lds_b_memref, [elem_off])
+            vc = arith.addf(va, vb)
+            fx.memref_store_vec(vc, rC)
+            store_idx = fx.thread_idx.x * VECS_PER_THREAD + v
+            fx.copy_atom_call(copyAtom, rC, fx.slice(tC, (None, store_idx)))
+
+    @flyc.jit
+    def launch(A: fx.Tensor, B: fx.Tensor, C: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        L = tdm_unique_add_kernel(A, B, C)
+        L.launch(grid=(grid_m, grid_n, 1), block=(BLOCK_DIM, 1, 1), stream=stream)
+
+    return launch
+
+
+# ---------------------------------------------------------------------------
+# Kernel: read-only TDM loads (mode=read-only)
+# ---------------------------------------------------------------------------
+
+
+def _compile_tdm_read_only(grid_m, grid_n):
+    """Each WG does TDM load of 2 tiles to LDS, no store. Measures pure TDM read BW."""
+    lds_a_offset = 0
+    lds_b_offset = ((TILE_BYTES + 127) // 128) * 128
+    total_lds = lds_b_offset + TILE_BYTES
+
+    smem_alloc = SmemAllocator(None, arch="gfx1250", global_sym_name="tdm_read_only_smem")
+    smem_alloc.ptr = total_lds
+
+    @flyc.kernel
+    def tdm_read_only_kernel(arg_a: fx.Tensor, arg_b: fx.Tensor, arg_c: fx.Tensor):
+        bx = gpu.block_id("x")
+        by = gpu.block_id("y")
+        _tid = gpu.thread_id("x")
+
+        bid_idx = bx * arith.index(grid_n) + by
+        blk_row = bid_idx * arith.index(TILE)
+        k_base = arith.index(0)
+
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            smem_alloc.finalized = False
+            smem_alloc.finalize()
+        smem_base = smem_alloc.get_base()
+        bf16_ty = T.bf16
+        smem_a = SmemPtr(smem_base, lds_a_offset, bf16_ty, shape=(TILE * TILE,))
+        smem_b = SmemPtr(smem_base, lds_b_offset, bf16_ty, shape=(TILE * TILE,))
+        lds_a_memref = get_op_result_or_value(smem_a.get())
+        lds_b_memref = get_op_result_or_value(smem_b.get())
+
+        desc_a = tdm_ops.make_tensor_descriptor_2d(
+            global_ptr=arg_a,
+            lds_memref=lds_a_memref,
+            global_offset=(blk_row, k_base),
+            tensor_shape=(TILE, TILE),
+            strides=(TILE, 1),
+            tile_shape=(TILE, TILE),
+            elem_bytes=ELEM_BYTES,
+            num_warps=NUM_WARPS,
+            workgroup_mask=0,
+        )
+        desc_b = tdm_ops.make_tensor_descriptor_2d(
+            global_ptr=arg_b,
+            lds_memref=lds_b_memref,
+            global_offset=(blk_row, k_base),
+            tensor_shape=(TILE, TILE),
+            strides=(TILE, 1),
+            tile_shape=(TILE, TILE),
+            elem_bytes=ELEM_BYTES,
+            num_warps=NUM_WARPS,
+            workgroup_mask=0,
+        )
+
+        tdm_ops.tensor_load_2d(desc_a)
+        tdm_ops.tensor_load_2d(desc_b)
+        tdm_ops.tensor_wait(0)
+        gpu.barrier()
+
+        # Every thread reads a vector from each LDS tile, adds, stores to C[bid]
+        # to prevent dead code elimination of the TDM loads.
+        vec_ty = T.vec(VEC_WIDTH, bf16_ty)
+        va = vector.load_op(vec_ty, lds_a_memref, [arith.index(0)])
+        vb = vector.load_op(vec_ty, lds_b_memref, [arith.index(0)])
+        vc = arith.addf(va, vb)
+        bid = fx.block_idx.x * grid_n + fx.block_idx.y
+        C = fx.rocdl.make_buffer_tensor(arg_c)
+        tC = fx.logical_divide(C, fx.make_layout(VEC_WIDTH, 1))
+        copyAtom = fx.make_copy_atom(fx.rocdl.BufferCopy(VEC_WIDTH * fx.BFloat16.width), fx.BFloat16)
+        rC = fx.make_rmem_tensor(VEC_WIDTH, fx.BFloat16)
+        fx.memref_store_vec(vc, rC)
+        fx.copy_atom_call(copyAtom, rC, fx.slice(tC, (None, bid)))
+
+    @flyc.jit
+    def launch(A: fx.Tensor, B: fx.Tensor, C: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        L = tdm_read_only_kernel(A, B, C)
+        L.launch(grid=(grid_m, grid_n, 1), block=(BLOCK_DIM, 1, 1), stream=stream)
+
+    return launch
+
+
+# ---------------------------------------------------------------------------
+# Kernel: shared tiles with multicast (mode=multicast)
+# ---------------------------------------------------------------------------
+
+
+def _compile_tdm_shared_add(grid_m, grid_n, cluster_m, cluster_n):
+    """GEMM-like tiling: A shared by row, B shared by col, with cluster multicast."""
+    use_cluster = cluster_m > 1 or cluster_n > 1
+
+    lds_a_offset = 0
+    lds_b_offset = ((TILE_BYTES + 127) // 128) * 128
+    total_lds = lds_b_offset + TILE_BYTES
+
+    smem_alloc = SmemAllocator(None, arch="gfx1250", global_sym_name="tdm_shared_add_smem")
+    smem_alloc.ptr = total_lds
+
+    stride_a = TILE
+    stride_b = grid_n * TILE
+    tile_elems = TILE * TILE
+
+    @flyc.kernel
+    def tdm_shared_add_kernel(arg_a: fx.Tensor, arg_b: fx.Tensor, arg_c: fx.Tensor):
+        bx = gpu.block_id("x")
+        by = gpu.block_id("y")
+        tid = gpu.thread_id("x")
+
+        if const_expr(use_cluster):
+            local_x, local_y = cluster.compute_cluster_position()
+            a_mcast_mask, b_mcast_mask = cluster.compute_mcast_masks(local_x, local_y, cluster_m, cluster_n)
+        else:
+            a_mcast_mask = 0
+            b_mcast_mask = 0
+
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            smem_alloc.finalized = False
+            smem_alloc.finalize()
+        smem_base = smem_alloc.get_base()
+        bf16_ty = T.bf16
+        smem_a = SmemPtr(smem_base, lds_a_offset, bf16_ty, shape=(TILE * TILE,))
+        smem_b = SmemPtr(smem_base, lds_b_offset, bf16_ty, shape=(TILE * TILE,))
+        lds_a_memref = get_op_result_or_value(smem_a.get())
+        lds_b_memref = get_op_result_or_value(smem_b.get())
+
+        blk_m = bx * arith.index(TILE)
+        blk_n = by * arith.index(TILE)
+        k_base = arith.index(0)
+
+        desc_a = tdm_ops.make_tensor_descriptor_2d(
+            global_ptr=arg_a,
+            lds_memref=lds_a_memref,
+            global_offset=(blk_m, k_base),
+            tensor_shape=(TILE, TILE),
+            strides=(stride_a, 1),
+            tile_shape=(TILE, TILE),
+            elem_bytes=ELEM_BYTES,
+            num_warps=NUM_WARPS,
+            workgroup_mask=a_mcast_mask,
+        )
+        desc_b = tdm_ops.make_tensor_descriptor_2d(
+            global_ptr=arg_b,
+            lds_memref=lds_b_memref,
+            global_offset=(k_base, blk_n),
+            tensor_shape=(TILE, TILE),
+            strides=(stride_b, 1),
+            tile_shape=(TILE, TILE),
+            elem_bytes=ELEM_BYTES,
+            num_warps=NUM_WARPS,
+            workgroup_mask=b_mcast_mask,
+        )
+
+        tdm_ops.tensor_load_2d(desc_a)
+        tdm_ops.tensor_load_2d(desc_b)
+        tdm_ops.tensor_wait(0)
+        if const_expr(use_cluster):
+            cluster.cluster_barrier()
+        else:
+            gpu.barrier()
+
+        bid = fx.block_idx.x * grid_n + fx.block_idx.y
+        C = fx.rocdl.make_buffer_tensor(arg_c)
+        tC = fx.logical_divide(C, fx.make_layout(tile_elems, 1))
+        tC = fx.slice(tC, (None, bid))
+        tC = fx.logical_divide(tC, fx.make_layout(VEC_WIDTH, 1))
+        copyAtom = fx.make_copy_atom(fx.rocdl.BufferCopy(VEC_WIDTH * fx.BFloat16.width), fx.BFloat16)
+        rC = fx.make_rmem_tensor(VEC_WIDTH, fx.BFloat16)
+        vec_ty = T.vec(VEC_WIDTH, bf16_ty)
+        base_elem = tid * arith.index(ELEMS_PER_THREAD)
+        for v in range_constexpr(VECS_PER_THREAD):
+            elem_off = base_elem + arith.index(v * VEC_WIDTH)
+            va = vector.load_op(vec_ty, lds_a_memref, [elem_off])
+            vb = vector.load_op(vec_ty, lds_b_memref, [elem_off])
+            vc = arith.addf(va, vb)
+            fx.memref_store_vec(vc, rC)
+            store_idx = fx.thread_idx.x * VECS_PER_THREAD + v
+            fx.copy_atom_call(copyAtom, rC, fx.slice(tC, (None, store_idx)))
+
+    cluster_dims_str = f"{cluster_m},{cluster_n},1"
+
+    @flyc.jit
+    def launch(A: fx.Tensor, B: fx.Tensor, C: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        L = tdm_shared_add_kernel(
+            A,
+            B,
+            C,
+            value_attrs={"rocdl.cluster_dims": cluster_dims_str} if use_cluster else {},
+        )
+        if use_cluster:
+            L.launch(
+                grid=(grid_m, grid_n, 1),
+                block=(BLOCK_DIM, 1, 1),
+                stream=stream,
+                cluster=(cluster_m, cluster_n, 1),
+            )
+        else:
+            L.launch(grid=(grid_m, grid_n, 1), block=(BLOCK_DIM, 1, 1), stream=stream)
+
+    return launch
+
+
+# ---------------------------------------------------------------------------
+# Benchmark timing (adapted from benchmark_common.py:bench_kernel_us)
+# ---------------------------------------------------------------------------
+
+
+def _bench_kernel_us(run_fn, warmup=10, iters=50, flush_mb=512):
+    """Per-iteration CUDA events timer with L2 flush and IQR-filtered median."""
+    l2_bytes = getattr(
+        torch.cuda.get_device_properties(torch.cuda.current_device()),
+        "L2_cache_size",
+        256 * 1024 * 1024,  # fallback if L2_cache_size unavailable (cmodel reports 96 MB)
+    )
+    alloc_bytes = max(l2_bytes * 2, flush_mb * 1024 * 1024)
+    flush_buf = torch.empty(alloc_bytes, dtype=torch.uint8, device="cuda")
+
+    for _ in range(warmup):
+        flush_buf.zero_()
+        run_fn()
+    torch.cuda.synchronize()
+
+    start_ev = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    end_ev = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+
+    for i in range(iters):
+        flush_buf.zero_()
+        start_ev[i].record()
+        run_fn()
+        end_ev[i].record()
+
+    torch.cuda.synchronize()
+    latencies = sorted(start_ev[i].elapsed_time(end_ev[i]) * 1e3 for i in range(iters))
+
+    n = len(latencies)
+    if n >= 8:
+        q1, q3 = latencies[n // 4], latencies[3 * n // 4]
+        iqr = q3 - q1
+        lo, hi = q1 - 1.5 * iqr, q3 + 1.5 * iqr
+        filtered = [x for x in latencies if lo <= x <= hi]
+        if filtered:
+            latencies = filtered
+
+    del flush_buf
+    return latencies[len(latencies) // 2]
+
+
+# ---------------------------------------------------------------------------
+# Benchmark runners
+# ---------------------------------------------------------------------------
+
+HBM_PEAK_TBS = 22.0
+
+
+def _run_unique(grid_m, grid_n, warmup, iters, flush_mb):
+    """Mode=unique: each WG reads unique tiles, all from HBM."""
+    total_wgs = grid_m * grid_n
+    tile_elems = TILE * TILE
+
+    torch.manual_seed(42)
+    a_dev = torch.randn((total_wgs * TILE, TILE), device="cuda", dtype=torch.bfloat16)
+    b_dev = torch.randn((total_wgs * TILE, TILE), device="cuda", dtype=torch.bfloat16)
+    c_dev = torch.zeros(total_wgs * tile_elems, device="cuda", dtype=torch.bfloat16)
+
+    launch_fn = _compile_tdm_unique_add(grid_m, grid_n)
+
+    median_us = _bench_kernel_us(lambda: launch_fn(a_dev, b_dev, c_dev), warmup, iters, flush_mb)
+
+    read_bytes = total_wgs * 2 * TILE * TILE * ELEM_BYTES
+    write_bytes = total_wgs * TILE * TILE * ELEM_BYTES
+    total_bytes = read_bytes + write_bytes
+    bw_tbs = total_bytes / (median_us / 1e6) / 1e12 if median_us > 0 else 0.0
+    return median_us, bw_tbs
+
+
+def _run_read_only(grid_m, grid_n, warmup, iters, flush_mb):
+    """Mode=read-only: TDM loads only, minimal store. Measures pure TDM read BW."""
+    total_wgs = grid_m * grid_n
+
+    torch.manual_seed(42)
+    a_dev = torch.randn((total_wgs * TILE, TILE), device="cuda", dtype=torch.bfloat16)
+    b_dev = torch.randn((total_wgs * TILE, TILE), device="cuda", dtype=torch.bfloat16)
+    c_dev = torch.zeros(total_wgs * VEC_WIDTH, device="cuda", dtype=torch.bfloat16)
+
+    launch_fn = _compile_tdm_read_only(grid_m, grid_n)
+
+    median_us = _bench_kernel_us(lambda: launch_fn(a_dev, b_dev, c_dev), warmup, iters, flush_mb)
+
+    read_bytes = total_wgs * 2 * TILE * TILE * ELEM_BYTES
+    bw_tbs = read_bytes / (median_us / 1e6) / 1e12 if median_us > 0 else 0.0
+    return median_us, bw_tbs
+
+
+def _run_multicast(grid_m, grid_n, cluster_x, cluster_y, warmup, iters, flush_mb):
+    """Mode=multicast: GEMM-like shared tiles, measures multicast throughput."""
+    total_wgs = grid_m * grid_n
+    tile_elems = TILE * TILE
+
+    M = grid_m * TILE
+    K = TILE
+    N = grid_n * TILE
+
+    torch.manual_seed(42)
+    a_dev = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
+    b_dev = torch.randn((K, N), device="cuda", dtype=torch.bfloat16)
+    c_dev = torch.zeros(total_wgs * tile_elems, device="cuda", dtype=torch.bfloat16)
+
+    launch_fn = _compile_tdm_shared_add(grid_m, grid_n, cluster_x, cluster_y)
+
+    median_us = _bench_kernel_us(lambda: launch_fn(a_dev, b_dev, c_dev), warmup, iters, flush_mb)
+
+    # Effective throughput: count all bytes each WG processes (L2 serves repeats)
+    eff_bytes = total_wgs * 2 * TILE * TILE * ELEM_BYTES
+    eff_tbs = eff_bytes / (median_us / 1e6) / 1e12 if median_us > 0 else 0.0
+    return median_us, eff_tbs
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description="TDM load bandwidth benchmark for gfx1250")
+    parser.add_argument(
+        "--mode",
+        choices=["all", "unique", "multicast", "read-only"],
+        default="all",
+        help="all: run all modes (default); unique: TDM load+add+store; read-only: TDM load only; multicast: cluster multicast",
+    )
+    parser.add_argument("--warmup", type=int, default=10, help="Warmup iterations (default: 10)")
+    parser.add_argument("--iters", type=int, default=50, help="Timed iterations (default: 50)")
+    parser.add_argument(
+        "--peak-bw", type=float, default=HBM_PEAK_TBS, help=f"Peak HBM BW in TB/s (default: {HBM_PEAK_TBS})"
+    )
+    parser.add_argument("--flush-mb", type=int, default=512, help="L2 flush buffer size in MB (default: 512)")
+    args = parser.parse_args()
+
+    arch = str(get_rocm_arch())
+    if arch != "gfx1250":
+        print(f"ERROR: TDM benchmark requires gfx1250, got {arch}", file=sys.stderr)
+        sys.exit(1)
+
+    # MI450: 8 XCDs × 256 CUs = 2048 CUs total
+    grid_sizes = [(4, 4), (8, 8), (16, 16), (32, 32), (32, 64), (64, 64), (64, 128), (128, 128), (256, 128), (256, 256)]
+    # Multicast mode: square grids only (fewer combos, cleaner comparison)
+    mcast_grid_sizes = [(8, 8), (16, 16), (32, 32), (64, 64), (128, 128)]
+
+    run_all = args.mode == "all"
+    if run_all or args.mode == "multicast":
+        _run_multicast_sweep(mcast_grid_sizes, args)
+    if run_all or args.mode == "read-only":
+        _run_read_only_sweep(grid_sizes, args)
+    if run_all or args.mode == "unique":
+        _run_unique_sweep(grid_sizes, args)
+
+
+def _run_read_only_sweep(grid_sizes, args):
+    """Sweep grid sizes with read-only kernel — measures peak TDM read bandwidth."""
+    print(f"\nTDM Pure Read Bandwidth (gfx1250, tile={TILE}x{TILE} bf16, TDM load only)")
+    print(f"  warmup={args.warmup}, iters={args.iters}, peak={args.peak_bw} TB/s")
+    print("  BW = read_bytes / time (2 tiles/WG, no store)")
+    print("=" * 72)
+    print(f"  {'Grid':>8s}  {'WGs':>6s}  {'Read(MB)':>9s}  {'Median(us)':>12s}  {'BW(TB/s)':>10s}  {'Util%':>7s}")
+    print("-" * 72)
+
+    for gm, gn in grid_sizes:
+        total_wgs = gm * gn
+        read_mb = total_wgs * 2 * TILE * TILE * ELEM_BYTES / (1024 * 1024)
+        try:
+            median_us, bw_tbs = _run_read_only(gm, gn, args.warmup, args.iters, args.flush_mb)
+        except Exception as e:
+            print(f"  {gm}x{gn:>3d}  {total_wgs:>6d}  {read_mb:>7.0f}    ERROR: {e}")
+            continue
+
+        util = bw_tbs / args.peak_bw * 100.0
+        print(f"  {gm}x{gn:>3d}  {total_wgs:>6d}  {read_mb:>7.0f}    {median_us:10.1f}    {bw_tbs:8.3f}   {util:5.1f}%")
+
+    print("=" * 72)
+
+
+def _run_unique_sweep(grid_sizes, args):
+    """Sweep grid sizes with unique tiles — measures raw HBM bandwidth."""
+    print(f"\nTDM Load HBM Bandwidth (gfx1250, tile={TILE}x{TILE} bf16, unique tiles per WG)")
+    print(f"  warmup={args.warmup}, iters={args.iters}, peak={args.peak_bw} TB/s")
+    print("  BW = (read + write) / time;  read = 2 tiles/WG, write = 1 tile/WG")
+    print("=" * 72)
+    print(f"  {'Grid':>8s}  {'WGs':>6s}  {'Data(MB)':>9s}  {'Median(us)':>12s}  {'BW(TB/s)':>10s}  {'Util%':>7s}")
+    print("-" * 72)
+
+    for gm, gn in grid_sizes:
+        total_wgs = gm * gn
+        data_mb = total_wgs * 3 * TILE * TILE * ELEM_BYTES / (1024 * 1024)
+        try:
+            median_us, bw_tbs = _run_unique(gm, gn, args.warmup, args.iters, args.flush_mb)
+        except Exception as e:
+            print(f"  {gm}x{gn:>3d}  {total_wgs:>6d}  {data_mb:>7.0f}    ERROR: {e}")
+            continue
+
+        util = bw_tbs / args.peak_bw * 100.0
+        print(f"  {gm}x{gn:>3d}  {total_wgs:>6d}  {data_mb:>7.0f}    {median_us:10.1f}    {bw_tbs:8.3f}   {util:5.1f}%")
+
+    print("=" * 72)
+
+
+def _run_multicast_sweep(grid_sizes, args):
+    """Sweep grid × cluster configs — measures multicast L2→LDS throughput."""
+    cluster_configs = [(1, 1), (2, 1), (1, 2), (2, 2), (4, 2), (2, 4), (4, 4), (8, 2), (2, 8)]
+
+    print(f"\nTDM Multicast Throughput (gfx1250, tile={TILE}x{TILE} bf16, multicast tiles)")
+    print(f"  warmup={args.warmup}, iters={args.iters}")
+    print("  Eff.BW = total_wgs * 2 tiles / time (effective L2→LDS throughput)")
+    print("=" * 78)
+    print(f"  {'Grid':>8s}  {'WGs':>6s}  {'Cluster':>8s}  {'Median(us)':>12s}  {'Eff.BW(TB/s)':>14s}  {'Speedup':>8s}")
+    print("-" * 78)
+
+    for gm, gn in grid_sizes:
+        baseline_us = None
+        for cx, cy in cluster_configs:
+            if gm % cx != 0 or gn % cy != 0:
+                continue
+            total_wgs = gm * gn
+            try:
+                median_us, eff_tbs = _run_multicast(gm, gn, cx, cy, args.warmup, args.iters, args.flush_mb)
+            except Exception as e:
+                print(f"  {gm}x{gn:>3d}  {total_wgs:>6d}    ({cx},{cy})    ERROR: {e}")
+                continue
+
+            if baseline_us is None:
+                baseline_us = median_us
+            speedup = baseline_us / median_us if median_us > 0 else 0.0
+
+            print(
+                f"  {gm}x{gn:>3d}  {total_wgs:>6d}    ({cx},{cy})  "
+                f"  {median_us:10.1f}      {eff_tbs:10.3f}    {speedup:6.2f}x"
+            )
+
+    print("=" * 78)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_cluster_launch_gfx1250.py
+++ b/tests/unit/test_cluster_launch_gfx1250.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Cluster launch tests for gfx1250.
+
+Validates the mgpuLaunchClusterKernel runtime path (hipDrvLaunchKernelEx)
+and cluster synchronization intrinsics.
+
+Tests:
+  1. Smoke: vec_add launched with cluster dims — proves the runtime launch path works.
+  2. Barrier: vec_add with cluster_barrier() — validates cluster sync intrinsics.
+
+See also: test_cluster_mcast_gemm_gfx1250.py for TDM multicast GEMM tests (deferred).
+"""
+
+import pytest
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
+if torch is None or not torch.cuda.is_available():
+    pytest.skip("CUDA/ROCm not available.", allow_module_level=True)
+
+from flydsl.runtime.device import get_rocm_arch  # noqa: E402
+
+_arch = str(get_rocm_arch())
+if _arch != "gfx1250":
+    pytest.skip(f"Cluster launch requires gfx1250, got {_arch}", allow_module_level=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 & 2: Simple vec_add kernel with cluster launch
+# ---------------------------------------------------------------------------
+
+VEC_WIDTH = 4
+BLOCK_DIM = 256
+TILE_ELEMS = BLOCK_DIM * VEC_WIDTH
+
+
+@flyc.kernel
+def vec_add_kernel(
+    A: fx.Tensor,
+    B: fx.Tensor,
+    C: fx.Tensor,
+    block_dim: fx.Constexpr[int],
+    vec_width: fx.Constexpr[int],
+    grid_dim_x: fx.Constexpr[int],
+):
+    """Element-wise C = A + B with buffer load/store."""
+    bid = fx.block_idx.y * grid_dim_x + fx.block_idx.x
+    tid = fx.thread_idx.x
+
+    A = fx.rocdl.make_buffer_tensor(A)
+    B = fx.rocdl.make_buffer_tensor(B)
+    C = fx.rocdl.make_buffer_tensor(C)
+
+    tA = fx.logical_divide(A, fx.make_layout(block_dim * vec_width, 1))
+    tB = fx.logical_divide(B, fx.make_layout(block_dim * vec_width, 1))
+    tC = fx.logical_divide(C, fx.make_layout(block_dim * vec_width, 1))
+
+    tA = fx.slice(tA, (None, bid))
+    tB = fx.slice(tB, (None, bid))
+    tC = fx.slice(tC, (None, bid))
+
+    tA = fx.logical_divide(tA, fx.make_layout(vec_width, 1))
+    tB = fx.logical_divide(tB, fx.make_layout(vec_width, 1))
+    tC = fx.logical_divide(tC, fx.make_layout(vec_width, 1))
+
+    copyAtom = fx.make_copy_atom(fx.rocdl.BufferCopy(vec_width * fx.Float32.width), fx.Float32)
+    rA = fx.make_rmem_tensor(vec_width, fx.Float32)
+    rB = fx.make_rmem_tensor(vec_width, fx.Float32)
+    rC = fx.make_rmem_tensor(vec_width, fx.Float32)
+
+    fx.copy_atom_call(copyAtom, fx.slice(tA, (None, tid)), rA)
+    fx.copy_atom_call(copyAtom, fx.slice(tB, (None, tid)), rB)
+
+    vC = fx.arith.addf(fx.memref_load_vec(rA), fx.memref_load_vec(rB))
+    fx.memref_store_vec(vC, rC)
+
+    fx.copy_atom_call(copyAtom, rC, fx.slice(tC, (None, tid)))
+
+
+@flyc.kernel
+def vec_add_cluster_barrier_kernel(
+    A: fx.Tensor,
+    B: fx.Tensor,
+    C: fx.Tensor,
+    block_dim: fx.Constexpr[int],
+    vec_width: fx.Constexpr[int],
+    grid_dim_x: fx.Constexpr[int],
+):
+    """Vec_add with a cluster_barrier() call to exercise cluster sync intrinsics."""
+    from flydsl.expr.rocdl.cluster import cluster_barrier
+
+    bid = fx.block_idx.y * grid_dim_x + fx.block_idx.x
+    tid = fx.thread_idx.x
+
+    A = fx.rocdl.make_buffer_tensor(A)
+    B = fx.rocdl.make_buffer_tensor(B)
+    C = fx.rocdl.make_buffer_tensor(C)
+
+    tA = fx.logical_divide(A, fx.make_layout(block_dim * vec_width, 1))
+    tB = fx.logical_divide(B, fx.make_layout(block_dim * vec_width, 1))
+    tC = fx.logical_divide(C, fx.make_layout(block_dim * vec_width, 1))
+
+    tA = fx.slice(tA, (None, bid))
+    tB = fx.slice(tB, (None, bid))
+    tC = fx.slice(tC, (None, bid))
+
+    tA = fx.logical_divide(tA, fx.make_layout(vec_width, 1))
+    tB = fx.logical_divide(tB, fx.make_layout(vec_width, 1))
+    tC = fx.logical_divide(tC, fx.make_layout(vec_width, 1))
+
+    copyAtom = fx.make_copy_atom(fx.rocdl.BufferCopy(vec_width * fx.Float32.width), fx.Float32)
+    rA = fx.make_rmem_tensor(vec_width, fx.Float32)
+    rB = fx.make_rmem_tensor(vec_width, fx.Float32)
+    rC = fx.make_rmem_tensor(vec_width, fx.Float32)
+
+    fx.copy_atom_call(copyAtom, fx.slice(tA, (None, tid)), rA)
+    fx.copy_atom_call(copyAtom, fx.slice(tB, (None, tid)), rB)
+
+    # Cluster barrier: sync all WGs in the cluster before computing.
+    # This exercises rocdl.s_barrier_signal / s_barrier_wait intrinsics.
+    cluster_barrier()
+
+    vC = fx.arith.addf(fx.memref_load_vec(rA), fx.memref_load_vec(rB))
+    fx.memref_store_vec(vC, rC)
+
+    fx.copy_atom_call(copyAtom, rC, fx.slice(tC, (None, tid)))
+
+
+def _run_vec_add_cluster(cluster_x, cluster_y, use_barrier=False):
+    """Launch vec_add with cluster dims and verify correctness."""
+    # Grid dims must be >= cluster dims and divisible by them.
+    # Use a 2D grid: gx tiles along x, gy tiles along y.
+    gx = max(cluster_x, 2) * 2  # ensure gx divisible by cluster_x
+    gy = max(cluster_y, 2) * 2  # ensure gy divisible by cluster_y
+    total_tiles = gx * gy
+    size = TILE_ELEMS * total_tiles
+
+    a_dev = torch.randn(size, device="cuda", dtype=torch.float32)
+    b_dev = torch.randn(size, device="cuda", dtype=torch.float32)
+    c_dev = torch.empty_like(a_dev)
+
+    assert gx % cluster_x == 0 and gy % cluster_y == 0
+    cluster_dims_str = f"{cluster_x},{cluster_y},1"
+    kernel_fn = vec_add_cluster_barrier_kernel if use_barrier else vec_add_kernel
+
+    @flyc.jit
+    def launch(A: fx.Tensor, B: fx.Tensor, C, n: fx.Int32, stream: fx.Stream = fx.Stream(None)):
+        L = kernel_fn(
+            A,
+            B,
+            C,
+            BLOCK_DIM,
+            VEC_WIDTH,
+            gx,
+            value_attrs={
+                "rocdl.cluster_dims": cluster_dims_str,
+            },
+        )
+        L.launch(
+            grid=(gx, gy, 1),
+            block=(BLOCK_DIM, 1, 1),
+            stream=stream,
+            cluster=(cluster_x, cluster_y, 1),
+        )
+
+    stream = torch.cuda.Stream()
+    tA = flyc.from_dlpack(a_dev).mark_layout_dynamic(leading_dim=0, divisibility=VEC_WIDTH)
+    launch(tA, b_dev, c_dev, size, stream=stream)
+    torch.cuda.synchronize()
+
+    max_err = (c_dev - (a_dev + b_dev)).abs().max().item()
+    assert max_err < 1e-5, f"vec_add cluster=({cluster_x},{cluster_y},1) max_err={max_err}"
+
+
+# --- Test 1: Cluster launch smoke test ---
+@pytest.mark.parametrize(
+    "cluster_x, cluster_y",
+    [
+        (2, 1),
+        (1, 2),
+        (2, 2),
+        (4, 1),
+    ],
+)
+def test_cluster_launch_vec_add(cluster_x, cluster_y):
+    """Smoke test: vec_add with cluster dims exercises mgpuLaunchClusterKernel."""
+    _run_vec_add_cluster(cluster_x, cluster_y, use_barrier=False)
+
+
+# --- Test 2: Cluster launch with cluster_barrier ---
+@pytest.mark.parametrize(
+    "cluster_x, cluster_y",
+    [
+        (2, 1),
+        (2, 2),
+    ],
+)
+def test_cluster_launch_with_barrier(cluster_x, cluster_y):
+    """Vec_add with cluster_barrier() validates cluster sync intrinsics."""
+    _run_vec_add_cluster(cluster_x, cluster_y, use_barrier=True)

--- a/tests/unit/test_cluster_mcast_gemm_gfx1250.py
+++ b/tests/unit/test_cluster_mcast_gemm_gfx1250.py
@@ -13,9 +13,6 @@ compile_wmma_gemm_tdm with cluster parameters. See
 temp-doc/cluster_mcast_gemm_known_issue.md for details.
 """
 
-import os
-import sys
-
 import pytest
 
 try:

--- a/tests/unit/test_cluster_mcast_gemm_gfx1250.py
+++ b/tests/unit/test_cluster_mcast_gemm_gfx1250.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Cluster multicast GEMM tests for gfx1250.
+
+Validates WMMA GEMM with TDM multicast via compile_wmma_gemm_tdm.
+These tests exercise the full cluster launch + data sharing pipeline.
+
+Status: DEFERRED — currently hangs during JIT compilation of
+compile_wmma_gemm_tdm with cluster parameters. See
+temp-doc/cluster_mcast_gemm_known_issue.md for details.
+"""
+
+import os
+import sys
+
+import pytest
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
+if torch is None or not torch.cuda.is_available():
+    pytest.skip("CUDA/ROCm not available.", allow_module_level=True)
+
+from flydsl.runtime.device import get_rocm_arch  # noqa: E402
+
+_arch = str(get_rocm_arch())
+if _arch != "gfx1250":
+    pytest.skip(f"Cluster mcast GEMM requires gfx1250, got {_arch}", allow_module_level=True)
+
+
+def _align_up(value: int, align: int) -> int:
+    return ((value + align - 1) // align) * align
+
+
+def _pad_2d_tensor(t, rows, cols):
+    r, c = t.shape
+    if r == rows and c == cols:
+        return t
+    out = torch.zeros((rows, cols), dtype=t.dtype, device=t.device)
+    out[:r, :c] = t
+    return out
+
+
+@pytest.mark.skip(reason="Hangs during JIT compilation with cluster params — deferred to another PR")
+@pytest.mark.parametrize(
+    "M, N, K, cluster_m, cluster_n",
+    [
+        (512, 512, 512, 2, 2),
+        (1024, 1024, 512, 2, 2),
+    ],
+)
+def test_cluster_mcast_gemm(M, N, K, cluster_m, cluster_n):
+    """WMMA GEMM with TDM multicast: end-to-end cluster launch + data sharing."""
+    from kernels.wmma_gemm_gfx1250 import compile_wmma_gemm_tdm
+    from tests.test_common import verify_output
+
+    tile_m, tile_n, tile_k = 128, 256, 128
+    num_buffers = 2
+    in_dtype = "bf16"
+
+    mpad = _align_up(M, tile_m)
+    npad = _align_up(N, tile_n)
+    kpad = _align_up(K, tile_k)
+
+    num_k_tiles = kpad // tile_k
+    if num_k_tiles < num_buffers:
+        pytest.skip(f"K too small for {num_buffers}-buffer pipeline")
+
+    wg_m = mpad // tile_m
+    wg_n = npad // tile_n
+    if wg_m < cluster_m or wg_n < cluster_n:
+        pytest.skip(f"WG grid ({wg_m},{wg_n}) too small for cluster ({cluster_m},{cluster_n})")
+    if (wg_m % cluster_m) != 0 or (wg_n % cluster_n) != 0:
+        pytest.skip(f"WG grid ({wg_m},{wg_n}) not divisible by cluster ({cluster_m},{cluster_n})")
+
+    torch.manual_seed(0)
+    torch_dtype = torch.bfloat16
+    a = torch.randn((M, K), dtype=torch_dtype, device="cpu")
+    b = torch.randn((K, N), dtype=torch_dtype, device="cpu")
+    ref = torch.mm(a.to(torch.float32), b.to(torch.float32))
+
+    a_pad = _pad_2d_tensor(a, mpad, kpad).cuda()
+    b_pad = _pad_2d_tensor(b, kpad, npad).cuda()
+    c_pad = torch.zeros((mpad, npad), dtype=torch_dtype, device="cuda")
+
+    launch_fn = compile_wmma_gemm_tdm(
+        M=mpad,
+        N=npad,
+        K=kpad,
+        tile_m=tile_m,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        m_warp=2,
+        n_warp=4,
+        in_dtype=in_dtype,
+        num_buffers=num_buffers,
+        cluster_m=cluster_m,
+        cluster_n=cluster_n,
+    )
+    launch_fn(
+        c_pad.contiguous().view(-1),
+        a_pad.contiguous().view(-1),
+        b_pad.contiguous().view(-1),
+        mpad,
+        npad,
+        torch.cuda.current_stream(),
+    )
+    torch.cuda.synchronize()
+
+    assert verify_output(c_pad[:M, :N].cpu().to(torch.float32), ref, rtol=3e-2, atol=3e-2)

--- a/tests/unit/test_tdm_mcast_add_gfx1250.py
+++ b/tests/unit/test_tdm_mcast_add_gfx1250.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""TDM multicast + cluster launch bandwidth test for gfx1250.
+
+Validates that TDM async loads with cluster multicast masks work
+correctly and measures the bandwidth benefit of multicast.
+
+The kernel mimics a GEMM tiling pattern:
+  A: (grid_m * T, T)  — WGs in the same row share one A tile (multicast)
+  B: (T, grid_n * T)  — WGs in the same col share one B tile (multicast)
+  C: (grid_m * T, grid_n * T) = broadcast(A_tile) + broadcast(B_tile)
+"""
+
+import pytest
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, const_expr, gpu, range_constexpr, tdm_ops, vector
+from flydsl.expr.rocdl import cluster
+from flydsl.expr.typing import T
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr, get_op_result_or_value
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
+if torch is None or not torch.cuda.is_available():
+    pytest.skip("CUDA/ROCm not available.", allow_module_level=True)
+
+from flydsl.runtime.device import get_rocm_arch  # noqa: E402
+
+_arch = str(get_rocm_arch())
+if _arch != "gfx1250":
+    pytest.skip(f"TDM multicast requires gfx1250, got {_arch}", allow_module_level=True)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TILE = 128
+BLOCK_DIM = 256
+WAVE_SIZE = 32
+NUM_WARPS = BLOCK_DIM // WAVE_SIZE
+VEC_WIDTH = 8
+ELEM_BYTES = 2  # bf16
+TILE_BYTES = TILE * TILE * ELEM_BYTES  # 32 KB
+ELEMS_PER_THREAD = (TILE * TILE) // BLOCK_DIM  # 64
+VECS_PER_THREAD = ELEMS_PER_THREAD // VEC_WIDTH  # 8
+
+
+# ---------------------------------------------------------------------------
+# Kernel compilation
+# ---------------------------------------------------------------------------
+
+
+def _compile_tdm_mcast_add(grid_m, grid_n, cluster_m, cluster_n):
+    """Compile the TDM multicast add kernel for given grid and cluster dims."""
+    use_cluster = cluster_m > 1 or cluster_n > 1
+
+    lds_a_offset = 0
+    lds_b_offset = ((TILE_BYTES + 127) // 128) * 128
+    total_lds = lds_b_offset + TILE_BYTES
+
+    smem_alloc = SmemAllocator(None, arch="gfx1250", global_sym_name="tdm_mcast_add_smem")
+    smem_alloc.ptr = total_lds
+
+    stride_a = TILE
+    stride_b = grid_n * TILE
+    tile_elems = TILE * TILE
+
+    @flyc.kernel
+    def tdm_mcast_add_kernel(
+        arg_a: fx.Tensor,
+        arg_b: fx.Tensor,
+        arg_c: fx.Tensor,
+    ):
+        # index-typed ids for TDM descriptors and LDS addressing
+        bx = gpu.block_id("x")
+        by = gpu.block_id("y")
+        tid = gpu.thread_id("x")
+
+        # --- Cluster multicast masks ---
+        if const_expr(use_cluster):
+            local_x, local_y = cluster.compute_cluster_position()
+            a_mcast_mask, b_mcast_mask = cluster.compute_mcast_masks(local_x, local_y, cluster_m, cluster_n)
+        else:
+            a_mcast_mask = 0
+            b_mcast_mask = 0
+
+        # --- LDS setup ---
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            smem_alloc.finalized = False
+            smem_alloc.finalize()
+        smem_base = smem_alloc.get_base()
+        bf16_ty = T.bf16
+        smem_a = SmemPtr(smem_base, lds_a_offset, bf16_ty, shape=(TILE * TILE,))
+        smem_b = SmemPtr(smem_base, lds_b_offset, bf16_ty, shape=(TILE * TILE,))
+        lds_a_memref = get_op_result_or_value(smem_a.get())
+        lds_b_memref = get_op_result_or_value(smem_b.get())
+
+        # --- TDM descriptors ---
+        blk_m = bx * arith.index(TILE)
+        blk_n = by * arith.index(TILE)
+        k_base = arith.index(0)
+
+        desc_a = tdm_ops.make_tensor_descriptor_2d(
+            global_ptr=arg_a,
+            lds_memref=lds_a_memref,
+            global_offset=(blk_m, k_base),
+            tensor_shape=(TILE, TILE),
+            strides=(stride_a, 1),
+            tile_shape=(TILE, TILE),
+            elem_bytes=ELEM_BYTES,
+            num_warps=NUM_WARPS,
+            workgroup_mask=a_mcast_mask,
+        )
+        desc_b = tdm_ops.make_tensor_descriptor_2d(
+            global_ptr=arg_b,
+            lds_memref=lds_b_memref,
+            global_offset=(k_base, blk_n),
+            tensor_shape=(TILE, TILE),
+            strides=(stride_b, 1),
+            tile_shape=(TILE, TILE),
+            elem_bytes=ELEM_BYTES,
+            num_warps=NUM_WARPS,
+            workgroup_mask=b_mcast_mask,
+        )
+
+        # --- Issue TDM loads and sync ---
+        tdm_ops.tensor_load_2d(desc_a)
+        tdm_ops.tensor_load_2d(desc_b)
+        tdm_ops.tensor_wait(0)
+        if const_expr(use_cluster):
+            cluster.cluster_barrier()
+        else:
+            gpu.barrier()
+
+        # --- Read from LDS, add, store to global via buffer store ---
+        # i32-typed ids for CuTE layout ops (fly.make_int_tuple requires i32/i64)
+        bid = fx.block_idx.x * grid_n + fx.block_idx.y
+
+        C = fx.rocdl.make_buffer_tensor(arg_c)
+        tC = fx.logical_divide(C, fx.make_layout(tile_elems, 1))
+        tC = fx.slice(tC, (None, bid))
+        tC = fx.logical_divide(tC, fx.make_layout(VEC_WIDTH, 1))
+
+        copyAtom = fx.make_copy_atom(fx.rocdl.BufferCopy(VEC_WIDTH * fx.BFloat16.width), fx.BFloat16)
+        rC = fx.make_rmem_tensor(VEC_WIDTH, fx.BFloat16)
+
+        vec_ty = T.vec(VEC_WIDTH, bf16_ty)
+        base_elem = tid * arith.index(ELEMS_PER_THREAD)
+
+        for v in range_constexpr(VECS_PER_THREAD):
+            elem_off = base_elem + arith.index(v * VEC_WIDTH)
+            va = vector.load_op(vec_ty, lds_a_memref, [elem_off])
+            vb = vector.load_op(vec_ty, lds_b_memref, [elem_off])
+            vc = arith.addf(va, vb)
+            fx.memref_store_vec(vc, rC)
+            store_idx = fx.thread_idx.x * VECS_PER_THREAD + v
+            fx.copy_atom_call(copyAtom, rC, fx.slice(tC, (None, store_idx)))
+
+    cluster_dims_str = f"{cluster_m},{cluster_n},1"
+
+    @flyc.jit
+    def launch(A: fx.Tensor, B: fx.Tensor, C: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        L = tdm_mcast_add_kernel(
+            A,
+            B,
+            C,
+            value_attrs={"rocdl.cluster_dims": cluster_dims_str} if use_cluster else {},
+        )
+        if use_cluster:
+            L.launch(
+                grid=(grid_m, grid_n, 1),
+                block=(BLOCK_DIM, 1, 1),
+                stream=stream,
+                cluster=(cluster_m, cluster_n, 1),
+            )
+        else:
+            L.launch(
+                grid=(grid_m, grid_n, 1),
+                block=(BLOCK_DIM, 1, 1),
+                stream=stream,
+            )
+
+    return launch
+
+
+# ---------------------------------------------------------------------------
+# Test runner
+# ---------------------------------------------------------------------------
+
+
+def _run_tdm_mcast_add(grid_m, grid_n, cluster_x, cluster_y, n_warmup=0, n_iters=1):
+    """Launch the TDM multicast add kernel and verify correctness.
+
+    Returns (max_err, avg_us) where avg_us is 0 if n_warmup == 0.
+    """
+    assert grid_m % cluster_x == 0 and grid_n % cluster_y == 0
+
+    M = grid_m * TILE
+    K = TILE
+    N = grid_n * TILE
+
+    tile_elems = TILE * TILE
+    total_c_elems = grid_m * grid_n * tile_elems
+
+    torch.manual_seed(42)
+    a_dev = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
+    b_dev = torch.randn((K, N), device="cuda", dtype=torch.bfloat16)
+    c_dev = torch.zeros(total_c_elems, device="cuda", dtype=torch.bfloat16)
+
+    launch_fn = _compile_tdm_mcast_add(grid_m, grid_n, cluster_x, cluster_y)
+    stream = torch.cuda.Stream()
+
+    # Warmup
+    for _ in range(n_warmup):
+        launch_fn(a_dev, b_dev, c_dev, stream=stream)
+    torch.cuda.synchronize()
+
+    avg_us = 0.0
+    if n_iters > 1 and n_warmup > 0:
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record(stream)
+        for _ in range(n_iters):
+            launch_fn(a_dev, b_dev, c_dev, stream=stream)
+        end_event.record(stream)
+        torch.cuda.synchronize()
+        avg_us = start_event.elapsed_time(end_event) * 1000.0 / n_iters
+    else:
+        launch_fn(a_dev, b_dev, c_dev, stream=stream)
+        torch.cuda.synchronize()
+
+    # Reference: flat tile bid = bx * grid_n + by, each tile = flatten(A_tile + B_tile)
+    c_ref = torch.zeros_like(c_dev)
+    for bx in range(grid_m):
+        a_tile = a_dev[bx * TILE : (bx + 1) * TILE, :]
+        for by in range(grid_n):
+            b_tile = b_dev[:, by * TILE : (by + 1) * TILE]
+            bid = bx * grid_n + by
+            c_ref[bid * tile_elems : (bid + 1) * tile_elems] = (a_tile + b_tile).flatten()
+
+    max_err = (c_dev.float() - c_ref.float()).abs().max().item()
+    return max_err, avg_us
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cluster_x, cluster_y",
+    [
+        (2, 1),
+        (1, 2),
+        (2, 2),
+    ],
+)
+def test_tdm_mcast_add_correctness(cluster_x, cluster_y):
+    """TDM multicast add: verify correctness with cluster multicast."""
+    grid_m = max(cluster_x, 2) * 2
+    grid_n = max(cluster_y, 2) * 2
+    max_err, _ = _run_tdm_mcast_add(grid_m, grid_n, cluster_x, cluster_y)
+    assert max_err < 1e-2, f"cluster=({cluster_x},{cluster_y}) max_err={max_err}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Bandwidth comparison
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark
+def test_tdm_mcast_add_bandwidth():
+    """Compare TDM multicast vs no-multicast bandwidth."""
+    grid_m, grid_n = 8, 8
+    n_warmup, n_iters = 5, 20
+
+    # No multicast baseline
+    max_err_base, us_base = _run_tdm_mcast_add(grid_m, grid_n, 1, 1, n_warmup, n_iters)
+    assert max_err_base < 1e-2, f"baseline max_err={max_err_base}"
+
+    # With multicast
+    max_err_mcast, us_mcast = _run_tdm_mcast_add(grid_m, grid_n, 2, 2, n_warmup, n_iters)
+    assert max_err_mcast < 1e-2, f"multicast max_err={max_err_mcast}"
+
+    total_wgs = grid_m * grid_n
+    read_bytes = total_wgs * 2 * TILE * TILE * ELEM_BYTES
+    write_bytes = total_wgs * TILE * TILE * ELEM_BYTES
+    total_bytes = read_bytes + write_bytes
+
+    bw_base = total_bytes / (us_base / 1e6) / 1e9 if us_base > 0 else 0
+    bw_mcast = total_bytes / (us_mcast / 1e6) / 1e9 if us_mcast > 0 else 0
+    speedup = us_base / us_mcast if us_mcast > 0 else 0
+
+    print(f"\n{'='*60}")
+    print(f"TDM Multicast Add Bandwidth (grid={grid_m}x{grid_n}, tile={TILE})")
+    print(f"  No multicast:   {us_base:8.1f} us  {bw_base:8.1f} GB/s")
+    print(f"  Multicast 2x2:  {us_mcast:8.1f} us  {bw_mcast:8.1f} GB/s")
+    print(f"  Speedup:        {speedup:.2f}x")
+    print(f"{'='*60}")


### PR DESCRIPTION
## Motivation

  gfx1250 (MI450) introduces cluster launch and TDM (Tensor Data Mover) hardware features for inter-workgroup async DMA and L2 multicast. The existing mgpuLaunchClusterKernel in FlyDSL runtime uses #ifdef hipLaunchAttributeClusterDimension for conditional compilation, but this is an enum value, not a preprocessor macro, making the guard unreliable. Additionally, there are no end-to-end tests or performance benchmarks for cluster launch and TDM multicast.

 ## Technical Details

  Runtime fix (lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp):
  - Replace #ifdef hipLaunchAttributeClusterDimension with #if defined(HIP_VERSION) && (HIP_VERSION >= 70200000)
  - Simplify error handling: remove the cluster=(1,1,1) fallback logic — hipDrvLaunchKernelEx should work correctly on ROCm 7.2+
  - The #else branch for HIP < 7.2 retains the fallback to hipModuleLaunchKernel with no behavioral change

 Cluster launch tests (tests/unit/test_cluster_launch_gfx1250.py):
  - vec_add smoke test: verifies hipDrvLaunchKernelEx + cluster dims end-to-end correctness
  - cluster_barrier test: verifies cluster_barrier() cross-WG synchronization

  TDM multicast correctness tests (tests/unit/test_tdm_mcast_add_gfx1250.py):
  - TDM 2D async load + LDS add + buffer store, parametrized over cluster configs: (2,1), (1,2), (2,2)
  - Bandwidth comparison benchmark (@pytest.mark.benchmark)

  TDM bandwidth benchmark (tests/perf/bench_tdm_bandwidth_gfx1250.py):
  - Three modes: read-only (pure TDM HBM read BW), unique (TDM load+add+store R/W BW), multicast (cluster multicast L2→LDS
  throughput)
  - L2 flush + CUDA event timing + IQR median, sweeping multiple grid and cluster configurations
  - Default --mode all runs all modes in sequence

  Cluster multicast GEMM (tests/unit/test_cluster_mcast_gemm_gfx1250.py):
  - WMMA GEMM + TDM multicast prototype, currently @pytest.mark.skip (JIT compilation hangs with cluster params, deferred to a follow-up PR)

##  Test Plan

  - python -m pytest tests/unit/test_cluster_launch_gfx1250.py -v --tb=short — cluster launch smoke + barrier
  - python -m pytest tests/unit/test_tdm_mcast_add_gfx1250.py -v --tb=short — TDM multicast correctness
  - python tests/perf/bench_tdm_bandwidth_gfx1250.py — three-mode bandwidth benchmark
  - Verify mgpuLaunchClusterKernel does not affect existing kernel launches on non-gfx1250 architectures

 ## Test Result

  Tested on gfx1250 hardware:
  - Cluster launch: vec_add and barrier tests pass
  - TDM multicast: correctness verified for (2,1), (1,2), (2,2) cluster configs
  - Bandwidth benchmark: read-only mode reaches ~19.9 TB/s at 256x256 grid (90.3% of 22 TB/s peak); unique mode reaches ~16 TB/s (72.8%)

##  Submission Checklist

  - Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
