### PR TITLE
[CI] skip build/test for docs-only changes

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -47,9 +47,10 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          # code is true when any changed file is NOT one of the non-code paths
-          # below (everything under '**' minus the negated docs / markdown /
-          # image / non-workflow .github patterns).
+          # 'every': a file is code only if it matches all patterns, so
+          # docs-only changes yield code=false. The default 'some' would match
+          # any file via '**' and make 'code' always true.
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'
@@ -80,6 +81,36 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
           MAX_RETRIES: 5
           RETRY_INTERVAL_SECONDS: 30
+
+  # Reports the required 'test (<runner>)' checks when the GPU 'test' job is
+  # skipped for a non-code change (a skipped matrix job emits no per-runner
+  # checks, which would leave branch protection waiting forever). Fails them if
+  # check-signal failed/was cancelled, since check-signal is not itself required.
+  test-skip:
+    needs: [check-signal, detect-changes]
+    if: >-
+      ${{ always()
+          && needs.detect-changes.result == 'success'
+          && needs.detect-changes.outputs.code_changed != 'true' }}
+    name: test
+    strategy:
+      matrix:
+        runners: [
+          'linux-flydsl-mi325-1',
+          'linux-flydsl-mi355-1',
+          'linux-flydsl-navi-2',
+        ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report skipped GPU tests (green) or fail if pre-checks failed (red)
+        env:
+          CHECK_SIGNAL_RESULT: ${{ needs.check-signal.result }}
+        run: |
+          if [ "$CHECK_SIGNAL_RESULT" = "failure" ] || [ "$CHECK_SIGNAL_RESULT" = "cancelled" ]; then
+            echo "::error::check-signal ${CHECK_SIGNAL_RESULT}; failing 'test (${{ matrix.runners }})' for this docs-only change."
+            exit 1
+          fi
+          echo "Docs-only change: GPU tests skipped (check-signal=${CHECK_SIGNAL_RESULT}); reporting 'test (${{ matrix.runners }})' as passed."
 
   # ---------------------------------------------------------------------------
   # Single-GPU tests: kernels, unit, examples, MLIR FileCheck, benchmarks.


### PR DESCRIPTION
- **detect-changes**: add `predicate-quantifier: 'every'` to `dorny/paths-filter`. With the default `some` quantifier the leading `'**'` matches every file, so `code` was always `true` and the skip never triggered. With `every`, a file counts as code only when it matches all patterns (matches `'**'` AND is none of the negated docs/markdown/image paths).
- **test-skip shim**: a job reusing the `test` matrix name so the per-runner required checks (`test (linux-flydsl-...)`) still get reported when the GPU tests are skipped. Otherwise GitHub never emits those check runs for a skipped matrix job and the PR hangs on "Expected — Waiting for status to be reported".
  - It runs only for non-code changes, so it never collides with the real `test` job.
  - `check-signal` is **not** a required check, so the shim guards it: if check-signal `failure`/`cancelled`, the shim fails the required checks with a clear reason (red X) instead of an opaque hang. A `skipped` check-signal (e.g. non-multi-gpu `labeled` events) still reports green.

## Behavior matrix

| Change | real `test` (GPU) | `test-skip` shim | required `test (...)` |
|---|---|---|---|
| code change | runs | skipped | reported by real test |
| docs-only + signal success | skipped | green | green |
| docs-only + signal failure/cancelled | skipped | exit 1 | red + reason |
| docs-only + signal skipped (labeled) | skipped | green | green |

## Verified

- Code change (.py) → `code_changed=true` → GPU `test` matrix ran, shim skipped (observed on a prior run of this branch).
