### PR TITLE
[Fix] Lower CDNA3 32x32x8 BF16 MFMA

### DIFF
--- a/lib/Dialect/FlyROCDL/CDNA3/MmaAtom.cpp
+++ b/lib/Dialect/FlyROCDL/CDNA3/MmaAtom.cpp
@@ -192,6 +192,7 @@ FailureOr<Value> MmaOpCDNA3_MFMAType::emitAtomCallSSA(OpBuilder &builder, Locati
   DISPATCH_MFMA_SSA(16, 2, elemTyA.isBF16(), mfma_f32_16x16x2bf16)
   DISPATCH_MFMA_SSA(4, 2, elemTyA.isBF16(), mfma_f32_4x4x2bf16)
   DISPATCH_MFMA_SSA(32, 4, elemTyA.isBF16(), mfma_f32_32x32x4bf16)
+  DISPATCH_MFMA_SSA(32, 8, elemTyA.isBF16(), mfma_f32_32x32x8bf16_1k)
   DISPATCH_MFMA_SSA(16, 8, elemTyA.isBF16(), mfma_f32_16x16x8bf16)
   DISPATCH_MFMA_SSA(16, 16, elemTyA.isBF16(), mfma_f32_16x16x16bf16_1k)
   DISPATCH_MFMA_SSA(16, 32, elemTyA.isBF16(), mfma_f32_16x16x32_bf16)

--- a/tests/mlir/Conversion/mma_atom.mlir
+++ b/tests/mlir/Conversion/mma_atom.mlir
@@ -49,3 +49,17 @@ func.func @test_mma_atom_call_ssa_fp8(
   %res = fly.mma_atom_call_ssa(%atom, %a, %b, %c) : (!fly.mma_atom<!fly_rocdl.cdna3.mfma<16x16x32, (f8E4M3FNUZ, f8E4M3FNUZ) -> f32>>, vector<8xi8>, vector<8xi8>, vector<4xf32>) -> vector<4xf32>
   return %res : vector<4xf32>
 }
+
+// CHECK-LABEL: @test_mma_atom_call_ssa_bf16_32x32x8
+// CHECK-SAME: (%[[A:.*]]: vector<4xbf16>, %[[B:.*]]: vector<4xbf16>, %[[C:.*]]: vector<16xf32>)
+func.func @test_mma_atom_call_ssa_bf16_32x32x8(
+    %a: vector<4xbf16>,
+    %b: vector<4xbf16>,
+    %c: vector<16xf32>) -> vector<16xf32> {
+  %atom = fly.make_mma_atom : !fly.mma_atom<!fly_rocdl.cdna3.mfma<32x32x8, (bf16, bf16) -> f32>>
+  // CHECK: %[[A_CAST:.*]] = llvm.bitcast %[[A]] : vector<4xbf16> to vector<4xi16>
+  // CHECK: %[[B_CAST:.*]] = llvm.bitcast %[[B]] : vector<4xbf16> to vector<4xi16>
+  // CHECK: %[[RES:.*]] = rocdl.mfma.f32.32x32x8bf16.1k %[[A_CAST]], %[[B_CAST]], %[[C]]
+  %res = fly.mma_atom_call_ssa(%atom, %a, %b, %c) : (!fly.mma_atom<!fly_rocdl.cdna3.mfma<32x32x8, (bf16, bf16) -> f32>>, vector<4xbf16>, vector<4xbf16>, vector<16xf32>) -> vector<16xf32>
+  return %res : vector<16xf32>
+}


### PR DESCRIPTION
## Summary
- Add the missing CDNA3 BF16 MFMA dispatch for `32x32x8` so `fly.mma_atom_call_ssa` legalizes to `rocdl.mfma.f32.32x32x8bf16.1k`.
- Add an MLIR conversion regression covering the SSA path and expected A/B operand bitcasts.

Fixes #790

## Test plan
- `cmake --build build-fly --target fly-opt -j 16`
- `cmake --build build-fly -j 16`
- `build-fly/bin/fly-opt tests/mlir/Conversion/mma_atom.mlir --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl`