### PR TITLE
Fix ROCm arch autodetect: fail fast by default with opt-in fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ Use names from `python/flydsl/utils/env.py`; do not introduce alternate spelling
 | External LLVM/MLIR codegen | `FLYDSL_COMPILE_LLVM_DIR` (install prefix; enables external-binary final codegen, part of the JIT cache key) |
 | IR dumps | `FLYDSL_DUMP_IR`, `FLYDSL_DUMP_DIR` |
 | Runtime kind | `FLYDSL_RUNTIME_KIND` |
-| GPU arch hints | `FLYDSL_GPU_ARCH`, `HSA_OVERRIDE_GFX_VERSION` |
+| GPU arch hints | `FLYDSL_GPU_ARCH`, `HSA_OVERRIDE_GFX_VERSION`, `FLYDSL_GPU_ARCH_FALLBACK` |
 | Debug info / pass diagnostics | `FLYDSL_DEBUG_ENABLE_DEBUG_INFO`, `FLYDSL_DEBUG_PRINT_AFTER_ALL`, `FLYDSL_DEBUG_AST_DIFF` |
 
 The JIT disk cache normally invalidates on kernel source and closure changes.

--- a/docs/architecture_guide.md
+++ b/docs/architecture_guide.md
@@ -393,7 +393,7 @@ Transforms Python control flow to MLIR ops at the AST level:
 1. `FLYDSL_GPU_ARCH` env var
 2. `HSA_OVERRIDE_GFX_VERSION` env var (supports `9.4.2` → `gfx942` format)
 3. `rocm_agent_enumerator` system tool
-4. Default: `gfx942`
+4. No default. Fails unless `FLYDSL_GPU_ARCH_FALLBACK` is set (`1`, `true`, `yes`, or `on`).
 
 ---
 

--- a/python/flydsl/runtime/device.py
+++ b/python/flydsl/runtime/device.py
@@ -28,25 +28,60 @@ def _arch_from_rocm_agent_enumerator() -> Optional[str]:
 
 
 @functools.lru_cache(maxsize=None)
-def _arch_from_hardware() -> str:
+def _arch_from_hardware() -> Optional[str]:
     """Cached hardware detection (rocm_agent_enumerator is slow)."""
     arch = _arch_from_rocm_agent_enumerator()
     if arch:
         return arch.split(":", 1)[0]
-    return "gfx942"
+    return None
+
+
+def _parse_arch_override(value: Optional[str]) -> Optional[str]:
+    """Accept either gfx-format or dotted HSA override values."""
+    if not value:
+        return None
+    value = value.strip()
+    if value.startswith("gfx"):
+        if len(value) == 3 or not value[3:].isdigit():
+            raise ValueError(f"Invalid FLYDSL_GPU_ARCH value: {value}")
+        return value
+    if value.count(".") == 2:
+        parts = value.split(".")
+        if all(part.isdigit() for part in parts):
+            return f"gfx{''.join(parts)}"
+        raise ValueError(f"Invalid HSA_OVERRIDE_GFX_VERSION value: {value}")
+    return None
+
+
+def _bool_env_var(name: str) -> bool:
+    """Boolean env var parser compatible with project conventions."""
+    return os.environ.get(name, "").lower() in ("1", "true", "yes", "on")
 
 
 def get_rocm_arch() -> str:
-    """Best-effort ROCm GPU arch string (e.g. 'gfx942')."""
+    """Resolved ROCm GPU architecture string (e.g. 'gfx942')."""
     env = os.environ.get("FLYDSL_GPU_ARCH") or os.environ.get("HSA_OVERRIDE_GFX_VERSION")
-    if env:
-        if env.startswith("gfx"):
-            return env
-        if env.count(".") == 2:
-            parts = env.split(".")
-            return f"gfx{parts[0]}{parts[1]}{parts[2]}"
+    if env is not None:
+        arch = _parse_arch_override(env)
+        if arch:
+            return arch
+        raise RuntimeError(
+            f"FLYDSL_GPU_ARCH/HSA_OVERRIDE_GFX_VERSION is set to an invalid value: {env!r}. "
+            "Expected values like 'gfx942' or '9.4.2'."
+        )
 
-    return _arch_from_hardware()
+    hardware_arch = _arch_from_hardware()
+    if hardware_arch:
+        return hardware_arch
+
+    if _bool_env_var("FLYDSL_GPU_ARCH_FALLBACK"):
+        return "gfx942"
+
+    raise RuntimeError(
+        "Unable to detect ROCm GPU architecture. "
+        "Set FLYDSL_GPU_ARCH (or HSA_OVERRIDE_GFX_VERSION), "
+        "or set FLYDSL_GPU_ARCH_FALLBACK=1 to use the legacy fallback."
+    )
 
 
 @functools.lru_cache(maxsize=None)

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,7 +49,7 @@ Use the same names as [`python/flydsl/utils/env.py`](../python/flydsl/utils/env.
 | Enable/disable JIT disk cache | `FLYDSL_RUNTIME_ENABLE_CACHE` (`0` / `false` to disable; in-memory cache remains active) |
 | IR dump | `FLYDSL_DUMP_IR`, `FLYDSL_DUMP_DIR` |
 | Device runtime kind | `FLYDSL_RUNTIME_KIND` |
-| ROCm arch hints (detection helpers) | `FLYDSL_GPU_ARCH`, `HSA_OVERRIDE_GFX_VERSION` |
+| ROCm arch hints (detection helpers) | `FLYDSL_GPU_ARCH`, `HSA_OVERRIDE_GFX_VERSION`, `FLYDSL_GPU_ARCH_FALLBACK` |
 
 Session-level pytest options are supported in `tests/conftest.py`:
 

--- a/tests/unit/test_runtime_device.py
+++ b/tests/unit/test_runtime_device.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Behavioral tests for GPU architecture detection and fallback."""
+
+import pytest
+
+from flydsl.runtime import device
+
+
+@pytest.fixture(autouse=True)
+def _clear_arch_cache():
+    """Avoid stale lru_cache hits when monkeypatching hardware detection."""
+    device._arch_from_hardware.cache_clear()
+    yield
+    device._arch_from_hardware.cache_clear()
+
+
+def test_get_rocm_arch_uses_explicit_env(monkeypatch):
+    """Explicit user override should always win."""
+    monkeypatch.setenv("FLYDSL_GPU_ARCH", "gfx950")
+    monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "7.0.0")
+    monkeypatch.delenv("FLYDSL_GPU_ARCH_FALLBACK", raising=False)
+    monkeypatch.setattr(device, "_arch_from_hardware", lambda: None)
+    assert device.get_rocm_arch() == "gfx950"
+
+
+def test_get_rocm_arch_raises_without_hardware_and_no_fallback(monkeypatch):
+    """Fail loudly when architecture cannot be detected."""
+    monkeypatch.delenv("FLYDSL_GPU_ARCH", raising=False)
+    monkeypatch.delenv("HSA_OVERRIDE_GFX_VERSION", raising=False)
+    monkeypatch.delenv("FLYDSL_GPU_ARCH_FALLBACK", raising=False)
+    monkeypatch.setattr(device, "_arch_from_hardware", lambda: None)
+    with pytest.raises(
+        RuntimeError, match="Unable to detect ROCm GPU architecture"
+    ):
+        device.get_rocm_arch()
+
+
+def test_get_rocm_arch_fallback_opt_in(monkeypatch):
+    """Opt-in fallback should restore legacy gfx942 behavior."""
+    monkeypatch.delenv("FLYDSL_GPU_ARCH", raising=False)
+    monkeypatch.delenv("HSA_OVERRIDE_GFX_VERSION", raising=False)
+    monkeypatch.setenv("FLYDSL_GPU_ARCH_FALLBACK", "1")
+    monkeypatch.setattr(device, "_arch_from_hardware", lambda: None)
+    assert device.get_rocm_arch() == "gfx942"
+
+
+def test_get_rocm_arch_fallback_env_true_false(monkeypatch):
+    """Fallback flag accepts common truthy and falsy values."""
+    monkeypatch.delenv("FLYDSL_GPU_ARCH", raising=False)
+    monkeypatch.delenv("HSA_OVERRIDE_GFX_VERSION", raising=False)
+    monkeypatch.setenv("FLYDSL_GPU_ARCH_FALLBACK", "false")
+    monkeypatch.setattr(device, "_arch_from_hardware", lambda: None)
+    with pytest.raises(RuntimeError, match="Unable to detect ROCm GPU architecture"):
+        device.get_rocm_arch()
+
+    monkeypatch.setenv("FLYDSL_GPU_ARCH_FALLBACK", "on")
+    assert device.get_rocm_arch() == "gfx942"
+
+
+def test_get_rocm_arch_raises_for_invalid_override(monkeypatch):
+    """Invalid explicit env override should fail with clear diagnostics."""
+    monkeypatch.setenv("FLYDSL_GPU_ARCH", "bad-arch")
+    monkeypatch.setattr(device, "_arch_from_hardware", lambda: None)
+    with pytest.raises(RuntimeError, match="invalid"):
+        device.get_rocm_arch()
+
+
+def test_parse_hsa_override(monkeypatch):
+    """HSA-style major.minor.patch override should convert to gfxNNN."""
+    monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "9.4.2")
+    monkeypatch.delenv("FLYDSL_GPU_ARCH", raising=False)
+    monkeypatch.delenv("FLYDSL_GPU_ARCH_FALLBACK", raising=False)
+    monkeypatch.setattr(device, "_arch_from_hardware", lambda: None)
+    assert device.get_rocm_arch() == "gfx942"
+
+
+def test_parse_hsa_override_multi_digit_parts(monkeypatch):
+    """Multi-digit dotted override values should be accepted."""
+    monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "11.0.0")
+    monkeypatch.delenv("FLYDSL_GPU_ARCH", raising=False)
+    monkeypatch.delenv("FLYDSL_GPU_ARCH_FALLBACK", raising=False)
+    monkeypatch.setattr(device, "_arch_from_hardware", lambda: None)
+    assert device.get_rocm_arch() == "gfx1100"


### PR DESCRIPTION
## Why
Current behavior silently falls back to `gfx942` when ROCm hardware detection fails, which can produce incorrect ISA targets on:
- non-ROCm hosts
- misconfigured runners
- unsupported or newly introduced GPUs

## What changed
- In `python/flydsl/runtime/device.py`:
  - `get_rocm_arch()` no longer silently defaults to `gfx942`.
  - Hardware detection now fails with a clear error unless a valid explicit override is provided.
  - Added explicit override validation for:
    - `FLYDSL_GPU_ARCH` (e.g. `gfx950`)
    - `HSA_OVERRIDE_GFX_VERSION` (e.g. `9.4.2`)
  - Added opt-in legacy fallback via `FLYDSL_GPU_ARCH_FALLBACK` (accepted values: `1`, `true`, `yes`, `on`).
- Added regression tests in `tests/unit/test_runtime_device.py` for:
  - explicit override path
  - invalid override values
  - detection failure behavior
  - fallback behavior
  - dotted override conversion
- Updated docs to match the new contract:
  - `CLAUDE.md`
  - `docs/architecture_guide.md`
  - `tests/README.md`

## Behavior details
- Priority order for `get_rocm_arch()`:
  1. `FLYDSL_GPU_ARCH`
  2. `HSA_OVERRIDE_GFX_VERSION`
  3. `rocm_agent_enumerator`
  4. `FLYDSL_GPU_ARCH_FALLBACK` (only when truthy)
  5. otherwise: raise `RuntimeError`

## Validation
- `python3 -m py_compile python/flydsl/runtime/device.py tests/unit/test_runtime_device.py`
- Full `pytest` execution is not available in this environment (`pytest` package missing).

## Notes for reviewers
- This is a behavioral change from silent fallback to explicit failure by default.
- Existing workflows that relied on the old fallback should keep working by setting `FLYDSL_GPU_ARCH_FALLBACK=1`.
- No behavior change when a valid architecture override is already set.
