### PR TITLE
[Perf] preshuffle_gemm: vectorize scale_a epilogue load (4x32b -> 1x128b)

### DIFF
--- a/kernels/preshuffle_gemm.py
+++ b/kernels/preshuffle_gemm.py
@@ -539,11 +539,9 @@ def compile_preshuffle_gemm(
 
             if const_expr(is_8bit):
                 # FP8/INT8: per-row(scale_a) × per-col(scale_b) scaling applied inline.
-                scale_a_buf = fx.rocdl.make_buffer_tensor(arg_scale_a, max_size=True)
                 scale_b_buf = fx.rocdl.make_buffer_tensor(arg_scale_b, max_size=True)
                 scale_copy = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), 32)
                 scale_reg_lay = fx.make_layout(1, 1)
-                scale_a_div = fx.logical_divide(scale_a_buf, fx.make_layout(1, 1))
                 scale_b_div = fx.logical_divide(scale_b_buf, fx.make_layout(1, 1))
 
                 def load_scale(div_tensor, index):
@@ -555,8 +553,15 @@ def compile_preshuffle_gemm(
                     load_scale(scale_b_div, by_n + (ni * num_waves + wave_id) * 16 + lane_mod_16)
                     for ni in range_constexpr(num_acc_n)
                 ]
+                # scale_a: the 4 contiguous per-row scales per mi (base is 4-aligned) load as
+                # one 128b buffer_load instead of 4×32b — matches the reference load count.
+                scale_a_rsrc = fx.buffer_ops.create_buffer_resource(arg_scale_a, max_size=True)
                 s_a_vals = [
-                    [load_scale(scale_a_div, bx_m + mi * 16 + lane_div_16 * 4 + ii) for ii in range_constexpr(4)]
+                    Vec(
+                        fx.buffer_ops.buffer_load(
+                            scale_a_rsrc, fx.Int32(bx_m + mi * 16 + lane_div_16 * 4), vec_width=4, dtype=T.f32
+                        )
+                    ).bitcast(fx.Float32)
                     for mi in range_constexpr(m_repeat)
                 ]
 


### PR DESCRIPTION
## Summary
Vectorize the per-row `scale_a` load in the fp8/int8 preshuffle GEMM epilogue:
the 4 contiguous per-row scales (base offset is 4-aligned) now load as **one
128-bit `buffer_load`** instead of **four 32-bit loads**.

## Why
An LLVM-IR diff of this kernel vs the aiter reference (matched config) showed the
compute is identical, and the *only* extra memory traffic was un-vectorized scale
loads: **34 scalar `i32` buffer loads vs the reference's 16 vectorized `<4 x i32>`**
(total `raw.ptr.buffer.load` 69 vs 46). This change cuts our scalar scale loads to
2 and brings the total `buffer.load` count to **46 — matching the reference**.

## Measurements (5cb28f6c-based build, gfx950, order-swapped A/B, median)
| shape (M×N×K) | before | after |
|---|---|---|
| 256×6144×1536  | ~465 | ~479 TFLOPS (**+3%**) |
| 32768×3072×1536 | ~1628 | ~1674 TFLOPS (**+2.8%**, won 4/4 rounds) |
| 2048×4096×512   | ~738 | ~738 (neutral — not load-bound) |

Larger-M shapes benefit most (more epilogue tiles → the 23-fewer-loads compound).

## Correctness (no threshold changes)
`verify_output` (rtol/atol 0.1) + OOB guard pass for fp8, int8 (shares the scale
path), and ragged M=127. Uses the same `buffer_ops.buffer_load(vec_width=4)`
pattern as `kernels/blockscale_preshuffle_gemm.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
