### PR TITLE
return full atom-tv-tile view from tiled-copy

### DIFF
--- a/lib/Dialect/Fly/IR/FlyOps.cpp
+++ b/lib/Dialect/Fly/IR/FlyOps.cpp
@@ -1509,6 +1509,13 @@ FLY_INFER_RETURN_TYPES(TiledCopyPartitionSrcOp) {
   LayoutBuilder<LayoutAttr> builder(context);
   LayoutAttr thrValView =
       layoutTiledCopyThrValViewSrc(builder, copyAtom, tiledLayoutThrVal, tileMN, srcLayout);
+    
+  if (thrIdx.isLeafInt()) {
+    if (thrIdx.getLeafAsInt().getValue() < 0) {
+      inferredReturnTypes.assign({RebuildLayoutLikeType(srcTy, thrValView)});
+      return success();
+    }
+  }
 
   SmallVector<Attribute> coordElems;
   coordElems.push_back(thrIdx);
@@ -1560,6 +1567,14 @@ FLY_INFER_RETURN_TYPES(TiledCopyPartitionDstOp) {
   LayoutBuilder<LayoutAttr> builder(context);
   LayoutAttr thrValView =
       layoutTiledCopyThrValViewDst(builder, copyAtom, tiledLayoutThrVal, tileMN, dstLayout);
+
+  if (thrIdx.isLeafInt()) {
+    if (thrIdx.getLeafAsInt().getValue() < 0) {
+      inferredReturnTypes.assign({RebuildLayoutLikeType(dstTy, thrValView)});
+      return success();
+    }
+  }
+
 
   SmallVector<Attribute> coordElems;
   coordElems.push_back(thrIdx);

--- a/lib/Dialect/Fly/IR/FlyOps.cpp
+++ b/lib/Dialect/Fly/IR/FlyOps.cpp
@@ -1509,7 +1509,7 @@ FLY_INFER_RETURN_TYPES(TiledCopyPartitionSrcOp) {
   LayoutBuilder<LayoutAttr> builder(context);
   LayoutAttr thrValView =
       layoutTiledCopyThrValViewSrc(builder, copyAtom, tiledLayoutThrVal, tileMN, srcLayout);
-    
+
   if (thrIdx.isLeafInt()) {
     if (thrIdx.getLeafAsInt().getValue() < 0) {
       inferredReturnTypes.assign({RebuildLayoutLikeType(srcTy, thrValView)});
@@ -1574,7 +1574,6 @@ FLY_INFER_RETURN_TYPES(TiledCopyPartitionDstOp) {
       return success();
     }
   }
-
 
   SmallVector<Attribute> coordElems;
   coordElems.push_back(thrIdx);

--- a/lib/Dialect/Fly/IR/FlyOps.cpp
+++ b/lib/Dialect/Fly/IR/FlyOps.cpp
@@ -1510,11 +1510,9 @@ FLY_INFER_RETURN_TYPES(TiledCopyPartitionSrcOp) {
   LayoutAttr thrValView =
       layoutTiledCopyThrValViewSrc(builder, copyAtom, tiledLayoutThrVal, tileMN, srcLayout);
 
-  if (thrIdx.isLeafInt()) {
-    if (thrIdx.getLeafAsInt().getValue() < 0) {
-      inferredReturnTypes.assign({RebuildLayoutLikeType(srcTy, thrValView)});
-      return success();
-    }
+  if (thrIdx.isLeafStaticValue(-1)) {
+    inferredReturnTypes.assign({RebuildLayoutLikeType(srcTy, thrValView)});
+    return success();
   }
 
   SmallVector<Attribute> coordElems;
@@ -1568,11 +1566,9 @@ FLY_INFER_RETURN_TYPES(TiledCopyPartitionDstOp) {
   LayoutAttr thrValView =
       layoutTiledCopyThrValViewDst(builder, copyAtom, tiledLayoutThrVal, tileMN, dstLayout);
 
-  if (thrIdx.isLeafInt()) {
-    if (thrIdx.getLeafAsInt().getValue() < 0) {
-      inferredReturnTypes.assign({RebuildLayoutLikeType(dstTy, thrValView)});
-      return success();
-    }
+  if (thrIdx.isLeafStaticValue(-1)) {
+    inferredReturnTypes.assign({RebuildLayoutLikeType(dstTy, thrValView)});
+    return success();
   }
 
   SmallVector<Attribute> coordElems;

--- a/lib/Dialect/Fly/Transforms/LayoutLowering.cpp
+++ b/lib/Dialect/Fly/Transforms/LayoutLowering.cpp
@@ -1798,8 +1798,8 @@ public:
     if (coordTy.getAttr().isLeafStaticValue(-1)) {
       LayoutValueAdaptor thrValViewLayout =
           replaceLeafOuterLayout(layoutBuilder, fullLayoutAdaptor, thrValView);
-      Value fullPartitionView = MakeViewOp::create(rewriter, loc, iter, thrValViewLayout.getValue());
-      rewriter.replaceOp(op, fullPartitionView);
+      Value fullView = MakeViewOp::create(rewriter, loc, iter, thrValViewLayout.getValue());
+      rewriter.replaceOp(op, fullView);
       return success();
     }
 

--- a/lib/Dialect/Fly/Transforms/LayoutLowering.cpp
+++ b/lib/Dialect/Fly/Transforms/LayoutLowering.cpp
@@ -1795,6 +1795,17 @@ public:
     LayoutValueAdaptor thrValView =
         ThrValViewFunc(layoutBuilder, copyAtom, tiledLayoutThrVal, tileMN, outerAdaptor);
 
+    auto crd = coordTy.getAttr();
+    if (crd.isLeafInt()) {
+      if (crd.getLeafAsInt().getValue() < 0) {
+        LayoutValueAdaptor theThrValView =
+            replaceLeafOuterLayout(layoutBuilder, fullLayoutAdaptor, thrValView);
+        Value new_view = MakeViewOp::create(rewriter, loc, iter, theThrValView.getValue());
+        rewriter.replaceOp(op, new_view);
+        return success();
+      }
+    }
+
     auto thrValShape = layoutBuilder.getShape(thrValView);
     auto thrValStride = layoutBuilder.getStride(thrValView);
     auto expandedShape = intTupleExpand(layoutBuilder, thrValShape, {2});

--- a/lib/Dialect/Fly/Transforms/LayoutLowering.cpp
+++ b/lib/Dialect/Fly/Transforms/LayoutLowering.cpp
@@ -1795,15 +1795,12 @@ public:
     LayoutValueAdaptor thrValView =
         ThrValViewFunc(layoutBuilder, copyAtom, tiledLayoutThrVal, tileMN, outerAdaptor);
 
-    auto crd = coordTy.getAttr();
-    if (crd.isLeafInt()) {
-      if (crd.getLeafAsInt().getValue() < 0) {
-        LayoutValueAdaptor theThrValView =
-            replaceLeafOuterLayout(layoutBuilder, fullLayoutAdaptor, thrValView);
-        Value new_view = MakeViewOp::create(rewriter, loc, iter, theThrValView.getValue());
-        rewriter.replaceOp(op, new_view);
-        return success();
-      }
+    if (coordTy.getAttr().isLeafStaticValue(-1)) {
+      LayoutValueAdaptor thrValViewLayout =
+          replaceLeafOuterLayout(layoutBuilder, fullLayoutAdaptor, thrValView);
+      Value fullPartitionView = MakeViewOp::create(rewriter, loc, iter, thrValViewLayout.getValue());
+      rewriter.replaceOp(op, fullPartitionView);
+      return success();
     }
 
     auto thrValShape = layoutBuilder.getShape(thrValView);

--- a/python/flydsl/expr/typing.py
+++ b/python/flydsl/expr/typing.py
@@ -1128,6 +1128,12 @@ class TiledCopy(BuiltinDslType):
     def layout_dst_tv_tiled(self):
         return static(self.type.tiled_tv_layout_dst)
 
+    def partition_S(self, src: Tensor):
+        return tiled_copy_partition_src(self, src, make_int_tuple(-1))
+
+    def partition_D(self, dst: Tensor):
+        return tiled_copy_partition_dst(self, dst, make_int_tuple(-1))
+
     def get_slice(self, thr_idx):
         from .derived import ThrCopy
 

--- a/tests/mlir/Transforms/layout_lowering.mlir
+++ b/tests/mlir/Transforms/layout_lowering.mlir
@@ -402,8 +402,10 @@ func.func @test_tiled_copy_partition_src_full_view(
   // CHECK-NOT: fly.tiled_copy.partition_src
   // CHECK-NOT: fly.slice
   // CHECK-NOT: fly.add_offset
-  // CHECK: fly.make_view
+  // CHECK: %[[PART:.*]] = fly.make_view
+  // CHECK-NOT: fly.make_view
   %partition = fly.tiled_copy.partition_src(%tiled_copy, %src, %sentinel) : (!fly.tiled_copy<!fly.copy_atom<!fly.universal_copy<128>, 32>, !fly.layout<((32,8),4):((32,1),8)>, !fly.tile<[8|128]>>, !fly.memref<i32, global, (128,128):(1,0)>, !fly.int_tuple<-1>) -> !fly.memref<i32, global, ((32,8),(4,1),(16,1)):((0,1),(0,0),(8,0))>
+  // CHECK: return %[[PART]]
   return %partition : !fly.memref<i32, global, ((32,8),(4,1),(16,1)):((0,1),(0,0),(8,0))>
 }
 
@@ -420,8 +422,10 @@ func.func @test_tiled_copy_partition_dst_full_view(
   // CHECK-NOT: fly.tiled_copy.partition_dst
   // CHECK-NOT: fly.slice
   // CHECK-NOT: fly.add_offset
-  // CHECK: fly.make_view
+  // CHECK: %[[PART:.*]] = fly.make_view
+  // CHECK-NOT: fly.make_view
   %partition = fly.tiled_copy.partition_dst(%tiled_copy, %src, %sentinel) : (!fly.tiled_copy<!fly.copy_atom<!fly.universal_copy<128>, 32>, !fly.layout<((32,8),4):((32,1),8)>, !fly.tile<[8|128]>>, !fly.memref<i32, global, (128,128):(1,0)>, !fly.int_tuple<-1>) -> !fly.memref<i32, global, ((32,8),(4,1),(16,1)):((0,1),(0,0),(8,0))>
+  // CHECK: return %[[PART]]
   return %partition : !fly.memref<i32, global, ((32,8),(4,1),(16,1)):((0,1),(0,0),(8,0))>
 }
 

--- a/tests/mlir/Transforms/layout_lowering.mlir
+++ b/tests/mlir/Transforms/layout_lowering.mlir
@@ -384,3 +384,79 @@ func.func @test_get_leaves_dynamic_only(%x: i32, %y: i64) -> (i32, i64) {
   %0:2 = fly.get_leaves(%t) {dynamicOnly = true} : (!fly.int_tuple<(4, ?, ?{i64})>) -> (i32, i64)
   return %0#0, %0#1 : i32, i64
 }
+
+// -----
+
+// === TiledCopy Partition ===
+
+// CHECK-LABEL: @test_tiled_copy_partition_src_full_view
+func.func @test_tiled_copy_partition_src_full_view(
+  %ptr: !fly.ptr<i32, global>,
+  %tiled_copy: !fly.tiled_copy<!fly.copy_atom<!fly.universal_copy<128>, 32>, !fly.layout<((32,8),4):((32,1),8)>, !fly.tile<[8|128]>>) -> !fly.memref<i32, global, ((32,8),(4,1),(16,1)):((0,1),(0,0),(8,0))> {
+
+  %34 = fly.make_int_tuple() : () -> !fly.int_tuple<(128,128)>
+  %35 = fly.make_int_tuple() : () -> !fly.int_tuple<(1,0)>
+  %layout = fly.make_layout(%34, %35) : (!fly.int_tuple<(128,128)>, !fly.int_tuple<(1,0)>) -> !fly.layout<(128,128):(1,0)>
+  %src = fly.make_view(%ptr, %layout) : (!fly.ptr<i32, global>, !fly.layout<(128,128):(1,0)>) -> !fly.memref<i32, global, (128,128):(1,0)>
+  %sentinel = fly.make_int_tuple() : () -> !fly.int_tuple<-1>
+  // CHECK-NOT: fly.tiled_copy.partition_src
+  // CHECK-NOT: fly.slice
+  // CHECK-NOT: fly.add_offset
+  // CHECK: fly.make_view
+  %partition = fly.tiled_copy.partition_src(%tiled_copy, %src, %sentinel) : (!fly.tiled_copy<!fly.copy_atom<!fly.universal_copy<128>, 32>, !fly.layout<((32,8),4):((32,1),8)>, !fly.tile<[8|128]>>, !fly.memref<i32, global, (128,128):(1,0)>, !fly.int_tuple<-1>) -> !fly.memref<i32, global, ((32,8),(4,1),(16,1)):((0,1),(0,0),(8,0))>
+  return %partition : !fly.memref<i32, global, ((32,8),(4,1),(16,1)):((0,1),(0,0),(8,0))>
+}
+
+// CHECK-LABEL: @test_tiled_copy_partition_dst_full_view
+func.func @test_tiled_copy_partition_dst_full_view(
+  %ptr: !fly.ptr<i32, global>,
+  %tiled_copy: !fly.tiled_copy<!fly.copy_atom<!fly.universal_copy<128>, 32>, !fly.layout<((32,8),4):((32,1),8)>, !fly.tile<[8|128]>>) -> !fly.memref<i32, global, ((32,8),(4,1),(16,1)):((0,1),(0,0),(8,0))> {
+
+  %34 = fly.make_int_tuple() : () -> !fly.int_tuple<(128,128)>
+  %35 = fly.make_int_tuple() : () -> !fly.int_tuple<(1,0)>
+  %layout = fly.make_layout(%34, %35) : (!fly.int_tuple<(128,128)>, !fly.int_tuple<(1,0)>) -> !fly.layout<(128,128):(1,0)>
+  %src = fly.make_view(%ptr, %layout) : (!fly.ptr<i32, global>, !fly.layout<(128,128):(1,0)>) -> !fly.memref<i32, global, (128,128):(1,0)>
+  %sentinel = fly.make_int_tuple() : () -> !fly.int_tuple<-1>
+  // CHECK-NOT: fly.tiled_copy.partition_dst
+  // CHECK-NOT: fly.slice
+  // CHECK-NOT: fly.add_offset
+  // CHECK: fly.make_view
+  %partition = fly.tiled_copy.partition_dst(%tiled_copy, %src, %sentinel) : (!fly.tiled_copy<!fly.copy_atom<!fly.universal_copy<128>, 32>, !fly.layout<((32,8),4):((32,1),8)>, !fly.tile<[8|128]>>, !fly.memref<i32, global, (128,128):(1,0)>, !fly.int_tuple<-1>) -> !fly.memref<i32, global, ((32,8),(4,1),(16,1)):((0,1),(0,0),(8,0))>
+  return %partition : !fly.memref<i32, global, ((32,8),(4,1),(16,1)):((0,1),(0,0),(8,0))>
+}
+
+// CHECK-LABEL: @test_tiled_copy_partition_src_thread_view
+func.func @test_tiled_copy_partition_src_thread_view(
+  %ptr: !fly.ptr<i32, global>,
+  %tid: i32,
+  %tiled_copy: !fly.tiled_copy<!fly.copy_atom<!fly.universal_copy<128>, 32>, !fly.layout<((32,8),4):((32,1),8)>, !fly.tile<[8|128]>>) -> !fly.memref<i32, global, ((4,1),16,1):((0,0),8,0)> {
+
+  %34 = fly.make_int_tuple() : () -> !fly.int_tuple<(128,128)>
+  %35 = fly.make_int_tuple() : () -> !fly.int_tuple<(1,0)>
+  %layout = fly.make_layout(%34, %35) : (!fly.int_tuple<(128,128)>, !fly.int_tuple<(1,0)>) -> !fly.layout<(128,128):(1,0)>
+  %src = fly.make_view(%ptr, %layout) : (!fly.ptr<i32, global>, !fly.layout<(128,128):(1,0)>) -> !fly.memref<i32, global, (128,128):(1,0)>
+  %slice_id = fly.make_int_tuple(%tid) : (i32) -> !fly.int_tuple<?>
+  // CHECK-NOT: fly.tiled_copy.partition_src
+  // CHECK: fly.add_offset
+  // CHECK: fly.make_view
+  %partition = fly.tiled_copy.partition_src(%tiled_copy, %src, %slice_id) : (!fly.tiled_copy<!fly.copy_atom<!fly.universal_copy<128>, 32>, !fly.layout<((32,8),4):((32,1),8)>, !fly.tile<[8|128]>>, !fly.memref<i32, global, (128,128):(1,0)>, !fly.int_tuple<?>) -> !fly.memref<i32, global, ((4,1),16,1):((0,0),8,0)>
+  return %partition : !fly.memref<i32, global, ((4,1),16,1):((0,0),8,0)>
+}
+
+// CHECK-LABEL: @test_tiled_copy_partition_dst_thread_view
+func.func @test_tiled_copy_partition_dst_thread_view(
+  %ptr: !fly.ptr<i32, global>,
+  %tid: i32,
+  %tiled_copy: !fly.tiled_copy<!fly.copy_atom<!fly.universal_copy<128>, 32>, !fly.layout<((32,8),4):((32,1),8)>, !fly.tile<[8|128]>>) -> !fly.memref<i32, global, ((4,1),16,1):((0,0),8,0)> {
+
+  %34 = fly.make_int_tuple() : () -> !fly.int_tuple<(128,128)>
+  %35 = fly.make_int_tuple() : () -> !fly.int_tuple<(1,0)>
+  %layout = fly.make_layout(%34, %35) : (!fly.int_tuple<(128,128)>, !fly.int_tuple<(1,0)>) -> !fly.layout<(128,128):(1,0)>
+  %src = fly.make_view(%ptr, %layout) : (!fly.ptr<i32, global>, !fly.layout<(128,128):(1,0)>) -> !fly.memref<i32, global, (128,128):(1,0)>
+  %slice_id = fly.make_int_tuple(%tid) : (i32) -> !fly.int_tuple<?>
+  // CHECK-NOT: fly.tiled_copy.partition_dst
+  // CHECK: fly.add_offset
+  // CHECK: fly.make_view
+  %partition = fly.tiled_copy.partition_dst(%tiled_copy, %src, %slice_id) : (!fly.tiled_copy<!fly.copy_atom<!fly.universal_copy<128>, 32>, !fly.layout<((32,8),4):((32,1),8)>, !fly.tile<[8|128]>>, !fly.memref<i32, global, (128,128):(1,0)>, !fly.int_tuple<?>) -> !fly.memref<i32, global, ((4,1),16,1):((0,0),8,0)>
+  return %partition : !fly.memref<i32, global, ((4,1),16,1):((0,0),8,0)>
+}


### PR DESCRIPTION
## Motivation

This PR introduces full partion view API into TiledCopy, according to [issue](https://github.com/ROCm/FlyDSL/issues/715)

To make minimal change, I reused existing tiled_copy_partition_src API by introducing -1 as sentinel thr_int_tuple.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
