### PR TITLE
[FlyROCDL] gfx1250 review follow-ups: signed-int WMMA, comment fixes, atom docs

### DIFF
--- a/.claude/skills/add-target-atom-op/SKILL.md
+++ b/.claude/skills/add-target-atom-op/SKILL.md
@@ -15,7 +15,8 @@ description: >
   per-atom offset or descriptor), or bringing up a new backend dialect
   (`FlyPTX`, `FlyCPU`, etc.). The current reference implementation is
   `FlyROCDL` with `CDNA3` MFMA, `CDNA3` BufferCopy, `CDNA4`
-  LDS-read-transpose, treat these as templates, not
+  LDS-read-transpose, `GFX1250` WMMA / MX-scaled WMMA (stateful scale) /
+  N-D TDM copy (stateful descriptor); treat these as templates, not
   prerequisites. Usage: /add-target-atom-op
 allowed-tools: Read Edit Bash Grep Glob Agent
 ---

--- a/.claude/skills/flydsl-kernel-authoring/SKILL.md
+++ b/.claude/skills/flydsl-kernel-authoring/SKILL.md
@@ -589,7 +589,25 @@ buffer_ops.buffer_store(data, rsrc, offset)
 | `fx.UniversalCopy32b()` | 32 | 1x f32 element copy |
 | `fx.UniversalCopy(64)` | 64 | 2x f32 elements |
 | `fx.UniversalCopy(128)` | 128 | 4x f32 elements |
-| `fx.rocdl.BufferCopy128b()` | 128 | AMD buffer load 4xf32 |
+| `fx.rocdl.BufferCopy128b()` | 128 | AMD buffer load 4xf32 (CDNA) |
+| `fx.rocdl.make_tdm_atom(...)` | whole tile | gfx1250 TDM async Global↔LDS DMA (1–5D) — see below |
+
+**gfx1250 TDM async copy** (`fx.rocdl.make_tdm_atom`): a whole-tile DMA whose
+descriptor (base pointer, per-dim extent for HW OOB handling, per-dim stride) is
+carried as **atom state**. The global operand of `copy_atom_call` is a
+shape/direction token only — its layout gives the compile-time N-D tile shape and
+its address space picks load vs store; its *pointer is unused* (base comes from
+state). Needs a **raw VA** (not `make_buffer_tensor`).
+
+```python
+lds = fx.SharedAllocator().allocate(fx.Array[fx.Float16, M * N]).peek()
+lds2d = fx.make_view(lds.ptr, fx.make_layout((M, N), (N, 1)))       # note: lds.ptr
+g2d = fx.make_view(fx.get_iter(A), fx.make_layout((M, N), (N, 1)))
+atom = fx.rocdl.make_tdm_atom(g2d, [M, N], num_warps=4)            # rank = len(extents), 1–5D
+fx.copy_atom_call(atom, g2d, lds2d)                               # Global → LDS
+fx.rocdl.tdm_ops.tensor_wait(0)                                  # await async DMA
+atom = fx.rocdl.advance_tdm_atom(atom, k_tile * k_stride_bytes)  # K-loop tile bump (imm_offset)
+```
 
 ---
 
@@ -649,6 +667,36 @@ result = rocdl.mfma_f32_16x16x32_fp8(a, b, acc)
 
 # INT8 MFMA
 result = rocdl.mfma_i32_16x16x32i8(a, b, acc)
+```
+
+### gfx1250 WMMA (wave32)
+
+gfx1250 uses **WMMA** (not MFMA), M=N=16. Build the atom with `rocdl.WMMA` (arch
+dispatched: gfx11 v16 ABI, gfx12 / gfx1250 v8 ABI) and issue it via
+`fx.make_mma_atom` + `fx.gemm` / `fx.mma_atom_call`:
+
+| dtype (A,B → Acc) | K | notes |
+|---|---|---|
+| f32 → f32 | 4 | |
+| f16 / bf16 → f32 or same | 32 | |
+| fp8 / bf8 (OCP E4M3FN / E5M2, any mix) → f32 or f16 | 64, 128 | |
+| i8 → i32 | 64 | `sign_a` / `sign_b` / `clamp` kwargs |
+| i4 → i32 | 32 | `sign_a` / `sign_b` / `clamp` kwargs |
+
+```python
+mma = fx.make_mma_atom(rocdl.WMMA(16, 16, 128, fx.Float8E4M3FN))       # fp8 → f32
+mma = fx.make_mma_atom(rocdl.WMMA(16, 16, 32, T.i4, T.i32, sign_a=True, sign_b=True, clamp=True))
+```
+
+**MX-scaled WMMA** — `rocdl.WMMAScale(m, n, k, elem_ty_a, ..., block_size=32)` for
+the E8M0 block-scaled f8/f6/f4 format (`16x16x128`, or `32x16x128` fp4-only).
+Per-operand scales are atom state; `block_size` 32 → i32 scale (i64 for 16):
+
+```python
+mma = fx.make_mma_atom(rocdl.WMMAScale(16, 16, 128, fx.Float8E4M3FN))
+mma = fx.atom_set_value(mma, "scale_a", fx.Int32(scale_a))
+mma = fx.atom_set_value(mma, "scale_b", fx.Int32(scale_b))
+fx.gemm(mma, frag_C, frag_A, frag_B, frag_C)
 ```
 
 ### GEMM Pattern (Preshuffle)

--- a/.claude/skills/flydsl-tile-programming/SKILL.md
+++ b/.claude/skills/flydsl-tile-programming/SKILL.md
@@ -443,8 +443,10 @@ layout checks), use the **debug-flydsl-kernel** skill.
 
                   Atom (Hardware Instruction)
                   ==========================
-   CopyAtom  = one hardware copy instruction (32b/64b/128b)
-   MmaAtom   = one MFMA instruction (16x16x4, 16x16x16, etc.)
+   CopyAtom  = one hardware copy instruction (32b/64b/128b buffer copy;
+               or a gfx1250 TDM whole-tile async Global<->LDS DMA)
+   MmaAtom   = one matrix instruction (CDNA MFMA 16x16x4/16x16x16/...;
+               gfx1250 WMMA / MX-scaled WMMA, wave32)
 
                   Tiled Operation (Thread Cooperation)
                   ====================================
@@ -474,9 +476,11 @@ Key insight: **Layout is the glue**. Every operation (divide, partition, copy, g
 ## MFMA Instruction Reference (AMD CDNA3/4)
 
 For the table of available MFMA instruction shapes (`MFMA(16,16,4,Float32)`,
-`MFMA(16,16,16,Float32)`, FP8/BF16/CDNA4-scaled variants) and how `make_tiled_mma`'s
-`(M_rep, N_rep, K_rep)` atom_layout works, see the **flydsl-kernel-authoring** skill (§6 MFMA
-Integration). Use it when choosing the MMA atom for the Pattern C (GEMM) skeleton above.
+`MFMA(16,16,16,Float32)`, FP8/BF16/CDNA4-scaled variants), the **gfx1250 WMMA /
+MX-scaled WMMA** atoms (wave32, `rocdl.WMMA` / `rocdl.WMMAScale`), and how
+`make_tiled_mma`'s `(M_rep, N_rep, K_rep)` atom_layout works, see the
+**flydsl-kernel-authoring** skill (§6 MFMA Integration + gfx1250 WMMA). Use it when
+choosing the MMA atom for the Pattern C (GEMM) skeleton above.
 
 ---
 

--- a/docs/api/compiler.rst
+++ b/docs/api/compiler.rst
@@ -109,9 +109,11 @@ ROCDL Operations
 
 The ``flydsl.expr.rocdl`` module provides AMD-specific operations:
 
-- **fx.rocdl.make_buffer_tensor** -- create buffer resource descriptor from tensor
+- **fx.rocdl.make_buffer_tensor** -- create buffer resource descriptor from tensor (CDNA buffer copy)
 - **fx.rocdl.BufferCopy32b** / **BufferCopy128b** -- buffer copy atoms
-- **fx.rocdl.MFMA** -- MFMA instruction atoms (e.g., ``MFMA(16, 16, 4, fx.Float32)``)
+- **fx.rocdl.MFMA** -- MFMA instruction atoms (CDNA3/CDNA4; e.g., ``MFMA(16, 16, 4, fx.Float32)``)
+- **fx.rocdl.WMMA** / **fx.rocdl.WMMAScale** -- gfx1250 (wave32) WMMA and E8M0 MX-scaled WMMA MMA atoms
+- **fx.rocdl.make_tdm_atom** / **fx.rocdl.TDM** / **fx.rocdl.advance_tdm_atom** -- gfx1250 TDM async Global↔LDS whole-tile copy atom (1–5D; descriptor as atom state)
 
 fly-opt CLI
 ------------

--- a/docs/api/dsl.rst
+++ b/docs/api/dsl.rst
@@ -208,9 +208,12 @@ ROCDL Operations (``flydsl.expr.rocdl``)
 
 AMD-specific operations for ROCm:
 
-- **fx.rocdl.make_buffer_tensor(tensor)** -- create buffer resource from tensor
+- **fx.rocdl.make_buffer_tensor(tensor)** -- create buffer resource from tensor (CDNA buffer copy)
 - **fx.rocdl.BufferCopy32b** / **BufferCopy128b** -- buffer copy instruction atoms
-- **fx.rocdl.MFMA(m, n, k, elem_ty_ab, elem_ty_acc=None)** -- MFMA instruction atom constructor (4th arg is the A/B element type; accumulator defaults to f32)
+- **fx.rocdl.MFMA(m, n, k, elem_ty_ab, elem_ty_acc=None)** -- MFMA instruction atom constructor (CDNA3/CDNA4; 4th arg is the A/B element type; accumulator defaults to f32)
+- **fx.rocdl.WMMA(m, n, k, elem_ty_ab, elem_ty_acc=None, \*\*kwargs)** -- WMMA MMA atom constructor (arch-dispatched: gfx11 / gfx12 / gfx1250). gfx1250 supports f32(K4), f16/bf16(K32), fp8/bf8(K64/128), i8(K64), i4(K32); integer paths take ``sign_a`` / ``sign_b`` / ``clamp``
+- **fx.rocdl.WMMAScale(m, n, k, elem_ty_a, elem_ty_b=None, elem_ty_acc=None, \*, opsel_a=0, opsel_b=0, mod_c=0, reuse_a=False, reuse_b=False, block_size=32)** -- gfx1250 MX-scaled WMMA (E8M0 block scale, f8/f6/f4; ``16x16x128`` or ``32x16x128`` fp4-only). Per-operand scales are atom state (``scale_a`` / ``scale_b``)
+- **fx.rocdl.make_tdm_atom(tensor, tensor_extents, strides=None, \*, num_warps, ...)** -- build a gfx1250 TDM (Tensor Data Mover) async Global↔LDS whole-tile copy atom (rank 1-5); the tile descriptor is carried as atom state. ``fx.rocdl.TDM(rank, num_warps, ...)`` builds the atom type only; ``fx.rocdl.advance_tdm_atom(atom, byte_offset)`` bumps the K-loop tile offset
 - **fx.rocdl.sched_mfma(cnt)** -- insert MFMA scheduling barrier
 - **fx.rocdl.sched_vmem(cnt)** -- insert VMEM scheduling barrier
 - **fx.rocdl.sched_dsrd(cnt)** -- insert DS read scheduling barrier

--- a/docs/architecture_guide.md
+++ b/docs/architecture_guide.md
@@ -224,7 +224,7 @@ external LLVM toolchain only for Stage C (`gpu-module-to-binary`).
 | 5 | `canonicalize` | Standard MLIR canonicalization (constant folding, etc.). |
 | 6 | `fly-convert-atom-call-to-ssa-form` | Converts `copy_atom_call` / `mma_atom_call` to their SSA counterparts; promotes register tensors to vector SSA values. |
 | 7 | `fly-promote-regmem-to-vectorssa` | Promotes `fly.make_ptr(register)` memory semantics to vector SSA values (requires #6). |
-| 8 | `convert-fly-to-rocdl` | Lowers remaining Fly ops to MLIR upstream + ROCDL dialects (copy atoms → `rocdl.buffer_load/store`, MMA atoms → `rocdl.mfma.*`). |
+| 8 | `convert-fly-to-rocdl` | Lowers remaining Fly ops to MLIR upstream + ROCDL dialects (copy atoms → `rocdl.buffer_load/store`, or gfx1250 TDM → `rocdl.tensor.load.to.lds` / `store.from.lds`; MMA atoms → `rocdl.mfma.*` on CDNA, `rocdl.wmma.*` on gfx11/gfx1250). |
 | 9 | `canonicalize` | Second canonicalization round after ROCDL lowering. |
 | 10 | `gpu.module(convert-scf-to-cf, cse, convert-gpu-to-rocdl{chipset=gfxNNN ...}, fly-rocdl-cluster-attr)` | Inside the GPU module: SCF→CF, CSE, GPU intrinsics→ROCDL, then `fly-rocdl-cluster-attr` injects `amdgpu-cluster-dims` into the `llvm.func` `passthrough`. |
 

--- a/docs/kernel_authoring_guide.md
+++ b/docs/kernel_authoring_guide.md
@@ -263,7 +263,7 @@ from flydsl.expr import rocdl
 # Buffer tensor — wraps a Tensor with AMD buffer resource descriptor
 A_buf = rocdl.make_buffer_tensor(A)
 
-# MFMA MMA atom constructor — returns MmaAtomCDNA3_MFMAType
+# MFMA MMA atom constructor (CDNA3/CDNA4) — returns MmaAtomCDNA3_MFMAType
 atom_type = rocdl.MFMA(m=16, n=16, k=32, elem_ty_ab=fx.Float8E4M3FNUZ)
 
 # Buffer copy atom types
@@ -271,6 +271,9 @@ copy_op = rocdl.BufferCopy128b()   # 128-bit buffer copy
 copy_op = rocdl.BufferCopy64b()    # 64-bit buffer copy
 copy_op = rocdl.BufferCopy32b()    # 32-bit buffer copy
 ```
+
+See [gfx1250 WMMA & TDM atoms](#gfx1250-wmma--tdm-atoms-wave32) below for the
+gfx1250 WMMA (incl. MX-scaled) MMA atoms and the TDM async copy atom.
 
 #### MFMA Instructions
 
@@ -321,6 +324,71 @@ val = rocdl.ds_bpermute(idx, src)
 data = rocdl.raw_ptr_buffer_load(rsrc, offset, soffset, aux)
 rocdl.raw_ptr_buffer_store(data, rsrc, offset, soffset, aux)
 ```
+
+#### gfx1250 WMMA & TDM atoms (wave32)
+
+gfx1250 kernels run **wave32** and use WMMA (not MFMA) for matrix math and the
+TDM (Tensor Data Mover) engine for async whole-tile Global↔LDS copies. All of the
+factories below live in `flydsl.expr.rocdl` (`from flydsl.expr import rocdl`).
+
+**WMMA MMA atom** — `rocdl.WMMA(m, n, k, elem_ty_ab, elem_ty_acc=None, **kwargs)`
+is arch-dispatched (gfx11 v16 ABI; gfx12 / gfx1250 v8 ABI). On gfx1250 it builds
+`MmaOpGFX1250_WMMAType` (M=N=16). Supported K / dtypes:
+
+| dtype (A,B → Acc) | K | notes |
+|---|---|---|
+| f32 → f32 | 4 | |
+| f16/bf16 → f32 or same | 32 | |
+| fp8/bf8 (E4M3FN / E5M2, any mix) → f32 or f16 | 64, 128 | native OCP fp8 |
+| i8 → i32 | 64 | `sign_a` / `sign_b` / `clamp` kwargs |
+| i4 → i32 | 32 | `sign_a` / `sign_b` / `clamp` kwargs |
+
+```python
+mma = fx.make_mma_atom(rocdl.WMMA(16, 16, 32, fx.Float16))          # f16 → f32
+mma = fx.make_mma_atom(rocdl.WMMA(16, 16, 128, fx.Float8E4M3FN))    # fp8 → f32
+# signed int4 with accumulator clamp:
+mma = fx.make_mma_atom(rocdl.WMMA(16, 16, 32, T.i4, T.i32, sign_a=True, sign_b=True, clamp=True))
+```
+
+**MX-scaled WMMA** — `rocdl.WMMAScale(m, n, k, elem_ty_a, elem_ty_b=None,
+elem_ty_acc=None, *, opsel_a=0, opsel_b=0, mod_c=0, reuse_a=False, reuse_b=False,
+block_size=32)` builds the E8M0 block-scaled WMMA (`V_WMMA_SCALE` /
+`V_WMMA_SCALE16`) for the unified f8/f6/f4 operand format. Shapes: `16x16x128`
+(f8/f6/f4) and `32x16x128` (fp4-only). Per-operand E8M0 scales are **atom state**
+(`scale_a` / `scale_b`); `block_size` 32 → i32 scale state, 16 → i64.
+
+```python
+mma = fx.make_mma_atom(rocdl.WMMAScale(16, 16, 128, fx.Float8E4M3FN))
+mma = fx.atom_set_value(mma, "scale_a", fx.Int32(scale_a))   # E8M0 scales
+mma = fx.atom_set_value(mma, "scale_b", fx.Int32(scale_b))
+fx.gemm(mma, frag_C, frag_A, frag_B, frag_C)
+```
+
+**TDM async copy atom** — the descriptor (base pointer, per-dim extent for HW
+out-of-bounds handling, per-dim stride) is carried as **atom state**; the global
+operand of `copy_atom_call` is a *shape/direction token only* (its layout gives
+the compile-time N-D tile shape, its address space picks load vs store — its
+pointer is unused). Build it with `rocdl.make_tdm_atom`:
+
+```python
+# make_tdm_atom(tensor, tensor_extents, strides=None, *, num_warps,
+#               pad_interval=0, pad_amount=0, cache_modifier=0,
+#               atomic_barrier=False, early_timeout=False)
+lds = fx.SharedAllocator().allocate(fx.Array[fx.Float16, M * N]).peek()
+lds2d = fx.make_view(lds.ptr, fx.make_layout((M, N), (N, 1)))       # note: lds.ptr
+g2d = fx.make_view(fx.get_iter(A), fx.make_layout((M, N), (N, 1)))  # raw VA, not make_buffer_tensor
+
+atom = rocdl.make_tdm_atom(g2d, [M, N], num_warps=4)   # rank = len(extents), 1–5D
+fx.copy_atom_call(atom, g2d, lds2d)                    # Global → LDS (direction from address spaces)
+rocdl.tdm_ops.tensor_wait(0)                           # await the async DMA (s_wait_tensorcnt)
+
+# K-loop: bump one scalar instead of re-deriving base (imm_offset, carry-safe i64)
+atom = rocdl.advance_tdm_atom(atom, k_tile * k_stride_bytes)
+```
+
+`rocdl.TDM(rank, num_warps, ...)` builds just the atom *type* when you want to set
+the descriptor state manually. Unlike the CDNA buffer copy, TDM needs a **raw VA**
+— do not wrap the global tensor in `make_buffer_tensor`.
 
 ### 4.5 GPU Operations (`fx.gpu`)
 

--- a/docs/layout_system_guide.md
+++ b/docs/layout_system_guide.md
@@ -331,6 +331,7 @@ ptr = fx.add_offset(ptr, offset)
 | `fx.rocdl.BufferCopy128b()` | AMD buffer-descriptor 128-bit copy |
 | `fx.rocdl.BufferCopy64b()` | AMD buffer-descriptor 64-bit copy |
 | `fx.rocdl.BufferCopy32b()` | AMD buffer-descriptor 32-bit copy |
+| `fx.rocdl.make_tdm_atom(tensor, extents, ...)` | gfx1250 TDM async Global↔LDS whole-tile copy (1–5D); descriptor carried as atom state |
 
 #### Construction
 
@@ -338,8 +339,12 @@ ptr = fx.add_offset(ptr, offset)
 # Create copy atom (copy_op_type, elem_type)
 copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Float32)
 
-# Create MMA atom
+# Create MMA atom (CDNA MFMA)
 mma_atom = fx.make_mma_atom(fx.rocdl.MFMA(16, 16, 4, fx.Float32))
+
+# gfx1250 (wave32): WMMA and MX-scaled WMMA MMA atoms
+mma_atom = fx.make_mma_atom(fx.rocdl.WMMA(16, 16, 128, fx.Float8E4M3FN))
+mma_atom = fx.make_mma_atom(fx.rocdl.WMMAScale(16, 16, 128, fx.Float8E4M3FN))  # E8M0 block scale
 
 # Build thread-value layout from thread and value layouts
 tiler_mn, layout_tv = fx.make_layout_tv(thr_layout, val_layout)

--- a/include/flydsl/Dialect/FlyROCDL/IR/MmaAtom.td
+++ b/include/flydsl/Dialect/FlyROCDL/IR/MmaAtom.td
@@ -78,13 +78,24 @@ def FlyROCDL_MmaOpGFX1250_WMMA : FlyROCDL_MmaOp<"MmaOpGFX1250_WMMA", "gfx1250.wm
     "int32_t":$k,
     "Type":$elemTyA,
     "Type":$elemTyB,
-    "Type":$elemTyAcc
+    "Type":$elemTyAcc,
+    // Integer-WMMA (iu4 / iu8) controls forwarded to the ROCDL intrinsic:
+    // signA/signB select signed operands; clamp saturates the i32 accumulator.
+    // Ignored on the float paths (verify() requires them false there). Default
+    // false = unsigned, no clamp.
+    "bool":$signA,
+    "bool":$signB,
+    "bool":$clamp
   );
-  let assemblyFormat = "`<` custom<MNKDimensionList>($m, $n, $k) `,` `(` $elemTyA `,` $elemTyB `)` `->` $elemTyAcc `>`";
+  let assemblyFormat = "`<` custom<MNKDimensionList>($m, $n, $k) `,` `(` $elemTyA `,` $elemTyB `)` `->` $elemTyAcc `,` `signA` `=` $signA `,` `signB` `=` $signB `,` `clamp` `=` $clamp `>`";
 
   let builders = [
+    // Back-compat: default sign/clamp to false (unsigned, no clamp).
     TypeBuilderWithInferredContext<(ins "int32_t":$m, "int32_t":$n, "int32_t":$k, "Type":$elemTyA, "Type":$elemTyB, "Type":$elemTyAcc), [{
-      return $_get(elemTyA.getContext(), m, n, k, elemTyA, elemTyB, elemTyAcc);
+      return $_get(elemTyA.getContext(), m, n, k, elemTyA, elemTyB, elemTyAcc, /*signA=*/false, /*signB=*/false, /*clamp=*/false);
+    }]>,
+    TypeBuilderWithInferredContext<(ins "int32_t":$m, "int32_t":$n, "int32_t":$k, "Type":$elemTyA, "Type":$elemTyB, "Type":$elemTyAcc, "bool":$signA, "bool":$signB, "bool":$clamp), [{
+      return $_get(elemTyA.getContext(), m, n, k, elemTyA, elemTyB, elemTyAcc, signA, signB, clamp);
     }]>
   ];
   let genVerifyDecl = 1;

--- a/lib/Bindings/Python/FlyROCDLExtension.cpp
+++ b/lib/Bindings/Python/FlyROCDLExtension.cpp
@@ -66,15 +66,17 @@ struct PyMmaOpGFX1250_WMMAType : PyConcreteType<PyMmaOpGFX1250_WMMAType> {
     c.def_static(
         "get",
         [](int32_t m, int32_t n, int32_t k, PyType &elemTyA, PyType &elemTyB, PyType &elemTyAcc,
-           DefaultingPyMlirContext context) {
+           bool signA, bool signB, bool clamp, DefaultingPyMlirContext context) {
           return PyMmaOpGFX1250_WMMAType(
               context->getRef(),
               wrap(MmaOpGFX1250_WMMAType::get(m, n, k, unwrap(elemTyA), unwrap(elemTyB),
-                                              unwrap(elemTyAcc))));
+                                              unwrap(elemTyAcc), signA, signB, clamp)));
         },
-        "m"_a, "n"_a, "k"_a, "elem_ty_a"_a, "elem_ty_b"_a, "elem_ty_acc"_a, nb::kw_only(),
-        "context"_a = nb::none(),
-        "Create a MmaOpGFX1250_WMMAType with m, n, k dimensions and element types");
+        "m"_a, "n"_a, "k"_a, "elem_ty_a"_a, "elem_ty_b"_a, "elem_ty_acc"_a, "sign_a"_a = false,
+        "sign_b"_a = false, "clamp"_a = false, nb::kw_only(), "context"_a = nb::none(),
+        "Create a MmaOpGFX1250_WMMAType with m, n, k dimensions and element types. "
+        "sign_a / sign_b / clamp are integer-only (iu4 / iu8) controls (signed operands / "
+        "accumulator saturation); they must be false on the float paths.");
   }
 };
 

--- a/lib/Dialect/FlyROCDL/GFX1250/CopyAtom.cpp
+++ b/lib/Dialect/FlyROCDL/GFX1250/CopyAtom.cpp
@@ -20,11 +20,12 @@ using namespace mlir::fly;
 namespace mlir::fly_rocdl {
 
 //===----------------------------------------------------------------------===//
-// CopyOpGFX1250TDMType — 2D TDM async Global<->LDS copy
+// CopyOpGFX1250TDMType — N-D TDM async Global<->LDS whole-tile copy (rank 1-5).
 //
-// 2D (non-gather) port of tdm_ops.py::make_tensor_descriptor_2d. The Global-side
-// memref layout supplies the tile geometry; the atom parameters supply padding,
-// warp count, and cache policy. Direction is inferred from the address spaces.
+// The Global-side memref layout supplies the compile-time tile geometry; the
+// atom parameters supply padding, warp count, and cache policy; the tile
+// descriptor (base / per-dim extent / per-dim stride) is runtime atom state.
+// Direction (load vs store) is inferred from the operand address spaces.
 //===----------------------------------------------------------------------===//
 
 namespace {

--- a/lib/Dialect/FlyROCDL/GFX1250/MmaAtom.cpp
+++ b/lib/Dialect/FlyROCDL/GFX1250/MmaAtom.cpp
@@ -116,9 +116,15 @@ Attribute MmaOpGFX1250_WMMAType::getThrValLayoutC() const {
 
 LogicalResult MmaOpGFX1250_WMMAType::verify(function_ref<InFlightDiagnostic()> emitError, int32_t m,
                                             int32_t n, int32_t k, Type elemTyA, Type elemTyB,
-                                            Type elemTyAcc) {
+                                            Type elemTyAcc, bool signA, bool signB, bool clamp) {
   if (m != 16 || n != 16)
     return emitError() << "GFX1250 WMMA requires M=N=16, got " << m << "x" << n;
+
+  // signA/signB/clamp are integer-only controls (iu4 / iu8). Reject them on the
+  // float paths, where the ROCDL intrinsic has no such operands.
+  if ((signA || signB || clamp) && !(elemTyA.isInteger(4) || elemTyA.isInteger(8)))
+    return emitError() << "signA/signB/clamp are only valid for integer (iu4/iu8) WMMA, got A="
+                       << elemTyA;
 
   // gfx1250 has native OCP fp8 (E4M3FN / E5M2), not the CDNA FNUZ variants.
   auto isF8 = [](Type ty) { return isa<Float8E4M3FNType>(ty) || isa<Float8E5M2Type>(ty); };
@@ -228,29 +234,30 @@ enum class WmmaVariant { ModsAllReuse, ModsC, ModsABClamp, ModsIUClamp };
 
 template <typename WmmaOp, WmmaVariant Variant>
 static FailureOr<Value> emitWmmaSSA(OpBuilder &builder, Location loc, VectorType accTy, Value a,
-                                    Value b, Value c) {
+                                    Value b, Value c, bool signA = false, bool signB = false,
+                                    bool clamp = false) {
   Value res;
   if constexpr (Variant == WmmaVariant::ModsAllReuse) {
+    // Float path: no sign/clamp operands.
     res = WmmaOp::create(builder, loc, accTy,
                          /*signA=*/false, a, /*signB=*/false, b,
                          /*modC=*/(uint16_t)0, c)
               .getResult();
   } else if constexpr (Variant == WmmaVariant::ModsC) {
+    // fp8 path: no sign/clamp operands.
     res = WmmaOp::create(builder, loc, accTy, a, b,
                          /*modC=*/(uint16_t)0, c,
                          /*reuseA=*/false, /*reuseB=*/false)
               .getResult();
   } else if constexpr (Variant == WmmaVariant::ModsABClamp) {
-    res = WmmaOp::create(builder, loc, accTy,
-                         /*signA=*/false, a, /*signB=*/false, b, c,
-                         /*reuseA=*/false, /*reuseB=*/false, /*clamp=*/false)
+    // iu8: sign + reuse + clamp controls.
+    res = WmmaOp::create(builder, loc, accTy, signA, a, signB, b, c,
+                         /*reuseA=*/false, /*reuseB=*/false, clamp)
               .getResult();
   } else {
     // IU form (e.g. iu4): sign/clamp controls but no reuseA/reuseB operands.
     static_assert(Variant == WmmaVariant::ModsIUClamp);
-    res = WmmaOp::create(builder, loc, accTy,
-                         /*signA=*/false, a, /*signB=*/false, b, c, /*clamp=*/false)
-              .getResult();
+    res = WmmaOp::create(builder, loc, accTy, signA, a, signB, b, c, clamp).getResult();
   }
   return res;
 }
@@ -286,9 +293,15 @@ FailureOr<Value> MmaOpGFX1250_WMMAType::emitAtomCallSSA(OpBuilder &builder, Loca
   if (c.getType() != accTy)
     c = LLVM::BitcastOp::create(builder, loc, accTy, c);
 
+  // Integer (iu4/iu8) sign/clamp controls; false/ignored on the float paths.
+  bool signA = getSignA();
+  bool signB = getSignB();
+  bool clamp = getClamp();
+
 #define DISPATCH_WMMA_SSA(M_, K_, PRED, OP, VARIANT)                                               \
   if (m == M_ && n == M_ && k == K_ && (PRED)) {                                                   \
-    return emitWmmaSSA<ROCDL::OP, WmmaVariant::VARIANT>(builder, loc, accTy, a, b, c);             \
+    return emitWmmaSSA<ROCDL::OP, WmmaVariant::VARIANT>(builder, loc, accTy, a, b, c, signA,       \
+                                                        signB, clamp);                             \
   }
 
 #define DISPATCH_WMMA_SSA_FP8(K_, ACC_PRED, ACC_PREFIX)                                            \

--- a/python/flydsl/expr/rocdl/universal.py
+++ b/python/flydsl/expr/rocdl/universal.py
@@ -83,15 +83,13 @@ def MFMA(m, n, k, elem_ty_ab, elem_ty_acc=None):
 def WMMA(m, n, k, elem_ty_ab, elem_ty_acc=None, **kwargs):
     """Create an arch-appropriate WMMA atom.
 
-    Supported kwargs (gfx11 integer paths only — iu8 / iu4):
+    Supported kwargs (integer paths only — iu8 / iu4):
         sign_a (bool, default False): treat A operand as signed.
         sign_b (bool, default False): treat B operand as signed.
         clamp  (bool, default False): saturate integer accumulator.
-    These are forwarded verbatim to MmaOpGFX11_WMMAType.get(); the ROCDL
-    intrinsic's verify() will reject them on fp16/bf16 paths.
-    The gfx12 / gfx1250 path (MmaOpGFX1250_WMMAType) does not expose these knobs
-    yet — its integer WMMA (iu8/iu4) hardcodes sign/clamp to false — and it will
-    raise if any of these kwargs are passed as True.
+    Forwarded to the arch-specific WMMA atom (MmaOpGFX11_WMMAType on gfx11,
+    MmaOpGFX1250_WMMAType on gfx12 / gfx1250); the atom's verify() rejects them
+    on the float (fp16/bf16/fp8) paths, where the intrinsic has no such operands.
     Future WMMA ops for new architectures should extend kwargs here rather
     than growing the positional signature.
     """
@@ -112,9 +110,17 @@ def WMMA(m, n, k, elem_ty_ab, elem_ty_acc=None, **kwargs):
     if arch.startswith("gfx11"):
         return MmaOpGFX11_WMMAType.get(m, n, k, ty_ab, ty_ab, ty_acc, **kwargs)
     if arch.startswith("gfx12"):
-        if any(kwargs.get(k) for k in ("sign_a", "sign_b", "clamp")):
-            raise ValueError("sign_a/sign_b/clamp are not supported on the gfx12 / gfx1250 WMMA path yet")
-        return MmaOpGFX1250_WMMAType.get(m, n, k, ty_ab, ty_ab, ty_acc)
+        return MmaOpGFX1250_WMMAType.get(
+            m,
+            n,
+            k,
+            ty_ab,
+            ty_ab,
+            ty_acc,
+            sign_a=bool(kwargs.get("sign_a", False)),
+            sign_b=bool(kwargs.get("sign_b", False)),
+            clamp=bool(kwargs.get("clamp", False)),
+        )
     raise ValueError(
         f"WMMA is not available on target arch {arch!r}; supported: gfx11xx (RDNA3 / RDNA3.5), gfx12xx (RDNA4), and gfx1250. "
     )

--- a/python/flydsl/expr/rocdl/universal.py
+++ b/python/flydsl/expr/rocdl/universal.py
@@ -89,8 +89,9 @@ def WMMA(m, n, k, elem_ty_ab, elem_ty_acc=None, **kwargs):
         clamp  (bool, default False): saturate integer accumulator.
     These are forwarded verbatim to MmaOpGFX11_WMMAType.get(); the ROCDL
     intrinsic's verify() will reject them on fp16/bf16 paths.
-    The gfx12 (RDNA4) path does not expose these knobs yet and will raise
-    if any are passed as True.
+    The gfx12 / gfx1250 path (MmaOpGFX1250_WMMAType) does not expose these knobs
+    yet — its integer WMMA (iu8/iu4) hardcodes sign/clamp to false — and it will
+    raise if any of these kwargs are passed as True.
     Future WMMA ops for new architectures should extend kwargs here rather
     than growing the positional signature.
     """
@@ -102,7 +103,9 @@ def WMMA(m, n, k, elem_ty_ab, elem_ty_acc=None, **kwargs):
 
     # Arch-aware dispatch:
     #   * RDNA3 / RDNA3.5 (gfx1100..gfx1152) use the legacy v16-operand WMMA ABI.
-    #   * RDNA4 (gfx1250)                    uses the new v8-operand ABI.
+    #   * RDNA4 (gfx12xx, e.g. gfx1201) and gfx1250 use the new v8-operand ABI;
+    #     both route through MmaOpGFX1250_WMMAType via the gfx12 prefix below.
+    #     (gfx1250 is its own arch, not RDNA4, but shares this WMMA atom.)
     from ...runtime.device import get_rocm_arch
 
     arch = (get_rocm_arch() or "").lower()
@@ -110,10 +113,10 @@ def WMMA(m, n, k, elem_ty_ab, elem_ty_acc=None, **kwargs):
         return MmaOpGFX11_WMMAType.get(m, n, k, ty_ab, ty_ab, ty_acc, **kwargs)
     if arch.startswith("gfx12"):
         if any(kwargs.get(k) for k in ("sign_a", "sign_b", "clamp")):
-            raise ValueError("sign_a/sign_b/clamp are not supported on the gfx12 (RDNA4) WMMA path yet")
+            raise ValueError("sign_a/sign_b/clamp are not supported on the gfx12 / gfx1250 WMMA path yet")
         return MmaOpGFX1250_WMMAType.get(m, n, k, ty_ab, ty_ab, ty_acc)
     raise ValueError(
-        f"WMMA is not available on target arch {arch!r}; supported: gfx11xx (RDNA3 / RDNA3.5) and gfx12xx (RDNA4). "
+        f"WMMA is not available on target arch {arch!r}; supported: gfx11xx (RDNA3 / RDNA3.5), gfx12xx (RDNA4), and gfx1250. "
     )
 
 

--- a/tests/kernels/test_gfx1250_atoms_device.py
+++ b/tests/kernels/test_gfx1250_atoms_device.py
@@ -148,7 +148,7 @@ def _compile_wmma_scale_fp8(M: int, N: int, K: int):
         copy_a = fx.make_copy_atom(fx.rocdl.BufferCopy(f8.width), f8)
         copy_c = fx.make_copy_atom(fx.rocdl.BufferCopy(f32.width), f32)
         tiled_copy_A = fx.make_tiled_copy_A(copy_a, tiled_mma)
-        tiled_copy_B = fx.make_tiled_copy_A(copy_a, tiled_mma)
+        tiled_copy_B = fx.make_tiled_copy_B(copy_a, tiled_mma)
         tiled_copy_C = fx.make_tiled_copy_C(copy_c, tiled_mma)
         thr_copy_A = tiled_copy_A.get_slice(tid)
         thr_copy_B = tiled_copy_B.get_slice(tid)

--- a/tests/mlir/Conversion/gfx1250_atoms_neg.mlir
+++ b/tests/mlir/Conversion/gfx1250_atoms_neg.mlir
@@ -55,3 +55,13 @@ func.func @bad_tdm_pad_pow2(
     %a: !fly.copy_atom<!fly_rocdl.gfx1250.tdm<rank = 2, warps = 1, pad = 48, 8, cache = 0, barrier = false, timeout = false>, 0>) {
   return
 }
+
+// -----
+
+// signA/signB/clamp are integer-only (iu4/iu8) controls; the verifier rejects
+// them on the float WMMA paths.
+// CHECK: signA/signB/clamp are only valid for integer (iu4/iu8) WMMA
+func.func @bad_wmma_sign_on_fp(
+    %a: !fly.mma_atom<!fly_rocdl.gfx1250.wmma<16x16x32, (f16, f16) -> f32, signA = true, signB = false, clamp = false>>) {
+  return
+}

--- a/tests/mlir/Conversion/wmma_gfx1250.mlir
+++ b/tests/mlir/Conversion/wmma_gfx1250.mlir
@@ -9,7 +9,7 @@
 
 // CHECK-LABEL: @test_wmma_iu4
 func.func @test_wmma_iu4(
-    %atom: !fly.mma_atom<!fly_rocdl.gfx1250.wmma<16x16x32, (i4, i4) -> i32>>) {
+    %atom: !fly.mma_atom<!fly_rocdl.gfx1250.wmma<16x16x32, (i4, i4) -> i32, signA = false, signB = false, clamp = false>>) {
   %lay_ab = fly.static : !fly.layout<16:1>
   %lay_cd = fly.static : !fly.layout<8:1>
   %d = fly.memref.alloca(%lay_cd) : (!fly.layout<8:1>) -> !fly.memref<i32, register, 8:1>
@@ -20,8 +20,32 @@ func.func @test_wmma_iu4(
   // CHECK-DAG: %[[A_VAL:.*]] = llvm.load %{{.*}} : !llvm.ptr<5> -> vector<2xi32>
   // CHECK-DAG: %[[B_VAL:.*]] = llvm.load %{{.*}} : !llvm.ptr<5> -> vector<2xi32>
   // CHECK-DAG: %[[C_VAL:.*]] = llvm.load %{{.*}} : !llvm.ptr<5> -> vector<8xi32>
+  // Unsigned (default): the printer elides the false sign/clamp attrs.
   // CHECK: %[[RES:.*]] = rocdl.wmma.i32.16x16x32.iu4 %[[A_VAL]], %[[B_VAL]], %[[C_VAL]] : (vector<2xi32>, vector<2xi32>, vector<8xi32>) -> vector<8xi32>
   // CHECK: llvm.store %[[RES]], %{{.*}} : vector<8xi32>, !llvm.ptr<5>
-  fly.mma_atom_call(%atom, %d, %a, %b, %c) : (!fly.mma_atom<!fly_rocdl.gfx1250.wmma<16x16x32, (i4, i4) -> i32>>, !fly.memref<i32, register, 8:1>, !fly.memref<i4, register, 16:1>, !fly.memref<i4, register, 16:1>, !fly.memref<i32, register, 8:1>) -> ()
+  fly.mma_atom_call(%atom, %d, %a, %b, %c) : (!fly.mma_atom<!fly_rocdl.gfx1250.wmma<16x16x32, (i4, i4) -> i32, signA = false, signB = false, clamp = false>>, !fly.memref<i32, register, 8:1>, !fly.memref<i4, register, 16:1>, !fly.memref<i4, register, 16:1>, !fly.memref<i32, register, 8:1>) -> ()
+  return
+}
+
+// -----
+
+// Signed int4 with clamp: signA/signB/clamp are forwarded to the intrinsic
+// (the rocdl op printer only shows the non-false attrs).
+
+// CHECK-LABEL: @test_wmma_iu4_signed_clamp
+func.func @test_wmma_iu4_signed_clamp(
+    %atom: !fly.mma_atom<!fly_rocdl.gfx1250.wmma<16x16x32, (i4, i4) -> i32, signA = true, signB = true, clamp = true>>) {
+  %lay_ab = fly.static : !fly.layout<16:1>
+  %lay_cd = fly.static : !fly.layout<8:1>
+  %d = fly.memref.alloca(%lay_cd) : (!fly.layout<8:1>) -> !fly.memref<i32, register, 8:1>
+  %a = fly.memref.alloca(%lay_ab) : (!fly.layout<16:1>) -> !fly.memref<i4, register, 16:1>
+  %b = fly.memref.alloca(%lay_ab) : (!fly.layout<16:1>) -> !fly.memref<i4, register, 16:1>
+  %c = fly.memref.alloca(%lay_cd) : (!fly.layout<8:1>) -> !fly.memref<i32, register, 8:1>
+
+  // CHECK: rocdl.wmma.i32.16x16x32.iu4
+  // CHECK-SAME: clamp = true
+  // CHECK-SAME: signA = true
+  // CHECK-SAME: signB = true
+  fly.mma_atom_call(%atom, %d, %a, %b, %c) : (!fly.mma_atom<!fly_rocdl.gfx1250.wmma<16x16x32, (i4, i4) -> i32, signA = true, signB = true, clamp = true>>, !fly.memref<i32, register, 8:1>, !fly.memref<i4, register, 16:1>, !fly.memref<i4, register, 16:1>, !fly.memref<i32, register, 8:1>) -> ()
   return
 }


### PR DESCRIPTION
## Motivation

Review follow-ups to #830 (gfx1250 MX-scaled WMMA + N-D TDM atoms): fix stale
comments, add the missing signed-integer WMMA controls, correct the device test,
and document the new atom surface.

## Technical Details

**Stale comments**
- `GFX1250/CopyAtom.cpp`: TDM header still said "2D port of `make_tensor_descriptor_2d`" → now N-D (1–5D), descriptor as atom state.
- `WMMA()` called gfx1250 "RDNA4" (it's its own arch; shares `MmaOpGFX1250_WMMAType` via the `gfx12` prefix). Fixed the comment + error strings.

**Signed-integer WMMA (`MmaOpGFX1250_WMMAType`)**
- Added `signA` / `signB` / `clamp` params (default false). Threaded into the iu8 (`ModsABClamp`) and iu4 (`ModsIUClamp`) emit variants; float paths ignore them and `verify()` rejects them there.
- Wired through the Python binding (`sign_a` / `sign_b` / `clamp` kwargs) and `WMMA()` (forwards on the gfx12/gfx1250 path instead of raising).
- FileCheck: signed iu4 lowering + a sign-on-float negative verifier case.

**Device test**
- Use `make_tiled_copy_B` (not `_A`) for the B operand in the scaled-WMMA test.

**Docs & skills** (gfx1250 WMMA / MX-scaled WMMA / TDM copy atom)
- `kernel_authoring_guide.md` §4.4 new "gfx1250 WMMA & TDM atoms (wave32)" subsection.
- `api/dsl.rst` + `api/compiler.rst` ROCDL factory lists.
- `layout_system_guide.md` Copy Atom Types table + MMA construction.
- `architecture_guide.md` lowering-pass row (WMMA / TDM targets).
- Skills: `flydsl-kernel-authoring` (Copy Atom table + WMMA section), `flydsl-tile-programming` (atom mental-model), `add-target-atom-op` (reference-impl list).

Note: review item #1 (rank-1 TDM whole-tile routing) was investigated and is **not** a bug — a rank-1 TDM lowers to a single correct `tensor.load.to.lds` (tile0=128); no change needed.

## Test Plan / Result

`fly-opt` builds; gfx1250 wmma / mma_scale / tdm / neg FileCheck (incl. new signed iu4 + sign-on-fp neg), the copy/layout-lowering regression sweep, and the l0 atom unit test pass. `black` / `ruff` / `clang-format` clean. Docs are text-only.

## Submission Checklist

- [x] Look over the contributing guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)