### PR TITLE
[kernels]: add common/mem_ops for shared memory/atomic helpers

### DIFF
--- a/kernels/common/kernels_common.py
+++ b/kernels/common/kernels_common.py
@@ -11,72 +11,15 @@ from contextlib import contextmanager
 
 import flydsl.expr as fx
 from flydsl._mlir import ir
-from flydsl._mlir.dialects import arith as _std_arith
 from flydsl._mlir.dialects import builtin
-from flydsl._mlir.dialects import fly as _fly
 from flydsl._mlir.dialects import gpu as _gpu
-from flydsl._mlir.dialects import llvm as _llvm
 from flydsl._mlir.dialects import scf as _scf
-from flydsl.expr import arith as _expr_arith
-from flydsl.expr import buffer_ops, const_expr
-from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch, is_rdna_arch
 
-
-def get_llvm_ptr(ptr, offset, dtype_bytes, ptr_type=None):
-    """Build a global (address-space 1) ``!llvm.ptr`` at ``ptr + offset*dtype_bytes``.
-
-    Shared home for the LLVM-ptr arithmetic used by atomic/global accesses
-    (previously duplicated in hgemm_splitk.py, small_m_hgemm.py, splitk_hgemm.py
-    and rmsnorm_kernel.py).
-    """
-    if ptr_type is None:
-        ptr_type = ir.Type.parse("!llvm.ptr<1>")
-    base_ptr = _fly.extract_aligned_pointer_as_index(ptr_type, ptr)
-    base_ptr = _llvm.PtrToIntOp(T.i64, base_ptr).result
-    byte_offset = _expr_arith.index_cast(T.i64, fx.Index(offset) * fx.Index(dtype_bytes))
-    llvm_ptr = _llvm.AddOp(base_ptr, byte_offset, _llvm.IntegerOverflowFlags(0)).result
-    llvm_ptr = _llvm.IntToPtrOp(ptr_type, llvm_ptr).result
-    return llvm_ptr._value if const_expr(hasattr(llvm_ptr, "_value")) else llvm_ptr
-
-
-def atomic_add(
-    dst,
-    offset,
-    value,
-    *,
-    dtype_bytes=4,
-    syncscope="agent",
-    ordering=None,
-    alignment=None,
-    ptr_type=None,
-):
-    """Atomically add ``value`` into ``dst[offset]`` in global memory.
-
-    inline (e.g. the rmsnorm backward ``dweight`` accumulation). Selects
-    ``fadd`` for a floating-point operand and integer ``add`` otherwise, from
-    the operand's IR type, so a single call covers both cases. Returns the
-    atomicrmw result (the value previously stored at ``dst[offset]``).
-
-    ``dtype_bytes`` sizes the byte offset and, unless ``alignment`` is given, is
-    reused as the access alignment.
-    """
-    ptr = get_llvm_ptr(dst, offset, dtype_bytes, ptr_type=ptr_type)
-    val = value.ir_value() if const_expr(hasattr(value, "ir_value")) else value
-    elem_ty = val.type.element_type if isinstance(val.type, ir.VectorType) else val.type
-    bin_op = _llvm.AtomicBinOp.fadd if isinstance(elem_ty, ir.FloatType) else _llvm.AtomicBinOp.add
-    if ordering is None:
-        ordering = _llvm.AtomicOrdering.monotonic
-    if alignment is None:
-        alignment = dtype_bytes
-    return _llvm.AtomicRMWOp(
-        bin_op,
-        ptr,
-        val,
-        ordering,
-        syncscope=syncscope,
-        alignment=alignment,
-    ).result
+# Memory/atomic primitives now live in mem_ops; re-exported here for back-compat.
+from kernels.common.mem_ops import _create_llvm_ptr
+from kernels.common.mem_ops import atomic_add as atomic_add
+from kernels.common.mem_ops import get_llvm_ptr as get_llvm_ptr
 
 
 @contextmanager
@@ -150,15 +93,6 @@ def get_warp_size(arch=None):
     if arch is None:
         arch = get_rocm_arch()
     return 32 if is_rdna_arch(arch) else 64
-
-
-def _create_llvm_ptr(value, address_space: int = 1):
-    value = buffer_ops._unwrap_value(value)
-    if isinstance(value.type, ir.IndexType):
-        i64_type = T.i64
-        value = buffer_ops._unwrap_value(_std_arith.IndexCastOp(i64_type, value).result)
-    ptr_type = ir.Type.parse(f"!llvm.ptr<{address_space}>")
-    return _llvm.IntToPtrOp(ptr_type, value).result
 
 
 def stream_ptr_to_async_token(stream_ptr_value, loc=None, ip=None):

--- a/kernels/common/mem_ops.py
+++ b/kernels/common/mem_ops.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Single home for kernel-facing memory & atomic helpers.
+
+Consolidates the LLVM-pointer construction, global load/store, and atomic
+primitives that were previously scattered across ``kernels_common.py`` and
+``utils.py`` (and hand-rolled inline in individual kernels). The original
+modules re-export these names, so existing imports keep working unchanged.
+
+Two distinct atomic mechanisms live here and are NOT interchangeable:
+  * ``atomic_add``        - LLVM ``atomicrmw`` on an ``!llvm.ptr`` (pointer atomics)
+  * ``buffer_atomic_add`` - AMD ``raw.ptr.buffer.atomic.fadd`` on a buffer resource
+"""
+
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import arith as _std_arith
+from flydsl._mlir.dialects import fly as _fly
+from flydsl._mlir.dialects import llvm as _llvm
+from flydsl.expr import arith as _expr_arith
+from flydsl.expr import buffer_ops, const_expr, rocdl
+from flydsl.expr.typing import T
+
+# Public API. Prefer the unified names; the legacy aliases at the bottom of this
+# list exist only so pre-consolidation imports keep working (re-exported by
+# kernels_common / utils) and should not be used in new code:
+#   element_ptr  <- get_llvm_ptr        aligned_ptr <- extract_global_ptr
+#   to_llvm_ptr  <- _create_llvm_ptr
+__all__ = [
+    # pointer construction / extraction (preferred)
+    "element_ptr",
+    "to_llvm_ptr",
+    "aligned_ptr",
+    "global_ptr_from_addr",
+    # global load / store
+    "global_load",
+    "global_load_i32",
+    "global_load_i64x2",
+    "global_store",
+    # atomics (two distinct mechanisms)
+    "atomic_add",
+    "buffer_atomic_add",
+    # legacy aliases (back-compat only)
+    "get_llvm_ptr",
+    "_create_llvm_ptr",
+    "extract_global_ptr",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Pointer construction / extraction
+# --------------------------------------------------------------------------- #
+def get_llvm_ptr(ptr, offset, dtype_bytes, ptr_type=None):
+    """Build a global (address-space 1) ``!llvm.ptr`` at ``ptr + offset*dtype_bytes``.
+
+    Shared home for the LLVM-ptr arithmetic used by atomic/global accesses
+    (previously duplicated in hgemm_splitk.py, small_m_hgemm.py, splitk_hgemm.py
+    and rmsnorm_kernel.py).
+    """
+    if ptr_type is None:
+        ptr_type = ir.Type.parse("!llvm.ptr<1>")
+    base_ptr = _fly.extract_aligned_pointer_as_index(ptr_type, ptr)
+    base_ptr = _llvm.PtrToIntOp(T.i64, base_ptr).result
+    byte_offset = _expr_arith.index_cast(T.i64, fx.Index(offset) * fx.Index(dtype_bytes))
+    llvm_ptr = _llvm.AddOp(base_ptr, byte_offset, _llvm.IntegerOverflowFlags(0)).result
+    llvm_ptr = _llvm.IntToPtrOp(ptr_type, llvm_ptr).result
+    return llvm_ptr._value if const_expr(hasattr(llvm_ptr, "_value")) else llvm_ptr
+
+
+# Unified name for the element-pointer helper above.
+element_ptr = get_llvm_ptr
+
+
+def _create_llvm_ptr(value, address_space: int = 1):
+    value = buffer_ops._unwrap_value(value)
+    if isinstance(value.type, ir.IndexType):
+        i64_type = T.i64
+        value = buffer_ops._unwrap_value(_std_arith.IndexCastOp(i64_type, value).result)
+    ptr_type = ir.Type.parse(f"!llvm.ptr<{address_space}>")
+    return _llvm.IntToPtrOp(ptr_type, value).result
+
+
+# Unified name: int/index scalar -> typed llvm.ptr (any address space).
+to_llvm_ptr = _create_llvm_ptr
+
+
+def extract_global_ptr(tensor):
+    raw = tensor.ir_value() if hasattr(tensor, "ir_value") and not isinstance(tensor, ir.Value) else tensor
+    ptr_type = ir.Type.parse("!llvm.ptr<1>")
+    return _fly.extract_aligned_pointer_as_index(ptr_type, raw)
+
+
+# Unified name: tensor/memref -> aligned global base pointer.
+aligned_ptr = extract_global_ptr
+
+
+def global_ptr_from_addr(addr_i64):
+    raw = addr_i64.ir_value() if hasattr(addr_i64, "ir_value") and not isinstance(addr_i64, ir.Value) else addr_i64
+    return _llvm.IntToPtrOp(ir.Type.parse("!llvm.ptr<1>"), raw).result
+
+
+# --------------------------------------------------------------------------- #
+# Global load / store
+# --------------------------------------------------------------------------- #
+def global_load(global_ptr, byte_offset, result_type, *, alignment):
+    ptr = buffer_ops.get_element_ptr(global_ptr, byte_offset=fx.Int64(byte_offset), elem_type=T.i8)
+    return _llvm.LoadOp(result_type, ptr, alignment=alignment).result
+
+
+def global_load_i64x2(global_ptr, byte_offset_i64):
+    return global_load(global_ptr, byte_offset_i64, T.i64x2, alignment=16)
+
+
+def global_load_i32(global_ptr, elem_offset_i32):
+    return global_load(global_ptr, fx.Int64(elem_offset_i32) * fx.Int64(4), T.i32, alignment=4)
+
+
+def global_store(global_ptr, byte_offset, value, *, alignment):
+    """Store ``value`` at ``global_ptr + byte_offset`` (mirror of ``global_load``).
+
+    Unwraps a FlyDSL expression operand the same way ``atomic_add`` does, so
+    callers may pass either a raw ``ir.Value`` or a FlyDSL expression. New in the
+    consolidation; the hand-rolled ``llvm.StoreOp`` sites are collected in a later
+    phase, so this has no call site yet.
+    """
+    val = value.ir_value() if const_expr(hasattr(value, "ir_value")) else value
+    ptr = buffer_ops.get_element_ptr(global_ptr, byte_offset=fx.Int64(byte_offset), elem_type=T.i8)
+    _llvm.StoreOp(val, ptr, alignment=alignment)
+
+
+# --------------------------------------------------------------------------- #
+# Atomics -- two distinct mechanisms (see module docstring)
+# --------------------------------------------------------------------------- #
+def atomic_add(
+    dst,
+    offset,
+    value,
+    *,
+    dtype_bytes=4,
+    syncscope="agent",
+    ordering=None,
+    alignment=None,
+    ptr_type=None,
+):
+    """Atomically add ``value`` into ``dst[offset]`` in global memory.
+
+    inline (e.g. the rmsnorm backward ``dweight`` accumulation). Selects
+    ``fadd`` for a floating-point operand and integer ``add`` otherwise, from
+    the operand's IR type, so a single call covers both cases. Returns the
+    atomicrmw result (the value previously stored at ``dst[offset]``).
+
+    ``dtype_bytes`` sizes the byte offset and, unless ``alignment`` is given, is
+    reused as the access alignment.
+    """
+    ptr = get_llvm_ptr(dst, offset, dtype_bytes, ptr_type=ptr_type)
+    val = value.ir_value() if const_expr(hasattr(value, "ir_value")) else value
+    elem_ty = val.type.element_type if isinstance(val.type, ir.VectorType) else val.type
+    bin_op = _llvm.AtomicBinOp.fadd if isinstance(elem_ty, ir.FloatType) else _llvm.AtomicBinOp.add
+    if ordering is None:
+        ordering = _llvm.AtomicOrdering.monotonic
+    if alignment is None:
+        alignment = dtype_bytes
+    return _llvm.AtomicRMWOp(
+        bin_op,
+        ptr,
+        val,
+        ordering,
+        syncscope=syncscope,
+        alignment=alignment,
+    ).result
+
+
+def buffer_atomic_add(vdata, rsrc, offset, soffset, aux):
+    """Buffer-resource atomic fadd (AMD ``raw.ptr.buffer.atomic.fadd``).
+
+    Single entry point for the buffer-resource atomic accumulation used by the
+    MoE gemm/blockscale wrappers (``atomic_add_f16x2 / _f32 / _x2``) and conv3d.
+    Distinct from ``atomic_add``: operates on a buffer resource + byte offset,
+    not an ``!llvm.ptr``, so the two are not interchangeable.
+    """
+    return rocdl.raw_ptr_buffer_atomic_fadd(vdata, rsrc, offset, soffset, aux)

--- a/kernels/common/utils.py
+++ b/kernels/common/utils.py
@@ -4,8 +4,15 @@
 import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm
-from flydsl.expr import arith, buffer_ops, const_expr, rocdl
+from flydsl.expr import arith, const_expr, rocdl
 from flydsl.expr.typing import T
+
+# Pointer/global-load helpers now live in mem_ops; re-exported here for back-compat.
+from kernels.common.mem_ops import extract_global_ptr as extract_global_ptr
+from kernels.common.mem_ops import global_load as global_load
+from kernels.common.mem_ops import global_load_i32 as global_load_i32
+from kernels.common.mem_ops import global_load_i64x2 as global_load_i64x2
+from kernels.common.mem_ops import global_ptr_from_addr as global_ptr_from_addr
 
 
 def rcp_f32(value):
@@ -82,29 +89,3 @@ def urem_const(value, divisor: int):
 def unflatten_k(k_flat, qkhe_loop: int = 2):
     n = qkhe_loop * 2
     return [[k_flat[td * n + j] for j in range(n)] for td in range(len(k_flat) // n)]
-
-
-def extract_global_ptr(tensor):
-    from flydsl._mlir.dialects import fly as _fly
-
-    raw = tensor.ir_value() if hasattr(tensor, "ir_value") and not isinstance(tensor, ir.Value) else tensor
-    ptr_type = ir.Type.parse("!llvm.ptr<1>")
-    return _fly.extract_aligned_pointer_as_index(ptr_type, raw)
-
-
-def global_ptr_from_addr(addr_i64):
-    raw = addr_i64.ir_value() if hasattr(addr_i64, "ir_value") and not isinstance(addr_i64, ir.Value) else addr_i64
-    return llvm.IntToPtrOp(ir.Type.parse("!llvm.ptr<1>"), raw).result
-
-
-def global_load(global_ptr, byte_offset, result_type, *, alignment):
-    ptr = buffer_ops.get_element_ptr(global_ptr, byte_offset=fx.Int64(byte_offset), elem_type=T.i8)
-    return llvm.LoadOp(result_type, ptr, alignment=alignment).result
-
-
-def global_load_i64x2(global_ptr, byte_offset_i64):
-    return global_load(global_ptr, byte_offset_i64, T.i64x2, alignment=16)
-
-
-def global_load_i32(global_ptr, elem_offset_i32):
-    return global_load(global_ptr, fx.Int64(elem_offset_i32) * fx.Int64(4), T.i32, alignment=4)

--- a/kernels/conv/conv3d_implicit_8wave.py
+++ b/kernels/conv/conv3d_implicit_8wave.py
@@ -17,6 +17,7 @@ import flydsl.expr as fx
 from flydsl._mlir.dialects import llvm
 from flydsl.expr import arith, buffer_ops, const_expr, range_constexpr, rocdl
 from flydsl.expr.typing import T
+from kernels.common.mem_ops import buffer_atomic_add
 
 TILE_M = 128
 TILE_N = 128
@@ -508,7 +509,7 @@ def compile_conv3d_implicit_8wave(n, c, d, h, w, k, kt, kh, kw, st, sh, sw, pt, 
                             if const_expr(use_splitk):
                                 off_b = fx.Int32(off_sk * 4)
                                 z0 = fx.Int32(0)
-                                rocdl.raw_ptr_buffer_atomic_fadd(a[i], y_rsrc, off_b, z0, z0)
+                                buffer_atomic_add(a[i], y_rsrc, off_b, z0, z0)
                             else:
                                 cval = (a[i] + bias_val).to(elem_ty) if const_expr(has_bias) else a[i].to(elem_ty)
                                 buffer_ops.buffer_store(cval, y_rsrc, off_nk)

--- a/kernels/conv/conv3d_implicit_8wave_fp8.py
+++ b/kernels/conv/conv3d_implicit_8wave_fp8.py
@@ -14,6 +14,7 @@ import flydsl.expr as fx
 from flydsl._mlir.dialects import llvm
 from flydsl.expr import arith, buffer_ops, const_expr, range_constexpr
 from flydsl.expr.typing import T
+from kernels.common.mem_ops import buffer_atomic_add
 from kernels.gemm.fp8_gemm_utils import Mfma16x16x128, make_fp8_buffer_tensor, pack_i32x4_i32x8
 
 TILE_M = 128
@@ -434,7 +435,7 @@ def compile_conv3d_implicit_8wave_fp8(
                                 if valid:
                                     off_b = fx.Int32((row * k + col) * 4)
                                     z0 = fx.Int32(0)
-                                    fx.rocdl.raw_ptr_buffer_atomic_fadd(out, y_rsrc, off_b, z0, z0)
+                                    buffer_atomic_add(out, y_rsrc, off_b, z0, z0)
                             else:
                                 if const_expr(has_bias):
                                     out = out + bias_val

--- a/kernels/gemm/hgemm_splitk.py
+++ b/kernels/gemm/hgemm_splitk.py
@@ -16,7 +16,7 @@ from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, roc
 from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch
 from flydsl.utils.smem_allocator import SMEM_CAPACITY_MAP, SmemAllocator, SmemPtr
-from kernels.common.kernels_common import get_llvm_ptr
+from kernels.common.kernels_common import atomic_add, get_llvm_ptr
 from kernels.common.tensor_shim import GTensor, STensor, _run_compiled, get_dtype_in_kernel
 from kernels.gemm.splitk_hgemm import swizzle_xor16
 
@@ -358,15 +358,7 @@ def compile_hgemm_kernel(
             # clean semaphore and signal if this is the last block within split-k group
             is_t0_cond_if = scf.IfOp(is_t0_cond, results_=[], has_else=False)
             with ir.InsertionPoint(is_t0_cond_if.then_block):
-                semaphore_ptr = get_llvm_ptr(semaphore, signal_idx, 4)
-                arrive_idx = llvm.AtomicRMWOp(
-                    llvm.AtomicBinOp.add,
-                    semaphore_ptr,
-                    arith.constant(1, type=T.i32),
-                    llvm.AtomicOrdering.monotonic,
-                    syncscope="agent",
-                    alignment=4,
-                ).result
+                arrive_idx = atomic_add(semaphore, signal_idx, arith.constant(1, type=T.i32), dtype_bytes=4)
                 cond_ksl = arith.cmpi(arith.CmpIPredicate.eq, fx.Index(arrive_idx), fx.Index(SPLIT_K - 1))
                 cond_ksl_if = scf.IfOp(cond_ksl, results_=[], has_else=False)
                 with ir.InsertionPoint(cond_ksl_if.then_block):

--- a/kernels/moe/mixed_moe_gemm_2stage/gemm2.py
+++ b/kernels/moe/mixed_moe_gemm_2stage/gemm2.py
@@ -18,6 +18,7 @@ from flydsl.runtime.device import get_rocm_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from kernels.common.layout_utils import crd2idx, idx2crd
 from kernels.common.layout_utils import get as layout_get
+from kernels.common.mem_ops import buffer_atomic_add
 from kernels.mma.mfma_epilogues import c_shuffle_epilog
 from kernels.mma.mfma_preshuffle_pipeline import (
     _buffer_load_vec,
@@ -1360,13 +1361,7 @@ def compile_mixed_moe_gemm2(
                 zero_i32 = arith.constant(0)
 
                 def atomic_add_f16x2(val_f16x2, byte_off_i32):
-                    rocdl.raw_ptr_buffer_atomic_fadd(
-                        val_f16x2,
-                        out_rsrc,
-                        byte_off_i32,
-                        zero_i32,
-                        zero_i32,
-                    )
+                    buffer_atomic_add(val_f16x2, out_rsrc, byte_off_i32, zero_i32, zero_i32)
 
                 # Weight scales for the N tile (col_g depends on lane/wave/by but not on (t,s)).
                 if const_expr(lds_out is None):

--- a/kernels/moe/moe_blockscale_2stage/gemm2.py
+++ b/kernels/moe/moe_blockscale_2stage/gemm2.py
@@ -19,6 +19,7 @@ from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from kernels.common.kernels_common import _if_then
+from kernels.common.mem_ops import buffer_atomic_add
 from kernels.mma.mfma_epilogues import c_shuffle_epilog, default_epilog
 from kernels.mma.mfma_preshuffle_pipeline import (
     buffer_copy_gmem16_dwordx4,
@@ -1001,13 +1002,7 @@ def compile_moe_blockscale_gemm2(
                 e_vec = _e_vec
 
                 def atomic_add_f16x2(val_f16x2, byte_off_i32):
-                    rocdl.raw_ptr_buffer_atomic_fadd(
-                        val_f16x2,
-                        out_rsrc,
-                        byte_off_i32,
-                        zero_i32,
-                        zero_i32,
-                    )
+                    buffer_atomic_add(val_f16x2, out_rsrc, byte_off_i32, zero_i32, zero_i32)
 
                 # Blockscale: dequant already done in compute_tile_bs_s2, no sw/sx needed here.
 
@@ -1016,13 +1011,7 @@ def compile_moe_blockscale_gemm2(
                     c4_i32 = fx.Int32(4)
 
                     def atomic_add_f32(val_f32, byte_off_i32):
-                        rocdl.raw_ptr_buffer_atomic_fadd(
-                            val_f32,
-                            out_rsrc,
-                            byte_off_i32,
-                            zero_i32,
-                            zero_i32,
-                        )
+                        buffer_atomic_add(val_f32, out_rsrc, byte_off_i32, zero_i32, zero_i32)
 
                     def _stage2_row_atomic(*, mi: int, ii: int, row_in_tile, row):
                         # Blockscale: dequant already done in compute_tile_bs_s2.

--- a/kernels/moe/moe_gemm_2stage/gemm1.py
+++ b/kernels/moe/moe_gemm_2stage/gemm1.py
@@ -16,6 +16,7 @@ from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from kernels.common.kernels_common import _if_then
+from kernels.common.mem_ops import buffer_atomic_add
 from kernels.mma.mfma_epilogues import c_shuffle_epilog, mfma_epilog
 from kernels.mma.mfma_preshuffle_pipeline import (
     buffer_copy_gmem16_dwordx4,
@@ -1369,13 +1370,7 @@ def compile_moe_gemm1(
                             else:
                                 # gfx950+: buffer_atomic_pk_add_bf16
                                 byte_off_i32 = arith.index_cast(T.i32, row_byte_ctx + byte_off_col)
-                                rocdl.raw_ptr_buffer_atomic_fadd(
-                                    frag,
-                                    out_rsrc,
-                                    byte_off_i32,
-                                    _z,
-                                    _z,
-                                )
+                                buffer_atomic_add(frag, out_rsrc, byte_off_i32, _z, _z)
                         else:
                             # f32 atomic: global atomicrmw fadd
                             ptr_addr_idx = row_byte_ctx + byte_off_col

--- a/kernels/moe/moe_gemm_2stage/gemm2.py
+++ b/kernels/moe/moe_gemm_2stage/gemm2.py
@@ -32,6 +32,7 @@ from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, scf
 from flydsl.expr.typing import T
 from kernels.common.kernels_common import _if_then
+from kernels.common.mem_ops import buffer_atomic_add
 from kernels.mma.mfma_epilogues import c_shuffle_epilog, default_epilog
 from kernels.mma.mfma_preshuffle_pipeline import (
     buffer_copy_gmem16_dwordx4,
@@ -1164,13 +1165,7 @@ def compile_moe_gemm2(
                 e_vec = _e_vec
 
                 def atomic_add_f16x2(val_f16x2, byte_off_i32):
-                    rocdl.raw_ptr_buffer_atomic_fadd(
-                        val_f16x2,
-                        out_rsrc,
-                        byte_off_i32,
-                        zero_i32,
-                        zero_i32,
-                    )
+                    buffer_atomic_add(val_f16x2, out_rsrc, byte_off_i32, zero_i32, zero_i32)
 
                 sw_pf = None
                 tw_pf = None
@@ -1205,13 +1200,7 @@ def compile_moe_gemm2(
                     c4_i32 = fx.Int32(4)
 
                     def atomic_add_f32(val_f32, byte_off_i32):
-                        rocdl.raw_ptr_buffer_atomic_fadd(
-                            val_f32,
-                            out_rsrc,
-                            byte_off_i32,
-                            zero_i32,
-                            zero_i32,
-                        )
+                        buffer_atomic_add(val_f32, out_rsrc, byte_off_i32, zero_i32, zero_i32)
 
                     def _stage2_row_atomic(*, mi: int, ii: int, row_in_tile, row):
                         fused2 = buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)

--- a/kernels/moe/moe_gemm_2stage_common_gfx1250.py
+++ b/kernels/moe/moe_gemm_2stage_common_gfx1250.py
@@ -14,6 +14,7 @@ import inspect
 from typing import Any
 
 from flydsl.runtime.device import get_rocm_arch
+from kernels.common.mem_ops import buffer_atomic_add
 from kernels.common.utils import align_up as _align_up
 
 
@@ -383,7 +384,7 @@ def _emit_stage1_gate_up_splitk_epilogue(
     mask_even_i32 = arith.constant(0xFFFFFFFE, type=T.i32)
 
     def atomic_add_x2(val_x2, byte_off_i32):
-        rocdl.raw_ptr_buffer_atomic_fadd(val_x2, out_rsrc, byte_off_i32, zero_i32, zero_i32)
+        buffer_atomic_add(val_x2, out_rsrc, byte_off_i32, zero_i32, zero_i32)
 
     inter_stride_i32 = i32_inter_in * c2_i32  # row stride for [tokens*topk, 2*inter_dim]
     if _use_bias:
@@ -552,7 +553,7 @@ def _emit_stage2_store_epilogue(
     mask_even_i32 = arith.constant(0xFFFFFFFE, type=T.i32)
 
     def atomic_add_x2(val_x2, byte_off_i32):
-        rocdl.raw_ptr_buffer_atomic_fadd(val_x2, out_rsrc, byte_off_i32, zero_i32, zero_i32)
+        buffer_atomic_add(val_x2, out_rsrc, byte_off_i32, zero_i32, zero_i32)
 
     if _use_bias:
         # bias[e, n] f32; flat index = e * model_dim + n. Routing-weight


### PR DESCRIPTION
Move get_llvm_ptr / atomic_add / pointer / global-load helpers into a single kernels/common/mem_ops.py; kernels_common and utils re-export them, so existing imports are unchanged. Add global_store and buffer_atomic_add as single entry points, an __all__ documenting the preferred vs legacy names, and an ir_value unwrap in global_store to match atomic_add.

Route the hgemm_splitk semaphore through atomic_add, and every raw_ptr_buffer_atomic_fadd site (MoE gemm/blockscale/mixed, conv3d and conv3d_fp8, gfx1250 common) through buffer_atomic_add.