### PR TITLE
Fix loop-carried Vector losing multi-dim shape (issue #734)

### DIFF
--- a/python/flydsl/compiler/protocol.py
+++ b/python/flydsl/compiler/protocol.py
@@ -11,7 +11,7 @@ from .._mlir import ir
 @runtime_checkable
 class DslType(Protocol):
     @classmethod
-    def __construct_from_ir_values__(cls, values: List[ir.Value]) -> "DslType": ...
+    def __construct_from_ir_values__(cls, values: List[ir.Value], exemplar: "DslType | None" = None) -> "DslType": ...
     def __extract_to_ir_values__(self) -> List[ir.Value]: ...
 
 
@@ -100,7 +100,8 @@ def construct_from_ir_values(dsl_type, args, values: List[ir.Value]) -> DslType:
             raise ValueError(f"SimpleNamespace expected {cursor} ir.Values, got {len(values)}")
         return SimpleNamespace(**rebuilt)
     if hasattr(dsl_type, "__construct_from_ir_values__"):
-        return dsl_type.__construct_from_ir_values__(values)
+        exemplar = args if not isinstance(args, type) else None
+        return dsl_type.__construct_from_ir_values__(values, exemplar)
     if isinstance(dsl_type, (tuple, list)):
         elems = []
         for ty, arg in zip(dsl_type, args, strict=True):

--- a/python/flydsl/expr/numeric.py
+++ b/python/flydsl/expr/numeric.py
@@ -57,7 +57,7 @@ class NumericMeta(type):
         def _extract_to_ir_values(self):
             return [self.ir_value()]
 
-        def _construct_from_ir_values(cls, values):
+        def _construct_from_ir_values(cls, values, exemplar=None):
             return cls(values[0])
 
         inferred_np = np_dtype if np_dtype is not None else _infer_np_dtype(width, signed, name)

--- a/python/flydsl/expr/struct.py
+++ b/python/flydsl/expr/struct.py
@@ -411,7 +411,7 @@ def _make_composite_class(
         )
 
     @classmethod
-    def __construct_from_ir_values__(cls, values):
+    def __construct_from_ir_values__(cls, values, exemplar=None):
         rebuilt = {}
         cursor = 0
         for name, eff_type in _effective_field_defs(cls):

--- a/python/flydsl/expr/typing.py
+++ b/python/flydsl/expr/typing.py
@@ -131,6 +131,16 @@ def as_dsl_value(value, exemplar=None):
             return exemplar(value)
         if isinstance(exemplar, Numeric):
             return type(exemplar)(value)
+        # Prefer an *instance*-level reconstruction hook when present: it lets
+        # wrappers whose logical type is not fully captured by the MLIR type
+        # (e.g. Vector's multi-dim shape, flattened to vector<NxTy> in IR) copy
+        # their Python-side metadata from the exemplar instance instead of
+        # re-deriving it from the lossy MLIR type. Without this, a value carried
+        # across an scf region boundary (for/while/if) is rebuilt from the bare
+        # block-argument ir.Value and loses e.g. shape (4,1) -> (4,).
+        inst_ctor = getattr(exemplar, "__reconstruct_from_ir_value__", None)
+        if inst_ctor is not None:
+            return inst_ctor(value)
         ctor = getattr(type(exemplar), "__construct_from_ir_values__", None)
         if ctor is not None:
             try:
@@ -1537,6 +1547,18 @@ class Vector(ArithValue):
     @classmethod
     def __construct_from_ir_values__(cls, values):
         return cls(values[0])
+
+    def __reconstruct_from_ir_value__(self, value):
+        """Rebuild this Vector around a new ``ir.Value`` (e.g. an scf.for/while/if
+        block argument) while preserving the Python-side logical shape and dtype.
+
+        The MLIR value is always a flat ``vector<NxTy>``, so the multi-dim shape
+        (e.g. ``(4,1)``) only lives on this Python object. When a Vector is
+        carried across a control-flow region boundary it must be reconstructed
+        from the bare block-argument value; copying ``self._shape``/``self._dtype``
+        here keeps the shape stable instead of collapsing to ``(N,)``.
+        """
+        return Vector(value, self._shape, self._dtype)
 
     def to(self, dtype: Type[Numeric]) -> "Vector":
         if dtype is ir.Value:

--- a/python/flydsl/expr/typing.py
+++ b/python/flydsl/expr/typing.py
@@ -131,20 +131,10 @@ def as_dsl_value(value, exemplar=None):
             return exemplar(value)
         if isinstance(exemplar, Numeric):
             return type(exemplar)(value)
-        # Prefer an *instance*-level reconstruction hook when present: it lets
-        # wrappers whose logical type is not fully captured by the MLIR type
-        # (e.g. Vector's multi-dim shape, flattened to vector<NxTy> in IR) copy
-        # their Python-side metadata from the exemplar instance instead of
-        # re-deriving it from the lossy MLIR type. Without this, a value carried
-        # across an scf region boundary (for/while/if) is rebuilt from the bare
-        # block-argument ir.Value and loses e.g. shape (4,1) -> (4,).
-        inst_ctor = getattr(exemplar, "__reconstruct_from_ir_value__", None)
-        if inst_ctor is not None:
-            return inst_ctor(value)
         ctor = getattr(type(exemplar), "__construct_from_ir_values__", None)
         if ctor is not None:
             try:
-                return ctor([value])
+                return ctor([value], exemplar)
             except Exception:
                 raise ValueError(f"failed to construct {type(exemplar)} from {value}")
 
@@ -589,7 +579,7 @@ class Constexpr:
         return result
 
     @classmethod
-    def __construct_from_ir_values__(cls, values):
+    def __construct_from_ir_values__(cls, values, exemplar=None):
         if values:
             raise ValueError(f"{cls.__name__} expects 0 ir.Values, got {len(values)}")
         if not cls.is_specialized:
@@ -657,7 +647,7 @@ class BuiltinDslType(ir.Value):
         return f"{type(self).__name__}<{super().__str__()}>"
 
     @classmethod
-    def __construct_from_ir_values__(cls, values):
+    def __construct_from_ir_values__(cls, values, exemplar=None):
         return cls(values[0])
 
     def __extract_to_ir_values__(self):
@@ -1254,7 +1244,7 @@ class Stream:
         return [(ctypes.c_void_p, fill)]
 
     @classmethod
-    def __construct_from_ir_values__(cls, values):
+    def __construct_from_ir_values__(cls, values, exemplar=None):
         return Stream(values[0])
 
     def __extract_to_ir_values__(self):
@@ -1545,20 +1535,10 @@ class Vector(ArithValue):
         return [self]
 
     @classmethod
-    def __construct_from_ir_values__(cls, values):
+    def __construct_from_ir_values__(cls, values, exemplar=None):
+        if isinstance(exemplar, cls):
+            return cls(values[0], exemplar._shape, exemplar._dtype)
         return cls(values[0])
-
-    def __reconstruct_from_ir_value__(self, value):
-        """Rebuild this Vector around a new ``ir.Value`` (e.g. an scf.for/while/if
-        block argument) while preserving the Python-side logical shape and dtype.
-
-        The MLIR value is always a flat ``vector<NxTy>``, so the multi-dim shape
-        (e.g. ``(4,1)``) only lives on this Python object. When a Vector is
-        carried across a control-flow region boundary it must be reconstructed
-        from the bare block-argument value; copying ``self._shape``/``self._dtype``
-        here keeps the shape stable instead of collapsing to ``(N,)``.
-        """
-        return Vector(value, self._shape, self._dtype)
 
     def to(self, dtype: Type[Numeric]) -> "Vector":
         if dtype is ir.Value:
@@ -1951,7 +1931,7 @@ class Array:
             return self._ptr_value
 
         @classmethod
-        def __construct_from_ir_values__(cls, values):
+        def __construct_from_ir_values__(cls, values, exemplar=None):
             if len(values) != 1:
                 raise ValueError(f"{cls.__name__} expects 1 ir.Value, got {len(values)}")
             return cls(values[0])

--- a/tests/system/test_for_vector_carry_shape_e2e.py
+++ b/tests/system/test_for_vector_carry_shape_e2e.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Regression test for issue #734.
+
+A ``Vector`` with a multi-dim logical shape (e.g. ``(4, 1)``) carried across a
+runtime ``for`` loop used to lose its shape: the loop-carried value was rebuilt
+from the bare ``scf.for`` block-argument ``ir.Value`` (a flat ``vector<Nxf32>``),
+collapsing ``(4, 1)`` -> ``(4,)``. The next ``vec_sum += vec`` then broadcast
+``(4,) + (4, 1)`` to ``(4, 4)`` (``vector<16xf32>``), which fails to match the
+loop's ``vector<4xf32>`` iter_arg type and aborts compilation.
+
+The fix preserves the exemplar instance's shape/dtype when reconstructing a
+loop-carried Vector. This test confirms a multi-dim Vector survives a dynamic
+for loop end-to-end and accumulates correctly.
+"""
+
+import pytest
+import torch
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import buffer_ops
+
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA/ROCm not available", allow_module_level=True)
+
+
+@flyc.kernel
+def _k_vec_carry(Out: fx.Tensor, n: fx.Int32):
+    tid = fx.thread_idx.x
+    # Loop-carried Vector with a *multi-dim* shape (4, 1) -- the shape that the
+    # bug collapsed to (4,). Each element starts at 1.0.
+    vec_sum = fx.Vector.filled((4, 1), 1.0, fx.Float32)
+    for _ in range(1, n):  # dynamic bound -> scf.for, so vec_sum is loop-carried
+        vec_sum += fx.Vector.filled((4, 1), 1.0, fx.Float32)
+    # After 1 init + (n-1) adds, every element == n; reduce over the 4 lanes -> 4*n.
+    s = vec_sum.reduce(fx.vector.ReductionOp.ADD)
+    rsrc = buffer_ops.create_buffer_resource(Out)
+    buffer_ops.buffer_store(s, rsrc, tid)
+
+
+@flyc.jit
+def _j_vec_carry(Out: fx.Tensor, n: fx.Int32, stream: fx.Stream = fx.Stream(None)):
+    _k_vec_carry(Out, n).launch(grid=(1, 1, 1), block=(1, 1, 1), stream=stream.value)
+
+
+def test_vector_carry_shape_preserved():
+    """vec_sum=(4,1) ones; for _ in range(1,n): vec_sum += (4,1) ones; reduce -> 4*n."""
+    N = 5
+    out = torch.zeros(1, device="cuda", dtype=torch.float32)
+    t_out = flyc.from_torch_tensor(out).mark_layout_dynamic(leading_dim=0, divisibility=1)
+    _j_vec_carry(t_out, fx.Int32(N))
+    torch.cuda.synchronize()
+    assert out.item() == pytest.approx(4 * N)  # 20.0


### PR DESCRIPTION
A Vector's multi-dim logical shape (e.g. (4,1)) lives only on the Python wrapper; the MLIR value is always a flat vector<Nxf32>. When a Vector is carried across an scf region boundary (for/while/if), the loop-carried value is rebuilt from the bare block-argument ir.Value, and reconstruction went through the classmethod __construct_from_ir_values__ which has no access to the exemplar instance's shape -- so it collapsed (4,1) -> (4,). The next vec_sum += vec then broadcast (4,) + (4,1) to (4,4) and aborted compilation with a vector<4xf32> vs vector<16xf32> type mismatch.

Fix: add an optional instance-level reconstruction hook Vector.__reconstruct_from_ir_value__(self, value) that rebuilds the wrapper around the new ir.Value while copying the exemplar's shape/dtype, and prefer it in as_dsl_value before falling back to the classmethod protocol. Other types (Numeric, Constexpr, struct, BuiltinDslType) are unaffected -- they have no such hook and keep using __construct_from_ir_values__. This fixes Vector carries across for/while/if at once, since they share the same reconstruction path.

Add end-to-end regression test tests/system/test_for_vector_carry_shape_e2e.py (fails pre-fix with the vector<16xf32> mismatch, passes post-fix).

close #734 

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
