### PR TITLE
[Docs] Refresh API docs, add kernel tuning guide, fix kernel-authoring skills

### DIFF
--- a/.claude/skills/flydsl-kernel-authoring/SKILL.md
+++ b/.claude/skills/flydsl-kernel-authoring/SKILL.md
@@ -3,7 +3,7 @@ name: flydsl-kernel-authoring
 description: >
   Comprehensive reference for authoring FlyDSL GPU kernels on AMD GPUs.
   Covers the layout algebra, tiled copy/MMA, buffer ops, loop-carried range loops,
-  SmemAllocator, autotuning, and common patterns. Use when writing,
+  SharedAllocator (LDS), autotuning, and common patterns. Use when writing,
   reviewing, or understanding FlyDSL kernel code.
 allowed-tools: Read Edit Bash Grep Glob Agent
 ---
@@ -56,8 +56,9 @@ Pipeline is built by `RocmBackend._pipeline_parts()` and split into three stages
 - `python/flydsl/expr/gpu.py` - GPU operations (thread_idx, block_idx, barrier)
 - `python/flydsl/expr/buffer_ops.py` - AMD buffer load/store intrinsics
 - `python/flydsl/expr/rocdl/` - MFMA/WMMA and other ROCm intrinsics (package: cdna4, cluster, inline_asm, tdm_ops, universal)
-- `python/flydsl/utils/smem_allocator.py` - LDS (shared memory) management
-- `kernels/` - Pre-built kernels (preshuffle_gemm.py, layernorm, softmax, rmsnorm)
+- `python/flydsl/expr/gpu.py` - `SharedAllocator` for LDS (shared memory), `thread_id`/`block_id`, `barrier`
+- `python/flydsl/utils/smem_allocator.py` - legacy `SmemAllocator` (un-migrated kernels only)
+- `kernels/` - Pre-built kernels, organized into subpackages: `gemm/` (preshuffle_gemm.py, mxfp4_preshuffle.py, ...), `norm/` (layernorm/softmax/rmsnorm), `attention/`, `moe/`, `mma/`, `common/`, `comm/`, `conv/`
 
 ---
 
@@ -160,7 +161,6 @@ fx.select(int_tuple, indices=[0, 2])      # Pick specific modes
 fx.group(int_tuple, begin=1, end=3)        # Group modes into nested tuple
 fx.append(base, elem)                      # Append mode
 fx.prepend(base, elem)                     # Prepend mode
-fx.zip(lhs, rhs)                           # Zip two IntTuples
 fx.slice(src, coord)                       # Slice at coordinate (None = keep mode)
 ```
 
@@ -204,7 +204,7 @@ launch(A, B, 1024)
 
 ### Current Syntax Quick Reference
 
-Use the current public FlyDSL surface from `kernels/preshuffle_gemm.py` when writing new kernels:
+Use the current public FlyDSL surface from `kernels/gemm/preshuffle_gemm.py` when writing new kernels:
 
 ```python
 Vec = fx.Vector
@@ -595,28 +595,37 @@ buffer_ops.buffer_store(data, rsrc, offset)
 
 ## 5. Shared Memory (LDS)
 
-### SmemAllocator Pattern
-```python
-from flydsl.utils.smem_allocator import SmemAllocator
-from flydsl.expr.typing import T
-from flydsl.compiler.kernel_function import CompilationContext
+### SharedAllocator Pattern (preferred for new kernels)
 
-allocator = SmemAllocator(None, arch="gfx942", global_sym_name="smem0")
-lds_a = allocator.allocate_array(T.f16, 8192)  # Allocate typed arrays
-lds_b = allocator.allocate_array(T.f16, 8192)
+Declare the LDS storage as an ``@fx.struct`` of ``fx.Array`` fields, allocate it
+inside the kernel with ``fx.SharedAllocator``, then ``.view()`` each field as a
+layout. In the default ``static=True`` mode the compiler sizes a per-leaf static
+LDS global, so ``launch(smem=...)`` is left unset.
+
+```python
+import flydsl.expr as fx
+
+@fx.struct
+class SharedStorage:
+    a: fx.Array[fx.Float16, 8192]
+    b: fx.Array[fx.Float16, 8192]
 
 @flyc.kernel
 def my_kernel(A: fx.Tensor, ...):
-    lds_base = allocator.get_base()       # Get base ptr inside kernel
-    lds_a_ptr = lds_a(lds_base)           # SmemPtr for typed access
-    val = lds_a_ptr.load([idx])
-    lds_a_ptr.store(val, [idx])
-
-    # Finalize in GPU module body (before launch)
-    comp_ctx = CompilationContext.get_current()
-    with ir.InsertionPoint(comp_ctx.gpu_module_body):
-        allocator.finalize()
+    lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+    lds_a = lds.a.view(fx.make_layout((64, 128), (128, 1)))
+    lds_b = lds.b.view(fx.make_layout((64, 128), (128, 1)))
+    # ds_write / ds_read happen through copy atoms or view loads/stores
 ```
+
+For the dynamic mode (``static=False``), the launch wrapper auto-infers
+``smem`` from ``SharedAllocator.allocated_bytes`` when ``smem=None``.
+
+### Legacy SmemAllocator
+
+`flydsl.utils.smem_allocator.SmemAllocator` remains for un-migrated kernels. Its
+surface is ``__init__``/``finalize``/``get_base`` plus ``SmemPtr.get/load/store``;
+prefer `SharedAllocator` for anything new.
 
 ### LDS Capacity
 | Architecture | GPU | LDS per CU |
@@ -643,7 +652,7 @@ result = rocdl.mfma_i32_16x16x32i8(a, b, acc)
 ```
 
 ### GEMM Pattern (Preshuffle)
-The preshuffle GEMM pattern in `kernels/preshuffle_gemm.py`:
+The preshuffle GEMM pattern in `kernels/gemm/preshuffle_gemm.py`:
 1. B matrix is pre-shuffled to layout: (N/16, K/64, 4, 16, kpack_bytes)
 2. A tiles loaded from global to LDS with XOR16 swizzle for bank-conflict avoidance
 3. K64-byte micro-steps: each step issues 2x K32 MFMA operations
@@ -670,7 +679,8 @@ for sh in [32, 16, 8, 4, 2, 1]:
 3. `gpu.barrier()`
 4. Wave 0 reads and reduces NUM_WAVES partials from LDS
 
-See `kernels/reduce.py` for reusable implementations.
+See the norm kernels in `kernels/norm/` (e.g. `rmsnorm_kernel.py`, which defines
+local `wave_reduce_add` / `block_reduce_add` closures) for worked reductions.
 
 ---
 
@@ -850,13 +860,13 @@ Pass raw `torch.Tensor` objects instead.
 
 3. **Cache stale after code changes**: The disk cache auto-invalidates on source/closure changes. Only set `FLYDSL_RUNTIME_ENABLE_CACHE=0` or clear `~/.flydsl/cache/` if you changed C++ passes or non-closure helpers.
 
-4. **LDS overflow**: Check capacity (64KB on gfx942, 160KB on gfx950). Use `SmemAllocator` which tracks allocations.
+4. **LDS overflow**: Check capacity (64KB on gfx942, 160KB on gfx950). `SharedAllocator` sizes the LDS global for you; the compiler errors if a static allocation exceeds the arch limit.
 
 5. **Dynamic vs Constexpr**: `Constexpr[int]` values are baked into IR -- different values produce different compiled kernels. Use `Int32` for truly dynamic values.
 
 6. **Tensor layout marking**: For dynamic shapes or alignment, use `flyc.from_dlpack(tensor).mark_layout_dynamic(leading_dim=0, divisibility=4)`.
 
-7. **SmemAllocator finalize**: Must call `allocator.finalize()` inside the GPU module body (use `CompilationContext.get_current().gpu_module_body`).
+7. **Legacy SmemAllocator finalize**: only for the legacy `SmemAllocator` path — call `allocator.finalize()` inside the GPU module body (`CompilationContext.get_current().gpu_module_body`). `SharedAllocator` needs no finalize step.
 
 8. **AMD wavefront size**: Always 64 on gfx9xx. Use shifts [32, 16, 8, 4, 2, 1] for full-wave reduction.
 
@@ -878,7 +888,7 @@ Pass raw `torch.Tensor` objects instead.
 | Tiling | Manual via divide/product operations | Auto-tiling with `tl.program_id` | Auto-tiling |
 | Memory access | Copy atoms, buffer load/store, TiledCopy | `tl.load`/`tl.store` | `gluon.load`/`gluon.store` |
 | MFMA | Direct `rocdl.mfma_*` intrinsics | `tl.dot` | `gluon.dot` |
-| Shared memory | SmemAllocator with explicit management | Implicit scratchpad | Implicit |
+| Shared memory | SharedAllocator + `@fx.struct` explicit management | Implicit scratchpad | Implicit |
 | Abstraction level | Low (near hardware) | Medium | Medium-High |
 | Compilation | MLIR (Fly dialect -> LLVM -> HSACO) | MLIR (Triton dialect -> LLVM) | MLIR |
 | Control | Maximum control over data layout and movement | Less control, more automation | Least control |

--- a/.claude/skills/flydsl-tile-programming/SKILL.md
+++ b/.claude/skills/flydsl-tile-programming/SKILL.md
@@ -376,31 +376,26 @@ fx.rocdl.sched_dswr(N)     # schedule N DS writes
 
 ## Step 6: Add Shared Memory (if needed)
 
-```python
-from flydsl.utils.smem_allocator import SmemAllocator
-from flydsl.compiler.kernel_function import CompilationContext
-from flydsl._mlir import ir
+Declare the LDS storage as an ``@fx.struct`` of ``fx.Array`` fields and allocate
+it inside the kernel with ``fx.SharedAllocator`` (the current LDS API — the
+compiler sizes the static LDS global, so ``launch(smem=...)`` is left unset):
 
-allocator = SmemAllocator(None, arch="gfx942", global_sym_name="smem0")
-lds_buf = allocator.allocate_array(fx.T.f16, num_elements)
+```python
+@fx.struct
+class SharedStorage:
+    buf: fx.Array[fx.Float16, num_elements]
 
 @flyc.kernel
 def kernel_with_lds(A: fx.Tensor, ...):
-    lds_base = allocator.get_base()
-    lds_ptr = lds_buf(lds_base)
+    lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+    lds_buf = lds.buf.view(fx.make_layout((rows, cols), (cols, 1)))
 
-    # Write to LDS
-    lds_ptr.store(value, [idx])
+    # Write to LDS, sync, read back (through view loads/stores or copy atoms)
     fx.gpu.barrier()
-
-    # Read from LDS
-    val = lds_ptr.load([idx])
-
-    # Finalize (inside GPU module body, before launch)
-    comp_ctx = CompilationContext.get_current()
-    with ir.InsertionPoint(comp_ctx.gpu_module_body):
-        allocator.finalize()
 ```
+
+(The legacy `flydsl.utils.smem_allocator.SmemAllocator` path still exists for
+un-migrated kernels but is not recommended for new code.)
 
 LDS capacity: gfx942 (MI300X) = 64KB, gfx950 (MI350) = 160KB.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ FlyDSL/
 | Layout algebra | [`docs/layout_system_guide.md`](docs/layout_system_guide.md) | Shape/Stride/Layout/Coord APIs, products, divides, coordinate mapping |
 | CuTe layout reference | [`docs/cute_layout_algebra_guide.md`](docs/cute_layout_algebra_guide.md) | Mathematical background and FlyDSL mapping of CuTe concepts |
 | Kernel authoring | [`docs/kernel_authoring_guide.md`](docs/kernel_authoring_guide.md) | `@flyc.kernel`, `@flyc.jit`, launch config, LDS, tiled copy/MMA |
+| Kernel tuning | [`docs/kernel_tuning_guide.md`](docs/kernel_tuning_guide.md) | Tiling, LDS double-buffer/swizzle, prefetch, MFMA scheduling, occupancy, ATT/PMC profiling |
 | Pre-built kernels | [`docs/prebuilt_kernels_guide.md`](docs/prebuilt_kernels_guide.md) | Norm, Softmax, GEMM, MoE, attention, dtype/config notes |
 | External bitcode integration | [`docs/extern_integration_guide.md`](docs/extern_integration_guide.md) | `ffi` + `link_extern`: plug pre-compiled LLVM bitcode into the JIT pipeline (`python/flydsl/expr/extern.py`, `compiler/extern_link.py`) |
 | Testing & benchmarking | [`docs/testing_benchmarking_guide.md`](docs/testing_benchmarking_guide.md) | Test categories, benchmark harness, performance comparisons |

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/ROCm/FlyDSL/actions/workflows/ci.yaml/badge.svg)](https://github.com/ROCm/FlyDSL/actions/workflows/ci.yaml)
 [![Benchmark](https://github.com/ROCm/FlyDSL/actions/workflows/flydsl.yaml/badge.svg)](https://github.com/ROCm/FlyDSL/actions/workflows/flydsl.yaml)
 [![Dashboard](https://img.shields.io/badge/Performance-Dashboard-blue)](https://rocm.github.io/FlyDSL/ci-dashboard/)
+[![Docs](https://img.shields.io/badge/Docs-rocm.github.io%2FFlyDSL-blue)](https://rocm.github.io/FlyDSL)
 
 </div>
 
@@ -168,6 +169,7 @@ bash scripts/build.sh -j64
 | Architecture | Compilation pipeline, project structure, environment config | [Architecture Guide](docs/architecture_guide.md) |
 | Layout System | FlyDSL layout algebra — Shape, Stride, Layout, Coord, all operations | [Layout Guide](docs/layout_system_guide.md) |
 | Kernel Authoring | Writing GPU kernels — MlirModule, tiled copies, MFMA, shared memory | [Kernel Guide](docs/kernel_authoring_guide.md) |
+| Kernel Tuning | Performance tuning — tiling, LDS swizzle, prefetch, MFMA scheduling, profiling | [Tuning Guide](docs/kernel_tuning_guide.md) |
 | Pre-built Kernels | Available kernels — GEMM, MoE, Softmax, Norm — config and usage | [Kernels Reference](docs/prebuilt_kernels_guide.md) |
 | Testing & Benchmarks | Test infrastructure, benchmarking, performance comparison | [Testing Guide](docs/testing_benchmarking_guide.md) |
 
@@ -206,6 +208,7 @@ Formula: `Index = dot(Coord, Stride) = sum(c_i * s_i)`
 | Architecture | Compilation pipeline, project structure, environment config | [Architecture Guide](docs/architecture_guide.md) |
 | Layout System | Fly layout algebra — Shape, Stride, Layout, Coord, all operations | [Layout Guide](docs/layout_system_guide.md) |
 | Kernel Authoring | Writing GPU kernels — `@flyc.kernel`, `@flyc.jit`, expression API | [Kernel Guide](docs/kernel_authoring_guide.md) |
+| Kernel Tuning | Performance tuning — tiling, LDS swizzle, prefetch, MFMA scheduling, profiling | [Tuning Guide](docs/kernel_tuning_guide.md) |
 | Pre-built Kernels | Available kernels — GEMM, Softmax, Norm — config and usage | [Kernels Reference](docs/prebuilt_kernels_guide.md) |
 | Testing & Benchmarks | Test infrastructure, benchmarking, performance comparison | [Testing Guide](docs/testing_benchmarking_guide.md) |
 
@@ -404,6 +407,7 @@ FlyDSL's design is inspired by ideas from several projects:
 - [ROCm Composable Kernel](https://github.com/ROCm/composable_kernel) — tile-based kernel design patterns for AMD GPUs
 - [ROCm AIter](https://github.com/ROCm/aiter) — test infrastructure and performance comparison baselines (MIT)
 - [Triton](https://github.com/triton-lang/triton) — Python DSL for GPU kernel authoring
+- [HipKittens](https://github.com/HazyResearch/HipKittens) — tile-based abstractions for high-performance AMD GPU kernels
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ FlyDSL's design is inspired by ideas from several projects:
 - [ROCm Composable Kernel](https://github.com/ROCm/composable_kernel) — tile-based kernel design patterns for AMD GPUs
 - [ROCm AIter](https://github.com/ROCm/aiter) — test infrastructure and performance comparison baselines (MIT)
 - [Triton](https://github.com/triton-lang/triton) — Python DSL for GPU kernel authoring
-- [HipKittens](https://github.com/HazyResearch/HipKittens) — tile-based abstractions for high-performance AMD GPU kernels
+- [HipKittens](https://github.com/HazyResearch/HipKittens) — minimal, opinionated C++ embedded primitives for fast AMD AI kernels (part of the ThunderKittens family)
 
 ## 📄 License
 

--- a/docs/api/dsl.rst
+++ b/docs/api/dsl.rst
@@ -32,7 +32,6 @@ Layout Construction
 - **fx.make_coord(\*coords)** -- create a coordinate tuple
 - **fx.make_ordered_layout(shape, order)** -- layout with explicit mode ordering
 - **fx.make_identity_layout(shape)** -- identity layout (strides = prefix products)
-- **fx.make_identity_tensor(shape)** -- identity coordinate tensor
 
 Layout Inspection
 ~~~~~~~~~~~~~~~~~~
@@ -43,7 +42,7 @@ Layout Inspection
 - **fx.depth(layout)** -- nesting depth
 - **fx.get_shape(layout)** -- extract shape tuple
 - **fx.get_stride(layout)** -- extract stride tuple
-- **fx.get_scalar(int_tuple, idx)** -- extract scalar from nested int tuple
+- **fx.get_scalar(int_tuple)** -- extract the scalar from a single-leaf int tuple (per-mode access is ``fx.get``)
 
 Layout Algebra
 ~~~~~~~~~~~~~~~
@@ -67,8 +66,8 @@ Layout Products & Divides
 Coordinate Mapping
 ~~~~~~~~~~~~~~~~~~~
 
-- **fx.crd2idx(coord, shape, stride)** -- coordinate to linear index
-- **fx.idx2crd(idx, shape)** -- linear index to coordinate
+- **fx.crd2idx(coord, layout)** -- coordinate to linear index
+- **fx.idx2crd(idx, layout)** -- linear index to coordinate
 - **fx.slice(tensor, slices)** -- slice a tensor by coordinates or ``None``
 - **fx.get(layout, idx)** -- access element at index
 
@@ -80,29 +79,30 @@ Memory Operations
 - **fx.memref_store(value, memref, indices)** -- scalar store to memref
 - **fx.memref_load_vec(memref)** -- load entire register as a vector
 - **fx.memref_store_vec(vec, memref)** -- store vector to register memref
-- **fx.make_fragment_layout_like(layout_like)** -- compute the corresponding fragment layout
+- **fx.make_fragment_layout_like(tensor)** -- compute the corresponding fragment layout
 - **fx.make_fragment_like(tensor)** -- allocate register fragment with same layout
 
 Copy & GEMM
 ~~~~~~~~~~~~~
 
 - **fx.make_copy_atom(instr, dtype)** -- create a CopyAtom from instruction descriptor
-- **fx.make_mma_atom(instr, dtype)** -- create an MmaAtom from MFMA descriptor
-- **fx.make_tile(layouts)** -- build a tile from a list of layouts
+- **fx.make_mma_atom(instr)** -- create an MmaAtom from an MMA op type (the op type carries the dtype, e.g. ``fx.rocdl.MFMA(16, 16, 4, fx.Float32)``)
+- **fx.make_tile(\*layouts)** -- build a tile from layouts (variadic)
 - **fx.make_tiled_copy(copy_atom, layout_tv, tile_mn)** -- build a TiledCopy
 - **fx.make_tiled_mma(mma_atom, ...)** -- build a TiledMma
-- **fx.copy(tiled_copy, src, dst, pred=None)** -- execute a tiled copy (with optional predicate mask)
-- **fx.gemm(tiled_mma, accum, A, B)** -- execute tiled matrix multiply-accumulate
+- **fx.copy(copy_atom, src, dst, pred=None)** -- execute a copy (with optional predicate mask)
+- **fx.gemm(mma_atom, d, a, b, c)** -- execute matrix multiply-accumulate (accumulator passed as both ``d`` and ``c``)
 - **fx.copy_atom_call(atom, src, dst)** -- invoke a single copy atom
-- **fx.mma_atom_call(atom, accum, A, B)** -- invoke a single MMA atom
+- **fx.mma_atom_call(atom, d, a, b, c)** -- invoke a single MMA atom
 
 Derived Tiled Operations (``flydsl.expr.derived``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 High-level classes for tiled copy and MMA partitioning:
 
-- **CopyAtom** -- single hardware copy instruction descriptor
-- **MmaAtom** -- single MMA instruction descriptor (MFMA)
+- **CopyAtom** (``flydsl.expr.typing``) -- single hardware copy instruction descriptor
+- **MmaAtom** (``flydsl.expr.typing``) -- single MMA instruction descriptor (MFMA)
+- **CopyAtomType**, **MmaAtomType** -- atom type wrappers exposed by ``flydsl.expr.derived``
 - **TiledCopy** -- multi-thread tiled copy; use ``get_slice(tid)`` → ``ThrCopy``
 - **TiledMma** -- multi-thread tiled MMA; use ``get_slice(tid)`` → ``ThrMma``
 - **ThrCopy** -- per-thread copy view: ``partition_S(src)``, ``partition_D(dst)``, ``retile(t)``
@@ -116,7 +116,8 @@ Type Annotations
 - **fx.Tensor** -- GPU tensor argument
 - **fx.Constexpr[int]** -- compile-time constant
 - **fx.Int32** -- dynamic int32 argument
-- **fx.Float32**, **fx.Float16**, **fx.BFloat16**, **fx.Float8** -- scalar types
+- **fx.Float32**, **fx.Float16**, **fx.BFloat16** -- scalar types
+- **fx.Float8E4M3FN**, **fx.Float8E4M3FNUZ**, **fx.Float8E5M2** -- FP8 scalar types
 - **fx.Stream** -- GPU stream argument
 - **fx.T** -- type namespace (``T.f32``, ``T.f16``, ``T.bf16``, ``T.i8``, ``T.index``, etc.)
 
@@ -192,7 +193,7 @@ AMD-specific operations for ROCm:
 
 - **fx.rocdl.make_buffer_tensor(tensor)** -- create buffer resource from tensor
 - **fx.rocdl.BufferCopy32b** / **BufferCopy128b** -- buffer copy instruction atoms
-- **fx.rocdl.MFMA(M, N, K, acc_type)** -- MFMA instruction atom constructor
+- **fx.rocdl.MFMA(m, n, k, elem_ty_ab, elem_ty_acc=None)** -- MFMA instruction atom constructor (4th arg is the A/B element type; accumulator defaults to f32)
 - **fx.rocdl.sched_mfma(cnt)** -- insert MFMA scheduling barrier
 - **fx.rocdl.sched_vmem(cnt)** -- insert VMEM scheduling barrier
 - **fx.rocdl.sched_dsrd(cnt)** -- insert DS read scheduling barrier
@@ -210,6 +211,6 @@ Compiler API (``flydsl.compiler``)
 - **@flyc.jit** -- decorator for host-side JIT launch functions
 - **flyc.from_dlpack(tensor)** -- convert DLPack-compatible tensors (PyTorch, etc.) to FlyDSL
 - **JitArgumentRegistry** -- registry for custom argument type adapters
-- **CompilationContext** -- context object available during kernel compilation
+- **flydsl.compiler.kernel_function.CompilationContext** -- context object available during kernel compilation (not a top-level ``flydsl.compiler`` symbol)
 
 .. seealso:: :doc:`compiler` for the full compilation pipeline and pass details.

--- a/docs/api/kernels.rst
+++ b/docs/api/kernels.rst
@@ -2,54 +2,50 @@ Pre-built Kernels
 =================
 
 FlyDSL ships with a collection of pre-built GPU kernels in the ``kernels/``
-directory. These serve as both ready-to-use components and reference
-implementations for kernel development.
+directory, organized into subpackages (``gemm/``, ``norm/``, ``attention/``,
+``moe/``, ``mma/``, ``common/``, ``comm/``, ``conv/``). These serve as both
+ready-to-use components and reference implementations for kernel development.
 
 GEMM Kernels
 -------------
 
-- ``kernels.preshuffle_gemm`` -- MFMA-based GEMM with LDS pipeline and pre-shuffled weights (FP8, INT8, BF16)
-- ``kernels.preshuffle_gemm_flyc`` -- Preshuffle GEMM using the new ``@flyc.kernel`` API
-- ``kernels.mixed_preshuffle_gemm`` -- Mixed-precision GEMM with pre-shuffled layouts
-- ``kernels.blockscale_preshuffle_gemm`` -- Block-scale (MXFP4) preshuffle GEMM
+- ``kernels.gemm.preshuffle_gemm`` -- MFMA-based GEMM with LDS pipeline and pre-shuffled weights (FP8, INT8, FP16, BF16)
+- ``kernels.gemm.mxfp4_preshuffle`` -- MXFP4 / FP4 (and f8f4) preshuffle GEMM
+- ``kernels.gemm.fp4_gemm_4wave`` -- 4-wave FP4 GEMM (gfx950)
+- ``kernels.gemm.blockscale_preshuffle_gemm`` -- Block-scale (MXFP4) preshuffle GEMM
+- ``kernels.gemm.hgemm_splitk`` -- FP16 split-K GEMM
 
 MoE (Mixture-of-Experts) Kernels
 ----------------------------------
 
-- ``kernels.moe_gemm_2stage`` -- MoE GEMM with 2-stage pipeline (stage1 + stage2)
-- ``kernels.mixed_moe_gemm_2stage`` -- Mixed-precision MoE GEMM
-- ``kernels.moe_blockscale_2stage`` -- MoE with block-scale quantization (MXFP4)
-- ``kernels.moe_reduce`` -- MoE reduction kernel: sums over the topk dimension
-  (``Y[t, d] = sum(X[t, :, d])``). Supports optional masking, f16/bf16/f32,
-  and is compiled via ``compile_moe_reduction()``.
+- ``kernels.moe.moe_gemm_2stage`` -- MoE GEMM with 2-stage pipeline (stage1 + stage2). Also
+  provides the MoE reduction (sum over the topk dimension, ``Y[t, d] = sum(X[t, :, d])``),
+  compiled via ``compile_moe_reduction()``.
+- ``kernels.moe.mixed_moe_gemm_2stage`` -- Mixed-precision MoE GEMM
+- ``kernels.moe.moe_blockscale_2stage`` -- MoE with block-scale quantization (MXFP4)
 
 Paged Attention
 ----------------
 
-- ``kernels.pa_decode_fp8`` -- Paged attention decode kernel with FP8 support
+- ``kernels.attention.pa_decode_fp8`` -- Paged attention decode kernel with FP8 support
 
 Normalization
 -------------
 
-- ``kernels.layernorm_kernel`` -- Layer normalization
-- ``kernels.rmsnorm_kernel`` -- RMS normalization
+- ``kernels.norm.layernorm_kernel`` -- Layer normalization
+- ``kernels.norm.rmsnorm_kernel`` -- RMS normalization
 
 Softmax
 -------
 
-- ``kernels.softmax_kernel`` -- Numerically stable softmax
-
-Reduction
----------
-
-- ``kernels.reduce`` -- Warp-level reduction utilities (``warp_reduce_sum``, ``warp_reduce_max``)
+- ``kernels.norm.softmax_kernel`` -- Numerically stable softmax
 
 Utilities
 ---------
 
-- ``kernels.kernels_common`` -- Shared constants and helper functions
-- ``kernels.layout_utils`` -- Layout utility functions
-- ``kernels.mfma_epilogues`` -- MFMA epilogue patterns (store, accumulate, scale)
-- ``kernels.mfma_preshuffle_pipeline`` -- Shared MFMA preshuffle helpers (B layout builder, K32 pack loads) used by preshuffle GEMM and MoE kernels
+- ``kernels.common.kernels_common`` -- Shared constants and helper functions
+- ``kernels.common.layout_utils`` -- Layout utility functions
+- ``kernels.mma.mfma_epilogues`` -- MFMA epilogue patterns (store, accumulate, scale)
+- ``kernels.mma.mfma_preshuffle_pipeline`` -- Shared MFMA preshuffle helpers (B layout builder, K32 pack loads) used by preshuffle GEMM and MoE kernels
 
 .. seealso:: :doc:`../prebuilt_kernels_guide` for detailed usage and configuration of each kernel.

--- a/docs/architecture_guide.md
+++ b/docs/architecture_guide.md
@@ -77,31 +77,50 @@ FlyDSL/
 │   ├── 03-tiledMma.py                # Tiled MMA (GEMM) with MFMA atoms
 │   └── 04-preshuffle_gemm.py         # Preshuffle GEMM end-to-end example
 │
-├── kernels/                          # Production GPU kernels
-│   ├── preshuffle_gemm.py            # GEMM (preshuffle layout)
-│   ├── blockscale_preshuffle_gemm.py # Blockscale GEMM
-│   ├── hgemm_splitk.py               # FP16 GEMM split-K
-│   ├── moe_gemm_2stage.py            # MoE GEMM (2-stage gate/up + reduce)
-│   ├── moe_blockscale_2stage.py      # MoE Blockscale GEMM
-│   ├── mixed_moe_gemm_2stage.py      # Mixed-precision MoE GEMM
-│   ├── pa_decode_fp8.py              # Paged attention decode (FP8)
-│   ├── flash_attn_generic.py         # FlashAttention generic fallback
-│   ├── flash_attn_gfx950.py          # FlashAttention gfx950 fast path
-│   ├── layernorm_kernel.py           # LayerNorm (layout API)
-│   ├── rmsnorm_kernel.py             # RMSNorm (layout API)
-│   ├── softmax_kernel.py             # Softmax (layout API)
-│   ├── fused_rope_cache_kernel.py    # Fused RoPE + KV cache
-│   ├── custom_all_reduce.py          # Multi-GPU all-reduce
-│   ├── rdna_f16_gemm.py              # RDNA FP16 GEMM
-│   ├── rdna_fp8_preshuffle_gemm.py   # RDNA FP8 GEMM
-│   ├── gemm_common_gfx1250.py        # GFX1250 GEMM common
-│   ├── gemm_fp8fp4_gfx1250.py        # GFX1250 FP8/FP4 GEMM
-│   ├── wmma_gemm_gfx1250.py          # GFX1250 WMMA GEMM
-│   ├── mfma_epilogues.py             # MFMA epilogue helpers
-│   ├── mfma_preshuffle_pipeline.py   # Preshuffle helpers for MFMA kernels
-│   ├── pipeline_utils.py             # Pipeline utility helpers
-│   ├── kernels_common.py             # Common kernel utilities
-│   └── tensor_shim.py                # GTensor/STensor abstraction
+├── kernels/                          # Production GPU kernels (organized by domain)
+│   ├── gemm/                         # Dense GEMM kernels
+│   │   ├── preshuffle_gemm.py        # GEMM (preshuffle layout)
+│   │   ├── blockscale_preshuffle_gemm.py # Blockscale GEMM
+│   │   ├── mxfp4_preshuffle.py       # MXFP4 preshuffle GEMM
+│   │   ├── fp4_gemm_4wave.py         # FP4 4-wave GEMM
+│   │   ├── fp8_gemm_4wave.py         # FP8 4-wave GEMM
+│   │   ├── fp8_gemm_8wave.py         # FP8 8-wave GEMM
+│   │   ├── hgemm_splitk.py           # FP16 GEMM split-K
+│   │   ├── rdna_f16_gemm.py          # RDNA FP16 GEMM
+│   │   ├── rdna_fp8_preshuffle_gemm.py # RDNA FP8 GEMM
+│   │   ├── gemm_common_gfx1250.py    # GFX1250 GEMM common
+│   │   ├── gemm_fp8fp4_gfx1250.py    # GFX1250 FP8/FP4 GEMM
+│   │   ├── wmma_gemm_gfx1250.py      # GFX1250 WMMA GEMM
+│   │   └── fp8_gemm_utils.py         # FP8 GEMM helpers
+│   ├── norm/                         # Normalization kernels
+│   │   ├── layernorm_kernel.py       # LayerNorm (layout API)
+│   │   ├── rmsnorm_kernel.py         # RMSNorm (layout API)
+│   │   └── softmax_kernel.py         # Softmax (layout API)
+│   ├── attention/                    # Attention kernels
+│   │   ├── pa_decode_fp8.py          # Paged attention decode (FP8)
+│   │   ├── pa_decode_swa.py          # Paged attention sliding-window
+│   │   ├── flash_attn_generic.py     # FlashAttention generic fallback
+│   │   ├── flash_attn_gfx950.py      # FlashAttention gfx950 fast path
+│   │   ├── mla_fwd_decode.py         # MLA forward decode
+│   │   └── fused_rope_cache_kernel.py # Fused RoPE + KV cache
+│   ├── moe/                          # Mixture-of-experts kernels
+│   │   ├── moe_gemm_2stage.py        # MoE GEMM (2-stage gate/up + reduce)
+│   │   ├── moe_blockscale_2stage.py  # MoE Blockscale GEMM
+│   │   ├── mixed_moe_gemm_2stage.py  # Mixed-precision MoE GEMM
+│   │   ├── moe_sorting_kernel.py     # MoE token sorting
+│   │   └── topk_gating_softmax_kernel.py # Top-k gating softmax
+│   ├── mma/                          # Shared MMA pipeline helpers
+│   │   ├── mfma_epilogues.py         # MFMA epilogue helpers
+│   │   ├── mfma_preshuffle_pipeline.py # Preshuffle helpers for MFMA kernels
+│   │   └── pipeline_utils.py         # Pipeline utility helpers
+│   ├── conv/                         # Convolution kernels
+│   │   └── conv3d_implicit_8wave.py  # Implicit-GEMM 3D convolution
+│   ├── comm/                         # Multi-GPU communication
+│   │   └── custom_all_reduce.py      # Multi-GPU all-reduce
+│   └── common/                       # Cross-domain kernel utilities
+│       ├── kernels_common.py         # Common kernel utilities
+│       ├── layout_utils.py           # Layout helpers
+│       └── tensor_shim.py            # GTensor/STensor abstraction
 │
 ├── tests/
 │   ├── mlir/                         # MLIR-level tests (Conversion, LayoutAlgebra, Transforms)
@@ -115,7 +134,7 @@ FlyDSL/
 └── scripts/                          # Build and test helpers
     ├── build.sh                      # Build FlyDSL (CMake + ninja)
     ├── build_llvm.sh                 # Build MLIR from ROCm llvm-project
-    ├── run_tests.sh                  # Run GEMM test suite
+    ├── run_tests.sh                  # Run full test suite (pytest + examples + FileCheck)
     ├── run_benchmark.sh              # Run benchmarks
     └── dumpir.sh                     # Dump intermediate IR
 ```

--- a/docs/cute_layout_algebra_guide.md
+++ b/docs/cute_layout_algebra_guide.md
@@ -80,7 +80,7 @@ coord = fx.make_coord(3, 5)
 The fundamental operation of a layout is mapping a logical coordinate to a physical index:
 
 ```
-index = crd2idx(coord, shape, stride) = dot(coord, stride)
+index = crd2idx(coord, layout) = dot(coord, stride)
 ```
 
 For a layout `L = ((S0, S1), (d0, d1))` and coordinate `(c0, c1)`:
@@ -92,7 +92,7 @@ index = c0 * d0 + c1 * d1
 The inverse operation recovers a coordinate from a linear index:
 
 ```
-coord = idx2crd(index, shape, stride)
+coord = idx2crd(index, layout)
 ```
 
 | Operation | Definition | FlyDSL API |
@@ -269,15 +269,21 @@ tA_thr = fx.slice(tA, (None, tid))
 
 **LDS allocation in FlyDSL:**
 ```python
-from flydsl.utils.smem_allocator import SmemAllocator
+import flydsl.expr as fx
 
-allocator = SmemAllocator(ctx, arch="gfx942")
-lds_gen = allocator.allocate_array(T.f16(), num_elems=128*64)
-allocator.finalize()
+# Declare the LDS storage layout as a @fx.struct of fx.Array fields ...
+@fx.struct
+class SharedStorage:
+    tile: fx.Array[fx.Float16, 128, 64]
 
-base = allocator.get_base()
-lds_ptr = lds_gen(base)
+# ... then allocate it inside the kernel and view each field as a layout.
+lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+lds_tile = lds.tile.view(fx.make_layout((128, 64), (64, 1)))
 ```
+
+The compiler sizes the per-leaf static LDS global automatically (default
+``static=True``), so ``launch(smem=...)`` is normally left unset. The legacy
+``flydsl.utils.smem_allocator.SmemAllocator`` remains for un-migrated kernels.
 
 ### 5.3 Swizzling (Bank Conflict Avoidance)
 
@@ -495,7 +501,7 @@ def tiledMma(A: fx.Tensor, B: fx.Tensor, C: fx.Tensor,
     gemm_kernel(A, B, C).launch(grid=(1, 1, 1), block=(256, 1, 1), stream=stream)
 ```
 
-See `examples/03-tiledMma.py` for the runnable script, and `kernels/preshuffle_gemm.py`
+See `examples/03-tiledMma.py` for the runnable script, and `kernels/gemm/preshuffle_gemm.py`
 for a production-quality GEMM implementation.
 
 ---
@@ -514,9 +520,9 @@ for a production-quality GEMM implementation.
 - `python/flydsl/expr/` — Layout algebra and expression API (`primitive.py`, `derived.py`, etc.)
 - `python/flydsl/expr/rocdl/` — ROCDL-specific operations
 - `python/flydsl/compiler/` — JIT compilation pipeline (`kernel_function.py`, `jit_function.py`)
-- `python/flydsl/utils/smem_allocator.py` — SmemAllocator
+- `python/flydsl/expr/gpu.py` — `SharedAllocator` for LDS allocation (`fx.SharedAllocator`)
+- `python/flydsl/utils/smem_allocator.py` — legacy `SmemAllocator`
 - `examples/01-vectorAdd.py` — VecAdd example with layout algebra
 - `examples/02-tiledCopy.py` — Tiled copy example
 - `examples/03-tiledMma.py` — Tiled MFMA GEMM example
-- `kernels/preshuffle_gemm.py` — Production GEMM implementation
-- `kernels/preshuffle_gemm_flyc.py` — GEMM using `@flyc.kernel` API
+- `kernels/gemm/preshuffle_gemm.py` — Production GEMM implementation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ to GPU/ROCDL.
    architecture_guide
    layout_system_guide
    kernel_authoring_guide
+   kernel_tuning_guide
    prebuilt_kernels_guide
    testing_benchmarking_guide
    cute_layout_algebra_guide

--- a/docs/kernel_authoring_guide.md
+++ b/docs/kernel_authoring_guide.md
@@ -374,38 +374,47 @@ def my_kernel(data: fx.Tensor, N: fx.Constexpr[int]):
 
 ## 6. Shared Memory (LDS)
 
-### 6.1 `SmemAllocator`
+### 6.1 `fx.SharedAllocator` + `@fx.struct`
+
+New kernels declare their LDS layout as a `@fx.struct` storage type and
+allocate it with `fx.SharedAllocator` (from `flydsl.expr.gpu`, reached as
+`fx.SharedAllocator`) inside the kernel body. Each field is an `fx.Array[elem,
+count, align]`; `.allocate(StorageStruct).peek()` returns a handle whose fields
+expose typed views:
 
 ```python
-from flydsl.utils.smem_allocator import SmemAllocator
-from flydsl.expr.typing import T
+import flydsl.expr as fx
 
-# Create allocator for target architecture
-allocator = SmemAllocator(None, arch="gfx942", global_sym_name="smem0")
+# Declare the LDS layout. Fields may be conditional on compile-time config.
+@fx.struct
+class SharedStorage:
+    s_red: fx.Array[fx.Float32, red_slots, 16]   # red_slots elems, 16B aligned
+    s_red2: fx.Array[fx.Float32, red_slots, 16]
 
-# Allocate typed arrays
-lds_a = allocator.allocate_array(T.f16, 8192)
-lds_b = allocator.allocate_array(T.f16, 8192)
+@flyc.kernel
+def my_kernel(...):
+    # Allocate the storage struct in LDS (inside the @kernel body).
+    lds = fx.SharedAllocator().allocate(SharedStorage).peek()
 
-# Inside kernel: get base pointer and typed views
-lds_base = allocator.get_base()
-lds_a_ptr = lds_a(lds_base)  # SmemPtr
-lds_b_ptr = lds_b(lds_base)  # SmemPtr
-
-# Load/store through SmemPtr
-val = lds_a_ptr.load([idx])
-lds_b_ptr.store(val, [idx])
+    # Get a logical view over each field and use it with the layout API.
+    s_red = lds.s_red.view(fx.make_layout(red_slots, 1))
+    s_red2 = lds.s_red2.view(fx.make_layout(red_slots, 1))
 ```
 
-### 6.2 Finalizing LDS Allocation
+By default `SharedAllocator` is `static=True`: each leaf emits a per-leaf static
+LDS global that the compiler sizes, so `launch(smem=...)` is left unset. Use
+`static=False` (dynamic) mode to have the launch wrapper auto-infer `smem` from
+`SharedAllocator.allocated_bytes` when `smem=None` (an explicit `smem` must be
+`>=` that size). See `kernels/gemm/preshuffle_gemm.py` and
+`kernels/norm/rmsnorm_kernel.py` for real usage.
 
-For `@flyc.kernel` style kernels, finalize the allocator in the GPU module:
+### 6.2 Legacy `SmemAllocator`
 
-```python
-comp_ctx = CompilationContext.get_current()
-with ir.InsertionPoint(comp_ctx.gpu_module_body):
-    allocator.finalize()
-```
+The older `SmemAllocator` / `SmemPtr` path
+(`python/flydsl/utils/smem_allocator.py`) remains for un-migrated kernels: it
+tracks byte offsets manually (`_align` / `finalize` / `get_base`) and its
+`finalize()` must be called inside the `gpu.module` body. Prefer
+`fx.SharedAllocator` for new kernels.
 
 ### 6.3 LDS Capacity
 
@@ -529,46 +538,62 @@ Shows the diff between original and rewritten AST for debugging control flow tra
 
 ## 11. Complete Example: Preshuffle GEMM
 
-From `kernels/preshuffle_gemm.py`:
+From `kernels/gemm/preshuffle_gemm.py`:
 
 ```python
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import gpu, buffer_ops, rocdl, range_constexpr
+from flydsl.expr import gpu, range_constexpr, rocdl
 from flydsl.expr.typing import T
-from flydsl.utils.smem_allocator import SmemAllocator
 
-def compile_preshuffle_gemm_a8(*, M, N, K, tile_m, tile_n, tile_k,
-                                 in_dtype="fp8", lds_stage=2, ...):
-    allocator = SmemAllocator(None, arch=gpu_arch, global_sym_name="smem0")
-    lds_a = allocator.allocate_array(T.i8, tile_m * tile_k)
-    # ... more allocations ...
+def compile_preshuffle_gemm(*, N, K, tile_m, tile_n, tile_k,
+                             in_dtype="fp8", out_dtype="bf16",
+                             epilogue="none", lds_stage=2, ...):
+    a_lds_elems = tile_m * tile_k
+
+    # Declare the LDS layout as a storage struct.
+    @fx.struct
+    class SharedStorage:
+        a0: fx.Array[layout_elem, a_lds_elems, 16]
+        if lds_stage == 2:
+            a1: fx.Array[layout_elem, a_lds_elems, 16]
 
     @flyc.kernel
-    def gemm_kernel(
+    def kernel_gemm(
         arg_c: fx.Tensor, arg_a: fx.Tensor, arg_b: fx.Tensor,
-        arg_scale_a: fx.Tensor, arg_scale_b: fx.Tensor,
-        m_in: fx.Int32, n_in: fx.Int32,
+        arg_scale_a: fx.Tensor, arg_scale_b: fx.Tensor, arg_bias: fx.Tensor,
+        i32_m: fx.Int32, i32_n: fx.Int32,
+        tiled_mma_arg: fx.TiledMma, tiled_copy_g2s: fx.TiledCopy,
     ):
-        tid = gpu.thread_idx.x
-        bid = gpu.block_idx.x
-        # ... complex GEMM implementation using MFMA, LDS, tiling ...
+        tid = fx.thread_idx.x
+        bid_x, bid_y, _ = fx.block_idx
+
+        gA = fx.rocdl.make_buffer_tensor(arg_a, ...)
+        gB = fx.rocdl.make_buffer_tensor(arg_b)
+        gC = fx.rocdl.make_buffer_tensor(arg_c, ...)
+
+        # Allocate LDS and take typed views over the storage fields.
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        # ... GEMM implementation using MFMA, LDS, tiling ...
 
     @flyc.jit
     def launch_fn(
         arg_c: fx.Tensor, arg_a: fx.Tensor, arg_b: fx.Tensor,
-        arg_scale_a: fx.Tensor, arg_scale_b: fx.Tensor,
+        arg_scale_a: fx.Tensor, arg_scale_b: fx.Tensor, arg_bias: fx.Tensor,
         M_val: fx.Int32, N_val: fx.Int32,
         stream: fx.Stream = fx.Stream(None),
     ):
-        gemm_kernel(arg_c, arg_a, arg_b, arg_scale_a, arg_scale_b,
-                    M_val, N_val).launch(
-            grid=(grid_x, grid_y), block=(256,),
-            smem=smem_bytes, stream=stream,
+        kernel_gemm(arg_c, arg_a, arg_b, arg_scale_a, arg_scale_b, arg_bias,
+                    M_val, N_val, tiled_mma, tiled_copy_g2s).launch(
+            grid=(grid_x, grid_y), block=(256,), stream=stream,
         )
 
     return launch_fn
 ```
+
+`M` is a runtime argument (`i32_m` / `M_val`), not a compile-time parameter, so
+one compiled kernel serves any `M`. Output post-processing is selected with
+`epilogue=` (`"none"`, `"bias"`, `"bias_relu"`, `"bias_silu"`, `"bias_gelu"`).
 
 ---
 
@@ -583,18 +608,18 @@ Writing a new kernel?
 │   └── See tests/kernels/test_vec_add.py
 │
 ├── Reduction (norm, softmax)?
-│   ├── Use warp_reduce / block_reduce from kernels/reduce.py
-│   └── See kernels/layernorm_kernel.py, kernels/softmax_kernel.py
+│   ├── Reductions are inline (wave/block reduce helpers within the kernel)
+│   └── See kernels/norm/rmsnorm_kernel.py, kernels/norm/softmax_kernel.py
 │
 ├── Matrix multiply (GEMM)?
-│   ├── Use @flyc.kernel + SmemAllocator + MFMA
-│   ├── B-preshuffle layout from mfma_preshuffle_pipeline.py
-│   └── See kernels/preshuffle_gemm.py
+│   ├── Use @flyc.kernel + fx.SharedAllocator + MFMA
+│   ├── B-preshuffle layout from kernels/mma/mfma_preshuffle_pipeline.py
+│   └── See kernels/gemm/preshuffle_gemm.py
 │
 ├── Need shared memory?
-│   ├── Use SmemAllocator with target arch
-│   ├── Call finalize() in GPU module body
-│   └── Call get_base() inside @kernel
+│   ├── Declare a @fx.struct storage layout
+│   ├── Allocate with fx.SharedAllocator().allocate(Storage).peek()
+│   └── Take .view(...) over each field inside @kernel
 │
 └── Need compile-time specialization?
     ├── Use Constexpr[T] parameters
@@ -620,8 +645,8 @@ Writing a new kernel?
 | `python/flydsl/expr/buffer_ops.py` | AMD buffer load/store operations |
 | `python/flydsl/expr/rocdl/` | ROCm dialect intrinsics (MFMA/WMMA, buffer, TDM, cluster) |
 | `python/flydsl/expr/primitive.py` | Layout algebra primitives (make_shape, crd2idx, etc.) |
-| `python/flydsl/utils/smem_allocator.py` | `SmemAllocator`, `SmemPtr`, LDS management |
-| `kernels/preshuffle_gemm.py` | Preshuffle GEMM kernel example |
-| `kernels/reduce.py` | Warp/block reduction primitives |
+| `python/flydsl/expr/gpu.py` | `SharedAllocator`, GPU ops (thread_id, barrier, ...) |
+| `python/flydsl/utils/smem_allocator.py` | Legacy `SmemAllocator` / `SmemPtr` LDS management |
+| `kernels/gemm/preshuffle_gemm.py` | Preshuffle GEMM kernel example |
 | `tests/kernels/test_vec_add.py` | Vector add kernel test |
 | `tests/kernels/test_preshuffle_gemm.py` | Preshuffle GEMM test |

--- a/docs/kernel_tuning_guide.md
+++ b/docs/kernel_tuning_guide.md
@@ -1,0 +1,396 @@
+# Kernel Tuning Guide
+
+Practical techniques for optimizing FlyDSL GPU kernels on AMD CDNA GPUs
+(MI300X `gfx942`, MI350/MI355X `gfx950`). The running example is the production
+preshuffle GEMM (`kernels/gemm/preshuffle_gemm.py`), but the levers — tiling,
+LDS double-buffering, bank-conflict swizzle, prefetch, MFMA scheduling, epilogue
+choice, and occupancy management — apply to any compute-bound kernel.
+
+This guide distills the project-local tuning skills. Each section points to the
+skill that carries the full detail and reproducible commands:
+
+| Skill | Focus |
+|---|---|
+| `/gemm-optimization` | End-to-end GEMM tiling, pipeline, scheduling, epilogue |
+| `/lds-optimization` | LDS bank conflicts, swizzle/padding, write→read latency |
+| `/prefetch-data-load` | Software prefetch (double-buffering) with loop-carried state |
+| `/kernel-trace-analysis` | rocprofv3 ATT traces + PMC counters → hotspot plan |
+| `/bisect-perf-regression` | `git bisect` a kernel perf regression to one commit |
+
+Tune **only after** a correctness baseline passes and you have a profile. Guessing
+at optimizations without a trace usually moves the bottleneck instead of removing it.
+
+---
+
+## 1. Tiling Strategy
+
+GEMM tiles the output `C[M, N]` and the reduction `K` into blocks. With a 256-thread
+block (4 waves × 64 lanes) the typical mapping is:
+
+```
+block_x → M tiles (tile_m rows)      wave_id  = tid // 64  → N partitioning
+block_y → N tiles (tile_n cols)      lane_id  = tid % 64   → M + N within wave
+```
+
+Derived per-tile parameters:
+
+```python
+m_repeat   = tile_m // 16            # M-direction 16x16 MFMA repeats
+n_per_wave = tile_n // 4             # N range per wave (4 waves split tile_n)
+num_acc_n  = n_per_wave // 16        # N-direction accumulators per wave
+```
+
+### Recommended configurations
+
+| Scenario | tile_m | tile_n | tile_k | Notes |
+|---|---|---|---|---|
+| Small batch (M ≤ 32) | 16 | 64–128 | 256–512 | Memory-bound; large `tile_k` for reuse |
+| Medium batch | 64 | 256 | 128 | Balanced compute/memory |
+| Large batch (M ≥ 4096) | 128 | 256 | 128 | Compute-dense; benefits from async copy |
+| FP4 (gfx950) | 32–64 | 128–256 | 256 | MFMA-scale instructions |
+
+### Constraints
+
+- `tile_m` must be a multiple of 16 (MFMA M dimension).
+- `tile_n` must be a multiple of 64 (4 waves × 16 N per MFMA).
+- `tile_k × elem_bytes` must be a multiple of 64 (the K64-byte micro-step).
+- `tile_k` must divide `K` evenly (the pre-shuffled B layout requires it).
+- LDS budget: `2 × tile_m × tile_k × elem_bytes` (double-buffered A) must fit in
+  **64 KB** on gfx942 / **160 KB** on gfx950.
+
+A quick MFMA count sanity check (FP8, K64 micro-step = 2× K32 MFMA):
+
+```
+MFMA_per_tile = k_unroll × m_repeat × num_acc_n × 2      # k_unroll = tile_k_bytes // pack // 64
+# tile 64×256×128, FP8: (128/64) × (64/16) × (256/4/16) × 2 = 2×4×4×2 = 64
+```
+
+See `/gemm-optimization` §1 for the full derivation and the worked 5120×5120×8320 example.
+
+---
+
+## 2. LDS Double-Buffering (Ping-Pong)
+
+With `lds_stage=2`, allocate **two** LDS buffers for the A tile. While one buffer
+feeds the MFMAs, the next K-tile's A is loaded into the other, hiding the
+global→LDS latency:
+
+```
+Buffer PONG: [compute k=0] [  load k=2  ] [compute k=2] ...
+Buffer PING: [  load k=1  ] [compute k=1] [  load k=3  ] ...
+```
+
+Allocate the two buffers with `fx.SharedAllocator` over an `@fx.struct` storage
+layout (the current LDS API — see the Kernel Authoring Guide):
+
+```python
+import flydsl.expr as fx
+
+@fx.struct
+class SharedStorage:
+    a_ping: fx.Array[fx.Int8, tile_m * tile_k]
+    a_pong: fx.Array[fx.Int8, tile_m * tile_k]
+
+lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+a_ping = lds.a_ping.view(fx.make_layout((tile_m, tile_k), (tile_k, 1)))
+a_pong = lds.a_pong.view(fx.make_layout((tile_m, tile_k), (tile_k, 1)))
+```
+
+The main loop then processes two K-tiles per iteration (one on each buffer),
+carrying the accumulators, the current B tile, and the A0 prefetch as
+loop-carried state. On spill-bound tiles (`num_acc_n = 8`), `lds_stage=1` (a
+single A buffer with B carried in the loop) can reduce VGPR pressure — but it
+regresses non-spilling tiles, so measure before switching. See `/gemm-optimization` §2.
+
+---
+
+## 3. LDS Bank-Conflict Swizzle
+
+LDS is banked: **32 banks** (4 B each) on gfx942, **64 banks** on gfx950;
+`bank = (byte_addr / 4) % num_banks`. When lanes in a wave access different
+addresses that map to the **same** bank, the accesses serialize (a *bank
+conflict*); accessing the **same** address broadcasts for free.
+
+A row-major tile with stride `tile_k` makes every row land on the same banks.
+The fix is an XOR swizzle that folds the row index into the column address at
+16-byte granularity — zero extra LDS, ~1 SALU op per address:
+
+```python
+def swizzle_xor16(row, col_bytes, k_blocks16):
+    return col_bytes ^ ((row % k_blocks16) * 16)   # k_blocks16 = tile_k_bytes // pack // 16
+```
+
+**The swizzle must be applied identically on the write (global→LDS) and read
+(LDS→VGPR) paths** — if only one side swizzles, the data is read from the wrong
+place. The physical write can stay linear as long as the read reverses the same
+mapping.
+
+### Arch note (gfx950 has 64 banks)
+
+Masks tuned for 32-bank gfx942 may be suboptimal on gfx950: a 128-byte stride is
+a *full* conflict on gfx942 but only a *2-way* conflict on gfx950 (full conflict
+needs a 256-byte stride there). Re-check swizzle width when porting.
+
+### Padding as an alternative
+
+Adding 1–4 elements of padding per row breaks the stride alignment without XOR
+math, at the cost of extra LDS. Prefer swizzle (zero overhead); use padding when
+the swizzle is awkward to integrate and LDS has headroom (gfx950's 160 KB gives
+plenty). See `/lds-optimization` for the diagnosis-by-trace workflow and the
+gfx950 `DS_READ_*_TR_*` transpose-load instructions.
+
+---
+
+## 4. Data Prefetch Pipeline
+
+Global loads (`buffer_load`) are **asynchronous**: the instruction returns
+immediately and data arrives later. Issue the *next* iteration's loads before
+consuming the *current* iteration's data, so load latency overlaps compute:
+
+```
+without: |load|stall|compute|load|stall|compute|
+with:    |load0|compute0+load1|compute1+load2|compute2|
+```
+
+### Loop-carried prefetch with `range(..., init=...)`
+
+A Python `for i in range(N)` is unrolled during tracing, so a `data = next_data`
+swap becomes invisible to MLIR (both alias one SSA value, and LLVM hoists the
+load as loop-invariant). Use FlyDSL's **runtime** loop with loop-carried values
+to create genuine SSA phi nodes:
+
+```python
+# Prologue: load iteration 0 before the loop
+next_a = buffer_ops.buffer_load(rsrc_a, offsets_0, vec_width=4)
+init_state = [_unwrap(v) for v in [next_a, acc]]
+
+# Runtime loop — bounds MUST be fx.Index(...), not Python ints (see pitfalls)
+for iv, state in range(fx.Index(0), fx.Index(N - 1), fx.Index(1), init=init_state):
+    a, acc = state[0], state[1]
+    next_a = buffer_ops.buffer_load(rsrc_a, compute_offsets(iv + 1), vec_width=4)  # async
+    acc = rocdl.mfma_f32_16x16x16_f16(transform(a), b, acc)   # overlaps next load
+    results = yield [_unwrap(v) for v in [next_a, acc]]
+
+# Epilogue: process the last iteration from `results`
+a, acc = results[0], results[1]
+acc = rocdl.mfma_f32_16x16x16_f16(transform(a), b, acc)
+```
+
+Three pitfalls (all covered in `/prefetch-data-load`):
+
+1. **Bounds must be `fx.Index(...)`.** Constant Python-int bounds make the
+   rewriter unroll the loop and silently ignore `init=`.
+2. **Unwrap init values at hard boundaries only.** Most carried values stay
+   `fx.Int32`/`fx.Float32`/`Vector`; unwrap to raw `ir.Value` only where a
+   low-level helper demands it.
+3. **Clear `SmemPtr._view_cache = None` before the epilogue** when a shared view
+   was created inside the loop, or the epilogue use hits an SSA dominance error.
+
+### Async copy (global → LDS DMA)
+
+On gfx942/gfx950, `use_async_copy=True` streams A directly from global memory
+into LDS (`raw_ptr_buffer_load_lds`), bypassing VGPR. This saves arch_vgpr and
+suits large `tile_m` (≥ 128) where there is enough compute to hide the DMA.
+gfx950 moves 16 B/DMA vs gfx942's 4 B/DMA.
+
+**Don't prefetch** a loop that is already memory-bound, or when occupancy is
+already 1 wave and adding buffers would spill — profile both ways.
+
+---
+
+## 5. MFMA Instruction Scheduling
+
+`hot_loop_scheduler()` emits `rocdl.sched_*` hints that tell the compiler how to
+interleave instruction classes inside the hot loop:
+
+| Hint | Allows |
+|---|---|
+| `rocdl.sched_mfma(N)` | N MFMA (`v_mfma_*`) |
+| `rocdl.sched_dsrd(N)` | N LDS reads (`ds_read_*`) |
+| `rocdl.sched_dswr(N)` | N LDS writes (`ds_write_*`) |
+| `rocdl.sched_vmem(N)` | N global loads (`buffer_load_*`) |
+| `rocdl.sched_barrier(0)` | scheduling fence — no reordering across |
+
+The standard pattern interleaves one VMEM load and one LDS read per group of
+MFMAs, pushing LDS writes to the tail so they overlap the last MFMAs and land
+before the iteration-boundary `gpu.barrier()`:
+
+```python
+for sche_i in range_constexpr(sche_iters):
+    rocdl.sched_vmem(1)                # global load (A or B)
+    rocdl.sched_mfma(mfma_group)       # num_acc_n MFMAs
+    rocdl.sched_dsrd(1)                # LDS read (A)
+    rocdl.sched_mfma(mfma_group)       # more MFMAs
+    if sche_i >= dswr_start - 1:
+        rocdl.sched_dswr(1)            # LDS write for next tile, at the tail
+rocdl.sched_barrier(0)
+```
+
+Async fat tiles benefit from evenly distributing `dsrd`/`vmem` across *all*
+MFMAs (`enable_scheduler=True`). Toggling the scheduler is a real lever: for some
+f16/bf16 tiles with `num_acc_n ≤ 2`, disabling it is faster; for async fat tiles
+enabling it wins +8–10%. Measure per tile. See `/gemm-optimization` §5.
+
+---
+
+## 6. Epilogue Strategies
+
+**Direct store (default).** Each thread writes its MFMA accumulators straight to
+global memory. No extra LDS, simplest — but stores can be non-coalesced for some
+tile shapes.
+
+**CShuffle epilogue.** Route accumulators through LDS to re-map thread→element so
+global writes are coalesced (`buffer_store_dwordx2`), at the cost of an LDS
+allocation and one barrier:
+
+```python
+e_vec = 4 if (tile_n % 128 == 0) else 2
+m_reps_shuffle = tile_m // 8
+n_reps_shuffle = tile_n // (32 * e_vec)
+```
+
+Use CShuffle for large `tile_n` (≥ 128) where output coalescing matters. The
+preshuffle GEMM also exposes fused epilogues via the `epilogue=` argument of
+`compile_preshuffle_gemm` (`"none"`, `"bias"`, `"bias_relu"`, `"bias_silu"`,
+`"bias_gelu"`).
+
+---
+
+## 7. Register Budget & Occupancy
+
+On CDNA3/CDNA4 the two VGPR files — **arch_vgpr** (VALU, VMEM, LDS ops, prefetch
+buffers) and **accum_vgpr / AGPR** (MFMA writeback) — share **one combined
+512-entry occupancy budget** per SIMD. Occupancy ≈ `512 / (arch_vgpr +
+accum_vgpr)` waves. Growing prefetch/LDS-address arch_vgpr therefore *does*
+compete with MFMA accumulators.
+
+| Combined arch + accum | Waves/SIMD | Impact |
+|---|---|---|
+| ≤ 128 | 4 | High occupancy |
+| ≤ 170 | 3 | Good |
+| ≤ 256 | 2 | Moderate |
+| ≤ 512 | 1 | Minimum |
+| > 512 | **SPILL** | Severe regression |
+
+Rough VGPR estimate for a FP8 tile:
+
+```
+accumulators = m_repeat × num_acc_n × 4     # → accum_vgpr
+B tile       = k_unroll × 2 × num_acc_n × 2 # → arch_vgpr
+A prefetch   ≈ 4 ; A tile regs = num_a_loads × 4 ; addressing ≈ 10–20
+```
+
+Query the actual allocation from the rocprofv3 database:
+
+```sql
+SELECT ks.KernelName, ki.arch_vgpr_count, ki.accum_vgpr_count
+FROM rocpd_kernel_dispatch kd
+JOIN rocpd_info_kernel_symbol ks ON kd.kernel_symbol_id = ks.id
+JOIN rocpd_info_kernel ki ON kd.kernel_id = ki.id
+WHERE ks.KernelName LIKE '%target_kernel%' LIMIT 5;
+```
+
+**Do not** use `maxnreg` to force `accum_vgpr=0` — it spills MFMA results through
+arch_vgpr via `v_accvgpr_read` (measured ~4.5× regression).
+
+---
+
+## 8. Performance Metrics & Roofline
+
+```python
+flops   = 2 * M * N * K
+tflops  = flops / (us / 1e6) / 1e12
+
+# bytes moved (FP8/INT8): A + B + C(bf16) + per-token scales
+bytes_moved = M*K*eb + N*K*eb + M*N*2 + (M + N)*4
+tbps = bytes_moved / 1e12 / (us / 1e6)
+```
+
+Peak references (gfx942 MI300X, single GCD): FP8 ~653 TFLOPS, INT8 ~653 TOPS,
+BF16 ~326 TFLOPS. Compare `flops / bytes_moved` (arithmetic intensity) to the
+roofline crossover. Practical rule of thumb: **M ≤ 512 → memory-bound** (chase
+bandwidth), **M > 512 → compute-bound** (chase MFMA utilization).
+
+> Benchmark noise on gfx950 can reach ±14% from clock variation. Run isolated
+> (60–80 iters) and take a median-of-7; diff against a baseline with
+> `python3 scripts/compare_benchmark.py base.csv cur.csv`.
+
+---
+
+## 9. Profiling: ATT Traces & PMC Counters
+
+Instruction-level stall data comes from a rocprofv3 ATT trace. Collect and
+analyze with the `/kernel-trace-analysis` skill, which bundles the
+`hotspot_analyzer.py` (ATT hotspots) and `pmc_l2_analyzer.py` (cache counters)
+helpers under `.claude/skills/kernel-trace-analysis/scripts/`:
+
+```bash
+# 1. discover the hot kernel
+rocprofv3 --stats --kernel-trace -f csv -- <CMD>
+# 2. collect ATT for that kernel (input.yaml: advanced_thread_trace, att_target_cu:1)
+FLYDSL_DEBUG_ENABLE_DEBUG_INFO=1 rocprofv3 -i /tmp/trace_input.yaml -- <CMD>
+# 3. hotspots mapped to source
+python .claude/skills/kernel-trace-analysis/scripts/hotspot_analyzer.py \
+    <ui_output_agent_*_dispatch_*> --topk 15 --mode both
+```
+
+Map the dominant stall type to a fix:
+
+| Trace symptom | Bottleneck | Action |
+|---|---|---|
+| `s_waitcnt vmcnt(0)` before MFMA | global-load latency exposed | improve prefetch overlap; bigger `tile_k` |
+| `s_waitcnt lgkmcnt(0)` after `ds_write` | LDS write→read latency exposed | insert independent work between them |
+| `ds_read`/`ds_write` high stall | LDS bank conflicts | apply XOR swizzle (§3) |
+| high `s_barrier` stall | sync overhead | fewer barriers; hoist loads into the wait |
+| MFMA utilization < 50% | memory-bound | larger tile; prefetch harder |
+| `s_nop` between MFMAs | pipeline bubbles | tune `hot_loop_scheduler` (§5) |
+
+**When the kernel is memory-bound, ATT is not enough** — it has no cache
+counters. Collect L2/HBM PMCs and use `pmc_l2_analyzer.py` (same skill scripts
+dir) for L2 hit rate, 32 B-partial fraction, and over-fetch. A frequent root cause is HBM channel
+imbalance from a linear (m-major) grid; a bijective XCD swizzle (`xcd_swizzle` on
+`compile_preshuffle_gemm`) rebalances channels. **Always confirm with PMCs — ISA
+inspection alone routinely mis-diagnoses memory bottlenecks.**
+
+---
+
+## 10. Bisecting a Performance Regression
+
+When a kernel got slower and you don't know which commit did it, binary-search
+with `/bisect-perf-regression`:
+
+```
+/bisect-perf-regression <good_commit> [bad_commit] -- <bench_cmd>
+```
+
+It establishes good/bad baselines, verifies the regression is real, then bisects
+(checking out, rebuilding if needed, extracting the metric) until one commit is
+isolated, and reports its diff. The bench command must run at every commit in the
+range and print a stable metric; the working tree is auto-stashed and restored.
+
+---
+
+## 11. Optimization Checklist
+
+| Stage | Check | If failing |
+|---|---|---|
+| Tiling | enough blocks to fill the GPU | reduce tile size |
+| Tiling | `tile_k × elem_bytes ≤ LDS/2` | reduce `tile_k` |
+| LDS | bank-conflict stall on `ds_read` | apply XOR swizzle |
+| Prefetch | VMEM stall before MFMA | loop-carried prefetch / async copy |
+| Pipeline | using `lds_stage=2` | enable double-buffer (unless spill-bound) |
+| Scheduler | `s_nop`/bubbles between MFMAs | tune `hot_loop_scheduler` |
+| Epilogue | uncoalesced output stores | CShuffle for large `tile_n` |
+| Registers | combined arch + accum ≤ 256 | fewer buffers / async copy |
+| ISA | MFMA ratio ≥ 40% of hot loop | cut non-MFMA overhead |
+| Memory | L2 hit / HBM balance (PMCs) | grid/XCD swizzle |
+
+---
+
+## See Also
+
+- [Kernel Authoring Guide](kernel_authoring_guide.md) — `@flyc.kernel`/`@flyc.jit`, LDS, tiled copy/MMA
+- [Pre-built Kernels](prebuilt_kernels_guide.md) — GEMM/MoE/attention configs and dtypes
+- [Testing & Benchmarking](testing_benchmarking_guide.md) — benchmark harness and CSV comparison
+- Project-local skills: `/gemm-optimization`, `/lds-optimization`, `/prefetch-data-load`,
+  `/kernel-trace-analysis`, `/bisect-perf-regression`

--- a/docs/layout_system_guide.md
+++ b/docs/layout_system_guide.md
@@ -39,7 +39,6 @@
 | | `fx.group(it, begin, end)` | `fly.group` | Group modes into nested tuple |
 | | `fx.append(base, elem)` | `fly.append` | Append mode to IntTuple |
 | | `fx.prepend(base, elem)` | `fly.prepend` | Prepend mode to IntTuple |
-| | `fx.zip(lhs, rhs)` | `fly.zip` | Zip two IntTuples |
 | **Recast** | `fx.recast_layout(ly, old, new)` | `fly.recast_layout` | Recast layout for type width change |
 
 ---
@@ -99,9 +98,8 @@ shape_nested = fx.make_shape(9, (4, 8))   # (9, (4, 8))
 col_major = fx.make_ordered_layout((M, N), order=(0, 1))  # stride order: M-first
 row_major = fx.make_ordered_layout((M, N), order=(1, 0))  # stride order: N-first
 
-# Identity layout / tensor
+# Identity layout
 identity = fx.make_identity_layout((M, N))
-id_tensor = fx.make_identity_tensor((M, N))
 ```
 
 ---
@@ -277,14 +275,6 @@ extended = fx.append(base_tuple, new_elem)
 extended = fx.prepend(base_tuple, new_elem)
 ```
 
-### `zip(lhs, rhs)`
-
-Zip two IntTuples mode-wise:
-
-```python
-zipped = fx.zip(shapes_a, shapes_b)
-```
-
 ### `slice(src, coord)`
 
 Slice an IntTuple/layout at a coordinate:
@@ -406,16 +396,16 @@ fx.gemm(mma_atom, d, a, b, c)
 | Property | Class | Description |
 |---|---|---|
 | `copy_atom.thr_layout` | `CopyAtom` | Thread layout of copy atom |
-| `copy_atom.tv_layout_src` | `CopyAtom` | Thread-value layout for source |
-| `copy_atom.tv_layout_dst` | `CopyAtom` | Thread-value layout for destination |
+| `copy_atom.layout_src_tv` | `CopyAtom` | Thread-value layout for source |
+| `copy_atom.layout_dst_tv` | `CopyAtom` | Thread-value layout for destination |
 | `mma_atom.thr_layout` | `MmaAtom` | Thread layout |
 | `mma_atom.shape_mnk` | `MmaAtom` | M×N×K tile dimensions |
-| `mma_atom.tv_layout_A/B/C` | `MmaAtom` | Thread-value layouts per operand |
-| `tiled_copy.tiled_tv_layout_S` | `TiledCopy` | Full tiled source layout |
-| `tiled_copy.tiled_tv_layout_D` | `TiledCopy` | Full tiled destination layout |
+| `mma_atom.layout_A_tv/layout_B_tv/layout_C_tv` | `MmaAtom` | Thread-value layouts per operand |
+| `tiled_copy.layout_src_tv_tiled` | `TiledCopy` | Full tiled source layout |
+| `tiled_copy.layout_dst_tv_tiled` | `TiledCopy` | Full tiled destination layout |
 | `tiled_mma.tile_size_mnk` | `TiledMma` | Tiled MMA dimensions |
 | `tiled_mma.thr_layout_vmnk` | `TiledMma` | Thread layout across V,M,N,K |
-| `tiled_mma.tiled_tv_layout_A/B/C` | `TiledMma` | Full tiled layouts per operand |
+| `tiled_mma.tv_layout_A_tiled/tv_layout_B_tiled/tv_layout_C_tiled` | `TiledMma` | Full tiled layouts per operand |
 
 ---
 

--- a/docs/prebuilt_kernels_guide.md
+++ b/docs/prebuilt_kernels_guide.md
@@ -6,10 +6,10 @@
 
 | Kernel | Builder Function | API Style | Dtypes | Key Feature |
 |---|---|---|---|---|
-| **LayerNorm** | `build_layernorm_module(M, N, dtype)` | Layout API (`@flyc.kernel`) | f32, f16, bf16 | Two-pass vectorized normalization |
-| **RMSNorm** | `build_rmsnorm_module(M, N, dtype)` | Layout API (`@flyc.kernel`) | f32, f16, bf16 | LDS-cached 3-pass pipeline |
+| **LayerNorm** | `build_layernorm_module(N, dtype)` | Layout API (`@flyc.kernel`) | f32, f16, bf16 | Two-pass vectorized normalization |
+| **RMSNorm** | `build_rmsnorm_module(N, dtype)` | Layout API (`@flyc.kernel`) | f32, f16, bf16 | LDS-cached 3-pass pipeline |
 | **Softmax** | `build_softmax_module(M, N, dtype)` | Layout API (`@flyc.kernel`) | f32, f16, bf16 | Online softmax, adaptive block size |
-| **GEMM** | `compile_preshuffle_gemm_a8(...)` | `@flyc.kernel` | fp8, int8, int4, fp16, bf16, fp4 | Preshuffle B, ping-pong LDS, MFMA 16x16 |
+| **GEMM** | `compile_preshuffle_gemm(...)` | `@flyc.kernel` | fp8, int8, fp16, bf16 | Preshuffle B, ping-pong LDS, MFMA 16x16 |
 | **FlashAttention** | `build_flash_attn_func_module(...)` | `@flyc.kernel` | bf16, f16 (any arch); fp8 e4m3fn (gfx950, D=128, dense) | Dual-wave SWP fwd, GQA/MQA, causal, descale ABI |
 
 > **Note on API styles**: All kernels use the `@flyc.kernel`/`@flyc.jit` API from `flydsl.compiler` and `flydsl.expr` (`python/flydsl/`).
@@ -18,15 +18,15 @@
 
 ## 1. Normalization Kernels
 
-### 1.1 LayerNorm (`kernels/layernorm_kernel.py`)
+### 1.1 LayerNorm (`kernels/norm/layernorm_kernel.py`)
 
 Computes `LayerNorm(x) = (x - mean) / sqrt(var + eps) * gamma + beta` for each row.
 
 **Builder:**
 ```python
-from kernels.layernorm_kernel import build_layernorm_module
+from kernels.norm.layernorm_kernel import build_layernorm_module
 
-executor = build_layernorm_module(M=32768, N=8192, dtype_str="bf16")
+executor = build_layernorm_module(N=8192, dtype_str="bf16")
 ```
 
 **Configuration Constants:**
@@ -57,15 +57,15 @@ layernorm_kernel(self, Input, Gamma, Beta, Output, m_in)
 __call__(self, Input, Gamma, Beta, Output, m_in)
 ```
 
-### 1.2 RMSNorm (`kernels/rmsnorm_kernel.py`)
+### 1.2 RMSNorm (`kernels/norm/rmsnorm_kernel.py`)
 
 Computes `RMSNorm(x) = x / sqrt(mean(x^2) + eps) * gamma`.
 
 **Builder:**
 ```python
-from kernels.rmsnorm_kernel import build_rmsnorm_module
+from kernels.norm.rmsnorm_kernel import build_rmsnorm_module
 
-executor = build_rmsnorm_module(M=32768, N=8192, dtype_str="bf16")
+executor = build_rmsnorm_module(N=8192, dtype_str="bf16")
 ```
 
 **Configuration Constants:** Same as LayerNorm (BLOCK_THREADS=256, VEC_WIDTH=8, etc.)
@@ -87,13 +87,13 @@ rmsnorm_kernel(self, Input, Gamma, Output, m_in)
 
 ## 2. Softmax Kernel
 
-### 2.1 Softmax (`kernels/softmax_kernel.py`)
+### 2.1 Softmax (`kernels/norm/softmax_kernel.py`)
 
 Computes row-wise softmax: `softmax(x)_i = exp(x_i - max(x)) / sum(exp(x - max(x)))`.
 
 **Builder:**
 ```python
-from kernels.softmax_kernel import build_softmax_module
+from kernels.norm.softmax_kernel import build_softmax_module
 
 executor = build_softmax_module(M=32768, N=8192, dtype_str="bf16")
 ```
@@ -125,7 +125,7 @@ softmax_kernel(self, A, C, m_in)
 
 ## 3. GEMM Kernel
 
-### 3.1 Preshuffle GEMM (`kernels/preshuffle_gemm.py`)
+### 3.1 Preshuffle GEMM (`kernels/gemm/preshuffle_gemm.py`)
 
 MFMA 16x16-based GEMM with B-matrix preshuffle layout: `C[M,N] = A[M,K] @ B[N,K]^T`.
 
@@ -133,33 +133,37 @@ Uses the new `@flyc.kernel` / `@flyc.jit` API.
 
 **Builder:**
 ```python
-from kernels.preshuffle_gemm import compile_preshuffle_gemm_a8
+from kernels.gemm.preshuffle_gemm import compile_preshuffle_gemm
 
-launch_fn = compile_preshuffle_gemm_a8(
-    M=16, N=5120, K=8192,
+launch_fn = compile_preshuffle_gemm(
+    N=5120, K=8192,
     tile_m=16, tile_n=128, tile_k=256,
     in_dtype="fp8",
+    out_dtype="bf16",
+    epilogue="none",
     lds_stage=2,
-    use_cshuffle_epilog=False,
 )
 ```
 
 Returns a `@flyc.jit`-decorated function that auto-compiles on first call.
 
-**Parameters:**
+**Parameters** (keyword-only):
 | Parameter | Type | Description |
 |---|---|---|
-| `M, N, K` | int | GEMM dimensions: A[M,K], B[N,K], C[M,N]. M and N can be 0 (dynamic). |
+| `N, K` | int | GEMM dimensions: A[M,K], B[N,K], C[M,N]. M is a runtime arg, not a compile-time parameter. |
 | `tile_m, tile_n, tile_k` | int | Block tile sizes |
-| `in_dtype` | str | `"fp8"`, `"int8"`, `"int4"`, `"fp16"`, `"bf16"`, `"fp4"` |
+| `in_dtype` | str | `"fp8"`, `"int8"`, `"fp16"`, `"bf16"` (default `"fp8"`) |
+| `out_dtype` | str | Output dtype (default `"bf16"`) |
+| `epilogue` | str | Fused epilogue: `"none"`, `"bias"`, `"bias_relu"`, `"bias_silu"`, `"bias_gelu"` (default `"none"`) |
 | `lds_stage` | int | `2` = ping-pong LDS (tuned), `1` = single LDS buffer |
-| `use_cshuffle_epilog` | bool | CK-style LDS CShuffle epilogue |
 | `waves_per_eu` | int | Occupancy hint (None = default, 1-4 = limit occupancy) |
+| `enable_scheduler` | bool | Enable the MLIR instruction scheduler (default `True`) |
 | `use_async_copy` | bool | Use async DMA for A tile global-to-LDS transfer |
+| `xcd_swizzle` | int | XCD remap factor for grid launch (0 = disabled) |
 
 **Key constraints:**
-- `tile_k * elem_bytes` must be divisible by 64 (K64-byte micro-step)
-- INT4 is W4A8: A is int8, B is packed int4 (2 values/byte), unpacked to int8 in-kernel
+- `tile_k` must be a positive divisor of `K`
+- FP4/MXFP4 GEMM is a separate kernel (`kernels/gemm/mxfp4_preshuffle.py`, `kernels/gemm/fp4_gemm_4wave.py`); INT4 is not supported by this kernel.
 
 **Pipeline details:**
 - **lds_stage=2 (ping-pong)**: Two LDS buffers for A tiles. Cross-tile A0 prefetch overlaps VMEM with LDS reads
@@ -167,21 +171,21 @@ Returns a `@flyc.jit`-decorated function that auto-compiles on first call.
 - **K64-byte micro-step**: Each step issues 2x K32 MFMA operations
 - **XOR16 swizzle**: Byte-level swizzle on LDS to avoid bank conflicts
 - **B-preshuffle**: Shape (N0, K0, KLane, NLane, KPackBytes) = (N/16, K/64, 4, 16, kpack_bytes)
-- **CShuffle epilogue**: Write C tile to LDS in row-major, remap threads for half2 packing via `ds_bpermute`
+- **Fused epilogue**: selected via `epilogue=` (bias add + optional relu/silu/gelu activation)
 
 **Launch function signature:**
 ```python
-launch_fn(arg_c, arg_a, arg_b, arg_scale_a, arg_scale_b, M_val, N_val, stream)
+launch_fn(arg_c, arg_a, arg_b, arg_scale_a, arg_scale_b, arg_bias, M_val, N_val, stream)
 ```
 
 Where:
-- `arg_c, arg_a, arg_b, arg_scale_a, arg_scale_b`: PyTorch tensors (auto-converted to memref)
+- `arg_c, arg_a, arg_b, arg_scale_a, arg_scale_b, arg_bias`: PyTorch tensors (auto-converted to memref). `arg_bias` is the fused epilogue bias (per-N, `out_dtype`); unused when `epilogue == "none"`.
 - `M_val, N_val`: Python int (auto-converted to Int32)
 - `stream`: `fx.Stream` (default stream if omitted)
 
 ---
 
-## 3b. FlashAttention Forward (`kernels/flash_attn_generic.py`, `kernels/flash_attn_gfx950.py`, `kernels/flash_attn_fp8_gfx950.py`)
+## 3b. FlashAttention Forward (`kernels/attention/flash_attn_generic.py`, `kernels/attention/flash_attn_gfx950.py`, `kernels/attention/flash_attn_fp8_gfx950.py`)
 
 Dense FlashAttention forward. `build_flash_attn_func_module(num_heads, head_dim,
 causal=..., dtype_str=..., num_kv_heads=...)` is the public builder; on
@@ -205,7 +209,7 @@ The PV path dequantizes fp8 V to bf16 in-kernel and accumulates P*V in bf16, kee
 the softmax probabilities at high precision. Build/launch example:
 
 ```python
-from kernels.flash_attn_generic import build_flash_attn_func_module
+from kernels.attention.flash_attn_generic import build_flash_attn_func_module
 
 exe = build_flash_attn_func_module(num_heads=H, head_dim=128, causal=False,
                                    dtype_str="fp8", num_kv_heads=H_kv)
@@ -225,25 +229,20 @@ python3 tests/kernels/test_flash_attn_fwd.py --dtype fp8 --compare --warmup 10 -
 
 ## 4. Shared Utilities
 
-### 4.1 Reduction Helpers (`kernels/kernels_common.py`)
+### 4.1 Common Kernel Helpers (`kernels/common/kernels_common.py`)
 
-Reusable warp and block reduction functions (used by normalization and softmax kernels).
+Shared kernel utilities used across GEMM/MoE/norm kernels.
 
 | Function | Description |
 |---|---|
-| `reduce_vec_max(vec, VEC_WIDTH, ...)` | Vector reduction to max via `maxnumf` |
-| `reduce_vec_sum(vec, VEC_WIDTH, ...)` | Vector reduction to sum via `add` |
-| `make_block_reduce(tid, BLOCK_SIZE, ...)` | Block-wide reduction: intra-wave XOR shuffle → LDS cross-wave sync |
-| `make_block_reduce_add(tid, ...)` | Block reduction for addition (single-wave fast path) |
-| `make_block_reduce_add2(tid, ...)` | Dual independent scalar reduction |
+| `get_warp_size(arch=None)` | Wave size for the arch: `32` on RDNA, else `64` |
+| `dtype_to_elem_type(dtype_str)` | Map a dtype string to the Fly element type |
+| `validate_moe_dtypes(a_dtype, b_dtype)` | Validate an allowed MoE A/B dtype pairing |
+| `get_llvm_ptr(ptr, offset, dtype_bytes, ...)` | Compute a byte-offset LLVM pointer |
+| `atomic_add(...)` | Emit an atomic add |
+| `_if_then(if_op, scf=None)` / `_if_else(if_op, scf=None)` | SCF `if`/`else` region context managers |
 
-**Reduction pattern:**
-1. Intra-wave: XOR shuffle with shifts 32, 16, 8, 4, 2, 1 (wave64)
-2. Lane 0 writes per-wave partial to LDS
-3. Barrier
-4. Wave 0 reduces `NUM_WAVES` partials from LDS
-
-### 4.2 MFMA Epilogues (`kernels/mfma_epilogues.py`)
+### 4.2 MFMA Epilogues (`kernels/mma/mfma_epilogues.py`)
 
 Configurable epilogue strategies for MFMA 16x16 kernels.
 
@@ -253,7 +252,7 @@ Configurable epilogue strategies for MFMA 16x16 kernels.
 | `c_shuffle_epilog(...)` | CK-style LDS CShuffle: write to LDS → barrier → remap threads → half2 store |
 | `mfma_epilog(use_cshuffle, ...)` | Dispatcher: calls default or CShuffle based on flag |
 
-### 4.3 Preshuffle Pipeline (`kernels/mfma_preshuffle_pipeline.py`)
+### 4.3 Preshuffle Pipeline (`kernels/mma/mfma_preshuffle_pipeline.py`)
 
 Shared data movement and layout utilities for preshuffle GEMM kernels.
 
@@ -269,14 +268,14 @@ Shared data movement and layout utilities for preshuffle GEMM kernels.
 
 ### 4.4 Layout Coordinate Helpers
 
-Native Fly dialect coordinate mapping (in `flydsl.expr` and `kernels/mfma_preshuffle_pipeline.py`):
+Native Fly dialect coordinate mapping (in `flydsl.expr` and `kernels/mma/mfma_preshuffle_pipeline.py`):
 
 | Function | Description |
 |---|---|
 | `fx.crd2idx(crd, layout)` | Coordinate → flat index (Fly dialect op) |
 | `fx.idx2crd(idx, layout)` | Flat index → coordinate tuple (Fly dialect op) |
 | `fx.get(int_tuple, mode)` | Extract element at index from `!fly.int_tuple` |
-| `crd2idx(crd, layout)` | Wrapper in `mfma_preshuffle_pipeline.py` (auto index cast) |
+| `crd2idx(crd, layout)` | Wrapper in `kernels/mma/mfma_preshuffle_pipeline.py` (auto index cast) |
 
 ---
 
@@ -284,7 +283,7 @@ Native Fly dialect coordinate mapping (in `flydsl.expr` and `kernels/mfma_preshu
 
 ### New API (GEMM)
 
-Used by `preshuffle_gemm.py`:
+Used by `kernels/gemm/preshuffle_gemm.py`:
 
 ```python
 import flydsl.compiler as flyc
@@ -309,30 +308,30 @@ def launch_fn(arg_c: fx.Tensor, ..., stream: fx.Stream = fx.Stream(None)):
 What operation do you need?
 │
 ├── Normalization
-│   ├── Need bias (beta) term? → LayerNorm (layernorm_kernel.py)
-│   └── No bias term?         → RMSNorm (rmsnorm_kernel.py)
+│   ├── Need bias (beta) term? → LayerNorm (kernels/norm/layernorm_kernel.py)
+│   └── No bias term?         → RMSNorm (kernels/norm/rmsnorm_kernel.py)
 │
 ├── Softmax
-│   └── Row-wise softmax      → Softmax (softmax_kernel.py)
+│   └── Row-wise softmax      → Softmax (kernels/norm/softmax_kernel.py)
 │
 ├── Matrix Multiply (GEMM)
 │   ├── Standard GEMM (uniform precision)
-│   │   ├── FP8 / INT8 / INT4(W4A8) / FP16 / BF16 / FP4
-│   │   └── → compile_preshuffle_gemm_a8()
+│   │   ├── FP8 / INT8 / FP16 / BF16
+│   │   └── → compile_preshuffle_gemm()
 │   │
 │   └── Uses new @flyc.kernel API
-│       └── See kernels/preshuffle_gemm.py
+│       └── See kernels/gemm/preshuffle_gemm.py
 │
 ├── MoE (Mixture of Experts)
 │   ├── Blockscale MoE (gate+up+reduce)
-│   │   └── → kernels/moe_blockscale_2stage.py
+│   │   └── → kernels/moe/moe_blockscale_2stage.py
 │   └── Standard MoE (fp8/f16/bf16/int8/int4)
-│       └── → kernels/moe_gemm_2stage.py
+│       └── → kernels/moe/moe_gemm_2stage.py
 │
 └── Building blocks
-    ├── Warp/block reduction     → kernels_common.py
-    ├── MFMA epilogue selection  → mfma_epilogues.py
-    └── Preshuffle data movement → mfma_preshuffle_pipeline.py
+    ├── Common kernel helpers    → kernels/common/kernels_common.py
+    ├── MFMA epilogue selection  → kernels/mma/mfma_epilogues.py
+    └── Preshuffle data movement → kernels/mma/mfma_preshuffle_pipeline.py
 ```
 
 ---
@@ -341,37 +340,37 @@ What operation do you need?
 
 | File | Description |
 |---|---|
-| `kernels/preshuffle_gemm.py` | GEMM (preshuffle layout) |
-| `kernels/blockscale_preshuffle_gemm.py` | Blockscale GEMM |
-| `kernels/hgemm_splitk.py` | FP16 GEMM split-K |
-| `kernels/moe_gemm_2stage.py` | MoE GEMM 2-stage (gate/up + reduce) |
-| `kernels/moe_blockscale_2stage.py` | MoE Blockscale 2-stage |
-| `kernels/mixed_moe_gemm_2stage.py` | Mixed-precision MoE GEMM |
-| `kernels/pa_decode_fp8.py` | Paged attention decode (FP8) |
-| `kernels/flash_attn_generic.py` | FlashAttention generic fallback |
-| `kernels/flash_attn_gfx950.py` | FlashAttention gfx950 bf16/f16 fast path |
-| `kernels/flash_attn_fp8_gfx950.py` | FlashAttention gfx950 fp8 dense fast path |
-| `kernels/layernorm_kernel.py` | LayerNorm (layout API) |
-| `kernels/rmsnorm_kernel.py` | RMSNorm (layout API) |
-| `kernels/softmax_kernel.py` | Softmax (layout API) |
-| `kernels/fused_rope_cache_kernel.py` | Fused RoPE + KV cache |
-| `kernels/custom_all_reduce.py` | Multi-GPU all-reduce |
-| `kernels/rdna_f16_gemm.py` | RDNA FP16 GEMM |
-| `kernels/rdna_fp8_preshuffle_gemm.py` | RDNA FP8 GEMM |
-| `kernels/gemm_common_gfx1250.py` | GFX1250 GEMM common |
-| `kernels/gemm_fp8fp4_gfx1250.py` | GFX1250 FP8/FP4 GEMM |
-| `kernels/wmma_gemm_gfx1250.py` | GFX1250 WMMA GEMM |
-| `kernels/mfma_epilogues.py` | MFMA epilogue helpers |
-| `kernels/mfma_preshuffle_pipeline.py` | Preshuffle data movement and layout utilities |
-| `kernels/pipeline_utils.py` | Pipeline utility helpers |
-| `kernels/kernels_common.py` | Common kernel utilities (reduction, etc.) |
-| `kernels/tensor_shim.py` | GTensor/STensor abstraction |
+| `kernels/gemm/preshuffle_gemm.py` | GEMM (preshuffle layout) |
+| `kernels/gemm/blockscale_preshuffle_gemm.py` | Blockscale GEMM |
+| `kernels/gemm/hgemm_splitk.py` | FP16 GEMM split-K |
+| `kernels/moe/moe_gemm_2stage.py` | MoE GEMM 2-stage (gate/up + reduce) |
+| `kernels/moe/moe_blockscale_2stage.py` | MoE Blockscale 2-stage |
+| `kernels/moe/mixed_moe_gemm_2stage.py` | Mixed-precision MoE GEMM |
+| `kernels/attention/pa_decode_fp8.py` | Paged attention decode (FP8) |
+| `kernels/attention/flash_attn_generic.py` | FlashAttention generic fallback |
+| `kernels/attention/flash_attn_gfx950.py` | FlashAttention gfx950 bf16/f16 fast path |
+| `kernels/attention/flash_attn_fp8_gfx950.py` | FlashAttention gfx950 fp8 dense fast path |
+| `kernels/norm/layernorm_kernel.py` | LayerNorm (layout API) |
+| `kernels/norm/rmsnorm_kernel.py` | RMSNorm (layout API) |
+| `kernels/norm/softmax_kernel.py` | Softmax (layout API) |
+| `kernels/attention/fused_rope_cache_kernel.py` | Fused RoPE + KV cache |
+| `kernels/comm/custom_all_reduce.py` | Multi-GPU all-reduce |
+| `kernels/gemm/rdna_f16_gemm.py` | RDNA FP16 GEMM |
+| `kernels/gemm/rdna_fp8_preshuffle_gemm.py` | RDNA FP8 GEMM |
+| `kernels/gemm/gemm_common_gfx1250.py` | GFX1250 GEMM common |
+| `kernels/gemm/gemm_fp8fp4_gfx1250.py` | GFX1250 FP8/FP4 GEMM |
+| `kernels/gemm/wmma_gemm_gfx1250.py` | GFX1250 WMMA GEMM |
+| `kernels/mma/mfma_epilogues.py` | MFMA epilogue helpers |
+| `kernels/mma/mfma_preshuffle_pipeline.py` | Preshuffle data movement and layout utilities |
+| `kernels/mma/pipeline_utils.py` | Pipeline utility helpers |
+| `kernels/common/kernels_common.py` | Common kernel utilities |
+| `kernels/common/tensor_shim.py` | GTensor/STensor abstraction |
 
 ## 8. Test Files
 
 | File | Tests |
 |---|---|
-| `tests/kernels/test_preshuffle_gemm.py` | GEMM fp8/int8/int4/bf16/fp4 |
+| `tests/kernels/test_preshuffle_gemm.py` | GEMM fp8/int8/fp16/bf16 |
 | `tests/kernels/test_blockscale_preshuffle_gemm.py` | Blockscale GEMM |
 | `tests/kernels/test_hgemm_splitk.py` | FP16 GEMM split-K |
 | `tests/kernels/test_moe_gemm.py` | MoE GEMM |

--- a/docs/testing_benchmarking_guide.md
+++ b/docs/testing_benchmarking_guide.md
@@ -66,7 +66,7 @@ Full end-to-end tests: compile FlyDSL kernels, execute on GPU, validate against 
 | `test_softmax.py` | Softmax | Row-wise softmax |
 | `test_layernorm.py` | LayerNorm | Layer normalization |
 | `test_rmsnorm.py` | RMSNorm | RMS normalization |
-| `test_preshuffle_gemm.py` | GEMM | Preshuffle MFMA GEMM (fp8/int8/int4/bf16) |
+| `test_preshuffle_gemm.py` | GEMM | Preshuffle MFMA GEMM (fp8/int8/fp16/bf16) |
 | `test_blockscale_preshuffle_gemm.py` | GEMM | Block-scale (MXFP4) preshuffle GEMM |
 | `test_moe_gemm.py` | MoE GEMM | Mixture-of-Experts GEMM |
 | `test_moe_blockscale.py` | MoE | MoE with block-scale quantization |
@@ -96,7 +96,7 @@ tests/python/examples/
 
 ### 2.1 `scripts/run_tests.sh`
 
-Runs the preshuffle GEMM test suite via pytest:
+Runs the full FlyDSL test suite:
 
 ```bash
 bash scripts/run_tests.sh
@@ -104,10 +104,12 @@ bash scripts/run_tests.sh
 
 **Features:**
 - Auto-discovers build directory (`build-fly/`)
-- Sets up `PYTHONPATH` and `LD_LIBRARY_PATH`
-- Runs `pytest tests/kernels/test_preshuffle_gemm.py`
+- Auto-selects the GPU with the most free VRAM when `HIP_VISIBLE_DEVICES` is unset
+- Sets up `PYTHONPATH` and `LD_LIBRARY_PATH`, and exports `FLYDSL_RUN_QUANT=1`
+- Runs `pytest` over `tests/kernels/`, `tests/unit/`, `tests/system/`, and `tests/python/examples/`
+- Runs the standalone `examples/` scripts and the MLIR FileCheck tests (`tests/mlir/`)
 - By default skips `large_shape`-marked tests (set `RUN_TESTS_FULL=1` for all)
-- Outputs pass/fail summary
+- Fail-fast: exits on the first failure
 
 **Environment setup:**
 ```bash
@@ -132,7 +134,6 @@ fp8,16,77824,5120,16,128,256
 fp8,5120,5120,8320,64,256,128
 fp8,9728,8192,8320,64,256,128
 int8,9728,8192,8320,64,256,128
-int4,9728,8192,8320,64,256,128
 bf16,5120,5120,8320,64,256,128
 '
 
@@ -235,26 +236,7 @@ gpu_us = bench_gpu_us_torch(fn, warmup=20, iters=200)
 
 ---
 
-## 5. Compilation Utilities (`tests/utils.py`)
-
-### `compile_to_hsaco()`
-
-Standalone compilation path for tests:
-
-```python
-from tests.utils import compile_to_hsaco
-
-hsaco = compile_to_hsaco(mlir_module, kernel_name="my_kernel")
-```
-
-**Pipeline stages:**
-1. Fly coordinate lowering
-2. `fly-to-standard` lowering
-3. `canonicalize` + `cse`
-4. Attach ROCDL target (auto-detect GPU arch)
-5. `convert-gpu-to-rocdl` (SCF→CF, bare pointer memref)
-6. `gpu-to-llvm` + `lower-to-llvm`
-7. `gpu-module-to-binary`
+## 5. Test Utilities (`tests/utils.py`)
 
 ### Weight Utilities
 
@@ -402,12 +384,12 @@ bash scripts/dumpir.sh
 
 | File | Description |
 |---|---|
-| `scripts/run_tests.sh` | GEMM test runner (pytest) |
+| `scripts/run_tests.sh` | Full test runner (pytest + examples + FileCheck) |
 | `scripts/run_benchmark.sh` | Benchmark harness with configurable shapes |
 | `scripts/dumpir.sh` | IR dump helper script |
 | `tests/conftest.py` | Pytest fixtures (MLIR context, module, insert point) |
 | `tests/test_common.py` | `perftest()`, `checkAllclose()`, `verify_output()` |
-| `tests/utils.py` | `compile_to_hsaco()`, `pertoken_quant()`, `shuffle_weight()` |
+| `tests/utils.py` | `pertoken_quant()`, `shuffle_weight()` |
 | `tests/kernels/benchmark_common.py` | `bench_gpu_us_torch()`, benchmark harness |
 | `tests/mlir/{LayoutAlgebra,Conversion,Transforms}/` | MLIR lit tests (18 files) |
 | `tests/python/examples/` | Python AOT examples |

--- a/docs/tutorials/kernel_development.rst
+++ b/docs/tutorials/kernel_development.rst
@@ -71,7 +71,7 @@ instructions via ``make_mma_atom`` and ``make_tiled_mma``:
        fx.gemm(mma_atom, frag_C, frag_A, frag_B, frag_C)
 
 See ``examples/03-tiledMma.py`` for a complete GEMM example and
-``kernels/preshuffle_gemm.py`` for a production GEMM implementation with
+``kernels/gemm/preshuffle_gemm.py`` for a production GEMM implementation with
 LDS pipeline.
 
 Shared Memory (LDS)
@@ -84,7 +84,7 @@ data movement:
 2. Use cooperative loads to fill LDS from global memory
 3. Synchronize with barriers before consuming LDS data
 
-See ``kernels/preshuffle_gemm.py`` for LDS double-buffering patterns.
+See ``kernels/gemm/preshuffle_gemm.py`` for LDS double-buffering patterns.
 
 Performance Optimization
 ------------------------
@@ -101,11 +101,10 @@ Reference Implementations
 
 Study these kernels for real-world patterns:
 
-- ``kernels/preshuffle_gemm.py`` -- MFMA + LDS pipeline GEMM
-- ``kernels/preshuffle_gemm_flyc.py`` -- GEMM using new ``@flyc.kernel`` API
-- ``kernels/softmax_kernel.py`` -- online numerically stable softmax
-- ``kernels/layernorm_kernel.py`` -- fused normalization
-- ``kernels/pa_decode_fp8.py`` -- paged attention decode with FP8
+- ``kernels/gemm/preshuffle_gemm.py`` -- MFMA + LDS pipeline GEMM
+- ``kernels/norm/softmax_kernel.py`` -- online numerically stable softmax
+- ``kernels/norm/layernorm_kernel.py`` -- fused normalization
+- ``kernels/attention/pa_decode_fp8.py`` -- paged attention decode with FP8
 
 .. seealso::
 


### PR DESCRIPTION
## Summary

The `kernels/` tree was reorganized into subpackages (`gemm/ norm/ attention/ mma/ common/ moe/ comm/ conv/`) and several public APIs were renamed/removed, but the docs and kernel-authoring skills still referenced the old flat paths and stale symbols. This PR refreshes the documentation to match the current API, adds a kernel tuning guide, and fixes the kernel-writing skills.

## README
- Add a **Docs** badge next to the Dashboard badge → `rocm.github.io/FlyDSL`.
- Add **[HipKittens](https://github.com/HazyResearch/HipKittens)** to Acknowledgements.
- Add a **Kernel Tuning** row to the documentation tables.

## API drift fixes (docs)
- Repath every `kernels/` reference (files and `automodule`/inline) to its subpackage.
- `compile_preshuffle_gemm_a8` → `compile_preshuffle_gemm` (no `M` arg; `use_cshuffle_epilog` → `epilogue=`).
- Preshuffle GEMM dtypes corrected to `fp8/int8/fp16/bf16` (int4 dropped; fp4/mxfp4 are separate kernels).
- Correct `build_layernorm_module` / `build_rmsnorm_module` signatures (no `M`).
- Remove phantom APIs: `compile_to_hsaco`, `kernels/reduce.py`, `SmemAllocator.allocate_array`, `reduce_vec_*/make_block_reduce*`, `make_identity_tensor`, `fx.zip`, `fx.Float8`, and 4 nonexistent `api/kernels.rst` modules.
- Fix `run_tests.sh` scope description (full suite, not just preshuffle GEMM).
- `dsl.rst`: correct `crd2idx`/`idx2crd`/`get_scalar`/`make_mma_atom`/`gemm`/`mma_atom_call` signatures and TV-layout property names.
- Switch LDS examples to `fx.SharedAllocator` + `@fx.struct`.

## New: kernel tuning guide
- `docs/kernel_tuning_guide.md` — distilled from the tuning skills: tiling strategy, LDS double-buffer + XOR bank-conflict swizzle, prefetch (loop-carried `range(..., init=...)` + async copy), MFMA scheduling, epilogue choice, occupancy/VGPR budget, roofline metrics, ATT/PMC profiling, and regression bisecting.
- Wired into `docs/index.rst`, the README tables, and the CLAUDE.md documentation map.

## Skills
- `flydsl-kernel-authoring` / `flydsl-tile-programming`: replace the fabricated `SmemAllocator.allocate_array` LDS pattern with `fx.SharedAllocator` + `@fx.struct` (legacy `SmemAllocator` noted), repath `kernels/` references, remove `fx.zip` and `kernels/reduce.py`.

## Verification
Docs-only change — no build/test run. Every API claim was re-verified against source; a final grep sweep shows no remaining stale references.

### Follow-up (not in this PR)
The `gemm-optimization` and `lds-optimization` tuning skills still show the legacy `SmemAllocator.allocate_array` API and could be modernized similarly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
