### PR TITLE
[Docs] Refer to gfx1250 by arch name only in docs and comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ helper code that is not part of the traced closure.
 | `gfx950` / `gfx95*` | MI350 / MI355X | 64 | MFMA | CDNA4 path; FP4, MFMA scale, wider LDS copy paths, 160KB LDS |
 | `gfx11*` | RDNA3 / RDNA3.5 (Strix Halo, e.g. gfx1151) | 32 | WMMA | No MFMA; f16/bf16 (and i8/i4) WMMA GEMM; legacy v16-operand WMMA ABI; **no native FP8** (kernels fail-fast); `kernels/rdna3_f16_gemm.py`. `is_rdna_arch()` returns True. |
 | `gfx120*` | RDNA4 (gfx1201 = Radeon AI PRO R9700) | 32 | WMMA | RDNA path, wave32; new v8-operand WMMA ABI; native FP8. `is_rdna_arch()` returns True. |
-| `gfx1250` | MI450 | 32 | WMMA / TDM | FP8/FP4 GEMM, MoE, async/TDM copy helpers, 320KB LDS. NOTE: `is_rdna_arch('gfx1250')` returns **False** and `get_warp_size` returns 64 — the gfx1250 kernels hardcode `WAVE_SIZE = 32` themselves. |
+| `gfx1250` | — | 32 | WMMA / TDM | FP8/FP4 GEMM, MoE, async/TDM copy helpers, 320KB LDS. NOTE: `is_rdna_arch('gfx1250')` returns **False** and `get_warp_size` returns 64 — the gfx1250 kernels hardcode `WAVE_SIZE = 32` themselves. |
 
 Use `from flydsl.runtime.device import get_rocm_arch, is_rdna_arch` rather than
 hard-coding behavior when possible. `is_rdna_arch()`

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ See `examples/` for more examples including tiled copy (`02-tiledCopy.py`), tile
 | **Quantization** | `test_quant.py` | Quantization utilities |
 
 **Verified Platforms**:
-*   AMD MI300X/MI308X (gfx942), AMD MI350/MI355X (gfx950), AMD MI450 (gfx1250), Radeon AI PRO R9700 (gfx1201)
+*   AMD MI300X/MI308X (gfx942), AMD MI350/MI355X (gfx950), gfx1250, Radeon AI PRO R9700 (gfx1201)
 *   Linux / ROCm 6.x, 7.x
 
 ## 🙏 Acknowledgements

--- a/docs/architecture_guide.md
+++ b/docs/architecture_guide.md
@@ -404,7 +404,7 @@ Transforms Python control flow to MLIR ops at the AST level:
 | `gfx942` | MI300A / MI300X | 64 KB | CDNA 3, primary development target |
 | `gfx950` | MI350 / MI355X | 160 KB | CDNA 4, larger LDS |
 | `gfx1201` | Radeon AI PRO R9700 | 64 KB | RDNA 4 |
-| `gfx1250` | MI450 | 320 KB | GFX12, wave32, WMMA, TDM ops |
+| `gfx1250` | — | 320 KB | GFX12, wave32, WMMA, TDM ops |
 | `gfx90a` | MI250X | 64 KB | CDNA 2 (verified platform) |
 
 ---

--- a/docs/kernel_authoring_guide.md
+++ b/docs/kernel_authoring_guide.md
@@ -414,7 +414,7 @@ with ir.InsertionPoint(comp_ctx.gpu_module_body):
 | `gfx942` (MI300X) | 64 KB |
 | `gfx950` (MI350/MI355X) | 160 KB |
 | `gfx1201` (Radeon AI PRO R9700) | 64 KB |
-| `gfx1250` (MI450) | 320 KB |
+| `gfx1250` | 320 KB |
 
 ---
 

--- a/python/flydsl/utils/smem_allocator.py
+++ b/python/flydsl/utils/smem_allocator.py
@@ -244,8 +244,8 @@ SMEM_CAPACITY_MAP = {
     "gfx950": 163840,  # MI300C / MI300X Enhanced Models: 64KB LDS per CU
     "gfx1151": 65536,  # RDNA3.5: 64KB LDS per WGP
     "gfx1201": 65536,  # RDNA4: 64KB LDS per WGP
-    # GFX1250 (MI450 Series) - 320KB LDS (WGP$ unified, 5 × 64KB segments)
-    "gfx1250": 327680,  # MI450: 320KB configurable as LDS
+    # GFX1250 - 320KB LDS (WGP$ unified, 5 × 64KB segments)
+    "gfx1250": 327680,  # 320KB configurable as LDS
 }
 
 


### PR DESCRIPTION
## Summary

Cleans up docs and code comments to refer to the gfx1250 architecture by its arch identifier only, removing specific product-name references.

## Changes

- `README.md` — verified-platforms list
- `CLAUDE.md` — GPU architecture support table
- `docs/architecture_guide.md` — LDS capacity table
- `docs/kernel_authoring_guide.md` — LDS capacity table
- `python/flydsl/utils/smem_allocator.py` — LDS size comments

No functional changes; `gfx1250` identifiers are preserved everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)