### PR TITLE
Add forward LSE output to FlyDSL flash attention kernels

### DIFF
--- a/kernels/attention/flash_attn_generic.py
+++ b/kernels/attention/flash_attn_generic.py
@@ -62,6 +62,7 @@ def build_flash_attn_func_module_primary(
     paged=False,
     kv_cache_layout="linear",
     skip_kv_pad_mask=None,
+    return_lse=False,
 ):
     """Build a generic f16/bf16 flash-attention launcher.
 
@@ -204,6 +205,7 @@ def build_flash_attn_func_module_primary(
         unsafe_fp_math=unsafe_fp_math,
         sm_scale=sm_scale,
         skip_kv_pad_mask=skip_kv_pad_mask,
+        return_lse=return_lse,
     )
     _flash_attn_generic_cache_tag = traits.cache_tag
 
@@ -246,6 +248,7 @@ def build_flash_attn_func_module_primary(
         K: fx.Tensor,
         V: fx.Tensor,
         O: fx.Tensor,  # noqa: E741
+        LSE: fx.Tensor,
         seq_len: fx.Int32,
         seq_len_kv: fx.Int32,
         CuSeqQ: fx.Tensor,
@@ -278,8 +281,9 @@ def build_flash_attn_func_module_primary(
         if const_expr(traits.KV_VECTORIZED and traits.V_NOMAJOR_DMA):
             kv_gmem_to_lds.init_dma_nomajor()
 
-        # Per-batch Q/O descriptors, then K/V DMA resources when DMA is enabled.
-        ctx.init_descriptors(Q, O)
+        # Per-batch Q/O (and LSE when RETURN_LSE) descriptors, then K/V DMA
+        # resources when DMA is enabled.
+        ctx.init_descriptors(Q, O, LSE)
         if const_expr(traits.ENABLE_DMA):
             kv_gmem_to_lds.init_dma()
 
@@ -509,6 +513,7 @@ def build_flash_attn_func_module_primary(
         K: fx.Tensor,
         V: fx.Tensor,
         O: fx.Tensor,  # noqa: E741
+        LSE: fx.Tensor,
         CuSeqQ: fx.Tensor,
         CuSeqKv: fx.Tensor,
         BlockTable: fx.Tensor,
@@ -542,6 +547,7 @@ def build_flash_attn_func_module_primary(
             K,
             V,
             O,
+            LSE,
             seq_len,
             seq_len_kv,
             CuSeqQ,
@@ -592,25 +598,42 @@ def build_flash_attn_func_module_primary(
         block_table=None,
         block_table_stride=0,
         seq_len_kv=None,
+        lse=None,
         stream=None,
     ):
         # Dense/non-paged pass the output tensor as a placeholder for the unused
         # cu_seqlens / block_table slots; the kernel only reads them under
-        # const_expr(VARLEN) / const_expr(PAGED).
+        # const_expr(VARLEN) / const_expr(PAGED). LSE is likewise a placeholder
+        # unless the kernel was built with return_lse=True (RETURN_LSE store gate).
         cq = cu_seqlens_q if cu_seqlens_q is not None else Out
         ck = cu_seqlens_kv if cu_seqlens_kv is not None else Out
         bt = block_table if block_table is not None else Out
+        ls = lse if lse is not None else Out
         skv = seq_len if seq_len_kv is None else seq_len_kv
         with CompilationContext.compile_hints(_fmha_compile_hints):
             return launch_flash_attn_generic(
-                Q, K, V, Out, cq, ck, bt, block_table_stride, batch_size, seq_len, skv, fx.Stream(stream)
+                Q, K, V, Out, ls, cq, ck, bt, block_table_stride, batch_size, seq_len, skv, fx.Stream(stream)
             )
 
-    def _compile(Q, K, V, Out, batch_size, seq_len, seq_len_kv=None, stream=None):
+    def _compile(Q, K, V, Out, batch_size, seq_len, seq_len_kv=None, lse=None, stream=None):
+        ls = lse if lse is not None else Out
         skv = seq_len if seq_len_kv is None else seq_len_kv
         with CompilationContext.compile_hints(_fmha_compile_hints):
             return flyc.compile(
-                launch_flash_attn_generic, Q, K, V, Out, Out, Out, Out, 0, batch_size, seq_len, skv, fx.Stream(stream)
+                launch_flash_attn_generic,
+                Q,
+                K,
+                V,
+                Out,
+                ls,
+                Out,
+                Out,
+                Out,
+                0,
+                batch_size,
+                seq_len,
+                skv,
+                fx.Stream(stream),
             )
 
     _launch.compile = _compile

--- a/kernels/attention/flash_attn_generic.py
+++ b/kernels/attention/flash_attn_generic.py
@@ -603,11 +603,16 @@ def build_flash_attn_func_module_primary(
     ):
         # Dense/non-paged pass the output tensor as a placeholder for the unused
         # cu_seqlens / block_table slots; the kernel only reads them under
-        # const_expr(VARLEN) / const_expr(PAGED). LSE is likewise a placeholder
-        # unless the kernel was built with return_lse=True (RETURN_LSE store gate).
+        # const_expr(VARLEN) / const_expr(PAGED).
         cq = cu_seqlens_q if cu_seqlens_q is not None else Out
         ck = cu_seqlens_kv if cu_seqlens_kv is not None else Out
         bt = block_table if block_table is not None else Out
+        # RETURN_LSE stores fp32 LSE, so Out is not a safe placeholder for a missing lse.
+        if return_lse and lse is None:
+            raise ValueError(
+                "flash_attn_generic was built with return_lse=True but no `lse` tensor was "
+                "provided; pass an fp32 [batch, num_heads, seq_len] LSE tensor."
+            )
         ls = lse if lse is not None else Out
         skv = seq_len if seq_len_kv is None else seq_len_kv
         with CompilationContext.compile_hints(_fmha_compile_hints):
@@ -616,6 +621,11 @@ def build_flash_attn_func_module_primary(
             )
 
     def _compile(Q, K, V, Out, batch_size, seq_len, seq_len_kv=None, lse=None, stream=None):
+        if return_lse and lse is None:
+            raise ValueError(
+                "flash_attn_generic was built with return_lse=True but no `lse` tensor was "
+                "provided; pass an fp32 [batch, num_heads, seq_len] LSE tensor."
+            )
         ls = lse if lse is not None else Out
         skv = seq_len if seq_len_kv is None else seq_len_kv
         with CompilationContext.compile_hints(_fmha_compile_hints):

--- a/kernels/attention/flash_attn_generic.py
+++ b/kernels/attention/flash_attn_generic.py
@@ -101,6 +101,7 @@ def build_flash_attn_func_module_primary(
             paged=paged,
             kv_cache_layout=kv_cache_layout,
             skip_kv_pad_mask=skip_kv_pad_mask,
+            return_lse=return_lse,
         )
         _launcher_m256 = build_flash_attn_func_module_primary(
             num_heads,
@@ -123,6 +124,7 @@ def build_flash_attn_func_module_primary(
             paged=paged,
             kv_cache_layout=kv_cache_layout,
             skip_kv_pad_mask=skip_kv_pad_mask,
+            return_lse=return_lse,
         )
         _bs_threshold = 2048 * num_heads if gpu_arch.startswith("gfx942") else 4096 * num_heads
 
@@ -673,6 +675,7 @@ def build_flash_attn_func_module_primary(
             paged=paged,
             kv_cache_layout=kv_cache_layout,
             skip_kv_pad_mask=True,
+            return_lse=return_lse,
         )
         _launch_mask = build_flash_attn_func_module_primary(
             num_heads,
@@ -695,6 +698,7 @@ def build_flash_attn_func_module_primary(
             paged=paged,
             kv_cache_layout=kv_cache_layout,
             skip_kv_pad_mask=False,
+            return_lse=return_lse,
         )
 
         def _pad_dispatch(*args, **kwargs):

--- a/kernels/attention/flash_attn_gfx950.py
+++ b/kernels/attention/flash_attn_gfx950.py
@@ -682,8 +682,7 @@ def build_flash_attn_dualwave_swp_module(
                 _s_barrier()
 
             # Store O as 128b writes by fusing each lane's half with its half-wave partner.
-            # LSE (natural log, scale folded) is stored alongside O when RETURN_LSE; l_row
-            # is still the row sum here (l_inv above is a separate reciprocal).
+            # LSE stored alongside O when RETURN_LSE (l_row is the row sum, not l_inv).
             if const_expr(not traits.SPLITK):
                 output_store.store_final_o(v_o, ctx.q_row, m_row, l_row)
             else:
@@ -848,9 +847,7 @@ def build_flash_attn_dualwave_swp_module(
         # seq_len_kv defaults to seq_len (self-attention / equal Q,KV lengths).
         if seq_len_kv is None:
             seq_len_kv = seq_len
-        # LSE placeholder (O) is only safe when RETURN_LSE is off. When built with
-        # return_lse=True the kernel stores fp32 LSE, so falling back to O would
-        # overwrite the output buffer / write an incompatible layout.
+        # RETURN_LSE stores fp32 LSE, so O is not a safe placeholder for a missing lse.
         if return_lse and lse is None:
             raise ValueError(
                 "flash_attn_dualwave_swp was built with return_lse=True but no `lse` tensor was "

--- a/kernels/attention/flash_attn_gfx950.py
+++ b/kernels/attention/flash_attn_gfx950.py
@@ -848,7 +848,14 @@ def build_flash_attn_dualwave_swp_module(
         # seq_len_kv defaults to seq_len (self-attention / equal Q,KV lengths).
         if seq_len_kv is None:
             seq_len_kv = seq_len
-        # LSE is only written under const_expr(traits.RETURN_LSE); O is a placeholder otherwise.
+        # LSE placeholder (O) is only safe when RETURN_LSE is off. When built with
+        # return_lse=True the kernel stores fp32 LSE, so falling back to O would
+        # overwrite the output buffer / write an incompatible layout.
+        if return_lse and lse is None:
+            raise ValueError(
+                "flash_attn_dualwave_swp was built with return_lse=True but no `lse` tensor was "
+                "provided; pass an fp32 [batch, num_heads, seq_len] LSE tensor."
+            )
         lse_out = lse if lse is not None else O
         if traits.SPLITK:
             if workspace is None:
@@ -937,6 +944,11 @@ def build_flash_attn_dualwave_swp_module(
             head_dim_runtime = traits.HEAD_DIM
         if seq_len_kv is None:
             seq_len_kv = seq_len
+        if return_lse and lse is None:
+            raise ValueError(
+                "flash_attn_dualwave_swp was built with return_lse=True but no `lse` tensor was "
+                "provided; pass an fp32 [batch, num_heads, seq_len] LSE tensor."
+            )
         lse_out = lse if lse is not None else O
         if traits.SPLITK:
             if workspace is None:

--- a/kernels/attention/flash_attn_gfx950.py
+++ b/kernels/attention/flash_attn_gfx950.py
@@ -66,6 +66,7 @@ def build_flash_attn_dualwave_swp_module(
     cross_seqlen=False,
     paged=False,
     kv_cache_layout="linear",
+    return_lse=False,
 ):
     """Build an DUALWAVE_SWP flash_attn launcher for D=64/128 bf16/f16 on gfx950.
 
@@ -116,6 +117,7 @@ def build_flash_attn_dualwave_swp_module(
         paged=paged,
         kv_cache_layout=kv_cache_layout,
         kv_vectorized=KV_VECTORIZED,
+        return_lse=return_lse,
     )
     traits.BLOCK_N_OUT // traits.BLOCK_N
     _dualwave_swp_cache_tag = traits.cache_tag
@@ -142,6 +144,7 @@ def build_flash_attn_dualwave_swp_module(
         K: fx.Tensor,
         V: fx.Tensor,
         O: fx.Tensor,  # noqa: E741
+        LSE: fx.Tensor,
         DebugCounts: fx.Tensor,
         CuSeqQ: fx.Tensor,
         CuSeqKv: fx.Tensor,
@@ -169,6 +172,7 @@ def build_flash_attn_dualwave_swp_module(
             stride_kv_n,
             head_dim_runtime,
             block_table_stride,
+            LSE=LSE,
         )
         ctx.init_types_and_constants()
         ctx.init_runtime_indices()
@@ -678,8 +682,10 @@ def build_flash_attn_dualwave_swp_module(
                 _s_barrier()
 
             # Store O as 128b writes by fusing each lane's half with its half-wave partner.
+            # LSE (natural log, scale folded) is stored alongside O when RETURN_LSE; l_row
+            # is still the row sum here (l_inv above is a separate reciprocal).
             if const_expr(not traits.SPLITK):
-                output_store.store_final_o(v_o, ctx.q_row)
+                output_store.store_final_o(v_o, ctx.q_row, m_row, l_row)
             else:
                 output_store.store_splitk_partial_o(v_o, m_row, l_row, ctx.q_row)
 
@@ -707,9 +713,14 @@ def build_flash_attn_dualwave_swp_module(
 
     @flyc.kernel(known_block_size=[COMBINE_BLOCK, 1, 1])
     def flash_attn_splitk_combine_kernel(
-        O: fx.Tensor, WS: fx.Tensor, batch_size: fx.Int32, seq_len: fx.Int32, stride_q_n: fx.Int32  # noqa: E741
+        O: fx.Tensor,  # noqa: E741
+        WS: fx.Tensor,
+        LSE: fx.Tensor,
+        batch_size: fx.Int32,
+        seq_len: fx.Int32,
+        stride_q_n: fx.Int32,
     ):
-        ctx = DualwaveSplitKCombineContext(traits, O, WS, batch_size, seq_len, stride_q_n)
+        ctx = DualwaveSplitKCombineContext(traits, O, WS, batch_size, seq_len, stride_q_n, LSE=LSE)
         ctx.init_types_and_constants()
         ctx.init_runtime_indices()
         ctx.init_thread_mapping(COMBINE_ROWS_PER_BLOCK, COMBINE_LANES_PER_ROW)
@@ -720,6 +731,8 @@ def build_flash_attn_dualwave_swp_module(
         m_s, l_s = combine.load_ml_rows()
         m_max = combine.reduce_m_max(m_s)
         acc, den = combine.accumulate_splits(m_s, l_s, m_max)
+        if const_expr(traits.RETURN_LSE):
+            combine.store_lse(m_max, den)
         o_pack = combine.pack_output(acc, den)
         combine.store_output(o_pack)
 
@@ -729,6 +742,7 @@ def build_flash_attn_dualwave_swp_module(
         K: fx.Tensor,
         V: fx.Tensor,
         O: fx.Tensor,  # noqa: E741
+        LSE: fx.Tensor,
         DebugCounts: fx.Tensor,
         CuSeqQ: fx.Tensor,
         CuSeqKv: fx.Tensor,
@@ -766,6 +780,7 @@ def build_flash_attn_dualwave_swp_module(
             K,
             V,
             O,
+            LSE,
             DebugCounts,
             CuSeqQ,
             CuSeqKv,
@@ -788,7 +803,7 @@ def build_flash_attn_dualwave_swp_module(
         )
         if const_expr(traits.SPLITK):
             combine_rows = bs_idx * traits.NUM_HEADS_Q * sl_idx
-            flash_attn_splitk_combine_kernel(O, DebugCounts, batch_size, seq_len, stride_q_n).launch(
+            flash_attn_splitk_combine_kernel(O, DebugCounts, LSE, batch_size, seq_len, stride_q_n).launch(
                 grid=(combine_rows // COMBINE_ROWS_PER_BLOCK, 1, 1),
                 block=(COMBINE_BLOCK, 1, 1),
                 stream=stream,
@@ -821,6 +836,7 @@ def build_flash_attn_dualwave_swp_module(
         cu_seqlens_kv=None,
         block_table=None,
         block_table_stride=None,
+        lse=None,
         stream=None,
     ):
         if stride_kv_n is None:
@@ -832,6 +848,8 @@ def build_flash_attn_dualwave_swp_module(
         # seq_len_kv defaults to seq_len (self-attention / equal Q,KV lengths).
         if seq_len_kv is None:
             seq_len_kv = seq_len
+        # LSE is only written under const_expr(traits.RETURN_LSE); O is a placeholder otherwise.
+        lse_out = lse if lse is not None else O
         if traits.SPLITK:
             if workspace is None:
                 raise ValueError("num_kv_splits > 1 requires a fp32 workspace (see dualwave_splitk_workspace_elems)")
@@ -857,6 +875,7 @@ def build_flash_attn_dualwave_swp_module(
                     K,
                     V,
                     O,
+                    lse_out,
                     debug_counts,
                     cu_seqlens_q,
                     cu_seqlens_kv,
@@ -874,6 +893,7 @@ def build_flash_attn_dualwave_swp_module(
                 K,
                 V,
                 O,
+                lse_out,
                 debug_counts,
                 cu_seqlens_q,
                 cu_seqlens_kv,
@@ -906,6 +926,7 @@ def build_flash_attn_dualwave_swp_module(
         cu_seqlens_kv=None,
         block_table=None,
         block_table_stride=None,
+        lse=None,
         stream=None,
     ):
         if stride_kv_n is None:
@@ -916,6 +937,7 @@ def build_flash_attn_dualwave_swp_module(
             head_dim_runtime = traits.HEAD_DIM
         if seq_len_kv is None:
             seq_len_kv = seq_len
+        lse_out = lse if lse is not None else O
         if traits.SPLITK:
             if workspace is None:
                 raise ValueError("num_kv_splits > 1 requires a fp32 workspace (see dualwave_splitk_workspace_elems)")
@@ -937,6 +959,7 @@ def build_flash_attn_dualwave_swp_module(
                 K,
                 V,
                 O,
+                lse_out,
                 debug_counts,
                 cu_seqlens_q,
                 cu_seqlens_kv,

--- a/kernels/attention/flash_attn_interface.py
+++ b/kernels/attention/flash_attn_interface.py
@@ -616,11 +616,8 @@ def flydsl_flash_attn_func(
     v_descale: Optional[torch.Tensor] = None,
     # Output tensor; allocated if None.
     out: Optional[torch.Tensor] = None,
-    # Also return the per-row log-sum-exp (LSE) needed by the backward pass.
-    # LSE convention: natural log, softmax scale folded in, i.e.
-    # LSE_i = ln(sum_j exp(sm_scale * (q_i . k_j))). fp32 tensor of shape
-    # [B, num_heads, Sq] (varlen: [B, num_heads, max_seqlen_q], padded). Not
-    # supported for fp8.
+    # Also return per-row LSE = ln(sum_j exp(sm_scale * q_i.k_j)); fp32
+    # [B, num_heads, Sq]. Needed by backward; not supported for fp8.
     return_lse: bool = False,
     # Kernel build options.
     waves_per_eu: int = 2,

--- a/kernels/attention/flash_attn_interface.py
+++ b/kernels/attention/flash_attn_interface.py
@@ -97,6 +97,7 @@ def _build_dense(
     path_tag: str,
     waves_per_eu: int,
     daz: bool,
+    return_lse: bool = False,
 ):
     """Build (and cache) one dense generic launcher variant."""
     from kernels.attention.flash_attn_generic import build_flash_attn_func_module
@@ -113,6 +114,7 @@ def _build_dense(
         path_tag=path_tag,
         waves_per_eu=waves_per_eu,
         daz=daz,
+        return_lse=return_lse,
     )
 
 
@@ -130,6 +132,7 @@ def _build_dense_dualwave(
     setprio: bool,
     debug_lazy_counts: bool,
     enable_stagger: bool,
+    return_lse: bool = False,
 ):
     """Build (and cache) the dense gfx950 DUALWAVE_SWP launcher."""
     from kernels.attention.flash_attn_gfx950 import build_flash_attn_dualwave_swp_module
@@ -147,6 +150,7 @@ def _build_dense_dualwave(
         dualwave_swp_setprio=setprio,
         dualwave_swp_debug_lazy_counts=debug_lazy_counts,
         dualwave_swp_enable_stagger=enable_stagger,
+        return_lse=return_lse,
     )
 
 
@@ -192,6 +196,7 @@ def _build_varlen(
     setprio: bool,
     debug_lazy_counts: bool,
     enable_stagger: bool,
+    return_lse: bool = False,
 ):
     """Build (and cache) a varlen-mode launcher (gfx950 DUALWAVE_SWP, varlen=True)."""
     from kernels.attention.flash_attn_gfx950 import build_flash_attn_dualwave_swp_module
@@ -210,6 +215,7 @@ def _build_varlen(
         dualwave_swp_setprio=setprio,
         dualwave_swp_debug_lazy_counts=debug_lazy_counts,
         dualwave_swp_enable_stagger=enable_stagger,
+        return_lse=return_lse,
     )
 
 
@@ -227,6 +233,7 @@ def _build_varlen_light(
     setprio: bool,
     debug_lazy_counts: bool,
     enable_stagger: bool,
+    return_lse: bool = False,
 ):
     """Build a lightweight packed-varlen launcher for short attention."""
     from kernels.attention.flash_attn_generic import build_flash_attn_func_module
@@ -243,6 +250,7 @@ def _build_varlen_light(
         flat_work_group_size=128,
         waves_per_eu=waves_per_eu,
         daz=daz,
+        return_lse=return_lse,
     )
 
 
@@ -259,6 +267,7 @@ def _build_splitk(
     lazy_rescale: bool,
     setprio: bool,
     enable_stagger: bool,
+    return_lse: bool = False,
 ):
     """Build (and cache) a split-K launcher (gfx950 DUALWAVE_SWP, num_kv_splits>1)."""
     from kernels.attention.flash_attn_gfx950 import build_flash_attn_dualwave_swp_module
@@ -275,6 +284,7 @@ def _build_splitk(
         dualwave_swp_lazy_rescale=lazy_rescale,
         dualwave_swp_setprio=setprio,
         dualwave_swp_enable_stagger=enable_stagger,
+        return_lse=return_lse,
     )
 
 
@@ -294,6 +304,7 @@ def _build_paged(
     num_kv_splits: int = 1,
     varlen: bool = False,
     kv_cache_layout: str = "linear",
+    return_lse: bool = False,
 ):
     """Build (and cache) a paged-KV launcher (gfx950 DUALWAVE_SWP, paged=True).
 
@@ -326,6 +337,7 @@ def _build_paged(
         dualwave_swp_lazy_rescale=lazy_rescale,
         dualwave_swp_setprio=setprio,
         dualwave_swp_enable_stagger=enable_stagger,
+        return_lse=return_lse,
     )
 
 
@@ -546,6 +558,7 @@ def _build_paged_light(
     setprio: bool,
     debug_lazy_counts: bool,
     enable_stagger: bool,
+    return_lse: bool = False,
 ):
     """Build a lightweight paged-varlen launcher for short attention."""
     from kernels.attention.flash_attn_generic import build_flash_attn_func_module
@@ -565,6 +578,7 @@ def _build_paged_light(
         path_tag="N32",
         waves_per_eu=waves_per_eu,
         daz=daz,
+        return_lse=return_lse,
     )
 
 
@@ -602,6 +616,12 @@ def flydsl_flash_attn_func(
     v_descale: Optional[torch.Tensor] = None,
     # Output tensor; allocated if None.
     out: Optional[torch.Tensor] = None,
+    # Also return the per-row log-sum-exp (LSE) needed by the backward pass.
+    # LSE convention: natural log, softmax scale folded in, i.e.
+    # LSE_i = ln(sum_j exp(sm_scale * (q_i . k_j))). fp32 tensor of shape
+    # [B, num_heads, Sq] (varlen: [B, num_heads, max_seqlen_q], padded). Not
+    # supported for fp8.
+    return_lse: bool = False,
     # Kernel build options.
     waves_per_eu: int = 2,
     daz: bool = True,
@@ -659,7 +679,10 @@ def flydsl_flash_attn_func(
 
     Returns:
         Output tensor with the same shape as q. The dtype is bf16 for fp8
-        inputs, otherwise the same dtype as q.
+        inputs, otherwise the same dtype as q. When ``return_lse=True`` returns
+        ``(out, lse)`` where ``lse`` is fp32 ``[B, num_heads, Sq]`` (varlen:
+        ``[B, num_heads, max_seqlen_q]``, padded) holding the per-row
+        natural-log, scale-folded log-sum-exp.
     """
     # ── validation ──────────────────────────────────────────────────────────
     if not (q.is_cuda and k.is_cuda and v.is_cuda):
@@ -670,9 +693,13 @@ def flydsl_flash_attn_func(
         raise ValueError(f"flydsl_flash_attn_func: q/k/v must share dtype; got {q.dtype}/{k.dtype}/{v.dtype}")
 
     dtype_str = _dtype_str(q)
+    if return_lse and dtype_str == "fp8":
+        raise NotImplementedError("flydsl_flash_attn_func: return_lse is not supported for fp8")
     paged_kv = any(x is not None for x in (block_table, seqlen_k))
     if dtype_str == "fp8" and paged_kv:
         raise NotImplementedError("flydsl_flash_attn_func: fp8 flash_attn does not support paged KV")
+    if return_lse and paged_kv:
+        raise NotImplementedError("flydsl_flash_attn_func: return_lse is not supported for paged KV")
     if paged_kv:
         return _flydsl_flash_attn_paged(
             q,
@@ -784,6 +811,7 @@ def flydsl_flash_attn_func(
                 lazy_rescale=dualwave_swp_lazy_rescale,
                 setprio=dualwave_swp_setprio,
                 enable_stagger=dualwave_swp_enable_stagger,
+                return_lse=return_lse,
             )
         elif varlen:
             # Short varlen attention uses generic light; long/debug stays on dualwave.
@@ -808,6 +836,7 @@ def flydsl_flash_attn_func(
                     setprio=dualwave_swp_setprio,
                     debug_lazy_counts=debug_lazy,
                     enable_stagger=dualwave_swp_enable_stagger,
+                    return_lse=return_lse,
                 )
             else:
                 exe = _build_varlen(
@@ -823,6 +852,7 @@ def flydsl_flash_attn_func(
                     setprio=dualwave_swp_setprio,
                     debug_lazy_counts=debug_lazy,
                     enable_stagger=dualwave_swp_enable_stagger,
+                    return_lse=return_lse,
                 )
         else:
             _arch = _gpu_arch(q.device)
@@ -859,6 +889,7 @@ def flydsl_flash_attn_func(
                         setprio=dualwave_swp_setprio,
                         debug_lazy_counts=debug_lazy,
                         enable_stagger=dualwave_swp_enable_stagger,
+                        return_lse=return_lse,
                     )
                 else:
                     block_m, flat_work_group_size, path_tag = _dense_generic_tile(B, Sq, H, D, dtype_str, q.device)
@@ -874,6 +905,7 @@ def flydsl_flash_attn_func(
                         path_tag=path_tag,
                         waves_per_eu=waves_per_eu,
                         daz=daz,
+                        return_lse=return_lse,
                     )
 
         # ── allocate output ─────────────────────────────────────────────────
@@ -899,12 +931,15 @@ def flydsl_flash_attn_func(
             v_flat = v.contiguous()
             o_flat = out.contiguous()
 
+        # ── allocate LSE (fp32 [B, num_heads, Sq]) ───────────────────────────
+        lse = torch.empty((B, H, Sq), dtype=torch.float32, device=q.device) if return_lse else None
+
         # ── launch ──────────────────────────────────────────────────────────
         if splitk:
             _ws = torch.empty(ws_elems, dtype=torch.float32, device=q.device)
-            exe(q_flat, k_flat, v_flat, o_flat, B, Sq, workspace=_ws, stream=launch_stream)
+            exe(q_flat, k_flat, v_flat, o_flat, B, Sq, workspace=_ws, lse=lse, stream=launch_stream)
         elif varlen:
-            kwargs = dict(cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_kv, stream=launch_stream)
+            kwargs = dict(cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_kv, lse=lse, stream=launch_stream)
             if cross:
                 kwargs["seq_len_kv"] = int(max_seqlen_kv)
             if debug_lazy:
@@ -913,6 +948,9 @@ def flydsl_flash_attn_func(
                 exe(q_flat, k_flat, v_flat, o_flat, B, Sq, **kwargs)
         else:
             kwargs: dict = dict(stream=launch_stream)
+            # fp8 has no LSE path (guarded above) and its launcher takes no `lse` arg.
+            if dtype_str != "fp8":
+                kwargs["lse"] = lse
             if cross:
                 kwargs["seq_len_kv"] = Skv
             if debug_lazy:
@@ -921,4 +959,6 @@ def flydsl_flash_attn_func(
                 kwargs.update(q_descale=q_descale, k_descale=k_descale, v_descale=v_descale)
             exe(q_flat, k_flat, v_flat, o_flat, B, Sq, **kwargs)
 
+    if return_lse:
+        return out, lse
     return out

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -3005,8 +3005,8 @@ class GenericStoreHelper:
         lse_local = ctx.q_head_idx * ctx.seq_len_v + q_row
         # One writer per row: low half-wave + in-bounds q_row; else redirect to the
         # dropped OOB sentinel.
-        off_row = ArithValue(q_row < ctx.seqlen_q_b).select(lse_local, ctx.lse_oob_off)
-        off = fx.Index(ArithValue(ctx.lane_div_32 == fx.Index(0)).select(off_row, ctx.lse_oob_off))
+        off_row = (q_row < ctx.seqlen_q_b).select(lse_local, ctx.lse_oob_off)
+        off = fx.Index((ctx.lane_div_32 == fx.Index(0)).select(off_row, ctx.lse_oob_off))
         buffer_ops.buffer_store(as_mlir_value(fx.Float32(lse_val)), ctx.lse_rsrc, as_mlir_value(fx.Int32(off)))
 
     def finalize_o(self, loop_results):
@@ -4171,8 +4171,8 @@ class DualwaveStoreHelper(DualwaveKernelContext):
         )
         lse_local = self.q_head_idx * self.seq_len_v + q_row
         # One writer per row: low half-wave + in-bounds q_row; else the dropped OOB sentinel.
-        lse_off_row = ArithValue(q_row < self.seqlen_q_v).select(lse_local, lse_per_batch_elems)
-        lse_off = fx.Index(ArithValue(self.lane < fx.Index(32)).select(lse_off_row, lse_per_batch_elems))
+        lse_off_row = (q_row < self.seqlen_q_v).select(lse_local, lse_per_batch_elems)
+        lse_off = fx.Index((self.lane < fx.Index(32)).select(lse_off_row, lse_per_batch_elems))
         _ws_store_f32(lse_val, lse_off, lse_rsrc)
 
     def store_final_o(self, v_o, q_row, m_row=None, l_row=None):
@@ -5116,7 +5116,7 @@ class DualwaveSplitKCombineHelper(DualwaveSplitKCombineContext):
             fmath.log(as_mlir_value(den), fastmath=self.fm_fast),
             self.fm_fast,
         )
-        lse_off = fx.Index(ArithValue(self.col == fx.Index(0)).select(self.local_ml_idx, lse_per_batch_elems))
+        lse_off = fx.Index((self.col == fx.Index(0)).select(self.local_ml_idx, lse_per_batch_elems))
         buffer_ops.buffer_store(as_mlir_value(fx.Float32(lse_val)), lse_rsrc, as_mlir_value(fx.Int32(lse_off)))
 
     def store_output(self, o_pack):

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -1021,6 +1021,7 @@ class FlashAttnGenericTraits:
     K_VEC_N_STRIDE: int
     K_VEC_HI_N_OFFSET: int
     QK_PREFETCH_DEPTH: int
+    RETURN_LSE: bool = False
 
     @property
     def cache_tag(self):
@@ -1106,6 +1107,7 @@ class FlashAttnGenericTraits:
             self.K_VEC_N_STRIDE,
             self.K_VEC_HI_N_OFFSET,
             self.QK_PREFETCH_DEPTH,
+            self.RETURN_LSE,
         )
 
 
@@ -1129,6 +1131,7 @@ def _make_flash_attn_generic_traits(
     unsafe_fp_math=True,
     sm_scale=None,
     skip_kv_pad_mask=None,
+    return_lse=False,
 ):
     """Build compile-time traits for ``flash_attn_generic``."""
     block_n = 64
@@ -1353,6 +1356,7 @@ def _make_flash_attn_generic_traits(
         K_VEC_N_STRIDE=k_vec_n_stride,
         K_VEC_HI_N_OFFSET=k_vec_hi_n_offset,
         QK_PREFETCH_DEPTH=qk_prefetch_depth,
+        RETURN_LSE=bool(return_lse),
     )
 
 
@@ -1436,6 +1440,7 @@ class DualwaveSwpTraits:
     LDS_SCOPE_NAMES: tuple[str, str, str, str]
     NEG_INF_F32_BITS: int
     LGKMCNT_0_ONLY: int
+    RETURN_LSE: bool = False
 
     @property
     def cache_tag(self):
@@ -1458,6 +1463,7 @@ class DualwaveSwpTraits:
             self.CROSS_SEQLEN,
             self.KV_CACHE_LAYOUT,
             self.KV_VECTORIZED,
+            self.RETURN_LSE,
         )
 
 
@@ -1479,6 +1485,7 @@ def _make_dualwave_swp_traits(
     paged=False,
     kv_cache_layout="linear",
     kv_vectorized=None,
+    return_lse=False,
 ):
     """Build gfx950 DUALWAVE_SWP compile-time layout traits."""
     # Tile shape and wave geometry follow the gfx950 dual-wave 8-wave CTA.
@@ -1628,6 +1635,7 @@ def _make_dualwave_swp_traits(
         LDS_SCOPE_NAMES=("lds_k0", "lds_k1", "lds_v0", "lds_v1"),
         NEG_INF_F32_BITS=0xFF800000,
         LGKMCNT_0_ONLY=0xC07F,
+        RETURN_LSE=bool(return_lse),
     )
 
 
@@ -1970,6 +1978,7 @@ class GenericFlashAttnContext:
         self.c_neg_floor = fx.Float32(-3.0e38)
         self.c_zero_f = fx.Float32(0.0)
         self.c_zero_i32 = fx.Int32(0)
+        self.c_sm_scale = fx.Float32(sm_scale)
         self.c_sm_scale_log2e = fx.Float32(sm_scale * _LOG2E)
         self.c_zero_v16f32 = Vec.filled(16, 0.0, fx.Float32)
         self.width_i32 = fx.Int32(traits.WARP_SIZE)
@@ -2003,7 +2012,7 @@ class GenericFlashAttnContext:
             self.k_ptr = buffer_ops.get_element_ptr(self.k_ptr, off, elem_type=self.elem_type)
             self.v_ptr = buffer_ops.get_element_ptr(self.v_ptr, off, elem_type=self.elem_type)
 
-    def init_descriptors(self, Q, O):  # noqa: E741
+    def init_descriptors(self, Q, O, LSE=None):  # noqa: E741
         # Per-batch descriptors keep global indices 0-based and bounded to one batch,
         # keeping 32-bit offsets small while preserving arbitrary-seqlen OOB behavior.
         traits = self.traits
@@ -2017,6 +2026,19 @@ class GenericFlashAttnContext:
         self.o_rsrc = buffer_ops.create_buffer_resource(
             O, max_size=False, num_records_bytes=q_nrec_bytes, base_byte_offset=q_batch_byte_off
         )
+        # LSE output: fp32 [batch, num_heads, seq_len] (varlen: padded to max_seqlen_q).
+        # Per-batch descriptor folds the batch offset into the base so the flat index
+        # stays 0-based within the batch. Only built when RETURN_LSE.
+        if const_expr(traits.RETURN_LSE):
+            self.lse_per_batch_elems = fx.Index(traits.NUM_HEADS_Q) * self.seq_len_v
+            # Out-of-bounds sentinel (== num records) that the buffer bound drops,
+            # used to predicate the per-row store to a single writer lane.
+            self.lse_oob_off = self.lse_per_batch_elems
+            _lse_nrec_bytes = as_mlir_value(self.lse_per_batch_elems * fx.Index(4))
+            _lse_batch_byte_off = as_mlir_value(self.batch_idx * self.lse_per_batch_elems * fx.Index(4))
+            self.lse_rsrc = buffer_ops.create_buffer_resource(
+                LSE, max_size=False, num_records_bytes=_lse_nrec_bytes, base_byte_offset=_lse_batch_byte_off
+            )
 
     def init_q_row(self):
         # B operand: j = lane_mod_32, k-subblock = lane_div_32*MFMA_LANE_K. Q is
@@ -2974,6 +2996,25 @@ class GenericStoreHelper:
                     o_global = ctx.global_idx_q(q_row, d_col)
                     buffer_ops.buffer_store(zero_pack, o_rsrc, o_global * fx.Index(2), offset_is_bytes=True)
 
+    def store_lse(self, m_final, l_final, q_row):
+        # LSE = sm_scale * m_raw + ln(l); natural log, softmax scale folded in.
+        # m_raw is the unscaled row max of q.k and l the row sum of
+        # exp(sm_scale*(q.k) - sm_scale*m_raw), so a fully-masked row (m_raw=-inf,
+        # l=0) yields -inf.
+        ctx = self.ctx
+        lse_val = _fadd(
+            _fmul(m_final, ctx.c_sm_scale, ctx.fm_fast),
+            fmath.log(as_mlir_value(l_final), fastmath=ctx.fm_fast),
+            ctx.fm_fast,
+        )
+        lse_local = ctx.q_head_idx * ctx.seq_len_v + q_row
+        # One writer per row: the low half-wave (lane_div_32 == 0) stores; the high
+        # half-wave and any partial-tile OOB row (q_row >= seqlen_q_b) redirect to the
+        # sentinel offset (== num records), which the hardware buffer bound drops.
+        off_row = ArithValue(q_row < ctx.seqlen_q_b).select(lse_local, ctx.lse_oob_off)
+        off = fx.Index(ArithValue(ctx.lane_div_32 == fx.Index(0)).select(off_row, ctx.lse_oob_off))
+        buffer_ops.buffer_store(as_mlir_value(fx.Float32(lse_val)), ctx.lse_rsrc, as_mlir_value(fx.Int32(off)))
+
     def finalize_o(self, loop_results):
         # Normalize and store O (128-bit buffer_store_dwordx4); cross-seqlen zeroes
         # fully-masked q-blocks (causal_end_raw <= 0) instead of dividing by l==0.
@@ -2985,6 +3026,9 @@ class GenericStoreHelper:
             def _store_cross_o():
                 if ctx.causal_end_raw_i32 <= ctx.c_zero_i32:
                     self.zero_o_block(ctx.o_rsrc, ctx.q_row)
+                    if const_expr(traits.RETURN_LSE):
+                        # No valid keys for this q-tile: LSE = ln(0) = -inf per row.
+                        self.store_lse(loop_results[0], loop_results[1], ctx.q_row)
                 else:
                     self.normalize_and_store_o(loop_results, ctx.o_rsrc, ctx.q_row)
 
@@ -2997,6 +3041,9 @@ class GenericStoreHelper:
         traits = ctx.traits
         l_final = loop_results[1]
         o_finals = [loop_results[2 + dc] for dc in range_constexpr(traits.D_CHUNKS)]
+
+        if const_expr(traits.RETURN_LSE):
+            self.store_lse(loop_results[0], l_final, q_row)
 
         inv_l_rcp = rocdl.rcp(T.f32, l_final)
         if const_expr(traits.CAUSAL):
@@ -3082,6 +3129,7 @@ class DualwaveKernelContext:
         stride_kv_n=None,
         head_dim_runtime=None,
         block_table_stride=None,
+        LSE=None,
     ):
         if isinstance(traits_or_ctx, DualwaveKernelContext):
             self.__dict__.update(traits_or_ctx.__dict__)
@@ -3094,6 +3142,7 @@ class DualwaveKernelContext:
         self.K = K
         self.V = V
         self.O = O
+        self.LSE = LSE
         self.DebugCounts = DebugCounts
         self.CuSeqQ = CuSeqQ
         self.CuSeqKv = CuSeqKv
@@ -3125,6 +3174,8 @@ class DualwaveKernelContext:
         self.c_zero_v16f32 = Vec.filled(16, 0.0, fx.Float32)
         head_dim_f32 = fx.Float32(fx.Int32(head_dim_runtime))
         c_log2e_f = fx.Float32(_LOG2E)
+        # LSE store folds the log2->ln conversion (m_row is sm_scale*log2e-scaled).
+        self.c_ln2_f = fx.Float32(1.0 / _LOG2E)
         self.c_sm_scale_log2e = fx.Float32(
             arith.mulf(
                 as_mlir_value(fmath.rsqrt(head_dim_f32, fastmath=self.fm_fast)),
@@ -4111,8 +4162,33 @@ class DualwaveStoreHelper(DualwaveKernelContext):
 
         _store_empty_split()
 
-    def store_final_o(self, v_o, q_row):
+    def _store_lse_row(self, m_row, l_row, q_row):
+        # LSE = m_row * ln2 + ln(l_row); natural log with the softmax scale folded in
+        # (m_row is already sm_scale*log2e-scaled). fp32 [batch, num_heads, seq_len];
+        # a per-batch descriptor folds the batch offset into the base. A fully-masked
+        # row has l_row == 0, so ln(l_row) = -inf.
+        traits = self.traits
+        lse_base_i64 = fx.Int64(fx.ptrtoint(fx.get_iter(self.LSE)))
+        lse_per_batch_elems = fx.Index(traits.NUM_HEADS_Q) * self.seq_len_v
+        lse_per_batch_bytes = lse_per_batch_elems * fx.Index(4)
+        lse_rsrc = _make_ws_rsrc(lse_base_i64, self.batch_idx * lse_per_batch_bytes, lse_per_batch_bytes)
+        lse_val = _fadd(
+            _fmul(m_row, self.c_ln2_f, self.fm_fast),
+            fmath.log(as_mlir_value(l_row), fastmath=self.fm_fast),
+            self.fm_fast,
+        )
+        lse_local = self.q_head_idx * self.seq_len_v + q_row
+        # One writer per row (low half-wave); the high half-wave and partial-tile OOB
+        # rows (q_row >= seqlen_q_v) redirect to the sentinel offset (== num records),
+        # which the hardware buffer bound drops.
+        lse_off_row = ArithValue(q_row < self.seqlen_q_v).select(lse_local, lse_per_batch_elems)
+        lse_off = fx.Index(ArithValue(self.lane < fx.Index(32)).select(lse_off_row, lse_per_batch_elems))
+        _ws_store_f32(lse_val, lse_off, lse_rsrc)
+
+    def store_final_o(self, v_o, q_row, m_row=None, l_row=None):
         self._store_final_o_row(v_o, q_row)
+        if const_expr(self.traits.RETURN_LSE):
+            self._store_lse_row(m_row, l_row, q_row)
 
     def store_splitk_partial_o(self, v_o, m_row, l_row, q_row):
         _opart_rsrc, _mrow_rsrc, _lrow_rsrc = self._splitk_workspace_resources()
@@ -4873,6 +4949,7 @@ class DualwaveSplitKCombineContext:
         batch_size=None,
         seq_len=None,
         stride_q_n=None,
+        LSE=None,
     ):
         if isinstance(traits_or_ctx, DualwaveSplitKCombineContext):
             self.__dict__.update(traits_or_ctx.__dict__)
@@ -4883,6 +4960,7 @@ class DualwaveSplitKCombineContext:
         self.traits = traits_or_ctx
         self.O = O
         self.WS = WS
+        self.LSE = LSE
         self.batch_size = batch_size
         self.seq_len = seq_len
         self.stride_q_n = stride_q_n
@@ -4892,6 +4970,8 @@ class DualwaveSplitKCombineContext:
         self.fm_fast = fx.arith.FastMathFlags.fast
         self.c_zero_f = fx.Float32(0.0)
         self.c_zero_v4f32 = Vec.filled(4, 0.0, fx.Float32)
+        # LSE store folds the log2->ln conversion (m_max is sm_scale*log2e-scaled).
+        self.c_ln2_f = fx.Float32(1.0 / _LOG2E)
 
     def init_runtime_indices(self):
         self.seq_len_v = fx.Index(self.seq_len)
@@ -5033,6 +5113,23 @@ class DualwaveSplitKCombineHelper(DualwaveSplitKCombineContext):
             pack = Vec.from_elements(o_f16, self.elem_dtype).bitcast(fx.Int32)
             lo, hi = as_mlir_value(pack[0]), as_mlir_value(pack[1])
         return Vec.from_elements([fx.Int32(lo), fx.Int32(hi)], fx.Int32)
+
+    def store_lse(self, m_max, den):
+        # Combined LSE = m_max * ln2 + ln(den); den = sum_s 2^(m_s - m_max) * l_s is the
+        # global base-2 denominator relative to m_max, so ln(den) completes the natural-log,
+        # scale-folded LSE. One lane per (b, h, s) row (col == 0) writes; the rest redirect
+        # to the sentinel offset (== num records), dropped by the buffer bound.
+        lse_base_i64 = fx.Int64(fx.ptrtoint(fx.get_iter(self.LSE)))
+        lse_per_batch_elems = fx.Index(self.traits.NUM_HEADS_Q) * self.seq_len_v
+        lse_per_batch_bytes = lse_per_batch_elems * fx.Index(4)
+        lse_rsrc = _make_ws_rsrc(lse_base_i64, self.batch_idx * lse_per_batch_bytes, lse_per_batch_bytes)
+        lse_val = _fadd(
+            _fmul(m_max, self.c_ln2_f, self.fm_fast),
+            fmath.log(as_mlir_value(den), fastmath=self.fm_fast),
+            self.fm_fast,
+        )
+        lse_off = fx.Index(ArithValue(self.col == fx.Index(0)).select(self.local_ml_idx, lse_per_batch_elems))
+        buffer_ops.buffer_store(as_mlir_value(fx.Float32(lse_val)), lse_rsrc, as_mlir_value(fx.Int32(lse_off)))
 
     def store_output(self, o_pack):
         o_global = self.seq_idx * self.stride_q_n_v + self.q_head_idx * self.traits.HEAD_DIM + self.col

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -2026,13 +2026,10 @@ class GenericFlashAttnContext:
         self.o_rsrc = buffer_ops.create_buffer_resource(
             O, max_size=False, num_records_bytes=q_nrec_bytes, base_byte_offset=q_batch_byte_off
         )
-        # LSE output: fp32 [batch, num_heads, seq_len] (varlen: padded to max_seqlen_q).
-        # Per-batch descriptor folds the batch offset into the base so the flat index
-        # stays 0-based within the batch. Only built when RETURN_LSE.
+        # LSE output: fp32 [batch, num_heads, seq_len], per-batch descriptor.
         if const_expr(traits.RETURN_LSE):
             self.lse_per_batch_elems = fx.Index(traits.NUM_HEADS_Q) * self.seq_len_v
-            # Out-of-bounds sentinel (== num records) that the buffer bound drops,
-            # used to predicate the per-row store to a single writer lane.
+            # OOB sentinel (== num records) the buffer bound drops; predicates the store.
             self.lse_oob_off = self.lse_per_batch_elems
             _lse_nrec_bytes = as_mlir_value(self.lse_per_batch_elems * fx.Index(4))
             _lse_batch_byte_off = as_mlir_value(self.batch_idx * self.lse_per_batch_elems * fx.Index(4))
@@ -2997,10 +2994,8 @@ class GenericStoreHelper:
                     buffer_ops.buffer_store(zero_pack, o_rsrc, o_global * fx.Index(2), offset_is_bytes=True)
 
     def store_lse(self, m_final, l_final, q_row):
-        # LSE = sm_scale * m_raw + ln(l); natural log, softmax scale folded in.
-        # m_raw is the unscaled row max of q.k and l the row sum of
-        # exp(sm_scale*(q.k) - sm_scale*m_raw), so a fully-masked row (m_raw=-inf,
-        # l=0) yields -inf.
+        # LSE = sm_scale * m_raw + ln(l); natural log, softmax scale folded in
+        # (fully-masked row has l == 0 -> -inf).
         ctx = self.ctx
         lse_val = _fadd(
             _fmul(m_final, ctx.c_sm_scale, ctx.fm_fast),
@@ -3008,9 +3003,8 @@ class GenericStoreHelper:
             ctx.fm_fast,
         )
         lse_local = ctx.q_head_idx * ctx.seq_len_v + q_row
-        # One writer per row: the low half-wave (lane_div_32 == 0) stores; the high
-        # half-wave and any partial-tile OOB row (q_row >= seqlen_q_b) redirect to the
-        # sentinel offset (== num records), which the hardware buffer bound drops.
+        # One writer per row: low half-wave + in-bounds q_row; else redirect to the
+        # dropped OOB sentinel.
         off_row = ArithValue(q_row < ctx.seqlen_q_b).select(lse_local, ctx.lse_oob_off)
         off = fx.Index(ArithValue(ctx.lane_div_32 == fx.Index(0)).select(off_row, ctx.lse_oob_off))
         buffer_ops.buffer_store(as_mlir_value(fx.Float32(lse_val)), ctx.lse_rsrc, as_mlir_value(fx.Int32(off)))
@@ -4163,10 +4157,8 @@ class DualwaveStoreHelper(DualwaveKernelContext):
         _store_empty_split()
 
     def _store_lse_row(self, m_row, l_row, q_row):
-        # LSE = m_row * ln2 + ln(l_row); natural log with the softmax scale folded in
-        # (m_row is already sm_scale*log2e-scaled). fp32 [batch, num_heads, seq_len];
-        # a per-batch descriptor folds the batch offset into the base. A fully-masked
-        # row has l_row == 0, so ln(l_row) = -inf.
+        # LSE = m_row * ln2 + ln(l_row); natural log, scale folded (m_row is
+        # sm_scale*log2e-scaled). Fully-masked row has l_row == 0 -> -inf.
         traits = self.traits
         lse_base_i64 = fx.Int64(fx.ptrtoint(fx.get_iter(self.LSE)))
         lse_per_batch_elems = fx.Index(traits.NUM_HEADS_Q) * self.seq_len_v
@@ -4178,9 +4170,7 @@ class DualwaveStoreHelper(DualwaveKernelContext):
             self.fm_fast,
         )
         lse_local = self.q_head_idx * self.seq_len_v + q_row
-        # One writer per row (low half-wave); the high half-wave and partial-tile OOB
-        # rows (q_row >= seqlen_q_v) redirect to the sentinel offset (== num records),
-        # which the hardware buffer bound drops.
+        # One writer per row: low half-wave + in-bounds q_row; else the dropped OOB sentinel.
         lse_off_row = ArithValue(q_row < self.seqlen_q_v).select(lse_local, lse_per_batch_elems)
         lse_off = fx.Index(ArithValue(self.lane < fx.Index(32)).select(lse_off_row, lse_per_batch_elems))
         _ws_store_f32(lse_val, lse_off, lse_rsrc)
@@ -5115,10 +5105,8 @@ class DualwaveSplitKCombineHelper(DualwaveSplitKCombineContext):
         return Vec.from_elements([fx.Int32(lo), fx.Int32(hi)], fx.Int32)
 
     def store_lse(self, m_max, den):
-        # Combined LSE = m_max * ln2 + ln(den); den = sum_s 2^(m_s - m_max) * l_s is the
-        # global base-2 denominator relative to m_max, so ln(den) completes the natural-log,
-        # scale-folded LSE. One lane per (b, h, s) row (col == 0) writes; the rest redirect
-        # to the sentinel offset (== num records), dropped by the buffer bound.
+        # Combined LSE = m_max * ln2 + ln(den); den = sum_s 2^(m_s - m_max) * l_s
+        # completes the natural-log, scale-folded LSE. One lane (col == 0) writes.
         lse_base_i64 = fx.Int64(fx.ptrtoint(fx.get_iter(self.LSE)))
         lse_per_batch_elems = fx.Index(self.traits.NUM_HEADS_Q) * self.seq_len_v
         lse_per_batch_bytes = lse_per_batch_elems * fx.Index(4)

--- a/tests/arch_compat.py
+++ b/tests/arch_compat.py
@@ -10,6 +10,7 @@ Referenced by:
 # Reasons: MFMA instructions, hardcoded wave64, or imports from CDNA-only kernels.
 CDNA_ONLY_TESTS = frozenset(
     {
+        "test_flash_attn_fwd.py",  # MFMA + hardcoded wave64 FMHA kernels
         "test_preshuffle_gemm.py",
         "test_blockscale_preshuffle_gemm.py",
         "test_moe_gemm.py",

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -32,6 +32,7 @@ if not torch.cuda.is_available():
 
 import pytest  # noqa: E402
 
+from flydsl.runtime.device import get_rocm_arch  # noqa: E402
 from kernels.attention.flash_attn_interface import flydsl_flash_attn_func  # noqa: E402
 from tests.test_common import run_perftest  # noqa: E402
 
@@ -3298,6 +3299,13 @@ def main():
 _ATOL_BF16 = 8e-3
 _ATOL_F16 = 4e-3
 
+# Split-K and varlen LSE use the gfx950 DUALWAVE_SWP kernel; dense LSE runs on the
+# gfx942-compatible generic path too. (RDNA is skipped file-wide via CDNA_ONLY_TESTS.)
+_requires_gfx950 = pytest.mark.skipif(
+    not str(get_rocm_arch()).startswith("gfx950"),
+    reason=f"requires gfx950 DUALWAVE_SWP, got {get_rocm_arch()!s}",
+)
+
 
 def _lse_sm_scale(head_dim: int) -> float:
     return 1.0 / math.sqrt(head_dim)
@@ -3367,6 +3375,7 @@ def test_lse_dense(dtype, causal, B, S, H, Hkv, D):
     _assert_lse_matches(lse, _reference_lse(q, k, causal, Hkv), atol)
 
 
+@_requires_gfx950
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("num_kv_splits", [2, 3])
 @pytest.mark.parametrize("D", [64, 128])
@@ -3384,6 +3393,7 @@ def test_lse_splitk(causal, num_kv_splits, D):
     _assert_lse_matches(lse, _reference_lse(q, k, causal, H), _ATOL_BF16)
 
 
+@_requires_gfx950
 @pytest.mark.parametrize("causal", [False, True])
 def test_lse_varlen(causal):
     dtype = torch.bfloat16

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -30,6 +30,8 @@ if not torch.cuda.is_available():
     print("CUDA/ROCm not available")
     sys.exit(1)
 
+import pytest  # noqa: E402
+
 from kernels.attention.flash_attn_interface import flydsl_flash_attn_func  # noqa: E402
 from tests.test_common import run_perftest  # noqa: E402
 
@@ -3282,6 +3284,190 @@ def main():
         else:
             print("Some tests FAILED")
             sys.exit(1)
+
+
+# ============================================================================
+# Forward LSE (log-sum-exp) correctness tests
+# ----------------------------------------------------------------------------
+# Validates the per-row LSE emitted by ``flydsl_flash_attn_func(..., return_lse=True)``
+# against a float32 PyTorch reference. The interface contract is:
+#
+#     LSE_i = ln( sum_j exp( sm_scale * (q_i . k_j) ) )     (masked keys excluded)
+#
+# i.e. natural log, with the softmax scale (sm_scale = 1/sqrt(head_dim)) folded in,
+# and a fully-masked row (no visible keys) storing -inf. Output layout is fp32
+# ``[B, num_heads, Sq]`` (varlen: ``[B, num_heads, max_seqlen_q]``, padded rows are
+# left undefined and not checked). Covers the dense (gfx950 dualwave / generic),
+# split-K combine, and varlen store paths, plus GQA, cross-attention (Skv != Sq)
+# and fully-masked rows.
+# ============================================================================
+
+# bf16 inputs accumulate the dot product in the kernel with a slightly different
+# ordering than the fp32 reference, so allow a small absolute tolerance.
+_ATOL_BF16 = 8e-3
+_ATOL_F16 = 4e-3
+
+
+def _lse_sm_scale(head_dim: int) -> float:
+    return 1.0 / math.sqrt(head_dim)
+
+
+def _reference_lse(q, k, causal, num_kv_heads):
+    """float32 reference LSE for dense inputs.
+
+    q: [B, Sq, H, D], k: [B, Skv, Hkv, D] -> lse: [B, H, Sq] (natural log, scale
+    folded). Causal is bottom-right aligned: key j is visible to query i iff
+    ``j <= i + (Skv - Sq)`` (matches the kernel's bottom-right convention).
+    """
+    B, Sq, H, D = q.shape
+    Skv, Hkv = k.shape[1], k.shape[2]
+    sm = _lse_sm_scale(D)
+    qf = q.float().permute(0, 2, 1, 3)  # B, H, Sq, D
+    kf = k.float().permute(0, 2, 1, 3)  # B, Hkv, Skv, D
+    kf = kf.repeat_interleave(H // Hkv, dim=1)  # B, H, Skv, D
+    scores = torch.einsum("bhqd,bhkd->bhqk", qf, kf) * sm
+    if causal:
+        qi = torch.arange(Sq, device=q.device).view(Sq, 1)
+        ki = torch.arange(Skv, device=q.device).view(1, Skv)
+        mask = (ki > (qi + (Skv - Sq))).view(1, 1, Sq, Skv)
+        scores = scores.masked_fill(mask, float("-inf"))
+    return torch.logsumexp(scores, dim=-1)  # B, H, Sq
+
+
+def _assert_lse_matches(lse, lse_ref, atol):
+    """Finite rows match within atol; -inf (fully-masked) rows match exactly."""
+    lse = lse.float()
+    lse_ref = lse_ref.float()
+    finite = torch.isfinite(lse_ref)
+    # Fully-masked rows: reference is -inf, kernel must be non-finite (i.e. -inf).
+    if (~finite).any():
+        assert bool(((~torch.isfinite(lse)) == (~finite)).all()), "masked (-inf) rows mismatch"
+    if finite.any():
+        diff = (lse[finite] - lse_ref[finite]).abs().max().item()
+        assert diff <= atol, f"LSE max abs diff {diff:.3e} exceeds atol {atol:.3e}"
+
+
+def _rand_lse(*shape, dtype, device="cuda"):
+    return torch.randn(*shape, device=device, dtype=dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "B,S,H,Hkv,D",
+    [
+        (2, 256, 8, 8, 128),  # MHA
+        (2, 256, 8, 2, 128),  # GQA
+        (1, 256, 4, 1, 128),  # MQA
+        (2, 192, 4, 4, 64),  # D=64
+        (3, 128, 6, 3, 128),  # GQA, odd batch
+    ],
+)
+def test_lse_dense(dtype, causal, B, S, H, Hkv, D):
+    torch.manual_seed(S + H + D + int(causal))
+    q = _rand_lse(B, S, H, D, dtype=dtype)
+    k = _rand_lse(B, S, Hkv, D, dtype=dtype)
+    v = _rand_lse(B, S, Hkv, D, dtype=dtype)
+    _, lse = flydsl_flash_attn_func(q, k, v, causal=causal, num_kv_heads=Hkv, return_lse=True)
+    torch.cuda.synchronize()
+    assert lse.shape == (B, H, S)
+    assert lse.dtype == torch.float32
+    atol = _ATOL_BF16 if dtype == torch.bfloat16 else _ATOL_F16
+    _assert_lse_matches(lse, _reference_lse(q, k, causal, Hkv), atol)
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("num_kv_splits", [2, 3])
+@pytest.mark.parametrize("D", [64, 128])
+def test_lse_splitk(causal, num_kv_splits, D):
+    # Split-K requires seq_len >= 384, D in {64,128}, bf16/f16.
+    B, S, H = 1, 512, 8
+    torch.manual_seed(S + D + num_kv_splits + int(causal))
+    dtype = torch.bfloat16
+    q = _rand_lse(B, S, H, D, dtype=dtype)
+    k = _rand_lse(B, S, H, D, dtype=dtype)
+    v = _rand_lse(B, S, H, D, dtype=dtype)
+    _, lse = flydsl_flash_attn_func(q, k, v, causal=causal, num_kv_splits=num_kv_splits, return_lse=True)
+    torch.cuda.synchronize()
+    assert lse.shape == (B, H, S)
+    _assert_lse_matches(lse, _reference_lse(q, k, causal, H), _ATOL_BF16)
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_lse_varlen(causal):
+    dtype = torch.bfloat16
+    D, H, Hkv = 128, 4, 4
+    seqs = [100, 200, 60]
+    torch.manual_seed(sum(seqs) + int(causal))
+    cu = torch.tensor([0, 100, 300, 360], dtype=torch.int32, device="cuda")
+    max_seqlen_q = max(seqs)
+    total = int(cu[-1].item())
+    q = _rand_lse(total, H, D, dtype=dtype)
+    k = _rand_lse(total, Hkv, D, dtype=dtype)
+    v = _rand_lse(total, Hkv, D, dtype=dtype)
+    _, lse = flydsl_flash_attn_func(
+        q,
+        k,
+        v,
+        causal=causal,
+        cu_seqlens_q=cu,
+        cu_seqlens_kv=cu,
+        max_seqlen_q=max_seqlen_q,
+        cross_seqlen=False,
+        return_lse=True,
+    )
+    torch.cuda.synchronize()
+    assert lse.shape == (len(seqs), H, max_seqlen_q)
+    for b, (s0, s1) in enumerate(zip(cu[:-1].tolist(), cu[1:].tolist())):
+        n = s1 - s0
+        qb = q[s0:s1].unsqueeze(0)  # 1, n, H, D
+        kb = k[s0:s1].unsqueeze(0)
+        ref = _reference_lse(qb, kb, causal, Hkv)[0]  # H, n
+        # Only the valid [:, :n] region is defined; padded rows are ignored.
+        _assert_lse_matches(lse[b, :, :n], ref, _ATOL_BF16)
+
+
+def test_lse_fully_masked_rows():
+    """Cross-attention causal with Skv < Sq: leading query rows see no keys -> -inf."""
+    dtype = torch.bfloat16
+    B, Sq, Skv, H, D = 2, 128, 32, 4, 128
+    torch.manual_seed(Sq + Skv)
+    q = _rand_lse(B, Sq, H, D, dtype=dtype)
+    k = _rand_lse(B, Skv, H, D, dtype=dtype)
+    v = _rand_lse(B, Skv, H, D, dtype=dtype)
+    _, lse = flydsl_flash_attn_func(q, k, v, causal=True, return_lse=True)
+    torch.cuda.synchronize()
+    ref = _reference_lse(q, k, True, H)
+    assert (~torch.isfinite(ref)).any(), "test setup should produce fully-masked rows"
+    _assert_lse_matches(lse, ref, _ATOL_BF16)
+
+
+def test_return_lse_false_returns_only_out():
+    """Backwards-compat: default return_lse=False returns a bare tensor."""
+    dtype = torch.bfloat16
+    q = _rand_lse(2, 128, 4, 128, dtype=dtype)
+    k = _rand_lse(2, 128, 4, 128, dtype=dtype)
+    v = _rand_lse(2, 128, 4, 128, dtype=dtype)
+    out = flydsl_flash_attn_func(q, k, v, causal=False)
+    torch.cuda.synchronize()
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == q.shape
+
+
+def test_return_lse_rejects_fp8():
+    dtype = torch.bfloat16
+    q = _rand_lse(2, 128, 4, 128, dtype=dtype)
+    with pytest.raises(NotImplementedError):
+        flydsl_flash_attn_func(
+            q.to(torch.float8_e4m3fn),
+            q.to(torch.float8_e4m3fn),
+            q.to(torch.float8_e4m3fn),
+            causal=False,
+            q_descale=torch.ones(1, device="cuda"),
+            k_descale=torch.ones(1, device="cuda"),
+            v_descale=torch.ones(1, device="cuda"),
+            return_lse=True,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -3289,17 +3289,8 @@ def main():
 # ============================================================================
 # Forward LSE (log-sum-exp) correctness tests
 # ----------------------------------------------------------------------------
-# Validates the per-row LSE emitted by ``flydsl_flash_attn_func(..., return_lse=True)``
-# against a float32 PyTorch reference. The interface contract is:
-#
-#     LSE_i = ln( sum_j exp( sm_scale * (q_i . k_j) ) )     (masked keys excluded)
-#
-# i.e. natural log, with the softmax scale (sm_scale = 1/sqrt(head_dim)) folded in,
-# and a fully-masked row (no visible keys) storing -inf. Output layout is fp32
-# ``[B, num_heads, Sq]`` (varlen: ``[B, num_heads, max_seqlen_q]``, padded rows are
-# left undefined and not checked). Covers the dense (gfx950 dualwave / generic),
-# split-K combine, and varlen store paths, plus GQA, cross-attention (Skv != Sq)
-# and fully-masked rows.
+# Validates return_lse=True output against a float32 PyTorch reference across the
+# dense, split-K combine and varlen paths (plus GQA, cross-attn, fully-masked rows).
 # ============================================================================
 
 # bf16 inputs accumulate the dot product in the kernel with a slightly different


### PR DESCRIPTION
## Motivation
This PR is motivated by the task described here https://amd-hub.atlassian.net/jira/software/c/projects/AIMODELS/boards/2992?assignee=712020%3Acedccbdf-bb1e-4e04-8c3b-edcdd7744eda&selectedIssue=AIMODELS-983, which prepares for a MSLK integration.

## Summary

Extends the FlyDSL flash attention **forward** kernels to optionally emit the per-row **log-sum-exp (LSE)** alongside the attention output. LSE is the normalization statistic the backward pass needs to recompute the softmax probabilities `P` without re-running the online softmax, so this is the enablement step for a pure-FlyDSL forward+backward attention path.

Opt-in via `return_lse=True`; default behavior is unchanged.

## Changes

- **`flash_attn_interface.py`**: add `return_lse` to `flydsl_flash_attn_func`; thread it through every build-cache helper; allocate fp32 `[B, num_heads, Sq]` and return `(out, lse)` when enabled. Cache is keyed on `return_lse` so the existing no-LSE kernels are never perturbed.
- **`flash_attn_generic.py`**: `return_lse` build flag; `LSE` tensor in the kernel/launch/compile signatures; store `sm_scale*m_raw + ln(l)` on both the normal store and the zeroed (fully-masked) tile.
- **`flash_attn_gfx950.py`**: same for the dualwave kernel (dense store `m_row*ln2 + ln(l_row)`), plus the **split-K combine kernel** finalizing `m_max*ln2 + ln(den)` from the per-split `(m, l)`. One writer per row via half-wave + OOB-sentinel guards.
- **`tests/kernels/test_flash_attn_lse.py`**: numerical validation vs a float32 PyTorch reference.
- **`docs/flash_attn_lse_contract.md`**: the A1↔A3 interface contract.

### Output tensor
- dtype `float32`, shape `[B, num_heads, Sq]` (varlen: `[B, num_heads, max_seqlen_q]`, padded rows undefined).

### Supported / unsupported paths
| Path | LSE |
|------|-----|
| dense (gfx950 dualwave / generic) | yes |
| dense split-K (`num_kv_splits > 1`) | yes |
| varlen (packed `cu_seqlens`) | yes |
| GQA / MQA, causal, cross-attn (Sq≠Skv) | yes |
| fp8 | no — raises `NotImplementedError` |
| paged KV (`block_table` / `seqlen_k`) | no — raises `NotImplementedError` |

fp8 and paged KV are decode-oriented and out of scope for the training backward path; they fail loudly rather than silently returning wrong LSE.

## Validation

`tests/kernels/test_flash_attn_lse.py` — **33 cases pass on gfx950**, covering dense MHA/GQA/MQA (`D=64/128`, bf16/f16), split-K, varlen, cross-attention, and fully-masked (`-inf`) rows. LSE matches the fp32 reference within ~8e-3 (bf16) / ~4e-3 (f16); fp32-accumulating paths (varlen light, `D=64`) match to ~1e-6.

## Performance — LSE store overhead
The LSE store is one fp32 write per query row (single lane per row), negligible next to the `O(S²·D)` attention compute. Measured on gfx950 (MI350), bf16, H=16, D=128, min-of-trials:
| Shape (B, S, H, D) | causal | no-LSE kernel (µs) | +LSE kernel (µs) | overhead |
| ------------------ | ------ | ------------------ | ---------------- | -------- |
| (4, 2048, 16, 128) | yes    | 99.1               | 100.3            | +1.3%    |
| (2, 4096, 16, 128) | yes    | 157.4              | 157.1            | ~0%      |
| (8, 1024, 16, 128) | no     | 99.2               | 99.5             | +0.3%    |
Pure kernel-side overhead is within run-to-run noise (≈0–1.3%). Through the full public API the delta is ≈3%, dominated by the extra `torch.empty` allocation of the LSE output tensor, not the GPU store.
## Performance — FlyDSL forward vs CK
FlyDSL forward throughput vs the CK backend (aiter `mha_fwd`), confirming the pure-FlyDSL forward path is competitive. gfx950 (MI350), bf16, host-side end-to-end (CUDA events), mean ± stddev over 3 runs. `aiter_asm` (hand-tuned `fmha_v3`) shown for reference. Baseline FlyDSL forward (LSE adds ≤1.3%, see above).
| Shape (B, S, H, Hkv, D) | mask       | FlyDSL µs   | FlyDSL TFLOPS | CK µs        | CK TFLOPS  | **Fly/CK** | asm µs      | asm TFLOPS |
| ----------------------- | ---------- | ----------- | ------------- | ------------ | ---------- | ---------- | ----------- | ---------- |
| (2, 2048, 16, 16, 128)  | causal     | 54.0 ± 0.2  | 636 ± 2       | 86.1 ± 1.2   | 399 ± 6    | **1.59×**  | 63.2 ± 0.5  | 544 ± 5    |
| (2, 4096, 16, 16, 128)  | causal     | 162.6 ± 1.2 | 846 ± 6       | 190.2 ± 3.1  | 723 ± 12   | **1.17×**  | 124.1 ± 0.2 | 1108 ± 2   |
| (1, 8192, 16, 16, 128)  | causal     | 267.4 ± 1.8 | 1028 ± 7      | 329.9 ± 2.6  | 833 ± 7    | **1.23×**  | 226.8 ± 0.2 | 1212 ± 1   |
| (2, 2048, 16,  2, 128)  | causal GQA | 54.2 ± 0.8  | 634 ± 9       | 86.2 ± 0.8   | 399 ± 4    | **1.59×**  | 63.3 ± 0.2  | 544 ± 2    |
| (4, 2048,  8,  8,  64)  | causal     | 42.4 ± 0.3  | 405 ± 3       | 62.4 ± 0.4   | 276 ± 2    | **1.47×**  | n/a         | n/a        |
| (8, 1024, 16, 16, 128)  | non-causal | 71.6 ± 0.2  | 960 ± 2       | 92.1 ± 2.4   | 747 ± 19   | **1.29×**  | 73.7 ± 0.2  | 933 ± 1    |
| (2, 4096, 16, 16, 128)  | non-causal | 212.6 ± 0.1 | 1293 ± 0      | 283.1 ± 1.0  | 971 ± 4    | **1.33×**  | 223.7 ± 0.2 | 1229 ± 1 |

**FlyDSL is faster than CK on every shape measured (1.17×–1.59×)**, and matches or beats the hand-tuned `aiter_asm` path on non-causal, GQA, short-sequence, and `D=64` shapes (asm remains ahead on long causal). Correctness matches CK: FlyDSL max-err vs the shared reference is on par (Fly/CK max-err ratio = 1.00×; e.g. 3.9e-03 bf16 causal, 2.4e-04 non-causal), all runs PASS the harness gate.


## Compatibility

Fully backwards compatible — `return_lse` defaults to `False` and returns a bare output tensor; LSE build variants are cached separately.

## Test plan

- [x] `pytest tests/kernels/test_flash_attn_lse.py` on gfx950 (33 passed)
- [x] CI on target architectures