### PR TITLE
[pa] Deterministic split-partition reduce for PS decode

### DIFF
--- a/kernels/pa_decode_fp8.py
+++ b/kernels/pa_decode_fp8.py
@@ -3186,18 +3186,21 @@ def pa_decode_ps_launch(
         s,
     )
 
-    from aiter.ops.attention import pa_reduce_v1
+    from kernels.pa_metadata import pa_ps_reduce
 
-    pa_reduce_v1(
+    # Deterministic FlyDSL reduce replaces aiter pa_reduce_v1/mla_reduce_v1, whose
+    # cross-workgroup combine has a concurrency race (non-deterministic output on
+    # identical partials → the flaky test_pa NaN). Same partial layout / reduce maps.
+    pa_ps_reduce(
         partial_output=partial_output[query_length:],
         partial_lse=partial_lse[query_length:],
         reduce_indptr=metadata["reduce_indptr"],
         reduce_final_map=metadata["reduce_final_map"],
         reduce_partial_map=metadata["reduce_partial_map"],
         max_seqlen_q=query_length,
-        num_kv_splits=0,
         final_output=output,
-        final_lse=None,
+        num_query_heads=num_query_heads,
+        head_size=int(query.shape[-1]),
     )
 
     return "ps_split_reduce"

--- a/kernels/pa_decode_fp8.py
+++ b/kernels/pa_decode_fp8.py
@@ -2105,9 +2105,8 @@ def pa_decode_ps_launch(
 
     from kernels.pa_metadata import pa_ps_reduce
 
-    # Deterministic FlyDSL reduce replaces aiter pa_reduce_v1/mla_reduce_v1, whose
-    # cross-workgroup combine has a concurrency race (non-deterministic output on
-    # identical partials → the flaky test_pa NaN). Same partial layout / reduce maps.
+    # Deterministic FlyDSL reduce replaces the racy aiter pa_reduce_v1/mla_reduce_v1
+    # (root cause of the flaky test_pa NaN). Same partial layout / reduce maps.
     pa_ps_reduce(
         partial_output=partial_output[query_length:],
         partial_lse=partial_lse[query_length:],
@@ -2118,6 +2117,7 @@ def pa_decode_ps_launch(
         final_output=output,
         num_query_heads=num_query_heads,
         head_size=int(query.shape[-1]),
+        stream=s,
     )
 
     return "ps_split_reduce"

--- a/kernels/pa_metadata.py
+++ b/kernels/pa_metadata.py
@@ -42,12 +42,23 @@ import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import scf
-from flydsl.expr import arith, buffer_ops, gpu, range_constexpr
+from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl
+from flydsl.expr import math as fly_math
 from flydsl.expr.typing import Int32, T
 from flydsl.runtime.device import get_rocm_arch
 from kernels.kernels_common import get_warp_size
 
 _WORK_INFO_FIELDS = 8
+
+LOG2E = 1.4426950408889634
+
+
+def _rcp_f32(value):
+    return rocdl.rcp(T.f32, value)
+
+
+def _exp2_f32_fast(value):
+    return fly_math.exp2(value, fastmath=arith.FastMathFlags.fast)
 
 
 def get_pa_metadata_info_v1(batch_size: int, num_head_k: int = 1, num_cu: int = None):
@@ -521,4 +532,212 @@ def get_pa_metadata_v1(
         reduce_final_map_flat,
         reduce_partial_map,
         num_batches,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Deterministic split-partition reduce (drop-in replacement for aiter
+# ``pa_reduce_v1`` / ``mla_reduce_v1`` on the FlyDSL PS decode path).
+#
+# ``mla_reduce_v1`` is a HIP kernel whose cross-workgroup combine has a
+# concurrency race: called twice on bit-identical partials it returns different
+# output ~4% of the time, occasionally producing ~10x errors and rarely garbage
+# (the flaky ``test_pa`` NaN). This kernel removes the race: each output element
+# is produced by exactly one thread that combines all of its group's splits
+# serially via online softmax. Because the per-split LSE is a per-(row, head)
+# scalar shared by every head_size lane, the combine is fully thread-independent
+# — no atomics, no cross-thread reduction → bit-deterministic.
+#
+# Partial layout (already produced by ``compile_pa_decode_metadata``; the caller
+# passes the ``[query_length:]`` slices, mirroring the old pa_reduce_v1 call):
+#   partial_output f32 : rows of [1, num_query_heads, head_size], row stride
+#                        ``stride_po_row = num_query_heads * head_size``; each
+#                        split partial is already normalized by its local denom.
+#   partial_lse    f32 : rows of [1, num_query_heads, 1], row stride
+#                        ``stride_pl_row = num_query_heads``; value =
+#                        running_max + log(running_sum).
+# Reduce maps (from get_pa_metadata / get_pa_metadata_v1):
+#   reduce_indptr      [batch+1] : group g splits = slots [indptr[g], indptr[g+1]).
+#   reduce_final_map   [batch,2] : group g → final output row range (qo_start, qo_end).
+#   reduce_partial_map [..]      : slot → partial row base (in the sliced buffer).
+# Combine: out = Σ_s w_s·o_s / Σ_s w_s,  w_s = exp(lse_s − max_s lse_s).
+# Direct (non-split) outputs are already final; their reduce groups are empty
+# (indptr delta 0) and are skipped, leaving those rows untouched.
+# ──────────────────────────────────────────────────────────────────────────
+@functools.lru_cache(maxsize=64)
+def compile_pa_ps_reduce(
+    *,
+    query_length: int,
+    num_query_heads: int,
+    head_size: int,
+    output_dtype_str: str,
+):
+    block_threads = head_size
+    assert 0 < block_threads <= 1024, "head_size must fit in one workgroup"
+
+    @flyc.kernel(known_block_size=(block_threads, 1, 1))
+    def pa_ps_reduce_kernel(
+        final_output_ptr: fx.Tensor,
+        partial_output_ptr: fx.Tensor,
+        partial_lse_ptr: fx.Tensor,
+        reduce_indptr_ptr: fx.Tensor,
+        reduce_final_map_ptr: fx.Tensor,
+        reduce_partial_map_ptr: fx.Tensor,
+        stride_out_seq: Int32,
+        stride_out_head: Int32,
+        stride_po_row: Int32,  # num_query_heads * head_size
+        stride_pl_row: Int32,  # num_query_heads
+    ):
+        tid = fx.Int32(gpu.thread_id("x"))
+        g = fx.Int32(gpu.block_id("x"))
+        qhead = fx.Int32(gpu.block_id("y"))
+        qi = fx.Int32(gpu.block_id("z"))
+
+        out_rsrc = buffer_ops.create_buffer_resource(final_output_ptr, max_size=True)
+        po_rsrc = buffer_ops.create_buffer_resource(partial_output_ptr, max_size=True)
+        pl_rsrc = buffer_ops.create_buffer_resource(partial_lse_ptr, max_size=True)
+        rip_rsrc = buffer_ops.create_buffer_resource(reduce_indptr_ptr, max_size=True)
+        rfm_rsrc = buffer_ops.create_buffer_resource(reduce_final_map_ptr, max_size=True)
+        rpm_rsrc = buffer_ops.create_buffer_resource(reduce_partial_map_ptr, max_size=True)
+
+        c_zero_f = fx.Float32(0.0)
+        c_one_f = fx.Float32(1.0)
+        c_neg_inf = fx.Float32(float("-inf"))
+        c_log2e = fx.Float32(LOG2E)
+        c_head = fx.Int32(head_size)
+
+        lo = buffer_ops.buffer_load(rip_rsrc, g, vec_width=1, dtype=T.i32)
+        hi = buffer_ops.buffer_load(rip_rsrc, g + fx.Int32(1), vec_width=1, dtype=T.i32)
+
+        # Empty group (direct / padding) → nothing to combine; leave row untouched.
+        if hi > lo:
+            qo_start = buffer_ops.buffer_load(rfm_rsrc, g * fx.Int32(2), vec_width=1, dtype=T.i32)
+            out_row = qo_start + qi
+
+            # Online-softmax combine over the group's splits (dynamic count).
+            # State = (running_max, running_denom, running_acc), per-thread.
+            for _s, st in fx.range(
+                fx.Index(arith.unwrap(lo)),
+                fx.Index(arith.unwrap(hi)),
+                1,
+                init=[c_neg_inf, c_zero_f, c_zero_f],
+            ):
+                m = fx.Float32(st[0])
+                denom = fx.Float32(st[1])
+                acc = fx.Float32(st[2])
+                slot = fx.Int32(_s)
+                prow = buffer_ops.buffer_load(rpm_rsrc, slot, vec_width=1, dtype=T.i32) + qi
+                lse = buffer_ops.buffer_load(pl_rsrc, prow * stride_pl_row + qhead, vec_width=1, dtype=T.f32)
+                v = buffer_ops.buffer_load(
+                    po_rsrc, prow * stride_po_row + qhead * c_head + tid, vec_width=1, dtype=T.f32
+                )
+                m_new = m.maximumf(lse)
+                scale_old = _exp2_f32_fast((m - m_new) * c_log2e)
+                w = _exp2_f32_fast((lse - m_new) * c_log2e)
+                denom_new = denom * scale_old + w
+                acc_new = acc * scale_old + v * w
+                results = yield [m_new, denom_new, acc_new]
+
+            denom_f = fx.Float32(results[1])
+            acc_f = fx.Float32(results[2])
+            safe_denom = arith.select(denom_f > c_zero_f, denom_f, c_one_f)
+            out_acc = acc_f * _rcp_f32(safe_denom)
+
+            out_off = out_row * stride_out_seq + qhead * stride_out_head + tid
+            if const_expr(output_dtype_str == "f32"):
+                out_val = out_acc
+            elif const_expr(output_dtype_str == "f16"):
+                out_val = out_acc.to(fx.Float16)
+            else:
+                out_val = out_acc.to(fx.BFloat16)
+            buffer_ops.buffer_store(out_val, out_rsrc, out_off)
+
+    @flyc.jit
+    def launch_pa_ps_reduce(
+        final_output,
+        partial_output,
+        partial_lse,
+        reduce_indptr,
+        reduce_final_map,
+        reduce_partial_map,
+        stride_out_seq,
+        stride_out_head,
+        stride_po_row,
+        stride_pl_row,
+        num_groups,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        pa_ps_reduce_kernel(
+            final_output,
+            partial_output,
+            partial_lse,
+            reduce_indptr,
+            reduce_final_map,
+            reduce_partial_map,
+            stride_out_seq,
+            stride_out_head,
+            stride_po_row,
+            stride_pl_row,
+        ).launch(
+            grid=(num_groups, num_query_heads, query_length),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return {"launch": launch_pa_ps_reduce, "kernel": pa_ps_reduce_kernel}
+
+
+_PA_PS_REDUCE_DTYPE_STR = {
+    torch.float32: "f32",
+    torch.float16: "f16",
+    torch.bfloat16: "bf16",
+}
+
+
+def pa_ps_reduce(
+    *,
+    partial_output: torch.Tensor,
+    partial_lse: torch.Tensor,
+    reduce_indptr: torch.Tensor,
+    reduce_final_map: torch.Tensor,
+    reduce_partial_map: torch.Tensor,
+    max_seqlen_q: int,
+    final_output: torch.Tensor,
+    num_query_heads: int,
+    head_size: int,
+    stream=None,
+) -> None:
+    """Deterministic drop-in replacement for ``aiter.pa_reduce_v1`` on the PS path.
+
+    ``partial_output`` / ``partial_lse`` must already be the ``[query_length:]``
+    slices (same as the old pa_reduce_v1 call site). One reduce group is launched
+    per batch tile; empty groups (``reduce_indptr`` delta 0 — direct outputs) skip
+    in-kernel, so passing ``reduce_indptr.numel() - 1`` groups needs no host sync.
+    """
+    num_groups = reduce_indptr.numel() - 1
+    stride_po_row = num_query_heads * head_size
+    stride_pl_row = num_query_heads
+    out_dtype_str = _PA_PS_REDUCE_DTYPE_STR[final_output.dtype]
+    compiled = compile_pa_ps_reduce(
+        query_length=int(max_seqlen_q),
+        num_query_heads=int(num_query_heads),
+        head_size=int(head_size),
+        output_dtype_str=out_dtype_str,
+    )
+    kwargs = {}
+    if stream is not None:
+        kwargs["stream"] = stream
+    compiled["launch"](
+        final_output,
+        partial_output,
+        partial_lse,
+        reduce_indptr,
+        reduce_final_map,
+        reduce_partial_map,
+        int(final_output.stride(0)),
+        int(final_output.stride(1)),
+        stride_po_row,
+        stride_pl_row,
+        num_groups,
+        **kwargs,
     )

--- a/kernels/pa_metadata.py
+++ b/kernels/pa_metadata.py
@@ -2118,35 +2118,22 @@ def compile_pa_decode_metadata(
     }
 
 
-# ──────────────────────────────────────────────────────────────────────────
-# Deterministic split-partition reduce (drop-in replacement for aiter
-# ``pa_reduce_v1`` / ``mla_reduce_v1`` on the FlyDSL PS decode path).
+# Deterministic split-partition reduce; drop-in replacement for the racy aiter
+# ``pa_reduce_v1`` / ``mla_reduce_v1`` on the PS decode path (root cause of the
+# flaky ``test_pa`` NaN). Each output element is combined by exactly one thread,
+# serially via online softmax (out = Σ_s w_s·o_s / Σ_s w_s, w_s = exp(lse_s − max)).
+# The per-split LSE is a per-(row, head) scalar shared by all head_size lanes, so
+# the combine is thread-independent — no atomics/cross-thread reduction → bit-exact.
 #
-# ``mla_reduce_v1`` is a HIP kernel whose cross-workgroup combine has a
-# concurrency race: called twice on bit-identical partials it returns different
-# output ~4% of the time, occasionally producing ~10x errors and rarely garbage
-# (the flaky ``test_pa`` NaN). This kernel removes the race: each output element
-# is produced by exactly one thread that combines all of its group's splits
-# serially via online softmax. Because the per-split LSE is a per-(row, head)
-# scalar shared by every head_size lane, the combine is fully thread-independent
-# — no atomics, no cross-thread reduction → bit-deterministic.
-#
-# Partial layout (already produced by ``compile_pa_decode_metadata``; the caller
-# passes the ``[query_length:]`` slices, mirroring the old pa_reduce_v1 call):
-#   partial_output f32 : rows of [1, num_query_heads, head_size], row stride
-#                        ``stride_po_row = num_query_heads * head_size``; each
-#                        split partial is already normalized by its local denom.
-#   partial_lse    f32 : rows of [1, num_query_heads, 1], row stride
-#                        ``stride_pl_row = num_query_heads``; value =
-#                        running_max + log(running_sum).
-# Reduce maps (from get_pa_metadata / get_pa_metadata_v1):
-#   reduce_indptr      [batch+1] : group g splits = slots [indptr[g], indptr[g+1]).
-#   reduce_final_map   [batch,2] : group g → final output row range (qo_start, qo_end).
-#   reduce_partial_map [..]      : slot → partial row base (in the sliced buffer).
-# Combine: out = Σ_s w_s·o_s / Σ_s w_s,  w_s = exp(lse_s − max_s lse_s).
-# Direct (non-split) outputs are already final; their reduce groups are empty
-# (indptr delta 0) and are skipped, leaving those rows untouched.
-# ──────────────────────────────────────────────────────────────────────────
+# Inputs (from compile_pa_decode_metadata / get_pa_metadata; caller passes the
+# ``[query_length:]`` slices, mirroring the old pa_reduce_v1 call):
+#   partial_output f32 : row [num_query_heads, head_size], stride stride_po_row;
+#                        each split already normalized by its local denom.
+#   partial_lse    f32 : row [num_query_heads], stride stride_pl_row; = max + log(sum).
+#   reduce_indptr [batch+1]: group g splits = slots [indptr[g], indptr[g+1]).
+#   reduce_final_map [batch,2]: group g → final output row range.
+#   reduce_partial_map: slot → partial row base (in the sliced buffer).
+# Direct (non-split) outputs have empty groups (indptr delta 0) and are skipped.
 @functools.lru_cache(maxsize=64)
 def compile_pa_ps_reduce(
     *,


### PR DESCRIPTION
## Problem

The FlyDSL paged-decode PS path (`kernels/pa_decode_fp8.py::pa_decode_ps_launch`) finished with aiter `pa_reduce_v1` → `mla_reduce_v1`, whose cross-workgroup combine has a **concurrency race**: called twice on bit-identical partials it returns different output ~4% of the time, occasionally producing ~10× errors and rarely garbage (up to ~1e27). This is the root cause of the flaky `tests/kernels/test_pa.py::test_multi_case_set[normal_accuracy]` NaN on gfx950 (e.g. CI run for #756). The FlyDSL compute phase is deterministic; the gluon path (own reduce) is unaffected.

## Change

Add `compile_pa_ps_reduce` / `pa_ps_reduce` in `kernels/pa_metadata.py` and use it in place of `pa_reduce_v1`. It consumes the **same** partial layout and reduce maps (`reduce_indptr`/`reduce_final_map`/`reduce_partial_map`), but is race-free by construction:

- grid `(num_groups, num_query_heads, query_length)`, block `head_size`; each thread owns one output element and combines its reduce-group's splits **serially via online softmax** (`w_s = exp(lse_s − max)`).
- The per-split LSE is a per-`(row, head)` scalar shared by every `head_size` lane, so the combine is **fully thread-independent** — no atomics, no cross-thread/cross-workgroup reduction → **bit-deterministic**.
- Empty reduce groups (direct outputs) skip via `reduce_indptr` delta, so no host sync is needed (CUDA-graph friendly).

## Verification (gfx950 / MI355, e4m3fn)

- `normal_accuracy` **64/64 PASS** — eager and under CUDA-graph capture (`USE_CUDA_GRAPH_TEST=True`, 0 capture failures).
- Determinism: `pa_ps_reduce` is bit-deterministic (2000 calls on identical partials → 0 differ). The flaky case-12 loop: **0 spikes / 21245** (was ~0.18%, incl. a 1e27 hit).

## Benchmarks (gfx950 / MI355, CUDA graph)

**End-to-end PA decode** (full `run_flydsl_ps`, compute + reduce; fair A/B in one process — identical captured metadata + compute, only the reduce swapped):

| shape | NEW `pa_ps_reduce` | OLD `pa_reduce_v1` | speedup |
|---|---|---|---|
| h16, b81, q3, per_token | 16.73 µs | 24.70 µs | **1.48×** |
| h8, b81, q1, per_tensor | 10.66 µs | 14.62 µs | **1.37×** |
| h16, b81, q4, per_token, varlen | 15.35 µs | 22.07 µs | **1.44×** |
| h8, b3, q1, per_tensor | 8.98 µs | 12.83 µs | **1.43×** |

Isolated reduce kernel (GPU time): **~0.6 µs vs ~9 µs (~15×)**.

> Note: a naive cross-process comparison can mislead here — the metadata scheduler is non-deterministic (work-split varies per run), so separate runs get different compute cost. The table above controls for this (same process, same captured metadata, same compute).

**Accuracy** — worst max-abs-error vs the Torch reference over 200 runs (exposes the old reduce's racy spikes):

| shape | NEW max\|err\| | OLD max\|err\| | tolerance |
|---|---|---|---|
| h16, b81, q3, per_token | **2.63e-03 ✓** | **2.25e-02 ✗ OVER** | 5.0e-03 |
| h8, b81, q1, per_tensor | 2.20e-03 ✓ | 2.20e-03 ✓ | 5.0e-03 |
| h16, b81, q4, per_token, varlen | 2.73e-02 ✓ | 2.73e-02 ✓ | 5.0e-02 |
| h8, b3, q1, per_tensor | 1.74e-03 ✓ | 1.74e-03 ✓ | 5.0e-03 |

NEW is within tolerance and **stable** on every shape; OLD intermittently exceeds tolerance — case12 was caught at **2.25e-2 (4.5× over)**, the flaky `test_pa` failure. (The other shapes share the same race; they just didn't spike within 200 runs.)

## Scope / note

This removes the **reduce-phase** race, which is what the CI `test_pa` (fresh metadata per call) hits. Stress-testing the CUDA-graph replay path (reused metadata) surfaced a **separate, smaller, pre-existing non-determinism in the compute kernel** (`pa_decode_metadata_kenrel`, unmodified here) that only appears with reused buffers (~0.5%). That is out of scope for this PR and tracked separately. The sliding-window path (`compile_pa_decode_sw_reduce`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
