### PR TITLE
[Fix] Call aiter pa_reduce_v1 by keyword to track arg-order change

### DIFF
--- a/kernels/pa_decode_fp8.py
+++ b/kernels/pa_decode_fp8.py
@@ -3188,16 +3188,20 @@ def pa_decode_ps_launch(
 
     from aiter.ops.attention import pa_reduce_v1
 
+    # Pass by keyword: aiter reordered pa_reduce_v1's positional args (num_kv_splits
+    # moved to a trailing optional), so positional calls silently misalign. Keyword
+    # names are stable across aiter versions. num_kv_splits=0 means auto (SM_count);
+    # the actual splits are data-driven via the reduce_* maps.
     pa_reduce_v1(
-        partial_output[query_length:],
-        partial_lse[query_length:],
-        metadata["reduce_indptr"],
-        metadata["reduce_final_map"],
-        metadata["reduce_partial_map"],
-        query_length,  # max_qlen
-        0,  # num_kv_splits: splits are data-driven via reduce_* maps
-        output,
-        None,
+        partial_output=partial_output[query_length:],
+        partial_lse=partial_lse[query_length:],
+        reduce_indptr=metadata["reduce_indptr"],
+        reduce_final_map=metadata["reduce_final_map"],
+        reduce_partial_map=metadata["reduce_partial_map"],
+        max_seqlen_q=query_length,
+        num_kv_splits=0,
+        final_output=output,
+        final_lse=None,
     )
 
     return "ps_split_reduce"

--- a/kernels/pa_decode_fp8.py
+++ b/kernels/pa_decode_fp8.py
@@ -3187,11 +3187,6 @@ def pa_decode_ps_launch(
     )
 
     from aiter.ops.attention import pa_reduce_v1
-
-    # Pass by keyword: aiter reordered pa_reduce_v1's positional args (num_kv_splits
-    # moved to a trailing optional), so positional calls silently misalign. Keyword
-    # names are stable across aiter versions. num_kv_splits=0 means auto (SM_count);
-    # the actual splits are data-driven via the reduce_* maps.
     pa_reduce_v1(
         partial_output=partial_output[query_length:],
         partial_lse=partial_lse[query_length:],


### PR DESCRIPTION
## Problem

CI (`flydsl.yaml` "Fly DSL test") clones **aiter at `main` HEAD** and was failing on **every PR** in `tests/kernels/test_pa.py`:

```
test_multi_case_set[normal_accuracy]
test_multi_case_set[sliding_window_accuracy]
RuntimeError: aiter::mla_reduce_v1() Expected a value of type 'int' for
argument 'num_kv_splits' but instead found type 'NoneType'.
```

This is environmental (the failing PRs don't touch paged attention) and started the moment aiter `main` changed.

## Root cause

aiter reordered `pa_reduce_v1`: `num_kv_splits` moved to a **trailing optional** (default `0`) and `final_output`/`final_lse` shifted forward:

```python
# old: ..., max_seqlen_q, num_kv_splits, final_output, final_lse=None
# new: ..., max_seqlen_q, final_output, final_lse=None, num_kv_splits=0
```

FlyDSL's **positional** call in `pa_decode_ps_launch` then misaligned — `0` → `final_output`, `output` → `final_lse`, `None` → `num_kv_splits` — so `mla_reduce_v1` received `num_kv_splits=None` and crashed.

## Fix

Call `pa_reduce_v1` with **keyword arguments**. The parameter *names* are stable across aiter versions, so the call is correct regardless of positional order. `num_kv_splits=0` preserves the previous "auto / SM_count" semantics (identical to the old explicit `0`).

## Verification

- `inspect`-bound the new call against both the old and new aiter signatures, and simulated the full `pa_reduce_v1 → mla_reduce_v1 → compiled op` chain — `final_output`=output tensor, `num_kv_splits`=0 in all cases.
- Ran on real GPU: `test_pa.py::test_multi_case_set[normal_accuracy]` and `[sliding_window_accuracy]` both **pass**.
- `black` + `ruff` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)