### PR TITLE
fix(preshuffle_gemm_v2): bound A/C buffers to M extent (ragged-M OOB) + regression test

### DIFF
--- a/kernels/preshuffle_gemm_v2.py
+++ b/kernels/preshuffle_gemm_v2.py
@@ -100,9 +100,17 @@ def compile_preshuffle_gemm_v2(
         else:
             tiled_mma = tiled_mma_arg
 
-        gA = fx.rocdl.make_buffer_tensor(arg_a)
+        # Bound A (read) and C (store) to the actual M extent so blocks covering
+        # rows past M (ragged M) drop their OOB loads/stores at the descriptor
+        # instead of faulting / writing past the allocation. B and scales are
+        # exact-multiple in N and stay max_size.
+        gA = fx.rocdl.make_buffer_tensor(
+            arg_a, max_size=False, num_records_bytes=fx.Int64(i32_m) * fx.Int64(K) * fx.Int64(elem_bytes)
+        )
         gB = fx.rocdl.make_buffer_tensor(arg_b)
-        gC = fx.rocdl.make_buffer_tensor(arg_c)
+        gC = fx.rocdl.make_buffer_tensor(
+            arg_c, max_size=False, num_records_bytes=fx.Int64(i32_m) * fx.Int64(N) * fx.Int64(2)
+        )
 
         tA = fx.flat_divide(gA, fx.make_tile(tile_m, tile_k))[None, None, bid_x, None]
         tB = fx.flat_divide(gB, fx.make_tile(tile_n, tile_k))[None, None, bid_y, None]

--- a/tests/kernels/test_preshuffle_gemm.py
+++ b/tests/kernels/test_preshuffle_gemm.py
@@ -217,7 +217,14 @@ def test_mfma_a8_flyc_preshuffle(
         b_packed = _pack_shuffled_int8_to_packed_int4_no_perm(b_shuffled)
 
     c_ref = run_torch(a_q, b_q, scale_a, scale_b, bias=None, dtype=torch.float32)
-    c_out_raw = torch.zeros((M, N), dtype=torch_out_dtype, device=device)
+    # Allocate guard rows past M and fill with a sentinel (outputs are >= 0, so a
+    # negative sentinel never collides). For ragged M, blocks covering rows
+    # [M, grid_rows) must have their C stores dropped by the buffer descriptor;
+    # the guard rows must stay sentinel after the run (OOB check below).
+    grid_rows = ((M + tile_m - 1) // tile_m) * tile_m
+    oob_sentinel = torch.tensor(-8192.0, dtype=torch_out_dtype, device=device)
+    c_alloc = torch.full((grid_rows, N), oob_sentinel, dtype=torch_out_dtype, device=device)
+    c_out_raw = c_alloc[:M]
 
     b_input = b_packed if is_int4 else b_shuffled
     if scale_a is None:
@@ -269,6 +276,10 @@ def test_mfma_a8_flyc_preshuffle(
 
     assert verify_output(c_out_scaled, c_ref, rtol=0.1, atol=0.1)
 
+    guard = c_alloc[M:]
+    n_bad = int((guard != oob_sentinel).sum().item())
+    assert n_bad == 0, f"C store wrote {n_bad} element(s) past row M={M} (missing num_records bound)"
+
     if HAS_AITER and bool(run_aiter_bench) and (not is_int4) and (in_dtype in ("fp8", "int8")):
         print("-" * 40)
         print("Running Aiter Benchmark...")
@@ -304,6 +315,32 @@ def test_mfma_a8_flyc_preshuffle(
     tflops = flops / (us / 1e6) / 1e12
     tbps = bytes_moved / 1e12 / (us / 1e6)
     print(f"[flyc] Throughput: {us:.1f} us, {tflops:.2f} TFLOPS, BW: {tbps:.3f} TB/s")
+
+
+@pytest.mark.parametrize("in_dtype", ["fp8", "fp16", "bf16"])
+def test_v2_preshuffle_c_store_oob(in_dtype):
+    """v2 layout-API kernel must not load A / store C past row M for ragged M.
+
+    M=33 with tile_m=32 makes the last block span rows [32, 64); rows [33, 64)
+    are out of bounds and must be dropped by the A/C buffer descriptors. The
+    harness fills guard rows past M with a sentinel and asserts none were
+    overwritten (in addition to verifying the in-range output).
+    """
+    if get_rocm_arch() not in ("gfx942", "gfx950"):
+        pytest.skip(f"v2 preshuffle GEMM requires gfx942/gfx950, got {get_rocm_arch()}")
+    test_mfma_a8_flyc_preshuffle(
+        in_dtype,
+        M=33,
+        N=1024,
+        K=2048,
+        tile_m=32,
+        tile_n=64,
+        tile_k=512,
+        use_async_copy=False,
+        test_graph=False,
+        run_aiter_bench=False,
+        use_v2=True,
+    )
 
 
 @pytest.mark.parametrize("out_dtype", ["bf16", "fp16"])


### PR DESCRIPTION
## Summary
Bounds the **A (read)** and **C (store)** buffer descriptors in `compile_preshuffle_gemm_v2` to the actual `M` extent via `num_records`, so blocks covering rows past `M` for **ragged M** (M not a multiple of `tile_m`) have their out-of-bounds loads/stores dropped by the hardware descriptor instead of faulting (A read) or writing past the allocation (C store).

This matches the existing v1 kernel (`preshuffle_gemm.py`), which already binds `a_rsrc`/`c_rsrc` with `max_size=False, num_records_bytes=...`. Previously the v2 kernel left A/C at `max_size=True` (`num_records = 0xFFFFFFFF`), so the descriptor bounds check was effectively a no-op.

## Test
- The shared harness now allocates **guard rows past M** (filled with a negative sentinel; outputs are ≥ 0) and asserts none are overwritten after the run — an OOB regression check that runs by default for every case.
- Adds `test_v2_preshuffle_c_store_oob` exercising the v2 kernel (fp8/fp16/bf16) on a ragged `M=33`, `tile_m=32` shape (last block spans rows [32, 64); rows [33, 64) must be dropped).

Verified on gfx950: the new OOB test and the v1 ragged-M cases pass; without the bound the same shape faults with an illegal memory access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)