### PR TITLE
perf(pa): use _run_compiled for PA decode kernel launches

### DIFF
--- a/kernels/attention/pa_decode_fp8.py
+++ b/kernels/attention/pa_decode_fp8.py
@@ -31,6 +31,7 @@ from kernels.attention.pa_common import _compute_block_base_dw_i64, _prefetch_q_
 from kernels.attention.pa_decode_swa import compile_pa_decode_sw, compile_pa_decode_sw_reduce
 from kernels.attention.pa_metadata import compile_pa_decode_metadata
 from kernels.common import dpp_utils
+from kernels.common.tensor_shim import _run_compiled
 from kernels.common.utils import (
     cdiv,
     exp2_f32_fast,
@@ -1816,7 +1817,8 @@ def pa_decode_ps_launch(
             head_dim=int(head_size),
         )
 
-        compiled_sw["launch"](
+        _run_compiled(
+            compiled_sw["launch"],
             exp_sums.data_ptr(),
             max_logits.data_ptr(),
             temporary_output.data_ptr(),
@@ -1864,7 +1866,8 @@ def pa_decode_ps_launch(
             head_size=head_size,
             output_dtype_str=_get_output_dtype_str(output),
         )
-        compiled_sw_reduce["launch"](
+        _run_compiled(
+            compiled_sw_reduce["launch"],
             output_5d.data_ptr(),
             exp_sums.data_ptr(),
             max_logits.data_ptr(),
@@ -1938,7 +1941,8 @@ def pa_decode_ps_launch(
             head_dim=int(head_size),
         )
         output_5d = output.reshape(batch_size, query_length, num_kv_heads, query_group_size, head_size)
-        compiled_small["launch"](
+        _run_compiled(
+            compiled_small["launch"],
             exp_sums.data_ptr(),
             max_logits.data_ptr(),
             temporary_output.data_ptr(),
@@ -1977,7 +1981,8 @@ def pa_decode_ps_launch(
             head_size=head_size,
             output_dtype_str=_get_output_dtype_str(output),
         )
-        compiled_sw_reduce["launch"](
+        _run_compiled(
+            compiled_sw_reduce["launch"],
             output_5d.data_ptr(),
             exp_sums.data_ptr(),
             max_logits.data_ptr(),
@@ -2032,7 +2037,8 @@ def pa_decode_ps_launch(
     stride_po_ql = metadata.get("stride_po_ql", num_query_heads * query.shape[-1])
     stride_pl_ql = metadata.get("stride_pl_ql", num_query_heads)
 
-    compiled["launch"](
+    _run_compiled(
+        compiled["launch"],
         output.data_ptr(),
         partial_output.data_ptr(),
         partial_lse.data_ptr(),

--- a/kernels/attention/pa_metadata.py
+++ b/kernels/attention/pa_metadata.py
@@ -50,6 +50,7 @@ from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from kernels.attention.pa_common import _compute_block_base_dw_i64, _prefetch_q_chunks
 from kernels.common import dpp_utils
 from kernels.common.kernels_common import get_warp_size
+from kernels.common.tensor_shim import _run_compiled
 from kernels.common.utils import (
     exp2_f32_fast,
     global_load_i64x2,
@@ -1291,7 +1292,8 @@ def get_pa_metadata_v1(
     work_info_flat = work_info.view(-1)
     reduce_final_map_flat = reduce_final_map.view(-1)
 
-    compiled["launch"](
+    _run_compiled(
+        compiled["launch"],
         seqlens_qo_indptr,
         pages_kv_indptr,
         context_lens,
@@ -1301,6 +1303,7 @@ def get_pa_metadata_v1(
         reduce_final_map_flat,
         reduce_partial_map,
         num_batches,
+        fx.Stream(None),
     )
 
 
@@ -2257,10 +2260,8 @@ def pa_ps_reduce(
         head_size=int(head_size),
         output_dtype_str=out_dtype_str,
     )
-    kwargs = {}
-    if stream is not None:
-        kwargs["stream"] = stream
-    compiled["launch"](
+    _run_compiled(
+        compiled["launch"],
         final_output,
         partial_output,
         partial_lse,
@@ -2272,5 +2273,5 @@ def pa_ps_reduce(
         stride_po_row,
         stride_pl_row,
         num_groups,
-        **kwargs,
+        stream if stream is not None else fx.Stream(None),
     )


### PR DESCRIPTION
## Summary
- Replace direct `@flyc.jit` `__call__` dispatch with `_run_compiled()` at all PA decode launch call sites in `kernels/attention/pa_decode_fp8.py` and `kernels/attention/pa_metadata.py`.
- `_run_compiled` (already used by `kernels/hgemm_splitk.py`) caches a `CompiledFunction` on the first call and skips `JitFunction.__call__`'s per-call `sig.bind` / cache-key build / cache lookup on subsequent decode steps, since PA decode is called repeatedly with stable shapes.
- Two call sites relied on JIT-side default/keyword `stream` handling, which `CompiledFunction` (positional-args only) doesn't support, so those now pass `stream` (or `fx.Stream(None)`) explicitly and positionally — behavior is unchanged.

## Test plan
- [x] `python3 -m pytest tests/kernels/test_pa.py -k "normal_accuracy"` — passes on MI308X (gfx942)
- [x] `python3 -m pytest tests/kernels/test_pa.py -k "sliding_window_accuracy"` — passes on MI308X (gfx942)
  - Both exercise the launch functions repeatedly via `measure_us` (warmup + timed iterations, including CUDA-graph capture), so the `_run_compiled` cached fast-path is hit many times per call site, not just the first compile.
- [x] `bash scripts/check_python_style.sh --fix` — no formatting changes needed
- [ ] The small-block (`block_size` 16/64) path (`compiled_small["launch"]`) isn't exercised by `test_pa.py` (only `block_size=1024` is tested), so that conversion wasn't GPU-verified — it's the same mechanical change as the other sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)