### PR TITLE
[Docs] Kernel-tuning primer + occupancy, recent-API coverage, skills modernization

### DIFF
--- a/.claude/skills/debug-flydsl-kernel/SKILL.md
+++ b/.claude/skills/debug-flydsl-kernel/SKILL.md
@@ -157,9 +157,9 @@ for i in range_constexpr(4): result[i] = ...
 Current FlyDSL supports runtime comparisons in Python `if`; the AST rewriter lowers dynamic conditions to `scf.IfOp`. Prefer readable DSL operators for runtime SSA values:
 ```python
 tid = gpu.thread_id("x")
-lane = tid % fx.Index(64)
-c_zero = fx.Index(0)
-c_limit = fx.Index(8)
+lane = tid % fx.Int64(64)
+c_zero = fx.Int64(0)
+c_limit = fx.Int64(8)
 
 # Runtime condition, lowered to scf.IfOp
 if lane == c_zero:

--- a/.claude/skills/flydsl-kernel-authoring/SKILL.md
+++ b/.claude/skills/flydsl-kernel-authoring/SKILL.md
@@ -214,8 +214,8 @@ bx = gpu.block_id("x")
 by = gpu.block_id("y")
 
 i32_m: fx.Int32
-c_m = fx.Index(i32_m)
-c4 = fx.Index(4)
+c_m = fx.Int64(i32_m)
+c4 = fx.Int64(4)
 zero_f = fx.Float32(0.0)
 
 layout = fx.make_layout((4, 64), (64, 1))
@@ -231,7 +231,7 @@ rsrc = buffer_ops.create_buffer_resource(tensor, max_size=True)
 word = buffer_ops.buffer_load(rsrc, fx.Int32(offset), vec_width=4, dtype=fx.Int32)
 ```
 
-Older code may use `gpu.thread_idx.x`, `gpu.block_idx.x`, `arith.constant(...)`, `T.i32`, and raw `vector.*` helpers. Keep those when editing existing code that already uses them heavily, but prefer `gpu.thread_id/block_id`, `fx.Index`/`fx.Int32`/`fx.Float32`, and `fx.Vector` for new code.
+Older code may use `gpu.thread_idx.x`, `gpu.block_idx.x`, `arith.constant(...)`, `T.i32`, and raw `vector.*` helpers. Keep those when editing existing code that already uses them heavily, but prefer `gpu.thread_id/block_id`, `fx.Int64`/`fx.Int32`/`fx.Float32`, and `fx.Vector` for new code.
 
 ### Parameter Types
 | Type | Description | At host boundary |
@@ -275,9 +275,9 @@ Use Python/DSL operators for runtime SSA comparisons. The AST rewriter lowers dy
 
 ```python
 tid = gpu.thread_id("x")
-lane = tid % fx.Index(64)
-c_zero = fx.Index(0)
-c_limit = fx.Index(8)
+lane = tid % fx.Int64(64)
+c_zero = fx.Int64(0)
+c_limit = fx.Int64(8)
 
 # Preferred: readable DSL comparisons
 if lane == c_zero:
@@ -383,10 +383,10 @@ tile_0 = prefetch(0)
 init_state = [acc_init, tile_0_flat_val1, tile_0_flat_val2, ...]
 
 # Runtime loop with loop-carried state
-# Use fx.Index(...) bounds so the AST rewriter does not treat this as a Python unrolled range.
-_start = fx.Index(0)
-_stop = fx.Index(N - 1)
-_step = fx.Index(1)
+# Use typed DSL integer bounds (fx.Int64) so the AST rewriter does not treat this as a Python unrolled range.
+_start = fx.Int64(0)
+_stop = fx.Int64(N - 1)
+_step = fx.Int64(1)
 for iv, state in range(_start, _stop, _step, init=init_state):
     acc_in = state[0]
     tile_in = state[1:]
@@ -412,7 +412,7 @@ compute(acc_final, tile_final)
 
 **Three critical pitfalls (all verified by debugging):**
 
-1. **Loop bounds must be DSL index values, NOT Python ints.** If you write `range(0, 15, 1, init=...)`, the AST rewriter treats constant bounds as a Python `range` and unrolls the loop — silently ignoring `init=`. Use `fx.Index(0)`, `fx.Index(15)`, `fx.Index(1)` instead.
+1. **Loop bounds must be a typed DSL integer such as `fx.Int64(...)`, NOT a plain Python int.** A plain int makes the AST rewriter unroll the loop and silently ignore `init=`. If you write `range(0, 15, 1, init=...)`, the AST rewriter treats the constant bounds as a Python `range` and unrolls; only plain Python-int bounds are unrolled, so a typed bound still produces a runtime `scf.for`. Use `fx.Int64(0)`, `fx.Int64(15)`, `fx.Int64(1)` instead.
 
 2. **Prefer internal types, but unwrap at hard boundaries.** Most `range(..., init=...)` uses accept DSL numeric/vector values. If a lower-level helper explicitly expects raw `ir.Value`, unwrap with `v.ir_value()` / `_raw(v)` at that boundary only.
 
@@ -424,7 +424,7 @@ compute(acc_final, tile_final)
 
 ### Arithmetic Operations
 ```python
-c42 = fx.Index(42)                              # index type constant (preferred)
+c42 = fx.Int64(42)                              # typed integer constant (preferred)
 c3_14 = fx.Float32(3.14)                        # f32 constant (preferred)
 mask = fx.Int32(0xFF)                            # i32 constant (preferred)
 
@@ -854,7 +854,7 @@ Pass raw `torch.Tensor` objects instead.
 
 ### Common Issues
 
-1. **Constants/casts**: Prefer `fx.Int32(...)`, `fx.Int64(...)`, `fx.Index(...)`, and `fx.Float32(...)`. Use `arith.constant(...)` only at low-level boundaries.
+1. **Constants/casts**: Prefer `fx.Int32(...)`, `fx.Int64(...)`, and `fx.Float32(...)` (`fx.Index(...)` is being deprecated in favor of `fx.Int64(...)`). Use `arith.constant(...)` only at low-level boundaries.
 
 2. **`buffer_ops.buffer_load` offset**: The `offset` parameter is in ELEMENTS, not bytes.
 

--- a/.claude/skills/flydsl-tile-programming/SKILL.md
+++ b/.claude/skills/flydsl-tile-programming/SKILL.md
@@ -332,7 +332,9 @@ for i in range(runtime_N):
     ...
 
 # Loop with carried state (software pipelining)
-start, stop, step = fx.Index(0), fx.Index(N - 1), fx.Index(1)
+# Bounds must be typed DSL integers (fx.Int64), NOT plain Python ints — a plain
+# int makes the AST rewriter unroll the loop and silently ignore init=.
+start, stop, step = fx.Int64(0), fx.Int64(N - 1), fx.Int64(1)
 for iv, state in range(start, stop, step, init=[acc_init, ...]):
     acc = state[0]
     # ... compute ...

--- a/.claude/skills/gemm-optimization/SKILL.md
+++ b/.claude/skills/gemm-optimization/SKILL.md
@@ -17,7 +17,7 @@ allowed-tools: Read Edit Bash Grep Glob Agent
 Comprehensive guide to writing and optimizing high-performance GEMM kernels in
 FlyDSL on AMD CDNA GPUs (MI300X gfx942, MI350 gfx950).
 
-Based on the production `kernels/preshuffle_gemm.py` implementation.
+Based on the production `kernels/gemm/preshuffle_gemm.py` implementation.
 
 ---
 
@@ -104,14 +104,29 @@ Buffer PING: [   Load tile_k=1  ] [Compute tile_k=1] [   Load tile_k=3  ] ...
 
 ### 2.2 FlyDSL Implementation
 
-```python
-# Two independent SmemAllocators (separate LDS regions)
-allocator_pong = SmemAllocator(None, arch="gfx942", global_sym_name="smem0")
-allocator_ping = SmemAllocator(None, arch="gfx942", global_sym_name="smem1")
+Declare both A buffers as `fx.Array` fields of an `@fx.struct` and allocate them
+with `fx.SharedAllocator` (the current LDS API — see `kernels/gemm/preshuffle_gemm.py`,
+where `a0`/`a1` are the pong/ping A buffers). In the default `static=True` mode the
+compiler sizes the static LDS globals for you.
 
-lds_a_pong = allocator_pong.allocate_array(T.i8, buffer_size_bytes)
-lds_a_ping = allocator_ping.allocate_array(T.i8, buffer_size_bytes)
+```python
+a_lds_elems = tile_m * tile_k  # elements per A buffer
+
+@fx.struct
+class SharedStorage:
+    a0: fx.Array[layout_elem, a_lds_elems, 16]  # PONG buffer
+    if lds_stage == 2:
+        a1: fx.Array[layout_elem, a_lds_elems, 16]  # PING buffer
+
+@flyc.kernel
+def kernel_gemm(...):
+    lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+    lds_a_pong = lds.a0.view(fx.make_layout((tile_m, tile_k), (tile_k, 1)))
+    lds_a_ping = lds.a1.view(fx.make_layout((tile_m, tile_k), (tile_k, 1)))
 ```
+
+The legacy `flydsl.utils.smem_allocator.SmemAllocator` path remains for un-migrated
+kernels but is not recommended for new code.
 
 ### 2.3 Main Loop Structure (2-Stage)
 

--- a/.claude/skills/lds-optimization/SKILL.md
+++ b/.claude/skills/lds-optimization/SKILL.md
@@ -216,29 +216,34 @@ swizzled_col = original_col XOR (row >> shift)
 
 This ensures threads accessing the same column in different rows hit different banks.
 
-### FlyDSL XOR Swizzle with SmemAllocator
+### FlyDSL XOR Swizzle with SharedAllocator
 
-In FlyDSL, LDS is managed through `SmemAllocator`. To apply swizzle, XOR the
-row index into the LDS address when computing store/load offsets:
+In FlyDSL, declare the LDS storage as an `@fx.struct` of `fx.Array` fields and
+allocate it inside the kernel with `fx.SharedAllocator` (the current LDS API).
+To apply swizzle, XOR the row index into the LDS address when computing
+store/load offsets:
 
 ```python
-from flydsl.utils.smem_allocator import SmemAllocator
+import flydsl.expr as fx
 
-allocator = SmemAllocator(None, arch="gfx942", global_sym_name="smem0")
-lds_key = allocator.allocate_array(T.f16, KV_BLOCK_SIZE * HEAD_SIZE)
+@fx.struct
+class SharedStorage:
+    key: fx.Array[fx.Float16, KV_BLOCK_SIZE * HEAD_SIZE]
 
 @flyc.kernel
 def my_kernel(...):
-    lds_base = allocator.get_base()
-    lds_key_ptr = lds_key(lds_base)
+    lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+    lds_key = lds.key.view(fx.make_layout((KV_BLOCK_SIZE, PADDED_STRIDE), (PADDED_STRIDE, 1)))
 
     # XOR-swizzle address: distribute bank accesses
     # row_idx and col_idx are the logical 2D coordinates
     # XOR_BITS controls swizzle width (typically 4 for fp16 vec=8)
     swizzled_col = col_idx ^ (row_idx & XOR_MASK)
-    lds_offset = row_idx * PADDED_STRIDE + swizzled_col
-    lds_key_ptr.store(data, [lds_offset])
+    fx.memref_store(data, lds_key, [row_idx, swizzled_col])
 ```
+
+The legacy `flydsl.utils.smem_allocator.SmemAllocator` path remains for
+un-migrated kernels but is not recommended for new code.
 
 ### Choosing Swizzle Parameters
 
@@ -260,10 +265,14 @@ Before (conflict-prone, linear layout):
 
 ```python
 # Linear shared memory layout — threads in same warp hit same banks
-lds_key = allocator.allocate_array(T.f16, KV_BLOCK_SIZE * HEAD_SIZE)
+@fx.struct
+class SharedStorage:
+    key: fx.Array[fx.Float16, KV_BLOCK_SIZE * HEAD_SIZE]
+
+lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+lds_key = lds.key.view(fx.make_layout((KV_BLOCK_SIZE, HEAD_SIZE), (HEAD_SIZE, 1)))
 # Store key tile: all threads write to column 0,1,2... -> bank conflicts
-lds_offset = row * HEAD_SIZE + col
-lds_key_ptr.store(data, [lds_offset])
+fx.memref_store(data, lds_key, [row, col])
 ```
 
 After (swizzled, conflict-free):
@@ -271,10 +280,10 @@ After (swizzled, conflict-free):
 ```python
 # XOR-swizzle distributes accesses across banks
 XOR_BITS = 4  # for fp16 vec=8: covers 4 banks per vec
-lds_key = allocator.allocate_array(T.f16, KV_BLOCK_SIZE * HEAD_SIZE)
+lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+lds_key = lds.key.view(fx.make_layout((KV_BLOCK_SIZE, HEAD_SIZE), (HEAD_SIZE, 1)))
 swizzled_col = col ^ ((row & 0x7) << XOR_BITS)
-lds_offset = row * HEAD_SIZE + swizzled_col
-lds_key_ptr.store(data, [lds_offset])  # now conflict-free
+fx.memref_store(data, lds_key, [row, swizzled_col])  # now conflict-free
 ```
 
 ## Optimization Method 2: Padding
@@ -308,19 +317,21 @@ PADDING = 1  # or a small number
 PADDED_HEAD_SIZE = HEAD_SIZE + PADDING
 
 # Allocate with extra column for padding
-lds_key = allocator.allocate_array(T.f16, KV_BLOCK_SIZE * PADDED_HEAD_SIZE)
+@fx.struct
+class SharedStorage:
+    key: fx.Array[fx.Float16, KV_BLOCK_SIZE * PADDED_HEAD_SIZE]
 
 @flyc.kernel
 def my_kernel(...):
-    lds_base = allocator.get_base()
-    lds_key_ptr = lds_key(lds_base)
+    lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+    # View with padded stride: physical row stride is PADDED_HEAD_SIZE
+    lds_key = lds.key.view(fx.make_layout((KV_BLOCK_SIZE, HEAD_SIZE), (PADDED_HEAD_SIZE, 1)))
 
-    # Write key data using padded stride (ignore padding column)
-    lds_offset = row * PADDED_HEAD_SIZE + col
-    lds_key_ptr.store(data, [lds_offset])
+    # Write key data using padded stride (padding column stays unused)
+    fx.memref_store(data, lds_key, [row, col])
 
-    # Read back using same padded stride
-    data = lds_key_ptr.load([row * PADDED_HEAD_SIZE + col])
+    # Read back using same padded-stride view
+    data = fx.memref_load(lds_key, [row, col])
 ```
 
 ### Padding Amount
@@ -428,7 +439,7 @@ After applying LDS optimizations:
 
 3. **LDS usage**: Check total LDS consumption:
    ```python
-   # Estimate: sum of all allocator.allocate_array() sizes * element_size
+   # Estimate: sum of all @fx.struct fx.Array field byte sizes
    # gfx942: Must be <= 65536 bytes (64 KB) per workgroup
    # gfx950: Must be <= 163840 bytes (160 KB) per workgroup
    # Note: gfx950 allocates LDS in 1280-byte granularity (1280-byte aligned blocks)

--- a/.claude/skills/oob-detection/SKILL.md
+++ b/.claude/skills/oob-detection/SKILL.md
@@ -74,15 +74,15 @@ temporary guard immediately before the load/store. In FlyDSL kernels, prefer a
 small `printf` with the failing coordinates:
 
 ```python
-load_start = q_elem + arith.constant(qwi * 4, type=T.i32)
-load_end = load_start + arith.constant(vec_width - 1, type=T.i32)
-legal_end = q_base + arith.constant(HEAD_SIZE - 1, type=T.i32)
+load_start = q_elem + fx.Int32(qwi * 4)
+load_end = load_start + fx.Int32(vec_width - 1)
+legal_end = q_base + fx.Int32(HEAD_SIZE - 1)
 
 if load_end > legal_end:
     fx.printf(
         "OOB q load: lane=%d qwi=%d q_base=%d load=[%d,%d] legal_end=%d\n",
         lane16id,
-        arith.constant(qwi, type=T.i32),
+        fx.Int32(qwi),
         q_base,
         load_start,
         load_end,

--- a/.claude/skills/prefetch-data-load/SKILL.md
+++ b/.claude/skills/prefetch-data-load/SKILL.md
@@ -106,9 +106,9 @@ init_state = [_unwrap(v) for v in [next_data_A, next_data_B, acc]]
 #### Step 2: Runtime loop with loop-carried state
 
 ```python
-_start = fx.Index(0)
-_stop = fx.Index(N - 1)  # N-1 iterations; last handled in epilogue
-_step = fx.Index(1)
+_start = fx.Int64(0)
+_stop = fx.Int64(N - 1)  # N-1 iterations; last handled in epilogue
+_step = fx.Int64(1)
 
 for iv, state in range(_start, _stop, _step, init=init_state):
     # Swap: prefetched -> current
@@ -190,8 +190,8 @@ def _unpack(state):
 pf_0 = issue_bt_k_loads(partition_0)
 init_state = _pack(flatten(pf_0['kv']), pf_0['part_start'], ...)
 
-# Runtime loop (bounds MUST be fx.Index, not Python ints!)
-for iv, state in range(fx.Index(0), fx.Index(N - 1), fx.Index(1), init=init_state):
+# Runtime loop (bounds MUST be a typed DSL integer like fx.Int64, not Python ints!)
+for iv, state in range(fx.Int64(0), fx.Int64(N - 1), fx.Int64(1), init=init_state):
     kv, part_start, bt, rmax, rsum, acc = _unpack(state)
     rmax, rsum, acc = compute_qk_softmax_pv(kv, part_start, bt, rmax, rsum, acc)
     pf_next = issue_bt_k_loads(next_partition(iv + 1))
@@ -211,10 +211,13 @@ K loads needed).
 
 ### Three Critical Pitfalls
 
-1. **Loop bounds must be `fx.Index(...)`, NOT Python ints.** If you write
-   `range(0, 15, 1, init=...)`, the AST rewriter treats constant bounds as a
-   Python `range` and unrolls the loop — silently ignoring `init=`. Use
-   `fx.Index(0)`, `fx.Index(15)`, `fx.Index(1)` instead.
+1. **Loop bounds must be a typed DSL integer such as `fx.Int64(...)`, NOT a
+   Python int.** A plain int makes the AST rewriter unroll the loop and silently
+   ignore `init=`. If you write `range(0, 15, 1, init=...)`, the AST rewriter
+   treats the constant bounds as a Python `range` and unrolls; only plain
+   Python-int bounds are unrolled, so a typed bound still produces a runtime
+   `scf.for` (the rewriter index-casts non-Python-int bounds into `scf.for`).
+   Use `fx.Int64(0)`, `fx.Int64(15)`, `fx.Int64(1)` instead.
 
 2. **Prefer internal types; unwrap only at hard boundaries.** Most loop-carried
    values can remain `fx.Int32`, `fx.Float32`, `ArithValue`, or `Vector`. If a
@@ -359,7 +362,7 @@ This works because:
 - **Don't reorder loads that have data dependencies**: if `load_B` depends on the result of `load_A` (e.g., block table lookup -> cache load), they must stay sequential within the prefetch block.
 - **Don't forget to handle conditional branches**: if scale loads are conditional (`KV_QUANT_MODE`), the prefetch must replicate the same conditions.
 - **Don't break the prologue/epilogue semantics**: the prologue covers iteration 0; the runtime loop runs N-1 iterations carrying prefetched data; epilogue processes the last iteration from `results`.
-- **Don't use Python ints as loop bounds when using `init=`**: use `fx.Index(...)` or the loop will be unrolled, silently ignoring `init=`.
+- **Don't use Python ints as loop bounds when using `init=`**: use a typed DSL integer such as `fx.Int64(...)`, NOT a plain int, or the AST rewriter will unroll the loop and silently ignore `init=`.
 
 ## Verification
 

--- a/docs/api/dsl.rst
+++ b/docs/api/dsl.rst
@@ -109,6 +109,8 @@ High-level classes for tiled copy and MMA partitioning:
 - **ThrMma** -- per-thread MMA view: ``partition_A(a)``, ``partition_B(b)``, ``partition_C(c)``
 - **make_layout_tv(thr, val)** -- build thread-value layout
 - **make_tiled_copy_A/B/C(copy_atom, tiled_mma)** -- create TiledCopy matched to MMA operands
+- **fx.gather(copy_atom, base_iter, offset_tensor, dst_tensor, \*, pred=None)** -- indexed load ``dst = base[offset]`` via a copy atom (offset tensor is ``(TV, Rest...)``)
+- **fx.scatter(copy_atom, src_tensor, base_iter, offset_tensor, \*, pred=None)** -- indexed store ``base[offset] = src`` (see ``examples/05-gather_scatter.py``)
 
 Type Annotations
 ~~~~~~~~~~~~~~~~~
@@ -120,6 +122,8 @@ Type Annotations
 - **fx.Float8E4M3FN**, **fx.Float8E4M3FNUZ**, **fx.Float8E5M2** -- FP8 scalar types
 - **fx.Stream** -- GPU stream argument
 - **fx.T** -- type namespace (``T.f32``, ``T.f16``, ``T.bf16``, ``T.i8``, ``T.index``, etc.)
+- **fx.Basis(value, modes)** / **fx.E(\*modes)** -- basis-stride leaves for by-mode layout construction (``E(0)`` → ``1E0``)
+- **fx.SyncScope** -- target-neutral LLVM sync scopes (``SyncScope.System``, ``SyncScope.SingleThread``); AMDGPU scopes live in ``flydsl.expr.rocdl.enum.SyncScope``
 
 GPU Intrinsics (``flydsl.expr.gpu``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -141,7 +145,7 @@ Prefer typed DSL values and operator-overloaded arithmetic:
    import flydsl.expr as fx
    from flydsl.expr.typing import Vector as Vec
 
-   c = fx.Index(42)
+   c = fx.Int64(42)
    v = fx.Int32(idx)
    f = fx.Float32(1.0)
    r = cond.select(a, b)
@@ -149,12 +153,25 @@ Prefer typed DSL values and operator-overloaded arithmetic:
 
 Preferred APIs:
 
-- **fx.Int32(value)**, **fx.Int64(value)**, **fx.Index(value)**, **fx.Float32(value)** -- constants and casts
+- **fx.Int32(value)**, **fx.Int64(value)**, **fx.Float32(value)** -- typed constants and casts (use **fx.Int64** for index/offset values and loop bounds; **fx.Index** is deprecated)
 - **ArithValue / Numeric operators** -- ``+``, ``-``, ``*``, ``/``, ``%``, ``<<``, ``>>``
 - **cond.select(true_val, false_val)** -- ternary select when ``cond`` is an ``ArithValue``
 - **arith.cmpi(predicate, lhs, rhs)** -- integer comparison
 - **arith.cmpf(predicate, lhs, rhs)** -- float comparison
-- **Direct ``arith.*FOp(..., fastmath=...)``** -- use only where explicit fastmath flags are required for performance
+- **arith.maxnumf(a, b)** -- float maximum returning the non-NaN operand (libm ``fmax``); preserves the DSL type of ``a``
+- **Chained comparisons** (``lo <= x < hi``) are supported inside traced kernels and lower to combined ``cmp`` + ``and``.
+
+Fastmath flags can be applied ambiently to a block or per-op:
+
+.. code-block:: python
+
+   with fx.fastmath(fx.FastMathFlags.fast):
+       y = a * b + c          # float operators/math funcs inherit the flags
+       z = fx.exp(a, fastmath="contract")   # explicit arg overrides the ambient scope
+
+- **fx.fastmath(flags)** -- context manager applying ``fastmath`` to float ops built in the block; nests and restores on exit
+- **fx.FastMathFlags** -- flag enum (``fast``, ``contract``, ``reassoc``, …; combine with ``|``)
+- **Direct ``arith.addf(..., fastmath=...)`` / ``arith.AddFOp(..., fastmath=...)``** -- per-op flags where an ambient scope is not desired
 
 Vector Values (``flydsl.expr.typing.Vector``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -182,7 +199,7 @@ AMD CDNA3/CDNA4 buffer load/store with hardware bounds checking:
    buffer_ops.buffer_store(data, rsrc, offset, mask=is_valid)
 
 - **create_buffer_resource(tensor, num_records=None, max_size=False)** -- create buffer descriptor
-- **buffer_load(rsrc, offset, vec_width, dtype, soffset_bytes, mask)** -- vector buffer load
+- **buffer_load(rsrc, offset, vec_width=4, dtype=None, mask=None, cache_modifier=0, soffset_bytes=None, is_scalar=False)** -- vector buffer load; ``is_scalar=True`` emits the uniform/SGPR ``s.buffer.load`` (vec_width 1 or 4, i32 result, no mask/soffset)
 - **buffer_store(data, rsrc, offset, soffset_bytes, mask)** -- buffer store
 - **BufferResourceDescriptor** -- descriptor dataclass
 

--- a/docs/extern_integration_guide.md
+++ b/docs/extern_integration_guide.md
@@ -132,4 +132,4 @@ method closing over runtime state), the caller should either:
 | [`python/flydsl/compiler/kernel_function.py`](../python/flydsl/compiler/kernel_function.py) | `CompilationContext` (carries `link_libs`, `post_load_processors`) |
 | [`python/flydsl/compiler/jit_function.py`](../python/flydsl/compiler/jit_function.py) | Passes `link_libs` into `MlirCompiler.compile` and propagates `post_load_processors` to `CompiledArtifact` |
 | [`python/flydsl/compiler/jit_executor.py`](../python/flydsl/compiler/jit_executor.py) | Looks up FlyDSL ROCm module loader symbols, owns `GpuJitModule`, and runs `post_load_processors` |
-| [`lib/Runtime/FlyRocmRuntimeWrappers.cpp`](../lib/Runtime/FlyRocmRuntimeWrappers.cpp) | C++ runtime: stateless `mgpuModuleLoad` wrapper |
+| [`lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp`](../lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp) | C++ runtime: stateless `mgpuModuleLoad` wrapper |

--- a/docs/kernel_authoring_guide.md
+++ b/docs/kernel_authoring_guide.md
@@ -18,7 +18,7 @@
 | **Tensor arg** | `fx.Tensor` | GPU tensor argument (via DLPack) |
 | **Stream arg** | `fx.Stream` | CUDA/HIP stream argument |
 | **Barrier** | `fx.gpu.barrier()` | Workgroup synchronization |
-| **Constants** | `fx.Int32` / `fx.Index` / `fx.Float32` | Create typed DSL constants |
+| **Constants** | `fx.Int32` / `fx.Int64` / `fx.Float32` | Create typed DSL constants (`fx.Int64` for index/offset values; `fx.Index` is deprecated) |
 | **Range loop** | `range_constexpr(n)` | Compile-time unrolled loop |
 | **Buffer load** | `buffer_ops.buffer_load(rsrc, off)` | AMD buffer load intrinsic |
 
@@ -194,7 +194,7 @@ raw_bid = gpu.block_id("x")
 import flydsl.expr as fx
 
 # Constants (prefer DSL numeric types)
-c42 = fx.Index(42)          # index type constant
+c42 = fx.Int64(42)          # 64-bit integer constant (prefer over the deprecated fx.Index)
 c3_14 = fx.Float32(3.14)    # f32 constant
 mask = fx.Int32(0xFF)       # i32 constant
 
@@ -205,8 +205,8 @@ result = a // 4
 result = a % 16
 
 # Cast (prefer DSL numeric constructors)
-idx = fx.Index(int_val)     # cast to index type
-i32_val = fx.Int32(idx)     # cast to i32
+i64_val = fx.Int64(int_val) # cast to 64-bit integer (fx.Index is deprecated)
+i32_val = fx.Int32(i64_val) # cast to i32
 
 # Select
 result = cond.select(true_val, false_val)  # when cond is an ArithValue

--- a/docs/kernel_tuning_guide.md
+++ b/docs/kernel_tuning_guide.md
@@ -22,6 +22,112 @@ at optimizations without a trace usually moves the bottleneck instead of removin
 
 ---
 
+## 0. Background: The GPU Performance Model
+
+Before the specific levers, it helps to have a mental model of *where a kernel's
+time goes*. A GPU does not make individual instructions fast — it hides their
+latency with parallelism. Each SIMD holds several wavefronts; when one wave
+stalls waiting on memory, the scheduler issues from another ready wave. So tuning
+is two problems: **keep enough independent work in flight to cover latency**, and
+**don't exceed the machine's throughput ceilings** (compute FLOPs or memory
+bandwidth). Almost every technique later in this guide is one of those two.
+
+### Thread traces and instruction interleaving
+
+An **ATT (Advanced Thread Trace)** records, per instruction on one CU, when it
+issued and how many cycles it *stalled*. Within a single wave, instructions issue
+in program order; a "stall" means the wave could not issue because it was waiting
+on a dependency — almost always an `s_waitcnt` counter or a barrier.
+
+The compiler (guided by the `sched_*` hints in §5) **interleaves independent
+instruction classes** — MFMA, global loads (VMEM), LDS reads/writes — so that a
+long-latency operation overlaps useful work instead of blocking it. Two hardware
+counters gate this:
+
+- **`vmcnt`** — outstanding VMEM (global/`buffer_load`) operations.
+- **`lgkmcnt`** — outstanding LDS and scalar-memory operations.
+
+An instruction that *consumes* a load result waits on the relevant counter
+(`s_waitcnt vmcnt(0)` / `lgkmcnt(0)`). If the consumer is issued too close to the
+load, the load's latency is exposed as stall cycles in the trace. Interleaving and
+scheduling exist to convert those stall cycles into issue cycles. Collect and read
+a trace with `/kernel-trace-analysis` (§9).
+
+### The latencies you are hiding
+
+Order-of-magnitude on CDNA (cycles; exact values vary by arch and contention):
+
+| Operation | Latency | Notes |
+|---|---|---|
+| SALU / VALU | ~1–8 | address math, integer/float ALU |
+| MFMA | ~16–64 | the compute you *want* to be waiting on |
+| LDS `ds_read`/`ds_write` | ~20–40 (gfx942) | async; more with bank conflicts |
+| Global load (HBM) | ~300+ | an order of magnitude above LDS |
+| `s_barrier` | variable | whole workgroup must arrive |
+
+The whole game is arranging enough independent instructions (and enough resident
+waves) between issuing a high-latency op and needing its result.
+
+### Hiding LDS latency
+
+LDS ops are asynchronous, and a `ds_read` that depends on a prior `ds_write` must
+be separated by `s_waitcnt lgkmcnt(0)` or an `s_barrier`. If the wait sits right
+after the write, the ~20–40-cycle latency is fully exposed. Hide it by
+**increasing the write→read distance** — schedule independent MFMAs, address math,
+or the next tile's global loads between the write and the wait — and by
+**A0-prefetching** the first LDS pack right after a barrier so the first
+`ds_read` overlaps the following VMEM loads. See §3 (swizzle) and §4 (prefetch);
+bank conflicts (§3) both raise per-op latency *and* cut effective LDS bandwidth.
+
+### Hiding global-memory latency
+
+Global loads are the longest-latency common op (~300+ cycles), so they dominate if
+exposed. The primary tool is **software prefetch / double-buffering** (§4): issue
+the *next* iteration's `buffer_load`s before consuming the current iteration's
+data, so the fetch overlaps compute. Larger `tile_k` increases reuse per byte
+fetched; higher **occupancy** gives the scheduler more waves to switch to while
+one is waiting. A useful trick in multi-phase kernels: **hoist the next phase's
+loads into a barrier-wait region** — the barrier is dead time anyway, so the load
+arrives for free.
+
+### Bandwidth
+
+Once latency is hidden, you hit a **throughput ceiling**. There are two:
+
+- **Compute** — MFMA FLOP/s. Peak (gfx942 MI300X, single GCD): ~653 TFLOPS FP8,
+  ~326 TFLOPS BF16, ~653 TOPS INT8.
+- **Memory bandwidth** — HBM GB/s, plus the L2 and LDS byte/cycle limits (LDS peak
+  128 B/cyc on gfx942, 256 B/cyc on gfx950).
+
+*Effective* memory bandwidth depends on access quality: **coalesced, vectorized**
+accesses (`buffer_load_dwordx4`, full 64 B cache lines) approach peak, while
+uncoalesced or partial-cache-line access wastes HBM. When a kernel is
+memory-bound, cache/HBM PMC counters (§9) — L2 hit rate, 32 B-partial fraction,
+over-fetch, per-channel balance — tell you *why*, which ISA inspection alone
+usually gets wrong.
+
+### Is the kernel memory-, compute-, or latency-bound?
+
+Compute the arithmetic intensity `AI = FLOPs / bytes_moved` and compare it to the
+roofline crossover (§8). Three regimes, each with a different fix and a different
+trace/PMC signature:
+
+| Regime | What's saturated | Trace / PMC signature | Where to look |
+|---|---|---|---|
+| **Compute-bound** | MFMA units | MFMA utilization high (≥ ~70%), memory pipes idle | §5 scheduling, §7 occupancy, cut non-MFMA overhead |
+| **Bandwidth-bound** | HBM / L2 / LDS BW | memory BW near peak, low L2 hit or high over-fetch; MFMA util moderate | §3 coalescing/swizzle, smaller dtype, bigger `tile_k`, XCD balance (§9) |
+| **Latency-bound** | *nothing* — work is stalled | **both** MFMA util and memory BW low, **high** `s_waitcnt`/`s_barrier` stall | §4 prefetch, §7 occupancy, §5 interleaving |
+
+The distinction that trips people up is **latency-bound vs bandwidth-bound**: a
+latency-bound kernel is slow while *neither* ceiling is saturated — the pipes are
+simply idle waiting on exposed latency (common at small `M` or low occupancy). The
+cure is more overlap and more waves in flight, not more bandwidth. A
+bandwidth-bound kernel, by contrast, is already moving bytes as fast as the memory
+system allows, so the cure is moving *fewer* or *better-shaped* bytes. Rule of
+thumb: **M ≤ 512 → likely memory/latency-bound; M > 512 → likely compute-bound.**
+
+---
+
 ## 1. Tiling Strategy
 
 GEMM tiles the output `C[M, N]` and the reduction `K` into blocks. With a 256-thread
@@ -164,8 +270,8 @@ to create genuine SSA phi nodes:
 next_a = buffer_ops.buffer_load(rsrc_a, offsets_0, vec_width=4)
 init_state = [_unwrap(v) for v in [next_a, acc]]
 
-# Runtime loop — bounds MUST be fx.Index(...), not Python ints (see pitfalls)
-for iv, state in range(fx.Index(0), fx.Index(N - 1), fx.Index(1), init=init_state):
+# Runtime loop — bounds MUST be a typed DSL integer (fx.Int64), not Python ints (see pitfalls)
+for iv, state in range(fx.Int64(0), fx.Int64(N - 1), fx.Int64(1), init=init_state):
     a, acc = state[0], state[1]
     next_a = buffer_ops.buffer_load(rsrc_a, compute_offsets(iv + 1), vec_width=4)  # async
     acc = rocdl.mfma_f32_16x16x16_f16(transform(a), b, acc)   # overlaps next load
@@ -178,8 +284,8 @@ acc = rocdl.mfma_f32_16x16x16_f16(transform(a), b, acc)
 
 Three pitfalls (all covered in `/prefetch-data-load`):
 
-1. **Bounds must be `fx.Index(...)`.** Constant Python-int bounds make the
-   rewriter unroll the loop and silently ignore `init=`.
+1. **Bounds must be a typed DSL integer (`fx.Int64(...)`).** Constant Python-int
+   bounds make the rewriter unroll the loop and silently ignore `init=`.
 2. **Unwrap init values at hard boundaries only.** Most carried values stay
    `fx.Int32`/`fx.Float32`/`Vector`; unwrap to raw `ir.Value` only where a
    low-level helper demands it.
@@ -258,21 +364,65 @@ preshuffle GEMM also exposes fused epilogues via the `epilogue=` argument of
 
 ## 7. Register Budget & Occupancy
 
-On CDNA3/CDNA4 the two VGPR files — **arch_vgpr** (VALU, VMEM, LDS ops, prefetch
-buffers) and **accum_vgpr / AGPR** (MFMA writeback) — share **one combined
-512-entry occupancy budget** per SIMD. Occupancy ≈ `512 / (arch_vgpr +
-accum_vgpr)` waves. Growing prefetch/LDS-address arch_vgpr therefore *does*
-compete with MFMA accumulators.
+**Occupancy** is how many wavefronts are resident per SIMD at once — the pool the
+scheduler draws from to hide latency (§0). It is the **minimum across three
+resource limiters**, capped by a hardware maximum:
 
-| Combined arch + accum | Waves/SIMD | Impact |
-|---|---|---|
-| ≤ 128 | 4 | High occupancy |
-| ≤ 170 | 3 | Good |
-| ≤ 256 | 2 | Moderate |
-| ≤ 512 | 1 | Minimum |
-| > 512 | **SPILL** | Severe regression |
+```
+occupancy (waves/SIMD) = min(vgpr_limit, lds_limit, sgpr_limit, HW_MAX)
+```
 
-Rough VGPR estimate for a FP8 tile:
+Whichever resource you exhaust *first* caps occupancy — so all three must be
+watched, and the arch you target changes each limit.
+
+### The three resources
+
+**1. VGPR.** On **CDNA3 (gfx942)** and **CDNA4 (gfx950)** the two vector-register
+files — **arch_vgpr** (VALU, VMEM, LDS ops, prefetch buffers) and **accum_vgpr /
+AGPR** (MFMA writeback) — share **one combined 512-entry budget** per SIMD, so
+`vgpr_limit = 512 // (arch_vgpr + accum_vgpr)`. Growing prefetch/LDS-address
+arch_vgpr therefore competes with MFMA accumulators for the same budget. (This is
+*not* the old separate-pool `256 / max(arch, accum)` model — that was CDNA1
+gfx908.)
+
+| Combined arch + accum (wave64) | vgpr_limit (waves/SIMD) |
+|---|---|
+| ≤ 64 | 8 (hardware max) |
+| ≤ 128 | 4 |
+| ≤ 170 | 3 |
+| ≤ 256 | 2 |
+| ≤ 512 | 1 |
+| > 512 | **SPILL** — severe regression |
+
+**2. LDS.** LDS is a per-CU pool shared by all resident workgroups, so
+`resident_workgroups = LDS_per_CU // LDS_per_workgroup`; more LDS per block →
+fewer concurrent blocks → fewer waves. The pool size is arch-specific:
+**64 KB (gfx942)**, **160 KB (gfx950)**, **320 KB (gfx1250)**. A 160 KB / 320 KB
+budget lets a kernel keep bigger tiles (or more buffers) resident before LDS,
+rather than VGPR, becomes the limiter.
+
+**3. SGPR.** Scalar registers (kernel args, buffer descriptors, loop/scalar
+state) also gate occupancy: on CDNA, ~**800 SGPRs per SIMD**, allocated in
+granules of 16, so `sgpr_limit = 800 // sgpr_per_wave`. SGPR is rarely the binding
+limit but can bite kernels with many buffer resources or scalar-heavy prologues.
+
+### Architecture differences at a glance
+
+| Arch | Wave | VGPR model | LDS/CU | Notes |
+|---|---|---|---|---|
+| gfx942 (CDNA3) | 64 | combined 512 (arch 256 + accum 256) / SIMD | 64 KB | MFMA; combined-pool occupancy |
+| gfx950 (CDNA4) | 64 | combined 512 (arch 256 + accum 256) / SIMD | 160 KB | + MFMA-scale / transpose loads; 2.5× LDS headroom |
+| gfx1250 | **32** | wave32 register file (per-wave counts differ) | 320 KB | wave32 accounting — a 32-lane wave; query per-kernel counts, don't assume the CDNA 512 rule |
+
+Because gfx1250 runs **wave32**, its per-wave VGPR/SGPR accounting differs from the
+wave64 CDNA parts — don't reuse the `512 // (arch+accum)` rule there. The
+occupancy *formula* (min over VGPR/LDS/SGPR, capped at the HW max) still holds;
+only the per-resource limits change. When in doubt, read the actual allocation
+back from the profiler rather than estimating.
+
+### Estimating and measuring
+
+Rough VGPR estimate for a wave64 FP8 tile:
 
 ```
 accumulators = m_repeat × num_acc_n × 4     # → accum_vgpr
@@ -280,15 +430,20 @@ B tile       = k_unroll × 2 × num_acc_n × 2 # → arch_vgpr
 A prefetch   ≈ 4 ; A tile regs = num_a_loads × 4 ; addressing ≈ 10–20
 ```
 
-Query the actual allocation from the rocprofv3 database:
+Query the real allocation (all three resources) from the rocprofv3 database:
 
 ```sql
-SELECT ks.KernelName, ki.arch_vgpr_count, ki.accum_vgpr_count
+SELECT ks.KernelName, ki.arch_vgpr_count, ki.accum_vgpr_count,
+       ki.sgpr_count, ki.lds_size
 FROM rocpd_kernel_dispatch kd
 JOIN rocpd_info_kernel_symbol ks ON kd.kernel_symbol_id = ks.id
 JOIN rocpd_info_kernel ki ON kd.kernel_id = ki.id
 WHERE ks.KernelName LIKE '%target_kernel%' LIMIT 5;
 ```
+
+`/kernel-trace-analysis` (§9) reports the computed occupancy and which resource is
+the binding limiter, so you know whether to cut VGPR, shrink LDS per block, or
+reduce SGPR pressure.
 
 **Do not** use `maxnreg` to force `accum_vgpr=0` — it spills MFMA results through
 arch_vgpr via `v_accvgpr_read` (measured ~4.5× regression).

--- a/docs/prebuilt_kernels_guide.md
+++ b/docs/prebuilt_kernels_guide.md
@@ -65,8 +65,17 @@ Computes `RMSNorm(x) = x / sqrt(mean(x^2) + eps) * gamma`.
 ```python
 from kernels.norm.rmsnorm_kernel import build_rmsnorm_module
 
-executor = build_rmsnorm_module(N=8192, dtype_str="bf16")
+executor = build_rmsnorm_module(N=8192, dtype_str="bf16", store_rstd=False)
 ```
+
+`build_rmsnorm_module(N, dtype_str, store_rstd=False, eps=EPS)` optionally
+writes the per-row reciprocal std (`rstd`) for use by the backward pass.
+
+**Backward:** `build_rmsnorm_bwd_module(N, dtype_str)` builds the fused RMSNorm
+backward kernel (grid `(M,)`, one block per row). Kernel signature
+`rmsnorm_bwd_kernel(Input, Gamma, DY, Rstd, DX, DWeight)`: it reads the forward
+`Rstd`, writes `DX` (input grad) and atomic-adds into `DWeight` (fp32 weight
+grad). `eps` is baked into `Rstd` by the forward, so it is not needed here.
 
 **Configuration Constants:** Same as LayerNorm (BLOCK_THREADS=256, VEC_WIDTH=8, etc.)
 
@@ -163,7 +172,16 @@ Returns a `@flyc.jit`-decorated function that auto-compiles on first call.
 
 **Key constraints:**
 - `tile_k` must be a positive divisor of `K`
-- FP4/MXFP4 GEMM is a separate kernel (`kernels/gemm/mxfp4_preshuffle.py`, `kernels/gemm/fp4_gemm_4wave.py`); INT4 is not supported by this kernel.
+- MX (block-scaled) GEMM is a separate kernel (`kernels/gemm/mxfp4_preshuffle.py`, `kernels/gemm/fp4_gemm_4wave.py`); INT4 is not supported by this kernel.
+
+**MX A x MXFP4 B GEMM (`kernels/gemm/mxfp4_preshuffle.py`, gfx950):** the
+`launch_gemm` `@flyc.jit` launcher runs `A x preshuffled MXFP4 B` with per-32
+E8M0 scales, selecting the A element type via `a_dtype` (`"fp4"`, `"fp6"`, or
+`"fp8"`; B is always MXFP4). This unified `launch_gemm` is the current gfx950
+entry point (it replaced the earlier standalone `compile_mxfp6_gemm` from #780);
+the separate `compile_mxfp4_gemm` in `kernels/gemm/gemm_fp8fp4_gfx1250.py` is the
+distinct gfx1250 kernel. `batch>1` runs a strided-batched GEMM over `grid.z`.
+Covered by `tests/kernels/test_preshuffle_gemm.py`.
 
 **Pipeline details:**
 - **lds_stage=2 (ping-pong)**: Two LDS buffers for A tiles. Cross-tile A0 prefetch overlaps VMEM with LDS reads


### PR DESCRIPTION
## Summary

Follow-up to #827 (merged). Adds the kernel-tuning background/occupancy material requested, documents recently added APIs, and modernizes the kernel skills. Docs-only + skills; no code changes.

## Kernel tuning guide
- **Performance-model primer (§0)**: the latency-hiding execution model — thread traces (ATT) & instruction interleaving, the `vmcnt`/`lgkmcnt` counters, an order-of-magnitude latency table, hiding **LDS** vs **global-memory** latency, **bandwidth** ceilings (compute vs memory) and coalescing, and a **memory- / compute- / latency-bound** analysis table with each regime's trace/PMC signature.
- **Occupancy (§7)** expanded to `occupancy = min(vgpr_limit, lds_limit, sgpr_limit, HW_MAX)` with all three resource limiters, plus per-arch differences: **gfx942/gfx950** wave64 combined-512 VGPR (64 KB vs 160 KB LDS) and **gfx1250** wave32 (320 KB LDS, distinct per-wave accounting). Updated the profiler query to pull SGPR/LDS too.

## Recently added APIs (docs)
- `dsl.rst`: `fx.gather`/`fx.scatter` (#805), `fx.Basis`/`fx.E` (#735), `fx.SyncScope` (#742), `fx.fastmath` + `FastMathFlags` (#789), `arith.maxnumf` + chained comparisons (#799/#778), current `buffer_load` signature.
- `prebuilt_kernels_guide.md`: rmsnorm backward + `store_rstd` (#795); unified gfx950 `launch_gemm` (`a_dtype` fp4/fp6/fp8, replaced standalone `compile_mxfp6_gemm` #780).
- `extern_integration_guide.md`: fixed `lib/Runtime/` → `lib/Runtime/ROCm/` path.

## fx.Index → fx.Int64
Per project direction, `fx.Index` is deprecated in favor of `fx.Int64` (incl. `scf.for`/`range` loop bounds — verified `fx.Int64` bounds still lower to `scf.for`). Applied across docs and skills; `fx.Index` kept only in deprecation notes.

## Skills modernization
- Replace fabricated `SmemAllocator.allocate_array` LDS examples with the real `fx.SharedAllocator` + `@fx.struct` + `.view()` pattern (`gemm-optimization`, `lds-optimization`); legacy `SmemAllocator` noted.
- Reduce casual raw-MLIR usage in favor of typed DSL where an equivalent exists; keep the intentional raw→typed teaching tables and low-level `scf.IfOp`/`ShuffleOp` guidance.
- Fix `kernels/` subpackage paths.

## Verification
Docs/skills only. Every API symbol verified importable from source; final grep sweep shows no stale `fx.Index` usage (only deprecation notes), no `allocate_array`, no `kernels/reduce`.

### Note
The codebase does not yet mark `fx.Index` deprecated (its docstring still says it "Replaces arith.index" and kernels use it). The docs/skills now steer to `fx.Int64` ahead of the code; a follow-up code change (deprecation warning + kernel migration) would make them match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
