### PR TITLE
[gfx1250][gemm] Fix A-scale VGPR and optimize decode GEMM

### DIFF
--- a/kernels/gemm_fp8fp4_gfx1250.py
+++ b/kernels/gemm_fp8fp4_gfx1250.py
@@ -291,6 +291,7 @@ def compile_fp8fp4_gemm(
     _a_frag_ds = wmma_m_rep * _a_frag_loads_per_wm
     _bs_ds_loads = wmma_n_rep * _b_frag_loads_per_wn + _scale_ds_loads
     _as_ds_loads = _a_frag_ds + _scale_ds_loads
+    _row_major_k_prefetch_bundle_ds = _a_frag_ds + _bs_ds_loads
 
     lds_a_stride_bytes = packed_tile_k_a + LDS_PAD_A_BYTES
 
@@ -436,6 +437,9 @@ def compile_fp8fp4_gemm(
     use_fp4_quadrant_schedule = compute_schedule_kind == COMPUTE_SCHEDULE_FP4_QUADRANT
     use_fp8_quadrant_schedule = compute_schedule_kind == COMPUTE_SCHEDULE_FP8_QUADRANT
     use_fp8_deep_pipeline_schedule = compute_schedule_kind == COMPUTE_SCHEDULE_FP8_DEEP_PIPELINE
+    _row_major_k_prefetch_eligible = wmma_m_rep == 1 and wmma_n_rep <= 2 and k_wmma_steps > 1
+    use_row_major_k_prefetch = _row_major_k_prefetch_eligible
+    _row_major_k_prefetch_depth = 2 if (use_row_major_k_prefetch and wmma_n_rep == 1 and k_wmma_steps > 2) else 1
 
     # A-scale VGPR-ring prefetch depth (K-tiles ahead).
     _bvs_D_default = 3 if (use_ascale_vgpr and use_row_major_streaming_schedule) else 1
@@ -1148,6 +1152,45 @@ def compile_fp8fp4_gemm(
                     mid_compute_callback=mid_compute_callback,
                 )
             else:
+                if const_expr(use_row_major_k_prefetch):
+
+                    def _load_bundle(ks):
+                        b_frags, b_scales, a_scales = _load_b_and_scales(
+                            b_buf, b_bases, as_buf, as_bases, bs_buf, bs_bases, ks
+                        )
+                        a_frag = load_a_frag(a_buf, a_bases[0], ks)
+                        return a_frag, b_frags, a_scales, b_scales
+
+                    def _emit_bundle(bundle, emit_filler_now=False):
+                        a_frag, b_frags, a_scales, b_scales = bundle
+                        if const_expr(emit_filler_now and emit_filler is not None):
+                            rocdl.sched_barrier(0)
+                            emit_filler()
+                        for wn in range_constexpr(wmma_n_rep):
+                            _emit_wmma(current_accs, 0, wn, a_frag, b_frags[wn], a_scales, b_scales)
+
+                    # Keep future K-subtile LDS reads outstanding while only draining
+                    # the current bundle before its single row-major WMMA.
+                    preload_depth = min(k_wmma_steps, _row_major_k_prefetch_depth + 1)
+                    bundle_queue = [_load_bundle(pre_ks) for pre_ks in range_constexpr(preload_depth)]
+                    next_ks = preload_depth
+                    for ks in range_constexpr(k_wmma_steps):
+                        is_last_ks = ks == k_wmma_steps - 1
+                        cur_bundle = bundle_queue.pop(0)
+                        rocdl.s_wait_dscnt(len(bundle_queue) * _row_major_k_prefetch_bundle_ds)
+
+                        _emit_bundle(cur_bundle, emit_filler_now=is_last_ks)
+
+                        if const_expr(ks == 0 and mid_compute_callback is not None):
+                            rocdl.sched_barrier(0)
+                            mid_compute_callback()
+
+                        if const_expr(next_ks < k_wmma_steps):
+                            bundle_queue.append(_load_bundle(next_ks))
+                            next_ks += 1
+
+                    return current_accs
+
                 prev_b, prev_bs, prev_as = _load_b_and_scales(b_buf, b_bases, as_buf, as_bases, bs_buf, bs_bases, 0)
                 for ks in range_constexpr(k_wmma_steps - 1):
                     _mid_cb = mid_compute_callback if ks == 0 else None
@@ -1677,6 +1720,17 @@ def compile_fp8fp4_gemm(
             return current_accs
 
         def hot_loop_scheduler():
+            if const_expr(use_row_major_k_prefetch):
+                _queue_depth = min(k_wmma_steps, _row_major_k_prefetch_depth + 1)
+                for _ks in range_constexpr(k_wmma_steps):
+                    if const_expr(_ks == 0):
+                        rocdl.sched_dsrd(_row_major_k_prefetch_bundle_ds * _queue_depth)
+                    elif const_expr(_ks + _queue_depth <= k_wmma_steps):
+                        rocdl.sched_dsrd(_row_major_k_prefetch_bundle_ds)
+                    rocdl.sched_mfma(wmma_n_rep)
+                rocdl.sched_barrier(0)
+                return
+
             _half_wm = wmma_m_rep // 2
             _half_wmma = _half_wm * wmma_n_rep
             _b_loads_per_frag = 2 if is_a8w4 else 4
@@ -2562,7 +2616,7 @@ def compile_fp8fp4_gemm(
             arena_alloc.finalize()
 
         gx = (i32_m + (tile_m - 1)) // tile_m
-        gy = (i32_n + (tile_n - 1)) // tile_n
+        gy = N // tile_n
         gz = split_k
 
         if const_expr(use_cluster):

--- a/kernels/gemm_fp8fp4_gfx1250.py
+++ b/kernels/gemm_fp8fp4_gfx1250.py
@@ -209,7 +209,7 @@ def compile_fp8fp4_gemm(
 
     num_k_tiles = split_k_chunk // tile_k
     if num_k_tiles < num_buffers:
-        raise ValueError(f"{num_buffers}-stage buffering requires num_k_tiles >= {num_buffers}, " f"got {num_k_tiles}")
+        raise ValueError(f"{num_buffers}-stage buffering requires num_k_tiles >= {num_buffers}, got {num_k_tiles}")
 
     gpu_arch = str(get_hip_arch())
     assert gpu_arch.startswith("gfx1250"), f"Expected gfx1250, got {gpu_arch}"
@@ -340,9 +340,7 @@ def compile_fp8fp4_gemm(
     arena_alloc = SmemAllocator(
         None,
         arch=gpu_arch,
-        global_sym_name=(
-            f"mxscale_{data_format}_{tile_m}x{tile_n}x{tile_k}_" f"{m_warp}x{n_warp}_{num_buffers}buf_arena"
-        ),
+        global_sym_name=(f"mxscale_{data_format}_{tile_m}x{tile_n}x{tile_k}_{m_warp}x{n_warp}_{num_buffers}buf_arena"),
     )
 
     stage_phys_order = [i for i in range(num_buffers) if i != _last_compute_stage]
@@ -565,16 +563,18 @@ def compile_fp8fp4_gemm(
 
             def _load_contig_i32_guarded_row(row, n, soff):
                 row_valid = row < m_idx
-                safe_row = arith.select(row_valid, row, arith.index(0))
-                vals = _load_contig_i32(
-                    _ascale_rsrc,
-                    safe_row * arith.index(_ascale_row_i32),
-                    n,
-                    soff,
-                )
-                for j in range_constexpr(n):
-                    vals[j] = arith.select(row_valid, vals[j], _scale_identity_i32)
-                return vals
+                if_op = scf.IfOp(row_valid, [T.i32] * n, has_else=True)
+                with ir.InsertionPoint(if_op.then_block):
+                    vals = _load_contig_i32(
+                        _ascale_rsrc,
+                        row * arith.index(_ascale_row_i32),
+                        n,
+                        soff,
+                    )
+                    scf.YieldOp([arith.unwrap(v) for v in vals])
+                with ir.InsertionPoint(if_op.else_block):
+                    scf.YieldOp([arith.unwrap(_scale_identity_i32) for _ in range(n)])
+                return list(if_op.results)
 
             def _load_ascale_impl(k_base, guarded):
                 kt = k_base // arith.index(tile_k)
@@ -2259,9 +2259,16 @@ def compile_fp8fp4_gemm(
             else:
                 _issue_active_tdm(i, addr_box)
             active_addr_lo = addr_box[0]
-        if const_expr(_bvs_active and loop_iters > 0):
-            _bvs_pf = [_bvs_prefetch(split_k_base + arith.index(_d * tile_k)) for _d in range(_bvs_D)]
-            _bvs_ra = [_v for _a in _bvs_pf for _v in _a]
+        _bvs_tail_seed = []
+        _bvs_tail_issue_start = loop_iters * num_buffers
+        if const_expr(_bvs_active):
+            _bvs_initial_depth = _bvs_D if loop_iters > 0 else min(_bvs_D, num_k_tiles)
+            _bvs_pf = [_bvs_prefetch(split_k_base + arith.index(_d * tile_k)) for _d in range(_bvs_initial_depth)]
+            if const_expr(loop_iters > 0):
+                _bvs_ra = [_v for _a in _bvs_pf for _v in _a]
+            else:
+                _bvs_tail_seed = list(_bvs_pf)
+                _bvs_tail_issue_start = _bvs_initial_depth
 
         _pipeline_fence(outstanding=TDM_LOADS_PER_STEP * (num_buffers - 2))
 
@@ -2354,8 +2361,14 @@ def compile_fp8fp4_gemm(
 
             accs = list(results[:n_accs])
             active_addr_lo = results[n_accs]
+            _result_off = n_accs + 1
             if const_expr(secondary_scale_tdm):
                 active_sec_lo = results[n_accs + 1]
+                _result_off = _result_off + 1
+            if const_expr(_bvs_active):
+                _bvs_tail_flat = list(results[_result_off : _result_off + _bvs_D * _vs_tile_a])
+                _bvs_tail_seed = [_bvs_tail_flat[_d * _vs_tile_a : (_d + 1) * _vs_tile_a] for _d in range(_bvs_D)]
+                _bvs_tail_issue_start = loop_iters * num_buffers + _bvs_D
         # Tail — same acc_mixed pattern: fence at top, TDM mid-compute.
         if const_expr(loop_iters > 0 and use_ws_tdm_split_signal_overlap):
             pipeline_fence_wait(use_cluster=use_cluster)
@@ -2380,8 +2393,8 @@ def compile_fp8fp4_gemm(
             _bvs_tail_kt[0] += 1
             return kb
 
-        _bvs_tail_ring = []
-        _bvs_tail_issue_kt = [loop_iters * num_buffers]
+        _bvs_tail_ring = list(_bvs_tail_seed)
+        _bvs_tail_issue_kt = [_bvs_tail_issue_start]
 
         def _bvs_tail_issue_one():
             if const_expr(_bvs_active and _bvs_tail_issue_kt[0] < num_k_tiles):
@@ -2396,8 +2409,6 @@ def compile_fp8fp4_gemm(
 
         if const_expr(_bvs_active):
             rocdl.sched_barrier(0)
-            for _ in range_constexpr(_bvs_D):
-                _bvs_tail_issue_one()
 
         for _load_stage, _compute_stage, _outstanding in tail_plan:
             _entry_kb, _pf_a_scales = _bvs_tail_scales()

--- a/kernels/gemm_fp8fp4_gfx1250.py
+++ b/kernels/gemm_fp8fp4_gfx1250.py
@@ -529,6 +529,7 @@ def compile_fp8fp4_gemm(
 
         warp_m_base = wave_m_idx * arith.index(warp_tile_m)
         warp_n_base = wave_n_idx * arith.index(warp_tile_n)
+        m_idx = fx.Index(i32_m)
 
         def _load_contig_i32(rsrc, base_idx, n, soff):
             # Load n contiguous i32 values through the widest legal buffer_load chunks.
@@ -546,29 +547,61 @@ def compile_fp8fp4_gemm(
                         out[start + c] = rv[c]
             return out
 
+        _scale_identity_i32 = arith.constant(0x7F7F7F7F, type=T.i32)
+
         if const_expr(use_ascale_vgpr):
             # A-scale VGPR path: read scale_A[M, K//32] directly from its row-major layout.
-            _ascale_rsrc = buffer_ops.create_buffer_resource(arg_a_scale, max_size=False)
+            _ascale_nbytes = m_idx * arith.index(K_scale)
+            _ascale_rsrc = buffer_ops.create_buffer_resource(
+                arg_a_scale,
+                max_size=False,
+                num_records_bytes=_ascale_nbytes,
+            )
             _ascale_row_i32 = K_scale // 4
             _ascale_row0 = blk_m + warp_m_base + lane16
             if const_expr(ascale_opsel):
                 _ascale_row0 = _ascale_row0 + lane_kgrp * arith.index(ascale_half * WMMA_M)
             _vs_tile_a = k_wmma_steps * ascale_load
 
-            def _load_ascale(k_base):
+            def _load_contig_i32_guarded_row(row, n, soff):
+                row_valid = row < m_idx
+                safe_row = arith.select(row_valid, row, arith.index(0))
+                vals = _load_contig_i32(
+                    _ascale_rsrc,
+                    safe_row * arith.index(_ascale_row_i32),
+                    n,
+                    soff,
+                )
+                for j in range_constexpr(n):
+                    vals[j] = arith.select(row_valid, vals[j], _scale_identity_i32)
+                return vals
+
+            def _load_ascale_impl(k_base, guarded):
                 kt = k_base // arith.index(tile_k)
                 soff = arith.index_cast(T.i32, kt * arith.index(scale_k_per_tile))
                 vals = [None] * (k_wmma_steps * ascale_load)
                 for i in range_constexpr(ascale_load):
-                    vidx = (_ascale_row0 + arith.index(i * WMMA_M)) * arith.index(_ascale_row_i32)
-                    ks_vals = _load_contig_i32(_ascale_rsrc, vidx, k_wmma_steps, soff)
+                    row = _ascale_row0 + arith.index(i * WMMA_M)
+                    if const_expr(guarded):
+                        ks_vals = _load_contig_i32_guarded_row(row, k_wmma_steps, soff)
+                    else:
+                        vidx = row * arith.index(_ascale_row_i32)
+                        ks_vals = _load_contig_i32(_ascale_rsrc, vidx, k_wmma_steps, soff)
                     for ks in range_constexpr(k_wmma_steps):
                         vals[ks * ascale_load + i] = ks_vals[ks]
                 return vals
 
+            def _load_ascale(k_base):
+                full_tile = (blk_m + arith.index(tile_m)) <= m_idx
+                if_op = scf.IfOp(full_tile, [T.i32] * _vs_tile_a, has_else=True)
+                with ir.InsertionPoint(if_op.then_block):
+                    scf.YieldOp([arith.unwrap(v) for v in _load_ascale_impl(k_base, guarded=False)])
+                with ir.InsertionPoint(if_op.else_block):
+                    scf.YieldOp([arith.unwrap(v) for v in _load_ascale_impl(k_base, guarded=True)])
+                return list(if_op.results)
+
             _bvs_prefetch = _load_ascale
 
-        m_idx = fx.Index(i32_m)
         # Runtime leading-dim strides (strided A/C). Dense callers pass lda == K,
         # ldc == N for byte-identical addressing. A's stride is in packed elements.
         if const_expr(PACK_FACTOR_A == 1):
@@ -804,8 +837,6 @@ def compile_fp8fp4_gemm(
         def _precompute_as32_bases(lds_ptr):
             """Tile-local first A row, relative to the copied 32-row block base."""
             return lds_ptr, (blk_m % arith.index(32)) + warp_m_base
-
-        _scale_identity_i32 = arith.constant(0x7F7F7F7F, type=T.i32)
 
         def _mask_a_scale_oob(word, row_abs):
             return arith.select(row_abs < m_idx, word, _scale_identity_i32)

--- a/kernels/gemm_fp8fp4_gfx1250.py
+++ b/kernels/gemm_fp8fp4_gfx1250.py
@@ -7,7 +7,6 @@ per-channel fp32 scales applied in the epilogue (``scale_mode="ptpc"``).
 """
 
 import functools
-import os
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
@@ -437,13 +436,17 @@ def compile_fp8fp4_gemm(
     use_fp4_quadrant_schedule = compute_schedule_kind == COMPUTE_SCHEDULE_FP4_QUADRANT
     use_fp8_quadrant_schedule = compute_schedule_kind == COMPUTE_SCHEDULE_FP8_QUADRANT
     use_fp8_deep_pipeline_schedule = compute_schedule_kind == COMPUTE_SCHEDULE_FP8_DEEP_PIPELINE
-    _row_major_k_prefetch_eligible = wmma_m_rep == 1 and wmma_n_rep <= 2 and k_wmma_steps > 1
-    use_row_major_k_prefetch = _row_major_k_prefetch_eligible
-    _row_major_k_prefetch_depth = 2 if (use_row_major_k_prefetch and wmma_n_rep == 1 and k_wmma_steps > 2) else 1
+    use_row_major_k_prefetch = wmma_m_rep == 1 and k_wmma_steps > 1
+    _row_major_k_prefetch_depth = 2 if use_row_major_k_prefetch else 1
+    _row_major_k_prefetch_depth = max(0, min(k_wmma_steps - 1, _row_major_k_prefetch_depth))
+    use_row_major_late_signal = use_row_major_k_prefetch
 
-    # A-scale VGPR-ring prefetch depth (K-tiles ahead).
-    _bvs_D_default = 3 if (use_ascale_vgpr and use_row_major_streaming_schedule) else 1
-    _bvs_D = max(1, int(os.environ.get("FLYDSL_BUFFER_VGPR_SCALE_DEPTH", str(_bvs_D_default))))
+    # A-scale VGPR-ring prefetch depth (K-tiles ahead).  Deeper K tiles expose
+    # more latency to hide; depth 4 improves the small-M row-major large-K path
+    if use_ascale_vgpr and use_row_major_streaming_schedule:
+        _bvs_D = 4 if num_buffers >= 4 else 3
+    else:
+        _bvs_D = 1
     _bvs_active = use_ascale_vgpr
 
     if is_mxscale:
@@ -456,6 +459,7 @@ def compile_fp8fp4_gemm(
     use_ws_tdm_split_signal_overlap = (
         (use_fp8_quadrant_schedule or use_fp8_deep_pipeline_schedule) and num_buffers == 4 and use_cluster
     )
+    use_tdm_late_signal_overlap = use_ws_tdm_split_signal_overlap or use_row_major_late_signal
 
     if use_fp4_quadrant_schedule:
         _fp4_half_wm = wmma_m_rep // 2
@@ -1124,6 +1128,7 @@ def compile_fp8fp4_gemm(
             lds_bs,
             emit_filler=None,
             mid_compute_callback=None,
+            late_compute_callback=None,
             scale_k_base=None,
             pf_a_scales=None,
         ):
@@ -1178,6 +1183,10 @@ def compile_fp8fp4_gemm(
                         is_last_ks = ks == k_wmma_steps - 1
                         cur_bundle = bundle_queue.pop(0)
                         rocdl.s_wait_dscnt(len(bundle_queue) * _row_major_k_prefetch_bundle_ds)
+
+                        if const_expr(is_last_ks and late_compute_callback is not None):
+                            rocdl.sched_barrier(0)
+                            late_compute_callback()
 
                         _emit_bundle(cur_bundle, emit_filler_now=is_last_ks)
 
@@ -1898,6 +1907,7 @@ def compile_fp8fp4_gemm(
                 lds_bs,
                 emit_filler=emit_filler,
                 mid_compute_callback=mid_compute_callback,
+                late_compute_callback=late_compute_callback,
                 scale_k_base=scale_k_base,
                 pf_a_scales=pf_a_scales,
             )
@@ -2330,7 +2340,7 @@ def compile_fp8fp4_gemm(
         # This overlaps TDM DMA with the remaining WMMA instructions,
         _fence_outstanding = TDM_LOADS_PER_STEP * (num_buffers - 2)
 
-        if const_expr(loop_iters > 0 and use_ws_tdm_split_signal_overlap):
+        if const_expr(loop_iters > 0 and use_tdm_late_signal_overlap):
             _pipeline_fence_signal(outstanding=_fence_outstanding)
 
         if const_expr(loop_iters > 0):
@@ -2368,12 +2378,12 @@ def compile_fp8fp4_gemm(
                     ):
                         _issue_active_tdm(_ls, _ab, k_prefetch=_k_off, sec_box=_sb)
 
-                    if const_expr(not use_ws_tdm_split_signal_overlap):
+                    if const_expr(not use_tdm_late_signal_overlap):
                         _pipeline_fence_signal(outstanding=_fence_outstanding)
                     pipeline_fence_wait(use_cluster=use_cluster)
 
                     _late_tdm_ws_fence_signal = None
-                    if const_expr(use_ws_tdm_split_signal_overlap):
+                    if const_expr(use_tdm_late_signal_overlap):
 
                         def _late_tdm_ws_split_signal():
                             _pipeline_fence_signal(outstanding=_fence_outstanding)
@@ -2424,7 +2434,7 @@ def compile_fp8fp4_gemm(
                 _bvs_tail_seed = [_bvs_tail_flat[_d * _vs_tile_a : (_d + 1) * _vs_tile_a] for _d in range(_bvs_D)]
                 _bvs_tail_issue_start = loop_iters * num_buffers + _bvs_D
         # Tail — same acc_mixed pattern: fence at top, TDM mid-compute.
-        if const_expr(loop_iters > 0 and use_ws_tdm_split_signal_overlap):
+        if const_expr(loop_iters > 0 and use_tdm_late_signal_overlap):
             pipeline_fence_wait(use_cluster=use_cluster)
         if const_expr(loop_iters > 0):
             _pipeline_fence(outstanding=0)
@@ -2594,6 +2604,8 @@ def compile_fp8fp4_gemm(
         expert_sched_mode,
         atomic_barrier_enable,
         ascale_load_path,
+        _row_major_k_prefetch_depth,
+        _bvs_D,
     )
 
     @flyc.jit

--- a/tests/kernels/test_gemm_fp8fp4_gfx1250.py
+++ b/tests/kernels/test_gemm_fp8fp4_gfx1250.py
@@ -874,7 +874,7 @@ def test_mxscale_ascale_32x4(data_format, M, tile_m, tile_n, tile_k, m_warp, n_w
     )
 
 
-@pytest.mark.parametrize("data_format", ["fp8", "a8w4"])
+@pytest.mark.parametrize("data_format", ["fp8", "a8w4", "fp4"])
 @pytest.mark.parametrize("M", [1, 13, 31])
 def test_mxscale_ascale_vgpr_small_m(data_format, M):
     _run_mxscale_gemm_test(

--- a/tests/kernels/test_gemm_fp8fp4_gfx1250.py
+++ b/tests/kernels/test_gemm_fp8fp4_gfx1250.py
@@ -418,7 +418,7 @@ def _run_mxscale_gemm_test(
     else:
         ref = reference_mxfp8_gemm(a, b, a_scale, b_scale, M, N, K)
 
-    print(f"Ref stats: min={ref.min():.2f}, max={ref.max():.2f}, " f"mean={ref.mean():.2f}, std={ref.std():.2f}")
+    print(f"Ref stats: min={ref.min():.2f}, max={ref.max():.2f}, mean={ref.mean():.2f}, std={ref.std():.2f}")
 
     a, b, a_scale, b_scale = _pad_mxscale_inputs(a, b, a_scale, b_scale, padded_shape)
 
@@ -1765,7 +1765,7 @@ def _run_benchmark(args):
     if needs_pad:
         print(f"  Kernel pad: M={padded_m}, N={padded_n}, K={padded_k}")
     print(f"  Tile: ({tile_m}, {tile_n}, {tile_k}), warps=({args.m_warp}x{args.n_warp})")
-    print(f"  Buffers={args.num_buffers}, out={args.out_dtype}, " f"inst_prefetch={args.inst_prefetch}")
+    print(f"  Buffers={args.num_buffers}, out={args.out_dtype}, inst_prefetch={args.inst_prefetch}")
     if args.warmup < 0:
         raise ValueError(f"--warmup must be >= 0, got {args.warmup}")
     if args.iters <= 0:
@@ -2042,25 +2042,24 @@ def _run_benchmark(args):
         print(f"      TFLOPS:       {logical_tflops:.4f}")
     else:
         print(f"      TFLOPS:       {logical_tflops:.4f} (logical), {tile_tflops:.4f} (tile-covered)")
-    print(f"      Bandwidth:    {bw_gbs:.1f} GB/s  " f"(read: {read_bw_gbs:.1f} + write: {write_bw_gbs:.1f})")
+    print(f"      Bandwidth:    {bw_gbs:.1f} GB/s  (read: {read_bw_gbs:.1f} + write: {write_bw_gbs:.1f})")
     print(
         f"      Bytes moved:  {bytes_moved / 1e6:.1f} MB  "
         f"(A={bytes_a / 1e6:.1f} B={bytes_b / 1e6:.1f} "
         f"scale={bytes_scale / 1e6:.1f} D={bytes_d / 1e6:.1f})"
     )
     print("      ---")
-    print(f"      WMMA/tile:    {wmma_per_tile} " f"({wmma_m_rep}m × {wmma_n_rep}n × {k_wmma_steps}k)")
+    print(f"      WMMA/tile:    {wmma_per_tile} ({wmma_m_rep}m × {wmma_n_rep}n × {k_wmma_steps}k)")
     if args.split_k > 1:
         print(
-            f"      Total tiles:  {m_tiles}×{n_tiles} spatial × "
-            f"{args.split_k} split-K × {k_tiles_local} local K-iters"
+            f"      Total tiles:  {m_tiles}×{n_tiles} spatial × {args.split_k} split-K × {k_tiles_local} local K-iters"
         )
     else:
         print(f"      Total tiles:  {m_tiles}×{n_tiles} spatial × {k_tiles} K-iters")
     print(f"      Seq WMMA/WG:  {seq_wmma}")
     print(f"      us/WMMA:      {us_per_wmma:.1f}")
     if us_per_wmma > 1000:
-        print(f"      WARNING: {us_per_wmma/1000:.1f} ms/WMMA indicates " f"WMMA_SCALE trap-handler emulation")
+        print(f"      WARNING: {us_per_wmma / 1000:.1f} ms/WMMA indicates WMMA_SCALE trap-handler emulation")
     print("=" * 72)
 
     return us, logical_tflops, bw_gbs
@@ -2267,7 +2266,7 @@ if __name__ == "__main__":
         "--no-flush-l2",
         action="store_true",
         default=False,
-        help="Disable L2 defeat for a hot-cache measurement. Applies to both eager " "and --use-graph modes.",
+        help="Disable L2 defeat for a hot-cache measurement. Applies to both eager and --use-graph modes.",
     )
     parser.add_argument(
         "--l2-flush-mb",

--- a/tests/kernels/test_gemm_fp8fp4_gfx1250.py
+++ b/tests/kernels/test_gemm_fp8fp4_gfx1250.py
@@ -6,7 +6,6 @@ Kernel implementation: kernels/gemm_fp8fp4_gfx1250.py
 
 import math
 import os
-import re
 import sys
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
@@ -35,6 +34,7 @@ if not torch.cuda.is_available():
 
 
 SCALE_BLOCK = 32
+_DT = {"f32": torch.float32, "bf16": torch.bfloat16, "f16": torch.float16}
 
 
 def preshuffle_scale(scale: torch.Tensor, *, inactive_fill: int = 0) -> torch.Tensor:
@@ -115,7 +115,7 @@ def _fp4_e2m1_packed_fill(rows: int, cols: int, value: float) -> torch.Tensor:
     return fp4_utils.f32_to_mxfp4(dense).view(torch.uint8)
 
 
-def _random_mxscale_inputs(M: int, N: int, K: int, data_format: str):
+def _random_ab_inputs(M: int, N: int, K: int, data_format: str):
     if data_format == "a8w4":
         a = random_fp8_data(M, K)
         b = fp4_utils.random_fp4_packed(N, K)
@@ -127,6 +127,11 @@ def _random_mxscale_inputs(M: int, N: int, K: int, data_format: str):
         b = random_fp8_data(N, K)
     else:
         raise ValueError(f"unsupported data_format={data_format!r}")
+    return a, b
+
+
+def _random_mxscale_inputs(M: int, N: int, K: int, data_format: str):
+    a, b = _random_ab_inputs(M, N, K, data_format)
     return a, b, fp4_utils.random_e8m0(M, K // SCALE_BLOCK), fp4_utils.random_e8m0(N, K // SCALE_BLOCK)
 
 
@@ -197,20 +202,37 @@ def _reference_scaled_gemm(a, b, a_scale, b_scale, M, N, K, convert_fn, convert_
     return torch.matmul(a_f32 * a_sc_exp, (b_f32 * b_sc_exp).T)
 
 
-def reference_mxfp4_gemm(a_packed, b_packed, a_scale, b_scale, M, N, K):
-    return _reference_scaled_gemm(a_packed, b_packed, a_scale, b_scale, M, N, K, fp4_utils.mxfp4_to_f32)
+def reference_ptpc_gemm(data_format, a, b, sa, sb, M, N, K):
+    """PTPC reference: D = (A @ B^T) * sa[:,None] * sb[None,:].
+
+    data_format="fp8": FP8 activation + FP8 weight.
+    data_format="a8w4": FP8 activation + FP4 (E2M1) weight.
+    """
+    a_f32 = fp4_utils.fp8_e4m3_to_f32(a.view(torch.uint8))[:M, :K]
+    convert_b = fp4_utils.mxfp4_to_f32 if data_format == "a8w4" else fp4_utils.fp8_e4m3_to_f32
+    b_f32 = convert_b(b.view(torch.uint8))[:N, :K]
+    raw = torch.matmul(a_f32, b_f32.T)
+    return raw * sa[:M].view(M, 1) * sb[:N].view(1, N)
 
 
-def reference_mxfp8_gemm(a, b, a_scale, b_scale, M, N, K):
-    """Standard FP8 reference with SCALE_BLOCK=32."""
-    return _reference_scaled_gemm(a, b, a_scale, b_scale, M, N, K, fp4_utils.fp8_e4m3_to_f32)
+def _reference_gemm(scale_mode: str, data_format: str, a, b, a_scale, b_scale, M, N, K):
+    if scale_mode == "ptpc":
+        return reference_ptpc_gemm(data_format, a, b, a_scale, b_scale, M, N, K)
+    if data_format == "a8w4":
+        return _reference_scaled_gemm(
+            a, b, a_scale, b_scale, M, N, K, fp4_utils.fp8_e4m3_to_f32, convert_fn_b=fp4_utils.mxfp4_to_f32
+        )
+    if data_format == "fp4":
+        return _reference_scaled_gemm(a, b, a_scale, b_scale, M, N, K, fp4_utils.mxfp4_to_f32)
+    if data_format == "fp8":
+        return _reference_scaled_gemm(a, b, a_scale, b_scale, M, N, K, fp4_utils.fp8_e4m3_to_f32)
+    raise ValueError(f"unsupported data_format={data_format!r}")
 
 
-def reference_a8w4_gemm(a_fp8, b_fp4, a_scale, b_scale, M, N, K):
-    """Standard A8W4 reference: FP8 activation + FP4 weight, SCALE_BLOCK=32."""
-    return _reference_scaled_gemm(
-        a_fp8, b_fp4, a_scale, b_scale, M, N, K, fp4_utils.fp8_e4m3_to_f32, convert_fn_b=fp4_utils.mxfp4_to_f32
-    )
+def _format_gemm_name(scale_mode: str, data_format: str) -> str:
+    if scale_mode == "ptpc":
+        return "PTPC-A8W4" if data_format == "a8w4" else "PTPC-FP8"
+    return "A8W4" if data_format == "a8w4" else ("MXFP4" if data_format == "fp4" else "MXFP8")
 
 
 def _e8m0_exp_range(scale: torch.Tensor) -> tuple[int, int]:
@@ -249,11 +271,7 @@ def _a8w4_tolerances(a_scale: torch.Tensor, b_scale: torch.Tensor, K: int, out_d
     return rtol, atol, diag
 
 
-def _align_up(value: int, align: int) -> int:
-    return ((value + align - 1) // align) * align
-
-
-def _mxscale_pack_factors(data_format: str) -> tuple[int, int]:
+def _pack_factors(data_format: str) -> tuple[int, int]:
     if data_format == "fp4":
         return 2, 2
     if data_format == "a8w4":
@@ -263,7 +281,7 @@ def _mxscale_pack_factors(data_format: str) -> tuple[int, int]:
     raise ValueError(f"unsupported data_format={data_format!r}")
 
 
-def _get_padded_problem_shape(
+def _get_problem_shape(
     data_format: str,
     M: int,
     N: int,
@@ -273,7 +291,7 @@ def _get_padded_problem_shape(
     tile_k: int,
     split_k: int,
 ) -> dict[str, int]:
-    """Validate tile alignment and return the (unpadded) kernel dimensions.
+    """Validate tile alignment and return the actual kernel dimensions.
 
     N/K must divide their tiles; M is ragged (hardware OOB). Fail loudly instead
     of silently host-padding.
@@ -285,7 +303,7 @@ def _get_padded_problem_shape(
     if K % (tile_k * split_k) != 0:
         raise ValueError(f"K={K} must be divisible by tile_k*split_k={tile_k * split_k} (no silent pad)")
 
-    pack_a, pack_b = _mxscale_pack_factors(data_format)
+    pack_a, pack_b = _pack_factors(data_format)
     return {
         "M": M,
         "N": N,
@@ -296,37 +314,45 @@ def _get_padded_problem_shape(
     }
 
 
-def _pad_2d_tensor(tensor: torch.Tensor, rows: int, cols: int, fill_value: int) -> torch.Tensor:
-    if tensor.shape == (rows, cols):
-        return tensor
-    padded = torch.full((rows, cols), fill_value, dtype=tensor.dtype, device=tensor.device)
-    padded[: tensor.shape[0], : tensor.shape[1]] = tensor
-    return padded
+def _expect_shape(name: str, tensor: torch.Tensor, shape: tuple[int, ...]):
+    assert tensor.shape == shape, f"{name}.shape={tuple(tensor.shape)} expected {shape}"
 
 
-def _pad_mxscale_inputs(
+def _validate_mxscale_inputs(
     a: torch.Tensor,
     b: torch.Tensor,
     a_scale: torch.Tensor,
     b_scale: torch.Tensor,
-    padded_shape: dict[str, int],
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Prepare mxscale tensors without extending A-scale rows."""
-    a = _pad_2d_tensor(a, padded_shape["M"], padded_shape["K"] // padded_shape["pack_a"], fill_value=0)
-    b = _pad_2d_tensor(b, padded_shape["N"], padded_shape["K"] // padded_shape["pack_b"], fill_value=0)
-    assert a_scale.shape == (padded_shape["M"], padded_shape["K_scale"])
-    b_scale = _pad_2d_tensor(b_scale, padded_shape["N"], padded_shape["K_scale"], fill_value=127)
-    return a, b, a_scale, b_scale
+    problem_shape: dict[str, int],
+):
+    """Validate the no-host-padding mxscale input contract."""
+    _expect_shape("A", a, (problem_shape["M"], problem_shape["K"] // problem_shape["pack_a"]))
+    _expect_shape("B", b, (problem_shape["N"], problem_shape["K"] // problem_shape["pack_b"]))
+    _expect_shape("A scale", a_scale, (problem_shape["M"], problem_shape["K_scale"]))
+    _expect_shape("B scale", b_scale, (problem_shape["N"], problem_shape["K_scale"]))
 
 
-def _format_kernel_pad(M: int, N: int, K: int, padded_shape: dict[str, int]) -> str:
-    padded_dims = (padded_shape["M"], padded_shape["N"], padded_shape["K"])
-    if padded_dims == (M, N, K):
-        return ""
-    return f", kernel_pad={padded_dims}"
+def _validate_ab_inputs(a: torch.Tensor, b: torch.Tensor, problem_shape: dict[str, int]):
+    _expect_shape("A", a, (problem_shape["M"], problem_shape["K"] // problem_shape["pack_a"]))
+    _expect_shape("B", b, (problem_shape["N"], problem_shape["K"] // problem_shape["pack_b"]))
 
 
-def _run_mxscale_gemm_test(
+def _with_strided_a(a: torch.Tensor, problem_shape: dict[str, int], lda: int) -> torch.Tensor:
+    """Return A backed by runtime lda when lda exceeds logical K."""
+    pack_a = problem_shape["pack_a"]
+    kernel_k = problem_shape["K"]
+    if lda % pack_a != 0:
+        raise ValueError(f"lda={lda} must be divisible by A pack factor {pack_a}")
+    _expect_shape("A", a, (problem_shape["M"], kernel_k // pack_a))
+    if lda == kernel_k:
+        return a
+    a_strided = torch.zeros(problem_shape["M"], lda // pack_a, dtype=a.dtype, device=a.device)
+    a_strided[:, : kernel_k // pack_a] = a
+    return a_strided
+
+
+def _run_gemm_test(
+    scale_mode,
     data_format,
     M,
     N,
@@ -338,6 +364,7 @@ def _run_mxscale_gemm_test(
     n_warp,
     num_buffers,
     out_dtype,
+    *,
     l2_prefetch_distance=0,
     cluster_m=1,
     cluster_n=1,
@@ -346,25 +373,36 @@ def _run_mxscale_gemm_test(
     expert_sched_mode=True,
     split_k=1,
     ascale_load_path=None,
+    lda_extra=0,
+    ldc_extra=0,
     return_launch_fn=False,
 ):
-    """Unified test body for FP4 and FP8."""
+    """Shared correctness body for mxscale and PTPC GEMM variants."""
+    if scale_mode not in ("mxscale", "ptpc"):
+        raise ValueError(f"unsupported scale_mode={scale_mode!r}")
+    if scale_mode == "ptpc" and data_format not in ("fp8", "a8w4"):
+        raise ValueError(f"scale_mode='ptpc' only supports data_format='fp8' or 'a8w4', got {data_format!r}")
+
+    is_mxscale = scale_mode == "mxscale"
+    is_ptpc = scale_mode == "ptpc"
     is_fp4 = data_format == "fp4"
     is_a8w4 = data_format == "a8w4"
 
     arch = str(get_rocm_arch())
     if arch != "gfx1250":
-        pytest.skip(f"WMMA_SCALE requires gfx1250, got {arch}")
+        pytest.skip(f"{scale_mode} GEMM requires gfx1250, got {arch}")
 
     if K % SCALE_BLOCK != 0:
         pytest.skip(f"K={K} must be divisible by SCALE_BLOCK={SCALE_BLOCK}")
 
-    padded_shape = _get_padded_problem_shape(data_format, M, N, K, tile_m, tile_n, tile_k, split_k)
-    padded_m = padded_shape["M"]
-    padded_n = padded_shape["N"]
-    padded_k = padded_shape["K"]
-    local_k = padded_k // split_k
-    if ascale_load_path is None:
+    problem_shape = _get_problem_shape(data_format, M, N, K, tile_m, tile_n, tile_k, split_k)
+    kernel_m = problem_shape["M"]
+    kernel_n = problem_shape["N"]
+    kernel_k = problem_shape["K"]
+    pack_b = problem_shape["pack_b"]
+    local_k = kernel_k // split_k
+
+    if is_mxscale and ascale_load_path is None:
         ascale_load_path = _select_ascale_load_path(M)
     tdm_store_enabled = split_k == 1
 
@@ -372,92 +410,99 @@ def _run_mxscale_gemm_test(
     if num_buffers > 1 and num_k_tiles < num_buffers:
         pytest.skip(f"{num_buffers}-buf requires num_k_tiles >= {num_buffers}")
 
-    # FP8 256x256 + f32 + TDM store exceeds LDS
-    if not is_fp4 and tile_m == 256 and tile_n == 256 and out_dtype == "f32" and tdm_store_enabled:
+    # FP8/A8W4 256x256 + f32 + TDM store exceeds LDS.
+    if is_mxscale and not is_fp4 and tile_m == 256 and tile_n == 256 and out_dtype == "f32" and tdm_store_enabled:
         pytest.skip("256x256 tile with f32 TDM store exceeds LDS limit")
 
-    _dtype_map = {"f32": torch.float32, "bf16": torch.bfloat16, "f16": torch.float16}
-    torch_out_dtype = _dtype_map[out_dtype]
+    torch_out_dtype = _DT[out_dtype]
 
     # Split-K accumulates at the output precision.
     kernel_out_dtype = out_dtype
-    torch_kernel_dtype = _dtype_map[kernel_out_dtype]
+    torch_kernel_dtype = _DT[kernel_out_dtype]
 
     torch.manual_seed(0)
+    if is_mxscale:
+        a, b, a_scale, b_scale = _random_mxscale_inputs(M, N, K, data_format)
+        a_scale_raw = a_scale.clone()
+        b_scale_raw = b_scale.clone()
+    else:
+        a, b = _random_ab_inputs(M, N, K, data_format)
+        a_scale = (0.5 + torch.rand(M, dtype=torch.float32)).contiguous()
+        b_scale = (0.5 + torch.rand(N, dtype=torch.float32)).contiguous()
+        a_scale_raw = None
+        b_scale_raw = None
 
-    fmt_name = "A8W4" if is_a8w4 else ("MXFP4" if is_fp4 else "MXFP8")
-    mcast_str = f", cluster=({cluster_m},{cluster_n})" if cluster_m > 1 or cluster_n > 1 else ""
-    tdm_str = ", tdm_store" if tdm_store_enabled else ", buffer_store"
-    pad_str = _format_kernel_pad(M, N, K, padded_shape)
+    ref = _reference_gemm(scale_mode, data_format, a, b, a_scale, b_scale, M, N, K)
+
+    fmt_name = _format_gemm_name(scale_mode, data_format)
+    run_attrs = []
+    if cluster_m > 1 or cluster_n > 1:
+        run_attrs.append(f"cluster=({cluster_m},{cluster_n})")
+    if split_k > 1:
+        run_attrs.append(f"split_k={split_k}")
+    if is_mxscale:
+        run_attrs.append("tdm_store" if tdm_store_enabled else "buffer_store")
+        run_attrs.append(f"ascale={ascale_load_path}")
+    if lda_extra:
+        run_attrs.append(f"lda={kernel_k + lda_extra}")
+    if ldc_extra:
+        run_attrs.append(f"ldc={kernel_n + ldc_extra}")
+    run_attrs.append("preshuffle")
+    attr_str = ", " + ", ".join(run_attrs) if run_attrs else ""
     print(
-        f"\nRunning {fmt_name} GEMM: M={M}, N={N}, K={K}{pad_str}, "
-        f"tiles=({tile_m},{tile_n},{tile_k}), bufs={num_buffers}"
-        f"{mcast_str}{tdm_str}, ascale={ascale_load_path}, preshuffle, out={out_dtype}"
+        f"\nRunning {fmt_name} GEMM: M={M}, N={N}, K={K}, "
+        f"tiles=({tile_m},{tile_n},{tile_k}), bufs={num_buffers}{attr_str}, out={out_dtype}"
     )
-
-    # Generate data
-    if is_a8w4:
-        a = random_fp8_data(M, K)  # FP8 activation
-        b = fp4_utils.random_fp4_packed(N, K)  # FP4 weight
-    elif is_fp4:
-        a = fp4_utils.random_fp4_packed(M, K)
-        b = fp4_utils.random_fp4_packed(N, K)
-    else:
-        a = random_fp8_data(M, K)
-        b = random_fp8_data(N, K)
-    a_scale = fp4_utils.random_e8m0(M, K // SCALE_BLOCK)
-    b_scale = fp4_utils.random_e8m0(N, K // SCALE_BLOCK)
-    a_scale_raw = a_scale.clone()
-    b_scale_raw = b_scale.clone()
-
-    # Reference
-    if is_a8w4:
-        ref = reference_a8w4_gemm(a, b, a_scale, b_scale, M, N, K)
-    elif is_fp4:
-        ref = reference_mxfp4_gemm(a, b, a_scale, b_scale, M, N, K)
-    else:
-        ref = reference_mxfp8_gemm(a, b, a_scale, b_scale, M, N, K)
-
     print(f"Ref stats: min={ref.min():.2f}, max={ref.max():.2f}, mean={ref.mean():.2f}, std={ref.std():.2f}")
 
-    a, b, a_scale, b_scale = _pad_mxscale_inputs(a, b, a_scale, b_scale, padded_shape)
+    lda = kernel_k + lda_extra
+    ldc = kernel_n + ldc_extra
 
-    a_scale = _prepare_a_scale_for_path(a_scale, ascale_load_path)
-    b_scale = preshuffle_scale(b_scale)
+    if is_mxscale:
+        _validate_mxscale_inputs(a, b, a_scale, b_scale, problem_shape)
+        a = _with_strided_a(a, problem_shape, lda)
+        a_scale = _prepare_a_scale_for_path(a_scale, ascale_load_path)
+        b_scale = preshuffle_scale(b_scale)
+    else:
+        _validate_ab_inputs(a, b, problem_shape)
+        _expect_shape("A scale", a_scale, (kernel_m,))
+        _expect_shape("B scale", b_scale, (kernel_n,))
+        a = _with_strided_a(a, problem_shape, lda)
 
-    # Preshuffle B data
-    K_packed = padded_k // padded_shape["pack_b"]
-    b = fp4_utils.preshuffle_b_16x16(b, padded_n, K_packed)
+    b = fp4_utils.preshuffle_b_16x16(b, kernel_n, kernel_k // pack_b)
 
-    # Upload & launch
     a_gpu = a.cuda()
     b_gpu = b.cuda()
     as_gpu = a_scale.cuda()
     bs_gpu = b_scale.cuda()
-    c_gpu = torch.zeros(padded_m, padded_n, dtype=torch_kernel_dtype, device="cuda")
+    c_gpu = torch.zeros(kernel_m, ldc, dtype=torch_kernel_dtype, device="cuda")
 
-    launch_fn = compile_mxscale_gemm(
-        data_format=data_format,
-        N=padded_n,
-        K=padded_k,
-        tile_m=tile_m,
-        tile_n=tile_n,
-        tile_k=tile_k,
-        m_warp=m_warp,
-        n_warp=n_warp,
-        num_buffers=num_buffers,
-        waves_per_eu=waves_per_eu,
-        l2_prefetch_distance=l2_prefetch_distance,
-        cluster_m=cluster_m,
-        cluster_n=cluster_n,
-        out_dtype=kernel_out_dtype,
-        inst_prefetch=inst_prefetch,
-        split_k=split_k,
-        expert_sched_mode=expert_sched_mode,
-        ascale_load_path=ascale_load_path,
-    )
+    compile_kwargs = {
+        "data_format": data_format,
+        "N": kernel_n,
+        "K": kernel_k,
+        "tile_m": tile_m,
+        "tile_n": tile_n,
+        "tile_k": tile_k,
+        "m_warp": m_warp,
+        "n_warp": n_warp,
+        "num_buffers": num_buffers,
+        "waves_per_eu": waves_per_eu,
+        "l2_prefetch_distance": l2_prefetch_distance,
+        "cluster_m": cluster_m,
+        "cluster_n": cluster_n,
+        "out_dtype": kernel_out_dtype,
+        "inst_prefetch": inst_prefetch,
+        "split_k": split_k,
+        "expert_sched_mode": expert_sched_mode,
+    }
+    if is_mxscale:
+        compile_kwargs["ascale_load_path"] = ascale_load_path
+        launch_fn = compile_mxscale_gemm(**compile_kwargs)
+    else:
+        launch_fn = compile_ptpc_gemm(**compile_kwargs)
 
-    # Keep 2D — dynamic_layout=True packs shape as i32; flattening overflows for M*K >= 2^31.
+    # Keep 2D: dynamic_layout=True packs shape as i32; flattening overflows for M*K >= 2^31.
     c_flat = c_gpu.contiguous()
     a_flat = a_gpu.contiguous()
     b_flat = b_gpu.contiguous()
@@ -471,16 +516,15 @@ def _run_mxscale_gemm_test(
         b_flat,
         as_flat,
         bs_flat,
-        padded_m,
-        padded_n,
-        padded_k,
-        padded_n,
+        kernel_m,
+        kernel_n,
+        lda,
+        ldc,
         torch.cuda.current_stream(),
     )
     torch.cuda.synchronize()
 
     c_out = c_gpu[:M, :N].to(torch_out_dtype).cpu()
-
     print(
         f"Out stats: min={c_out.float().min():.2f}, max={c_out.float().max():.2f}, "
         f"mean={c_out.float().mean():.2f}, std={c_out.float().std():.2f}"
@@ -490,9 +534,8 @@ def _run_mxscale_gemm_test(
         print("WARNING: kernel output is all zeros!")
 
     if out_dtype in ("bf16", "f16"):
-        ref_cmp = ref.to(torch_out_dtype)
         c_out_f = c_out.float()
-        ref_f = ref_cmp.float()
+        ref_f = ref.to(torch_out_dtype).float()
     else:
         c_out_f = c_out.float()
         ref_f = ref.float()
@@ -500,17 +543,20 @@ def _run_mxscale_gemm_test(
     diff = (c_out_f - ref_f).abs()
     print(f"Abs diff: max={diff.max():.4f}, mean={diff.mean():.4f}")
 
-    # Compute cosine in float64: for large M/N/K with large E8M0 scales the values
-    # (and their squares) overflow float32's accurate-summation range, so an fp32
-    # cosine reduction saturates and can print values outside [-1, 1]. fp64 keeps
-    # the diagnostic meaningful. (Pass/fail is gated by assert_close below, not this.)
+    # Compute cosine in float64: large scaled outputs can overflow float32's
+    # accurate-summation range, while pass/fail is gated by assert_close below.
     cos_sim = torch.nn.functional.cosine_similarity(
         c_out_f.flatten().unsqueeze(0).double(), ref_f.flatten().unsqueeze(0).double()
     ).item()
     print(f"Cosine similarity: {cos_sim:.6f}")
 
-    # Tolerances: FP4 is exact; FP8/A8W4 have FP accumulation error
-    if is_fp4:
+    if is_ptpc:
+        peak = float(ref_f.abs().max())
+        if out_dtype in ("bf16", "f16"):
+            torch.testing.assert_close(c_out_f, ref_f, rtol=2e-2, atol=max(5e-2, 2e-2 * peak))
+        else:
+            torch.testing.assert_close(c_out_f, ref_f, rtol=1e-3, atol=max(1e-2, K * 0.6))
+    elif is_fp4:
         if out_dtype in ("bf16", "f16"):
             torch.testing.assert_close(c_out_f, ref_f, rtol=1e-3, atol=1e-2)
         else:
@@ -519,45 +565,35 @@ def _run_mxscale_gemm_test(
         rtol, atol, tol_diag = _a8w4_tolerances(a_scale_raw, b_scale_raw, K, out_dtype)
         print(tol_diag)
         torch.testing.assert_close(c_out_f, ref_f, rtol=rtol, atol=atol)
-    else:
-        # FP8: standard SCALE_BLOCK=32 reference
-        if out_dtype in ("bf16", "f16"):
-            # split-k atomic-adds at output precision; peak-scale tolerance to
-            # absorb the compounded bf16/f16 rounding on large-magnitude outputs.
-            if split_k > 1:
-                peak = float(ref_f.abs().max())
-                torch.testing.assert_close(c_out_f, ref_f, rtol=2e-2, atol=max(5e-2, 2e-2 * peak))
-            else:
-                torch.testing.assert_close(c_out_f, ref_f, rtol=1e-2, atol=5e-2)
+    elif out_dtype in ("bf16", "f16"):
+        # Split-K atomic-adds at output precision; peak-scale tolerance absorbs
+        # compounded bf16/f16 rounding on large-magnitude outputs.
+        if split_k > 1:
+            peak = float(ref_f.abs().max())
+            torch.testing.assert_close(c_out_f, ref_f, rtol=2e-2, atol=max(5e-2, 2e-2 * peak))
         else:
-            atol = max(1e-2, K * 0.6)
-            torch.testing.assert_close(c_out_f, ref_f, rtol=1e-3, atol=atol)
+            torch.testing.assert_close(c_out_f, ref_f, rtol=1e-2, atol=5e-2)
+    else:
+        torch.testing.assert_close(c_out_f, ref_f, rtol=1e-3, atol=max(1e-2, K * 0.6))
+
     print("PASSED")
     if return_launch_fn:
         return launch_fn
 
 
-def _get_latest_artifact(launch_fn):
-    """Return the most recent CompiledArtifact produced by a JIT launch."""
-    last_compiled = getattr(launch_fn, "_last_compiled", None)
-    if last_compiled is not None:
-        return last_compiled[1]
-
-    mem_cache = getattr(launch_fn, "_mem_cache", None)
-    if mem_cache:
-        newest_key = next(reversed(mem_cache))
-        return mem_cache[newest_key]
-
-    raise AssertionError("expected launch_fn to have a compiled artifact")
-
-
-def _extract_i64_metadata(compiled_ir: str, key: str) -> int:
-    match = re.search(rf"{key}\s*=\s*(\d+)\s*:\s*i64", compiled_ir)
-    assert match is not None, f"{key} not found in compiled IR:\n{compiled_ir}"
-    return int(match.group(1))
-
-
 # ── pytest parametrized tests ──
+
+
+def _gen_mxfp4_gemm_configs():
+    # (M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers)
+    base = [
+        (128, 512, 7168, 128, 128, 256, 2, 2),
+        (128, 7168, 256, 128, 256, 128, 2, 2),
+        (128, 4096, 7168, 128, 256, 256, 2, 2),
+        (128, 7168, 2048, 128, 256, 256, 2, 2),
+        (1024, 1024, 1024, 256, 256, 256, 2, 2),
+    ]
+    return [(*shape, num_buffers) for shape in base for num_buffers in (2, 3, 4)]
 
 
 def _gen_mxfp8_gemm_configs():
@@ -581,6 +617,17 @@ def _gen_a8w4_gemm_configs():
     ]
     cfgs = [(*shape, num_buffers) for shape in base for num_buffers in (2, 3)]
     cfgs.append((256, 256, 512, 256, 256, 128, 2, 2, 4))
+    return cfgs
+
+
+def _gen_mxscale_gemm_configs():
+    cfgs = []
+    for data_format, gen in (
+        ("fp4", _gen_mxfp4_gemm_configs),
+        ("fp8", _gen_mxfp8_gemm_configs),
+        ("a8w4", _gen_a8w4_gemm_configs),
+    ):
+        cfgs += [(data_format, *cfg) for cfg in gen()]
     return cfgs
 
 
@@ -609,18 +656,12 @@ def test_mxscale_compile_auto_selects_splitk_store_path():
 
 
 @pytest.mark.parametrize(
-    "M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp",
-    [
-        (128, 512, 7168, 128, 128, 256, 2, 2),
-        (128, 7168, 256, 128, 256, 128, 2, 2),
-        (128, 4096, 7168, 128, 256, 256, 2, 2),
-        (128, 7168, 2048, 128, 256, 256, 2, 2),
-        (1024, 1024, 1024, 256, 256, 256, 2, 2),
-    ],
+    "data_format, M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers",
+    _gen_mxscale_gemm_configs(),
 )
-@pytest.mark.parametrize("num_buffers", [2, 3, 4])
 @pytest.mark.parametrize("out_dtype", ["f32", "bf16"])
-def test_mxfp4_gemm(
+def test_mxscale_gemm(
+    data_format,
     M,
     N,
     K,
@@ -632,8 +673,9 @@ def test_mxfp4_gemm(
     num_buffers,
     out_dtype,
 ):
-    _run_mxscale_gemm_test(
-        "fp4",
+    _run_gemm_test(
+        "mxscale",
+        data_format,
         M,
         N,
         K,
@@ -644,39 +686,7 @@ def test_mxfp4_gemm(
         n_warp,
         num_buffers,
         out_dtype,
-    )
-
-
-@pytest.mark.parametrize(
-    "M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers",
-    _gen_mxfp8_gemm_configs(),
-)
-@pytest.mark.parametrize("out_dtype", ["f32", "bf16"])
-def test_mxfp8_gemm(
-    M,
-    N,
-    K,
-    tile_m,
-    tile_n,
-    tile_k,
-    m_warp,
-    n_warp,
-    num_buffers,
-    out_dtype,
-):
-    _run_mxscale_gemm_test(
-        "fp8",
-        M,
-        N,
-        K,
-        tile_m,
-        tile_n,
-        tile_k,
-        m_warp,
-        n_warp,
-        num_buffers,
-        out_dtype,
-        l2_prefetch_distance=2,
+        l2_prefetch_distance=2 if data_format in ("fp8", "a8w4") else 0,
     )
 
 
@@ -688,7 +698,8 @@ def test_mxfp8_gemm_splitk(split_k, out_dtype):
     Exercises the auto-selected atomic epilogue path. K=2048/tile_k=128 gives
     every split_k value >= 2 local K-tiles (needed for double buffering).
     """
-    _run_mxscale_gemm_test(
+    _run_gemm_test(
+        "mxscale",
         "fp8",
         128,
         256,
@@ -702,53 +713,6 @@ def test_mxfp8_gemm_splitk(split_k, out_dtype):
         out_dtype=out_dtype,
         l2_prefetch_distance=2,
         split_k=split_k,
-    )
-
-
-@pytest.mark.parametrize(
-    "M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers",
-    _gen_a8w4_gemm_configs(),
-)
-@pytest.mark.parametrize("out_dtype", ["f32", "bf16"])
-def test_a8w4_gemm(M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers, out_dtype):
-    _run_mxscale_gemm_test(
-        "a8w4",
-        M,
-        N,
-        K,
-        tile_m,
-        tile_n,
-        tile_k,
-        m_warp,
-        n_warp,
-        num_buffers,
-        out_dtype,
-        l2_prefetch_distance=2,
-    )
-
-
-@pytest.mark.parametrize(
-    "M, N, K",
-    [
-        (13, 2816, 2816),
-        (33, 5632, 2816),
-    ],
-)
-def test_a8w4_gemm_irregular_m_tile16(M, N, K):
-    # Small-M path: ragged M via OOB, one wave dedicated to the M dimension.
-    _run_mxscale_gemm_test(
-        "a8w4",
-        M,
-        N,
-        K,
-        16,
-        256,
-        256,
-        1,
-        4,
-        num_buffers=2,
-        out_dtype="bf16",
-        l2_prefetch_distance=2,
     )
 
 
@@ -807,7 +771,8 @@ def _gen_bs32_configs():
 
 @pytest.mark.parametrize("data_format, M, N, K, tile_n, tile_k, n_warp, num_buffers, out_dtype", _gen_bs32_configs())
 def test_mxscale_bscale_32x4(data_format, M, N, K, tile_n, tile_k, n_warp, num_buffers, out_dtype):
-    _run_mxscale_gemm_test(
+    _run_gemm_test(
+        "mxscale",
         data_format,
         M,
         N,
@@ -857,7 +822,8 @@ def _gen_ascale_32x4_configs():
 def test_mxscale_ascale_32x4(data_format, M, tile_m, tile_n, tile_k, m_warp, n_warp, nbuf):
     N = 2 * tile_n
     K = tile_k * nbuf
-    _run_mxscale_gemm_test(
+    _run_gemm_test(
+        "mxscale",
         data_format,
         M,
         N,
@@ -877,7 +843,8 @@ def test_mxscale_ascale_32x4(data_format, M, tile_m, tile_n, tile_k, m_warp, n_w
 @pytest.mark.parametrize("data_format", ["fp8", "a8w4", "fp4"])
 @pytest.mark.parametrize("M", [1, 13, 31])
 def test_mxscale_ascale_vgpr_small_m(data_format, M):
-    _run_mxscale_gemm_test(
+    _run_gemm_test(
+        "mxscale",
         data_format,
         M,
         128,
@@ -906,7 +873,8 @@ def test_mxscale_ascale_vgpr_small_m(data_format, M):
     ],
 )
 def test_mxscale_ascale_vgpr_general(data_format, M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, nbuf):
-    _run_mxscale_gemm_test(
+    _run_gemm_test(
+        "mxscale",
         data_format,
         M,
         N,
@@ -941,7 +909,8 @@ def test_mxscale_ascale_vgpr_general(data_format, M, N, K, tile_m, tile_n, tile_
 def test_mxfp4_gemm_mcast(
     M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, cluster_m, cluster_n, num_buffers, out_dtype
 ):
-    _run_mxscale_gemm_test(
+    _run_gemm_test(
+        "mxscale",
         "fp4",
         M,
         N,
@@ -983,7 +952,7 @@ def test_mxscale_gemm_cudagraph(data_format, M, N, K, tile_m, tile_n, tile_k, m_
 
     is_fp4 = data_format == "fp4"
 
-    # Build inputs (mirrors _run_mxscale_gemm_test, but no padding needed
+    # Build inputs (mirrors _run_gemm_test("mxscale", ...), but no padding needed
     # because we pick a clean shape).
     torch.manual_seed(0)
     if is_fp4:
@@ -1267,206 +1236,78 @@ def _bench_kernel_us(run_once, flush_cache=None, warmup=10, iters=50, post_run=N
     return _iqr_trimmed_median_us(latencies_us)
 
 
-def reference_ptpc_gemm(data_format, a, b, sa, sb, M, N, K):
-    """PTPC reference: D = (A @ B^T) * sa[:,None] * sb[None,:].
-
-    data_format="fp8": FP8 activation + FP8 weight.
-    data_format="a8w4": FP8 activation + FP4 (E2M1) weight.
-    """
-    a_f32 = fp4_utils.fp8_e4m3_to_f32(a.view(torch.uint8))[:M, :K]
-    convert_b = fp4_utils.mxfp4_to_f32 if data_format == "a8w4" else fp4_utils.fp8_e4m3_to_f32
-    b_f32 = convert_b(b.view(torch.uint8))[:N, :K]
-    raw = torch.matmul(a_f32, b_f32.T)
-    return raw * sa[:M].view(M, 1) * sb[:N].view(1, N)
-
-
-def _run_ptpc_gemm_test(
-    M,
-    N,
-    K,
-    tile_m,
-    tile_n,
-    tile_k,
-    m_warp,
-    n_warp,
-    num_buffers,
-    out_dtype,
-    *,
-    data_format="fp8",
-    l2_prefetch_distance=2,
-    cluster_m=1,
-    cluster_n=1,
-    split_k=1,
-    lda_pad=0,
-    ldc_pad=0,
-):
-    """Correctness body for PTPC (per-token per-channel) GEMM.
-
-    A scale sa[M] (per-token) and B scale sb[N] (per-channel) are fp32, constant
-    along K. The K-loop runs the WMMA unscaled (fp8) or with an identity scale
-    (a8w4); sa*sb is applied in the epilogue. data_format: "fp8" or "a8w4".
-    """
-    arch = str(get_rocm_arch())
-    if arch != "gfx1250":
-        pytest.skip(f"PTPC requires gfx1250, got {arch}")
-
-    padded_shape = _get_padded_problem_shape(data_format, M, N, K, tile_m, tile_n, tile_k, split_k)
-    padded_m, padded_n, padded_k = padded_shape["M"], padded_shape["N"], padded_shape["K"]
-    local_k = padded_k // split_k
-    num_k_tiles = local_k // tile_k
-    if num_buffers > 1 and num_k_tiles < num_buffers:
-        pytest.skip(f"{num_buffers}-buf requires num_k_tiles >= {num_buffers}")
-
-    _dtype_map = {"f32": torch.float32, "bf16": torch.bfloat16, "f16": torch.float16}
-    torch_out_dtype = _dtype_map[out_dtype]
-    kernel_out_dtype = out_dtype  # split-k atomic-adds at output precision
-    torch_kernel_dtype = _dtype_map[kernel_out_dtype]
-
-    torch.manual_seed(0)
-    a = random_fp8_data(M, K)  # FP8 activation for both fp8 and a8w4
-    b = fp4_utils.random_fp4_packed(N, K) if data_format == "a8w4" else random_fp8_data(N, K)
-    # Per-token / per-channel fp32 scales in a benign range to avoid degeneracy.
-    sa = (0.5 + torch.rand(M, dtype=torch.float32)).contiguous()
-    sb = (0.5 + torch.rand(N, dtype=torch.float32)).contiguous()
-
-    ref = reference_ptpc_gemm(data_format, a, b, sa, sb, M, N, K)
-    print(
-        f"\nRunning PTPC {data_format.upper()} GEMM: M={M}, N={N}, K={K}, tiles=({tile_m},{tile_n},{tile_k}), "
-        f"bufs={num_buffers}, split_k={split_k}, out={out_dtype}"
-    )
-    print(f"Ref stats: min={ref.min():.2f}, max={ref.max():.2f}, mean={ref.mean():.2f}, std={ref.std():.2f}")
-
-    # Pad data to tile-aligned shapes; B is preshuffled like the mxscale path.
-    # A8W4 packs the FP4 weight 2-per-byte, so B's column count is K/pack_b.
-    K_packed_b = padded_k // padded_shape["pack_b"]
-    a = _pad_2d_tensor(a, padded_m, padded_k, fill_value=0)
-    b = _pad_2d_tensor(b, padded_n, K_packed_b, fill_value=0)
-    b = fp4_utils.preshuffle_b_16x16(b, padded_n, K_packed_b)
-    # Pad scales (pad region is discarded in the [:M,:N] slice).
-    sa_p = torch.zeros(padded_m, dtype=torch.float32)
-    sa_p[:M] = sa
-    sb_p = torch.zeros(padded_n, dtype=torch.float32)
-    sb_p[:N] = sb
-
-    # Optional strided A/C: back data with a wider leading dim (lda/ldc), exercising
-    # the runtime-stride descriptor path. lda/ldc are logical leading dims (elements).
-    pack_a = padded_shape["pack_a"]
-    lda = padded_k + lda_pad
-    ldc = padded_n + ldc_pad
-    if lda_pad:
-        a_full = torch.zeros(padded_m, lda // pack_a, dtype=a.dtype)
-        a_full[:, : padded_k // pack_a] = a
-        a = a_full
-
-    a_gpu = a.cuda()
-    b_gpu = b.cuda()
-    sa_gpu = sa_p.cuda()
-    sb_gpu = sb_p.cuda()
-    c_gpu = torch.zeros(padded_m, ldc, dtype=torch_kernel_dtype, device="cuda")
-
-    launch_fn = compile_ptpc_gemm(
-        N=padded_n,
-        K=padded_k,
-        data_format=data_format,
-        tile_m=tile_m,
-        tile_n=tile_n,
-        tile_k=tile_k,
-        m_warp=m_warp,
-        n_warp=n_warp,
-        num_buffers=num_buffers,
-        l2_prefetch_distance=l2_prefetch_distance,
-        cluster_m=cluster_m,
-        cluster_n=cluster_n,
-        out_dtype=kernel_out_dtype,
-        split_k=split_k,
-    )
-
-    flyc.compile(
-        launch_fn,
-        c_gpu.contiguous(),
-        a_gpu.contiguous(),
-        b_gpu.contiguous(),
-        sa_gpu.contiguous(),
-        sb_gpu.contiguous(),
-        padded_m,
-        padded_n,
-        lda,
-        ldc,
-        torch.cuda.current_stream(),
-    )
-    torch.cuda.synchronize()
-
-    c_out = c_gpu[:M, :N].to(torch_out_dtype).cpu()
-    print(
-        f"Out stats: min={c_out.float().min():.2f}, max={c_out.float().max():.2f}, "
-        f"mean={c_out.float().mean():.2f}, std={c_out.float().std():.2f}"
-    )
-    if c_out.float().abs().max() < 1e-10:
-        print("WARNING: kernel output is all zeros!")
-
-    c_out_f = c_out.float()
-    ref_f = ref.to(torch_out_dtype).float() if out_dtype in ("bf16", "f16") else ref.float()
-    diff = (c_out_f - ref_f).abs()
-    print(f"Abs diff: max={diff.max():.4f}, mean={diff.mean():.4f}")
-    cos_sim = torch.nn.functional.cosine_similarity(
-        c_out_f.flatten().unsqueeze(0).double(), ref_f.flatten().unsqueeze(0).double()
-    ).item()
-    print(f"Cosine similarity: {cos_sim:.6f}")
-
-    peak = float(ref_f.abs().max())
-    if out_dtype in ("bf16", "f16"):
-        torch.testing.assert_close(c_out_f, ref_f, rtol=2e-2, atol=max(5e-2, 2e-2 * peak))
-    else:
-        torch.testing.assert_close(c_out_f, ref_f, rtol=1e-3, atol=max(1e-2, K * 0.6))
-    print("PASSED")
+def _gen_ptpc_gemm_configs():
+    # (data_format, M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers)
+    return [
+        ("fp8", 256, 256, 512, 256, 256, 128, 2, 2, 4),  # deep-pipeline eligible
+        ("fp8", 128, 256, 512, 128, 256, 128, 2, 2, 4),  # quadrant fallback
+        ("a8w4", 128, 256, 512, 128, 256, 128, 2, 4, 2),  # row-major + wave-spec TDM
+        ("a8w4", 128, 256, 1024, 128, 256, 256, 2, 4, 3),
+    ]
 
 
 @pytest.mark.parametrize("out_dtype", ["bf16", "f32"])
 @pytest.mark.parametrize(
-    "M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers",
-    [
-        (256, 256, 512, 256, 256, 128, 2, 2, 4),  # deep-pipeline eligible
-        (128, 256, 512, 128, 256, 128, 2, 2, 4),  # quadrant fallback
-    ],
+    "data_format, M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers",
+    _gen_ptpc_gemm_configs(),
 )
-def test_ptpc_fp8_gemm(M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers, out_dtype):
-    _run_ptpc_gemm_test(M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers, out_dtype)
+def test_ptpc_gemm(data_format, M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers, out_dtype):
+    _run_gemm_test(
+        "ptpc",
+        data_format,
+        M,
+        N,
+        K,
+        tile_m,
+        tile_n,
+        tile_k,
+        m_warp,
+        n_warp,
+        num_buffers,
+        out_dtype,
+    )
 
 
-@pytest.mark.parametrize("lda_pad, ldc_pad", [(128, 0), (0, 256), (128, 256)])
-def test_ptpc_fp8_gemm_strided(lda_pad, ldc_pad):
+@pytest.mark.parametrize("scale_mode, data_format", [("ptpc", "fp8"), ("mxscale", "fp8"), ("mxscale", "fp4")])
+@pytest.mark.parametrize("lda_extra, ldc_extra", [(128, 0), (0, 256), (128, 256)])
+def test_gemm_strided(scale_mode, data_format, lda_extra, ldc_extra):
     """Strided A/C: data backed by a wider leading dim, passed via runtime lda/ldc."""
-    _run_ptpc_gemm_test(
-        128, 256, 512, 128, 256, 128, 2, 2, num_buffers=4, out_dtype="bf16", lda_pad=lda_pad, ldc_pad=ldc_pad
+    _run_gemm_test(
+        scale_mode,
+        data_format,
+        128,
+        256,
+        512,
+        128,
+        256,
+        128,
+        2,
+        2,
+        num_buffers=4,
+        out_dtype="bf16",
+        lda_extra=lda_extra,
+        ldc_extra=ldc_extra,
     )
 
 
 @pytest.mark.parametrize("split_k", [2, 4])
-@pytest.mark.parametrize("out_dtype", ["bf16", "f32"])
-def test_ptpc_fp8_gemm_splitk(split_k, out_dtype):
+@pytest.mark.parametrize("data_format, out_dtype", [("fp8", "bf16"), ("fp8", "f32"), ("a8w4", "bf16")])
+def test_ptpc_gemm_splitk(data_format, split_k, out_dtype):
     """PTPC split-K: each chunk applies sa*sb then atomic-adds; sum stays correct."""
-    _run_ptpc_gemm_test(128, 256, 2048, 128, 256, 128, 2, 4, num_buffers=2, out_dtype=out_dtype, split_k=split_k)
-
-
-@pytest.mark.parametrize("out_dtype", ["bf16", "f32"])
-@pytest.mark.parametrize(
-    "M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers",
-    [
-        (128, 256, 512, 128, 256, 128, 2, 4, 2),  # row-major (a8w4) + wave-spec TDM
-        (128, 256, 1024, 128, 256, 256, 2, 4, 3),
-    ],
-)
-def test_ptpc_a8w4_gemm(M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers, out_dtype):
-    """PTPC A8W4 (FP8 act + FP4 weight): K-loop uses identity-scale f8f6f4 WMMA;
-    real per-token/per-channel sa*sb is applied in the epilogue."""
-    _run_ptpc_gemm_test(M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers, out_dtype, data_format="a8w4")
-
-
-@pytest.mark.parametrize("split_k", [2, 4])
-def test_ptpc_a8w4_gemm_splitk(split_k):
-    """PTPC A8W4 split-K: identity-scale K-loop + epilogue sa*sb + atomic add."""
-    _run_ptpc_gemm_test(
-        128, 256, 2048, 128, 256, 128, 2, 4, num_buffers=2, out_dtype="bf16", split_k=split_k, data_format="a8w4"
+    _run_gemm_test(
+        "ptpc",
+        data_format,
+        128,
+        256,
+        2048,
+        128,
+        256,
+        128,
+        2,
+        4,
+        num_buffers=2,
+        out_dtype=out_dtype,
+        split_k=split_k,
     )
 
 
@@ -1475,173 +1316,107 @@ def test_ptpc_a8w4_gemm_splitk(split_k):
 # allocated at the real M. A-load TDM skips rows>=M, sa buffer_load OOB->0, C
 # buffer_store clips via num_records. N,K stay tile-aligned.
 # ---------------------------------------------------------------------------
-_DT = {"f32": torch.float32, "bf16": torch.bfloat16, "f16": torch.float16}
-_MPAD_MS = [1, 16, 31, 64, 65, 100, 127, 128, 129, 130, 192, 255, 256, 257, 384, 500, 1000, 2048]
+_RAGGED_M_VALUES = [
+    1,
+    16,
+    31,
+    64,
+    65,
+    100,
+    127,
+    128,
+    129,
+    130,
+    192,
+    255,
+    256,
+    257,
+    384,
+    500,
+    1000,
+    2048,
+]
+_RAGGED_M_BASE_CONFIGS = [
+    ("ptpc", "fp8", "bf16"),
+    ("ptpc", "fp8", "f32"),
+    ("ptpc", "a8w4", "bf16"),
+    ("mxscale", "fp8", "bf16"),
+    ("mxscale", "fp8", "f32"),
+]
 
 
-def _assert_mpad(c_real, ref, out_dtype):
-    c = c_real.float()
-    ref_f = ref.to(_DT[out_dtype]).float()
-    peak = float(ref_f.abs().max())
-    if out_dtype in ("bf16", "f16"):
-        torch.testing.assert_close(c, ref_f, rtol=2e-2, atol=max(5e-2, 2e-2 * peak))
-    else:
-        torch.testing.assert_close(c, ref_f, rtol=1e-3, atol=max(1e-2, ref.shape[-1] * 0.6))
-
-
-def _run_ptpc_mpad(
-    M,
-    N,
-    K,
-    *,
-    data_format="fp8",
-    out_dtype="bf16",
-    split_k=1,
-    tile_m=128,
-    tile_n=128,
-    tile_k=128,
-    m_warp=2,
-    n_warp=2,
-    num_buffers=4,
-    cluster_m=1,
-    cluster_n=1,
-):
-    arch = str(get_rocm_arch())
-    if arch != "gfx1250":
-        pytest.skip(f"requires gfx1250, got {arch}")
-    assert N % tile_n == 0 and K % tile_k == 0, "M-pad test keeps N,K tile-aligned"
-    # split_k atomic-adds at output precision (per-lane predicate on row < M).
-    kernel_out_dtype = out_dtype
-    torch.manual_seed(0)
-    a = random_fp8_data(M, K)
-    b = fp4_utils.random_fp4_packed(N, K) if data_format == "a8w4" else random_fp8_data(N, K)
-    sa = (0.5 + torch.rand(M, dtype=torch.float32)).contiguous()
-    sb = (0.5 + torch.rand(N, dtype=torch.float32)).contiguous()
-    ref = reference_ptpc_gemm(data_format, a, b, sa, sb, M, N, K)
-    pack_b = 2 if data_format == "a8w4" else 1
-    b_ps = fp4_utils.preshuffle_b_16x16(b, N, K // pack_b)
-    c_gpu = torch.zeros(M, N, dtype=_DT[kernel_out_dtype], device="cuda")  # real M; zero for atomic
-    launch = compile_ptpc_gemm(
-        N=N,
-        K=K,
-        data_format=data_format,
-        tile_m=tile_m,
-        tile_n=tile_n,
-        tile_k=tile_k,
-        m_warp=m_warp,
-        n_warp=n_warp,
-        num_buffers=num_buffers,
-        out_dtype=kernel_out_dtype,
-        split_k=split_k,
-        cluster_m=cluster_m,
-        cluster_n=cluster_n,
+@pytest.mark.parametrize("scale_mode, data_format, out_dtype", _RAGGED_M_BASE_CONFIGS)
+@pytest.mark.parametrize("M", _RAGGED_M_VALUES)
+def test_gemm_ragged_m(M, scale_mode, data_format, out_dtype):
+    n_warp = 4 if data_format == "a8w4" else 2
+    num_buffers = 2 if data_format == "a8w4" else 4
+    _run_gemm_test(
+        scale_mode,
+        data_format,
+        M,
+        256,
+        512,
+        128,
+        128,
+        128,
+        2,
+        n_warp,
+        num_buffers,
+        out_dtype,
     )
-    launch(c_gpu, a.cuda(), b_ps.cuda(), sa.cuda(), sb.cuda(), M, N, K, N, torch.cuda.current_stream())
-    torch.cuda.synchronize()
-    _assert_mpad(c_gpu[:M].cpu(), ref, kernel_out_dtype)
-
-
-def _run_mxscale_mpad(
-    M,
-    N,
-    K,
-    *,
-    out_dtype="bf16",
-    tile_m=128,
-    tile_n=128,
-    tile_k=128,
-    m_warp=2,
-    n_warp=2,
-    num_buffers=4,
-    cluster_m=1,
-    cluster_n=1,
-):
-    arch = str(get_rocm_arch())
-    if arch != "gfx1250":
-        pytest.skip(f"requires gfx1250, got {arch}")
-    assert N % tile_n == 0 and K % tile_k == 0, "M-pad test keeps N,K tile-aligned"
-    torch.manual_seed(0)
-    a = random_fp8_data(M, K)
-    b = random_fp8_data(N, K)
-    a_scale = fp4_utils.random_e8m0(M, K // SCALE_BLOCK)  # real M, unpadded
-    b_scale = fp4_utils.random_e8m0(N, K // SCALE_BLOCK)
-    ref = reference_mxfp8_gemm(a, b, a_scale, b_scale, M, N, K)
-    ascale_load_path = _select_ascale_load_path(M)
-    as_ps = _prepare_a_scale_for_path(a_scale, ascale_load_path)
-    bs_ps = preshuffle_scale(b_scale)
-    b_ps = fp4_utils.preshuffle_b_16x16(b, N, K)
-    c_gpu = torch.zeros(M, N, dtype=_DT[out_dtype], device="cuda")  # real M
-    launch = compile_mxscale_gemm(
-        data_format="fp8",
-        N=N,
-        K=K,
-        tile_m=tile_m,
-        tile_n=tile_n,
-        tile_k=tile_k,
-        m_warp=m_warp,
-        n_warp=n_warp,
-        num_buffers=num_buffers,
-        out_dtype=out_dtype,
-        cluster_m=cluster_m,
-        cluster_n=cluster_n,
-        ascale_load_path=ascale_load_path,
-    )
-    launch(c_gpu, a.cuda(), b_ps.cuda(), as_ps.cuda(), bs_ps.cuda(), M, N, K, N, torch.cuda.current_stream())
-    torch.cuda.synchronize()
-    _assert_mpad(c_gpu[:M].cpu(), ref, out_dtype)
-
-
-@pytest.mark.parametrize("out_dtype", ["bf16", "f32"])
-@pytest.mark.parametrize("M", _MPAD_MS)
-def test_ptpc_fp8_gemm_mpad(M, out_dtype):
-    _run_ptpc_mpad(M, 256, 512, out_dtype=out_dtype)
-
-
-@pytest.mark.parametrize("M", _MPAD_MS)
-def test_ptpc_a8w4_gemm_mpad(M):
-    _run_ptpc_mpad(M, 256, 512, data_format="a8w4", m_warp=2, n_warp=4, num_buffers=2)
-
-
-@pytest.mark.parametrize("out_dtype", ["bf16", "f32"])
-@pytest.mark.parametrize("M", _MPAD_MS)
-def test_mxfp8_gemm_mpad(M, out_dtype):
-    _run_mxscale_mpad(M, 256, 512, out_dtype=out_dtype)
 
 
 @pytest.mark.parametrize("split_k", [2, 4])
 @pytest.mark.parametrize("M", [1, 64, 129, 192, 257, 500])
-def test_ptpc_fp8_gemm_splitk_mpad(M, split_k):
+def test_ptpc_fp8_gemm_splitk_ragged_m(M, split_k):
     # split_k atomic output predicated per-lane on row < M (auto buffer/atomic path).
-    _run_ptpc_mpad(M, 256, 2048, m_warp=2, n_warp=4, num_buffers=2, split_k=split_k)
+    _run_gemm_test(
+        "ptpc",
+        "fp8",
+        M,
+        256,
+        2048,
+        128,
+        256,
+        128,
+        2,
+        4,
+        num_buffers=2,
+        out_dtype="bf16",
+        split_k=split_k,
+    )
 
 
 # Tile/warp-config diversity: the per-warp partial-tile clip uses
 # warp_tile_m = tile_m // m_warp, so M must be exercised against different warp
-# boundaries. Existing mpad tests are all m_warp=2 (warp_tile_m=64); these add
+# boundaries. Existing ragged-M tests are all m_warp=2 (warp_tile_m=64); these add
 # warp_tile_m in {128 (single M-warp / tile_m=256), 32 (fine 4-way split)}.
-_MPAD_WARP_CFGS = [
+_RAGGED_M_WARP_CONFIGS = [
     # (tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers)
     (128, 128, 128, 1, 4, 4),  # warp_tile_m=128: single M-warp, no M split
     (128, 128, 128, 4, 2, 2),  # warp_tile_m=32: fine-grained M warps
     (256, 128, 128, 2, 2, 2),  # tile_m=256, warp_tile_m=128
 ]
 # Boundary-diverse M for warp_tile_m in {32, 128}: partial/full/OOB warps + aligned.
-_MPAD_WARP_MS = [1, 33, 64, 100, 129, 200, 256, 333]
+_RAGGED_M_WARP_VALUES = [1, 33, 64, 100, 129, 200, 256, 333]
 
 
-@pytest.mark.parametrize("tile_m,tile_n,tile_k,m_warp,n_warp,num_buffers", _MPAD_WARP_CFGS)
-@pytest.mark.parametrize("M", _MPAD_WARP_MS)
-def test_ptpc_fp8_gemm_mpad_warps(M, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers):
-    _run_ptpc_mpad(
+@pytest.mark.parametrize("tile_m,tile_n,tile_k,m_warp,n_warp,num_buffers", _RAGGED_M_WARP_CONFIGS)
+@pytest.mark.parametrize("M", _RAGGED_M_WARP_VALUES)
+def test_ptpc_fp8_gemm_ragged_m_warps(M, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers):
+    _run_gemm_test(
+        "ptpc",
+        "fp8",
         M,
         256,
         512,
-        tile_m=tile_m,
-        tile_n=tile_n,
-        tile_k=tile_k,
-        m_warp=m_warp,
-        n_warp=n_warp,
+        tile_m,
+        tile_n,
+        tile_k,
+        m_warp,
+        n_warp,
         num_buffers=num_buffers,
+        out_dtype="bf16",
     )
 
 
@@ -1649,34 +1424,34 @@ def test_ptpc_fp8_gemm_mpad_warps(M, tile_m, tile_n, tile_k, m_warp, n_warp, num
 #   M=129,200,450 -> partial last M-tile, grid divisible
 #   M=256,512 -> tile-aligned
 #   M=257,300 -> grid_m 3->4 (rounded); M=300 also makes tile3 fully OOB
-_MPAD_CLUSTER_MS = [100, 129, 200, 256, 257, 300, 450, 512]
-_MPAD_CLUSTERS = [(2, 2), (2, 4)]
+_RAGGED_M_CLUSTER_VALUES = [100, 129, 200, 256, 257, 300, 450, 512]
+_RAGGED_M_CLUSTERS = [(2, 2), (2, 4)]
+_RAGGED_M_CLUSTER_CONFIGS = [
+    ("ptpc", "fp8"),
+    ("ptpc", "a8w4"),
+    ("mxscale", "fp8"),
+]
+_RAGGED_M_CLUSTER_TM256_VALUES = [100, 300, 512, 600, 700, 1024]
 
 
-@pytest.mark.parametrize("cluster_m,cluster_n", _MPAD_CLUSTERS)
-@pytest.mark.parametrize("M", _MPAD_CLUSTER_MS)
-def test_ptpc_fp8_gemm_mpad_cluster(M, cluster_m, cluster_n):
-    _run_ptpc_mpad(M, 512, 512, m_warp=2, n_warp=2, num_buffers=2, cluster_m=cluster_m, cluster_n=cluster_n)
-
-
-@pytest.mark.parametrize("cluster_m,cluster_n", _MPAD_CLUSTERS)
-@pytest.mark.parametrize("M", _MPAD_CLUSTER_MS)
-def test_ptpc_a8w4_gemm_mpad_cluster(M, cluster_m, cluster_n):
-    _run_ptpc_mpad(
-        M, 512, 512, data_format="a8w4", m_warp=2, n_warp=4, num_buffers=2, cluster_m=cluster_m, cluster_n=cluster_n
-    )
-
-
-@pytest.mark.parametrize("cluster_m,cluster_n", _MPAD_CLUSTERS)
-@pytest.mark.parametrize("M", _MPAD_CLUSTER_MS)
-def test_mxfp8_gemm_mpad_cluster(M, cluster_m, cluster_n):
-    _run_mxscale_mpad(
+@pytest.mark.parametrize("scale_mode, data_format", _RAGGED_M_CLUSTER_CONFIGS)
+@pytest.mark.parametrize("cluster_m,cluster_n", _RAGGED_M_CLUSTERS)
+@pytest.mark.parametrize("M", _RAGGED_M_CLUSTER_VALUES)
+def test_gemm_ragged_m_cluster(M, cluster_m, cluster_n, scale_mode, data_format):
+    n_warp = 4 if data_format == "a8w4" else 2
+    _run_gemm_test(
+        scale_mode,
+        data_format,
         M,
         512,
         512,
-        m_warp=2,
-        n_warp=2,
+        128,
+        128,
+        128,
+        2,
+        n_warp,
         num_buffers=2,
+        out_dtype="bf16",
         cluster_m=cluster_m,
         cluster_n=cluster_n,
     )
@@ -1684,40 +1459,44 @@ def test_mxfp8_gemm_mpad_cluster(M, cluster_m, cluster_n):
 
 @pytest.mark.parametrize("split_k", [2, 4])
 @pytest.mark.parametrize("M", [100, 129, 256, 300, 450])
-def test_ptpc_fp8_gemm_splitk_mpad_cluster(M, split_k):
+def test_ptpc_fp8_gemm_splitk_ragged_m_cluster(M, split_k):
     # split_k atomic output (per-lane row<M predicate) combined with cluster>1.
-    _run_ptpc_mpad(M, 512, 2048, m_warp=2, n_warp=2, num_buffers=2, split_k=split_k, cluster_m=2, cluster_n=2)
-
-
-@pytest.mark.parametrize("cluster_m,cluster_n", [(2, 2), (2, 4)])
-@pytest.mark.parametrize("M", [100, 300, 512, 600, 700, 1024])
-def test_ptpc_fp8_gemm_mpad_cluster_tm256(M, cluster_m, cluster_n):
-    _run_ptpc_mpad(
+    _run_gemm_test(
+        "ptpc",
+        "fp8",
         M,
-        1024,
         512,
-        tile_m=256,
-        tile_n=256,
-        m_warp=2,
-        n_warp=2,
+        2048,
+        128,
+        128,
+        128,
+        2,
+        2,
         num_buffers=2,
-        cluster_m=cluster_m,
-        cluster_n=cluster_n,
+        out_dtype="bf16",
+        split_k=split_k,
+        cluster_m=2,
+        cluster_n=2,
     )
 
 
-@pytest.mark.parametrize("cluster_m,cluster_n", [(2, 2), (2, 4)])
-@pytest.mark.parametrize("M", [100, 300, 512, 600, 700, 1024])
-def test_mxfp8_gemm_mpad_cluster_tm256(M, cluster_m, cluster_n):
-    _run_mxscale_mpad(
+@pytest.mark.parametrize("scale_mode", ["ptpc", "mxscale"])
+@pytest.mark.parametrize("cluster_m,cluster_n", _RAGGED_M_CLUSTERS)
+@pytest.mark.parametrize("M", _RAGGED_M_CLUSTER_TM256_VALUES)
+def test_gemm_ragged_m_cluster_tm256(M, cluster_m, cluster_n, scale_mode):
+    _run_gemm_test(
+        scale_mode,
+        "fp8",
         M,
         1024,
         512,
-        tile_m=256,
-        tile_n=256,
-        m_warp=2,
-        n_warp=2,
+        256,
+        256,
+        128,
+        2,
+        2,
         num_buffers=2,
+        out_dtype="bf16",
         cluster_m=cluster_m,
         cluster_n=cluster_n,
     )
@@ -1735,22 +1514,21 @@ def _run_benchmark(args):
     if K % SCALE_BLOCK != 0:
         raise ValueError(f"K={K} must be divisible by SCALE_BLOCK={SCALE_BLOCK}")
 
-    padded_shape = _get_padded_problem_shape(data_format, M, N, K, tile_m, tile_n, tile_k, args.split_k)
-    padded_m = padded_shape["M"]
-    padded_n = padded_shape["N"]
-    padded_k = padded_shape["K"]
-    PACK_A = padded_shape["pack_a"]
-    PACK_B = padded_shape["pack_b"]
+    problem_shape = _get_problem_shape(data_format, M, N, K, tile_m, tile_n, tile_k, args.split_k)
+    kernel_m = problem_shape["M"]
+    kernel_n = problem_shape["N"]
+    kernel_k = problem_shape["K"]
+    PACK_A = problem_shape["pack_a"]
+    PACK_B = problem_shape["pack_b"]
 
     is_fp4 = data_format == "fp4"
     is_a8w4 = data_format == "a8w4"
     is_ptpc = getattr(args, "scale_mode", "mxscale") == "ptpc"
     if is_ptpc and data_format not in ("fp8", "a8w4"):
         raise ValueError(f"scale_mode='ptpc' only supports data_format='fp8' or 'a8w4', got {data_format!r}")
-    _dtype_map = {"f32": torch.float32, "bf16": torch.bfloat16, "f16": torch.float16}
     # split_k atomic-adds at output precision (bf16/f16).
     kernel_out_dtype = args.out_dtype
-    torch_kernel_dtype = _dtype_map[kernel_out_dtype]
+    torch_kernel_dtype = _DT[kernel_out_dtype]
     elem_bytes_d = 2 if kernel_out_dtype in ("bf16", "f16") else 4
     if is_ptpc:
         fmt_name = "PTPC-A8W4" if is_a8w4 else "PTPC-FP8"
@@ -1760,10 +1538,7 @@ def _run_benchmark(args):
     print("=" * 72)
     print(f"  {fmt_name} GEMM Benchmark on gfx1250")
     print(f"  PyTorch {torch.__version__}, Device: {torch.cuda.get_device_name(0)}")
-    needs_pad = (padded_m, padded_n, padded_k) != (M, N, K)
     print(f"  Shape: M={M}, N={N}, K={K}")
-    if needs_pad:
-        print(f"  Kernel pad: M={padded_m}, N={padded_n}, K={padded_k}")
     print(f"  Tile: ({tile_m}, {tile_n}, {tile_k}), warps=({args.m_warp}x{args.n_warp})")
     print(f"  Buffers={args.num_buffers}, out={args.out_dtype}, inst_prefetch={args.inst_prefetch}")
     if args.warmup < 0:
@@ -1793,7 +1568,7 @@ def _run_benchmark(args):
     if is_ptpc:
         # PTPC: fp8 A with fp32 per-token (sa[M]) / per-channel (sb[N]) scales, no scale preshuffle.
         # B is fp8 (data_format="fp8") or FP4-packed 2-per-byte (data_format="a8w4").
-        K_packed_b = padded_k // PACK_B
+        K_packed_b = kernel_k // PACK_B
         b_kind = "fp4 (a8w4)" if is_a8w4 else "fp8"
         fill_spec = _parse_fill_mode(getattr(args, "fill_mode", "random"))
         if fill_spec[0] == "const":
@@ -1802,10 +1577,8 @@ def _run_benchmark(args):
             a_raw = torch.full((M, K), fp8_byte, dtype=torch.uint8)
             b_raw = _fp4_e2m1_packed_fill(N, K, value) if is_a8w4 else torch.full((N, K), fp8_byte, dtype=torch.uint8)
             # Neutral per-token/per-channel scales so the const output stays predictable.
-            a_scale = torch.zeros(padded_m, dtype=torch.float32)
-            a_scale[:M] = 1.0
-            b_scale = torch.zeros(padded_n, dtype=torch.float32)
-            b_scale[:N] = 1.0
+            a_scale = torch.ones(M, dtype=torch.float32)
+            b_scale = torch.ones(N, dtype=torch.float32)
             if is_a8w4:
                 eff_b = _nearest_mxfp4_value(value)
                 b_note = f"fp4 B={eff_b:g}" + (f" (snapped from {value:g})" if eff_b != value else "")
@@ -1815,40 +1588,40 @@ def _run_benchmark(args):
         else:
             a_raw = random_fp8_data(M, K)
             b_raw = fp4_utils.random_fp4_packed(N, K) if is_a8w4 else random_fp8_data(N, K)
-            a_scale = torch.zeros(padded_m, dtype=torch.float32)
-            a_scale[:M] = 0.5 + torch.rand(M, dtype=torch.float32)
-            b_scale = torch.zeros(padded_n, dtype=torch.float32)
-            b_scale[:N] = 0.5 + torch.rand(N, dtype=torch.float32)
+            a_scale = (0.5 + torch.rand(M, dtype=torch.float32)).contiguous()
+            b_scale = (0.5 + torch.rand(N, dtype=torch.float32)).contiguous()
             print(f"  Fill mode: random fp8 A / {b_kind} B, fp32 per-token/per-channel scales")
-        a = _pad_2d_tensor(a_raw, padded_m, padded_k, fill_value=0)
-        b = _pad_2d_tensor(b_raw, padded_n, K_packed_b, fill_value=0)
-        b = fp4_utils.preshuffle_b_16x16(b, padded_n, K_packed_b)
+        a = a_raw
+        b = b_raw
+        _validate_ab_inputs(a, b, problem_shape)
+        _expect_shape("A scale", a_scale, (kernel_m,))
+        _expect_shape("B scale", b_scale, (kernel_n,))
+        b = fp4_utils.preshuffle_b_16x16(b, kernel_n, K_packed_b)
     else:
         a, b, a_scale, b_scale, fill_spec = _fill_mode_inputs(
             M, N, K, data_format, getattr(args, "fill_mode", "random")
         )
         print(f"  Fill mode: {_fill_mode_label(fill_spec, data_format)}")
 
-        a, b, a_scale, b_scale = _pad_mxscale_inputs(a, b, a_scale, b_scale, padded_shape)
-
+        _validate_mxscale_inputs(a, b, a_scale, b_scale, problem_shape)
         a_scale = _prepare_a_scale_for_path(a_scale, ascale_load_path)
         b_scale = preshuffle_scale(b_scale)
 
-        K_packed = padded_k // PACK_B
-        b = fp4_utils.preshuffle_b_16x16(b, padded_n, K_packed)
+        K_packed = kernel_k // PACK_B
+        b = fp4_utils.preshuffle_b_16x16(b, kernel_n, K_packed)
 
     a_gpu = a.cuda()
     b_gpu = b.cuda()
     as_gpu = a_scale.cuda()
     bs_gpu = b_scale.cuda()
-    c_gpu = torch.zeros(padded_m, padded_n, dtype=torch_kernel_dtype, device="cuda")
+    c_gpu = torch.zeros(kernel_m, kernel_n, dtype=torch_kernel_dtype, device="cuda")
 
     print("\n[1/3] Compiling kernel...")
     t0 = time.perf_counter()
     if is_ptpc:
         launch_fn = compile_ptpc_gemm(
-            N=padded_n,
-            K=padded_k,
+            N=kernel_n,
+            K=kernel_k,
             data_format=data_format,
             tile_m=tile_m,
             tile_n=tile_n,
@@ -1869,8 +1642,8 @@ def _run_benchmark(args):
     else:
         launch_fn = compile_mxscale_gemm(
             data_format=data_format,
-            N=padded_n,
-            K=padded_k,
+            N=kernel_n,
+            K=kernel_k,
             tile_m=tile_m,
             tile_n=tile_n,
             tile_k=tile_k,
@@ -1896,10 +1669,10 @@ def _run_benchmark(args):
         b_gpu,
         as_gpu,
         bs_gpu,
-        padded_m,
-        padded_n,
-        padded_k,
-        padded_n,
+        kernel_m,
+        kernel_n,
+        kernel_k,
+        kernel_n,
         torch.cuda.current_stream(),
     )
 
@@ -1910,10 +1683,10 @@ def _run_benchmark(args):
             b_,
             as_,
             bs_,
-            padded_m,
-            padded_n,
-            padded_k,
-            padded_n,
+            kernel_m,
+            kernel_n,
+            kernel_k,
+            kernel_n,
             torch.cuda.current_stream(),
         )
 
@@ -2009,10 +1782,10 @@ def _run_benchmark(args):
     wmma_n_rep = warp_tile_n // WMMA_N_EFF
     k_wmma_steps = tile_k // WMMA_K
     wmma_per_tile = wmma_m_rep * wmma_n_rep * k_wmma_steps
-    m_tiles = (padded_m + tile_m - 1) // tile_m
-    n_tiles = (padded_n + tile_n - 1) // tile_n
-    k_tiles = padded_k // tile_k
-    k_tiles_local = (padded_k // args.split_k) // tile_k
+    m_tiles = (kernel_m + tile_m - 1) // tile_m
+    n_tiles = (kernel_n + tile_n - 1) // tile_n
+    k_tiles = kernel_k // tile_k
+    k_tiles_local = (kernel_k // args.split_k) // tile_k
     # Sequential WMMAs per workgroup (all k_tiles execute sequentially)
     seq_wmma = k_tiles_local * wmma_per_tile
     us_per_wmma = us / seq_wmma if seq_wmma > 0 else 0
@@ -2020,15 +1793,15 @@ def _run_benchmark(args):
     logical_flops = 2.0 * M * N * K
     tile_m_covered = m_tiles * tile_m
     tile_n_covered = n_tiles * tile_n
-    tile_flops = 2.0 * tile_m_covered * tile_n_covered * padded_k
+    tile_flops = 2.0 * tile_m_covered * tile_n_covered * kernel_k
     time_s = us / 1e6
     logical_tflops = logical_flops / time_s / 1e12 if time_s > 0 else 0.0
     tile_tflops = tile_flops / time_s / 1e12 if time_s > 0 else 0.0
 
-    bytes_a = padded_m * padded_k // PACK_A
-    bytes_b = padded_n * padded_k // PACK_B
-    bytes_scale = (padded_m + padded_n) * (4 if is_ptpc else padded_shape["K_scale"])
-    bytes_d = padded_m * padded_n * elem_bytes_d
+    bytes_a = kernel_m * kernel_k // PACK_A
+    bytes_b = kernel_n * kernel_k // PACK_B
+    bytes_scale = (kernel_m + kernel_n) * (4 if is_ptpc else problem_shape["K_scale"])
+    bytes_d = kernel_m * kernel_n * elem_bytes_d
     read_bytes = bytes_a + bytes_b + bytes_scale
     write_bytes = bytes_d
     bytes_moved = read_bytes + write_bytes
@@ -2077,14 +1850,14 @@ def _run_graph_verify(args):
     if K % SCALE_BLOCK != 0:
         raise SystemExit(f"K={K} must be divisible by SCALE_BLOCK={SCALE_BLOCK}")
 
-    padded_shape = _get_padded_problem_shape(data_format, M, N, K, tile_m, tile_n, tile_k, args.split_k)
-    padded_m = padded_shape["M"]
-    padded_n = padded_shape["N"]
-    padded_k = padded_shape["K"]
+    problem_shape = _get_problem_shape(data_format, M, N, K, tile_m, tile_n, tile_k, args.split_k)
+    kernel_m = problem_shape["M"]
+    kernel_n = problem_shape["N"]
+    kernel_k = problem_shape["K"]
 
     print("=" * 72)
     print(f"  Graph functional verification ({data_format}) on gfx1250")
-    print(f"  Shape: M={M}, N={N}, K={K}  (padded {padded_m}x{padded_n}x{padded_k})")
+    print(f"  Shape: M={M}, N={N}, K={K}")
     print(
         f"  Tile: ({tile_m},{tile_n},{tile_k}) warps=({args.m_warp}x{args.n_warp}) "
         f"nb={args.num_buffers} sk={args.split_k} "
@@ -2097,27 +1870,25 @@ def _run_graph_verify(args):
     expect_nonzero_output = _expect_nonzero_graph_output(a, b, data_format, fill_spec)
     print(f"  Fill: {_fill_mode_label(fill_spec, data_format)}")
 
-    a, b, a_scale, b_scale = _pad_mxscale_inputs(a, b, a_scale, b_scale, padded_shape)
-
+    _validate_mxscale_inputs(a, b, a_scale, b_scale, problem_shape)
     ascale_load_path = _select_ascale_load_path(M)
     a_scale = _prepare_a_scale_for_path(a_scale, ascale_load_path)
     b_scale = preshuffle_scale(b_scale)
-    K_packed = padded_k // padded_shape["pack_b"]
-    b = fp4_utils.preshuffle_b_16x16(b, padded_n, K_packed)
+    K_packed = kernel_k // problem_shape["pack_b"]
+    b = fp4_utils.preshuffle_b_16x16(b, kernel_n, K_packed)
 
     a_gpu = a.cuda()
     b_gpu = b.cuda()
     as_gpu = a_scale.cuda()
     bs_gpu = b_scale.cuda()
-    _dtype_map = {"f32": torch.float32, "bf16": torch.bfloat16, "f16": torch.float16}
     # split_k atomic-adds at output precision (bf16/f16).
     kernel_out_dtype = args.out_dtype
-    c_gpu = torch.zeros(padded_m, padded_n, dtype=_dtype_map[kernel_out_dtype], device="cuda")
+    c_gpu = torch.zeros(kernel_m, kernel_n, dtype=_DT[kernel_out_dtype], device="cuda")
 
     launch_fn = compile_mxscale_gemm(
         data_format=data_format,
-        N=padded_n,
-        K=padded_k,
+        N=kernel_n,
+        K=kernel_k,
         tile_m=tile_m,
         tile_n=tile_n,
         tile_k=tile_k,
@@ -2148,10 +1919,10 @@ def _run_graph_verify(args):
         b_flat,
         as_flat,
         bs_flat,
-        padded_m,
-        padded_n,
-        padded_k,
-        padded_n,
+        kernel_m,
+        kernel_n,
+        kernel_k,
+        kernel_n,
         torch.cuda.current_stream(),
     )
 
@@ -2162,10 +1933,10 @@ def _run_graph_verify(args):
             b_flat,
             as_flat,
             bs_flat,
-            padded_m,
-            padded_n,
-            padded_k,
-            padded_n,
+            kernel_m,
+            kernel_n,
+            kernel_k,
+            kernel_n,
             torch.cuda.current_stream(),
         )
 
@@ -2306,7 +2077,9 @@ if __name__ == "__main__":
     def _run_correctness_test():
         """Run the functional test (computes a reference and asserts correctness)."""
         if args.scale_mode == "ptpc":
-            _run_ptpc_gemm_test(
+            _run_gemm_test(
+                "ptpc",
+                args.data_format,
                 args.M,
                 args.N,
                 args.K,
@@ -2317,14 +2090,14 @@ if __name__ == "__main__":
                 args.n_warp,
                 num_buffers=args.num_buffers,
                 out_dtype=args.out_dtype,
-                data_format=args.data_format,
                 l2_prefetch_distance=args.l2_prefetch_distance,
                 cluster_m=args.cluster_m,
                 cluster_n=args.cluster_n,
                 split_k=args.split_k,
             )
         else:
-            _run_mxscale_gemm_test(
+            _run_gemm_test(
+                "mxscale",
                 args.data_format,
                 args.M,
                 args.N,


### PR DESCRIPTION
## Motivation

Fix the small-M mxscale A-scale VGPR regression. Optimize exposed LDS/TDM latency on row-major decode GEMM shapes.

## Technical Details

Predicates ragged-M A-scale VGPR loads and preserves the VGPR A-scale prefetch ring through tail handling.

Adds and simplifies row-major K-step LDS->VGPR prefetch scheduling for single-M-rep decode shapes. Enables late TDM fence signaling on the row-major K-prefetch path, and tunes the A-scale VGPR ring depth for 4-buffer row-major mxscale kernels.

## Test Plan

Ran focused benchmark/correctness on A8W4/MXFP8/MXFP4/PTPC row-major decode shapes.

## Test Result

Correctness verification passed. A8W4 `M=1, N=12288, K=3072` mxscale optimized from ~5us to ~4.5us, `M=64` currently measures 7.2us.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.