### PR TITLE
autotune: keep CI search opt-in (#770)

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -13,6 +13,9 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${REPO_ROOT}"
 
+# Broad test runs must be deterministic; dedicated autotune tests opt in per test.
+export FLYDSL_AUTOTUNE=0
+
 # Auto-select GPU with the most free VRAM (skip if HIP_VISIBLE_DEVICES is already set).
 if [[ -z "${HIP_VISIBLE_DEVICES:-}" ]] && command -v python3 &>/dev/null; then
     _best_gpu=$(python3 -c "

--- a/tests/unit/test_autotune.py
+++ b/tests/unit/test_autotune.py
@@ -386,7 +386,8 @@ def test_autotune_decorator_wraps_into_autotuner():
 
 # ── two-track default/search ─────────────────────────────────────────────
 def test_cache_hit_precedes_default_and_search(monkeypatch):
-    monkeypatch.delenv("FLYDSL_AUTOTUNE", raising=False)
+    # The broad test runner uses the explicit off value; search stays opt-in.
+    monkeypatch.setenv("FLYDSL_AUTOTUNE", "0")
     default_calls = 0
 
     def fn(a, out, BLOCK):


### PR DESCRIPTION
## Summary

Keep broad FlyDSL test runs deterministic:

- `scripts/run_tests.sh` explicitly sets `FLYDSL_AUTOTUNE=0` before pytest and standalone examples.
- The GPU-free default/cache-path test exercises that explicit off value and fails if benchmarking is reached.
- Dedicated autotune tests remain responsible for setting `FLYDSL_AUTOTUNE=1` around the forced-search cases they own.

The shared runner is used by both the source and wheel CI workflows, so this is one guard rather than duplicated workflow configuration.

## Why this is the right CI boundary

Autotune search is timing-sensitive and expensive. Shared CI should verify deterministic control-flow and correctness contracts, not select or commit a performance winner from noisy runner timing.

The current offline-artifact work in #786 already owns artifact identity, validation, fallback, and emit/load tests. Its artifacts are content-addressed deployment inputs generated on the intended GPU; FlyDSL currently has no committed artifact tree. The previous `configs/autotune/` registry and standalone committed-config validator were therefore both stale and unnecessary.

This PR adds no job, runner, config registry, or autotuner API.

## Verification

- `python3 -m pytest tests/unit/test_autotune.py -q` — 23 passed
- `bash scripts/check_python_style.sh --base upstream/main --include-local`
- `bash -n scripts/run_tests.sh`
- `git diff --check`

Rebased onto current `main`; the final diff is one commit touching two files.

Refs #770. Complements #786.
