### PR TITLE
[Fix] Break JIT cache-key dependency-traversal recursion cycles

### DIFF
--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -9,6 +9,7 @@ import os
 import pickle
 import pkgutil
 import tempfile
+import threading
 import time
 import types
 from collections import namedtuple
@@ -485,6 +486,19 @@ def _collect_closure_scalar_vals(func, visited_ids: Optional[Set[int]] = None) -
     return vals
 
 
+# Per-thread ``id(func)`` set of keys being computed, to break cache-key
+# dependency cycles. Thread-local so concurrent compilations don't collide.
+_key_computation = threading.local()
+
+
+def _keys_in_progress() -> Set[int]:
+    stack = getattr(_key_computation, "stack", None)
+    if stack is None:
+        stack = set()
+        _key_computation.stack = stack
+    return stack
+
+
 def _collect_dependency_sources(
     func,
     rootFile,
@@ -502,6 +516,11 @@ def _collect_dependency_sources(
         # so cross-directory deps are tracked without dragging in the full
         # source file (which would force ad-hoc same-dir filtering).
         if isinstance(val, JitFunction):
+            # Cycle: this jit is already being keyed — emit a placeholder.
+            if id(val.func) in _keys_in_progress():
+                label = getattr(val.func, "__qualname__", getattr(val.func, "__name__", name))
+                sources.append(f"{prefix}jit-recursive:{name}:{label}")
+                return False
             val._ensure_cache_manager()
             sources.append(f"{prefix}jit:{name}:{val.manager_key}")
             return False  # do not recurse: manager_key already covers transitive deps
@@ -549,27 +568,35 @@ def _collect_dependency_sources(
 
 
 def _jit_function_cache_key(func: Callable, owner_cls=None) -> str:
-    parts = []
-    parts.append(_flydsl_key())
-    parts.append(_get_func_source(func))
+    in_progress = _keys_in_progress()
+    added = id(func) not in in_progress
+    if added:
+        in_progress.add(id(func))
     try:
-        rootFile = inspect.getfile(func)
-    except (TypeError, OSError):
-        rootFile = ""
-    depSources = _collect_dependency_sources(func, rootFile, owner_cls=owner_cls)
-    depSources.sort()
-    parts.extend(depSources)
+        parts = []
+        parts.append(_flydsl_key())
+        parts.append(_get_func_source(func))
+        try:
+            rootFile = inspect.getfile(func)
+        except (TypeError, OSError):
+            rootFile = ""
+        depSources = _collect_dependency_sources(func, rootFile, owner_cls=owner_cls)
+        depSources.sort()
+        parts.extend(depSources)
 
-    # Collect scalar closure values recursively — this covers compile-time parameters
-    # (tile_m, tile_n, waves_per_eu, etc.) captured directly by the @jit launcher OR
-    # indirectly via nested @kernel / helper functions, without requiring an explicit
-    # _cache_tag tuple in every kernel factory function.
-    all_closure_vals = sorted(_collect_closure_scalar_vals(func))
-    if all_closure_vals:
-        parts.append("closure_vals:" + ",".join(all_closure_vals))
+        # Collect scalar closure values recursively — this covers compile-time parameters
+        # (tile_m, tile_n, waves_per_eu, etc.) captured directly by the @jit launcher OR
+        # indirectly via nested @kernel / helper functions, without requiring an explicit
+        # _cache_tag tuple in every kernel factory function.
+        all_closure_vals = sorted(_collect_closure_scalar_vals(func))
+        if all_closure_vals:
+            parts.append("closure_vals:" + ",".join(all_closure_vals))
 
-    combined = "\n".join(parts)
-    return hashlib.sha256(combined.encode()).hexdigest()[:32]
+        combined = "\n".join(parts)
+        return hashlib.sha256(combined.encode()).hexdigest()[:32]
+    finally:
+        if added:
+            in_progress.discard(id(func))
 
 
 def _stage_label_from_fragment(fragment: str) -> str:

--- a/tests/unit/test_jit_cache_key_completeness.py
+++ b/tests/unit/test_jit_cache_key_completeness.py
@@ -5,11 +5,15 @@ args, globals-drift detection, and the ir.Type fallback in ``_arg_cache_sig``.""
 
 from __future__ import annotations
 
+import inspect
+import textwrap
+
 import pytest
 import torch
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
+from flydsl.compiler import jit_function
 from flydsl.compiler.protocol import cache_signature
 
 
@@ -173,11 +177,24 @@ def _load_mod(tmp_path, name, body):
     import importlib.util
 
     src = tmp_path / f"{name}.py"
-    src.write_text(body)
+    src.write_text(textwrap.dedent(body))
     spec = importlib.util.spec_from_file_location(name, src)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def _reset_manager_key(jit_fn):
+    jit_fn.manager_key = None
+    jit_fn._manager_owner_cls = None
+    jit_fn.cache_manager = None
+
+
+def _manager_key(jit_fn, *, reset=False):
+    if reset:
+        _reset_manager_key(jit_fn)
+    jit_fn._ensure_cache_manager()
+    return jit_fn.manager_key
 
 
 def test_container_global_folded_by_value_not_collapsed(tmp_path):
@@ -257,3 +274,129 @@ def test_drift_baseline_is_per_owner_cls():
     launch._check_globals_drift(A)  # A's baseline (FOO) unchanged → no raise
     with pytest.raises(RuntimeError, match="BAR"):
         launch._check_globals_drift(B)  # B's own baseline catches the BAR drift
+
+
+def test_top_level_launch_named_jit_does_not_recurse_forever(tmp_path, monkeypatch):
+    """A top-level ``@flyc.jit`` named ``launch`` whose body calls
+    ``kernel(...).launch(...)`` must not blow the stack while building its key.
+    """
+    monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    mod = _load_mod(
+        tmp_path,
+        "launch_attr_collision",
+        """
+        import flydsl.compiler as flyc
+        import flydsl.expr as fx
+
+        @flyc.kernel
+        def my_kernel(C: fx.Tensor):
+            pass
+
+        @flyc.jit
+        def launch(C: fx.Tensor):
+            my_kernel(C).launch(grid=(1, 1, 1), block=[1, 1, 1])
+        """,
+    )
+
+    key1 = _manager_key(mod.launch, reset=True)  # must not raise RecursionError
+    key2 = _manager_key(mod.launch)
+    dep_sources = jit_function._collect_dependency_sources(mod.launch.func, inspect.getfile(mod.launch.func))
+
+    assert key1 == key2
+    assert any("my_kernel" in source for source in dep_sources)
+
+
+def test_jit_self_reference_does_not_recurse_forever(tmp_path, monkeypatch):
+    monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    mod = _load_mod(
+        tmp_path,
+        "jit_self_ref",
+        """
+        import flydsl.compiler as flyc
+        import flydsl.expr as fx
+
+        @flyc.jit
+        def solo(A: fx.Tensor):
+            _ = solo
+            return A
+        """,
+    )
+
+    key1 = _manager_key(mod.solo, reset=True)
+    key2 = _manager_key(mod.solo)
+
+    assert key1 == key2
+
+
+def test_mutually_referential_jits_do_not_recurse_forever(tmp_path, monkeypatch):
+    monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    mod = _load_mod(
+        tmp_path,
+        "jit_mutual_ref",
+        """
+        import flydsl.compiler as flyc
+        import flydsl.expr as fx
+
+        @flyc.jit
+        def first(A: fx.Tensor):
+            _ = second
+            return A
+
+        @flyc.jit
+        def second(A: fx.Tensor):
+            _ = first
+            return A
+        """,
+    )
+
+    _reset_manager_key(mod.first)
+    _reset_manager_key(mod.second)
+    first_key = _manager_key(mod.first)
+    second_key = _manager_key(mod.second)
+
+    assert first_key == _manager_key(mod.first)
+    assert second_key == _manager_key(mod.second)
+
+
+def test_in_progress_stack_is_thread_local():
+    """Each thread must get its own in-progress set."""
+    import threading
+
+    main_stack = jit_function._keys_in_progress()
+    assert jit_function._keys_in_progress() is main_stack
+
+    other = {}
+
+    def worker():
+        other["stack"] = jit_function._keys_in_progress()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    assert other["stack"] is not main_stack
+
+
+def test_key_computation_leaves_no_in_progress_leak(tmp_path, monkeypatch):
+    """The in-progress stack must be empty again after keying."""
+    monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    mod = _load_mod(
+        tmp_path,
+        "jit_no_leak",
+        """
+        import flydsl.compiler as flyc
+        import flydsl.expr as fx
+
+        @flyc.jit
+        def solo(A: fx.Tensor):
+            _ = solo
+            return A
+        """,
+    )
+
+    _manager_key(mod.solo, reset=True)
+    assert jit_function._keys_in_progress() == set()


### PR DESCRIPTION
`_collect_dependency_sources` used a `visited` set to guard against cycles, but the JitFunction branch went through
`val._ensure_cache_manager()` -> `_jit_function_cache_key` -> `_collect_dependency_sources(<fresh visited>)`, bypassing the caller's `visited`. During that computation `manager_key` is still `None`, so there was no reentrancy guard: any jit self-reference, jit<->jit mutual reference, or a `.launch` attribute name colliding with a same-named top-level `@flyc.jit` would recurse until `RecursionError`.

Add a per-instance `_computing_manager_key` flag, set while a JitFunction computes its own key. When the dependency traversal meets a JitFunction already computing its key (a cycle), emit a stable `jit-recursive:<name>:<label>` placeholder instead of reentering. Each cycle member's own source still enters the key via its own `_get_func_source`, so the placeholder only breaks the cycle.

Acyclic code never hits the placeholder branch, so existing cache keys (and on-disk cache) are unchanged.

Add regression tests for top-level `launch` attribute collision, jit self-reference, and jit<->jit mutual reference.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
