### PR TITLE
[CI] Make benchmark baselines fork-safe and bounded

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -103,6 +103,8 @@ jobs:
       # If that cache is unavailable, checkout fails before the tests start.
       GIT_CONFIG_GLOBAL: /dev/null
       GIT_CONFIG_NOSYSTEM: "1"
+      # Temporary quarantine for linux-flydsl-navi-2 GPU 1; see #858.
+      CI_HIP_VISIBLE_DEVICES: ${{ contains(matrix.runners, 'navi') && '3' || '' }}
     strategy:
       matrix:
         runners: [
@@ -137,8 +139,13 @@ jobs:
             DEVICE_FLAG="--device /dev/dri"
           fi
 
+          GPU_ENV_ARGS=()
+          if [ -n "${CI_HIP_VISIBLE_DEVICES}" ]; then
+            GPU_ENV_ARGS=(--env "HIP_VISIBLE_DEVICES=${CI_HIP_VISIBLE_DEVICES}")
+          fi
+
           echo "Starting container: flydsl_test:ci"
-          docker run -dt --network=host --user root --device=/dev/kfd $DEVICE_FLAG \
+          docker run -dt --network=host --user root --device=/dev/kfd $DEVICE_FLAG "${GPU_ENV_ARGS[@]}" \
           -v "${GITHUB_WORKSPACE:-$PWD}/flydsl-test:/flydsl-test" \
           --ipc=host --group-add video \
           --shm-size 16g \
@@ -228,6 +235,7 @@ jobs:
           docker exec flydsl_test bash -c "python3 -c 'import triton; assert tuple(map(int, triton.__version__.split(\"+\", 1)[0].split(\".\")[:3])) >= (3, 6, 0), triton.__version__; print(\"Installed triton\", triton.__version__)'"
 
       - name: Run tests
+        timeout-minutes: 60
         run: |
           docker exec flydsl_test bash -c "export PYTHONPATH=/tmp/aiter:\${PYTHONPATH:-} && export AITER_REPO=/tmp/aiter && cd /flydsl-test && RUN_TESTS_FULL=1 bash scripts/run_tests.sh"
 

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -23,6 +23,9 @@ env:
   DOCKER_IMAGE: "rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.9.1"
   GITHUB_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
+  # PRs compare against their exact base; main pushes compare against the previous commit.
+  BASE_REPO_NAME: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
+  BASE_COMMIT_SHA: ${{ github.event.pull_request.base.sha || github.event.before || 'main' }}
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -91,7 +94,7 @@ jobs:
     # changes (code_changed == 'false') skip this job entirely, so no GPU runner
     # is used; a detect-changes failure falls back to running.
     if: >-
-      ${{ always()
+      ${{ !cancelled()
           && needs.check-signal.result == 'success'
           && (needs.detect-changes.result != 'success'
               || needs.detect-changes.outputs.code_changed == 'true') }}
@@ -254,63 +257,59 @@ jobs:
 
       - name: Run benchmark baselines
         id: bench-baselines
-        timeout-minutes: 180
+        timeout-minutes: 45
         continue-on-error: true
         run: |
-          docker exec -i flydsl_test bash <<'BASH'
+          docker exec -i \
+            -e BASE_REPO_NAME \
+            -e BASE_COMMIT_SHA \
+            flydsl_test bash <<'BASH'
           set -u
           cd /flydsl-test
-          rm -rf /tmp/flydsl-bench-main-* /tmp/flydsl-bench-tag
+          rm -rf /tmp/flydsl-bench-main /tmp/flydsl-bench-tag
           rm -f /tmp/bench_main.csv /tmp/bench_latest_tag.csv /tmp/bench_main_label /tmp/bench_latest_tag_label
           git worktree prune || true
-          git fetch origin main --depth=8
+          base_repo_url="https://github.com/${BASE_REPO_NAME}.git"
 
-          found_main=0
-          idx=0
-          for commit in $(git rev-list --max-count=8 FETCH_HEAD); do
+          if git fetch "${base_repo_url}" "${BASE_COMMIT_SHA}" --no-tags --depth=1; then
+            commit="$(git rev-parse FETCH_HEAD)"
             label="main"
-            if [ "${idx}" -gt 0 ]; then
-              label="main~${idx}"
-            fi
-            worktree="/tmp/flydsl-bench-main-${idx}"
-            csv="/tmp/bench_candidate_${idx}.csv"
-            output="/tmp/bench_candidate_${idx}.out"
+            worktree="/tmp/flydsl-bench-main"
+            csv="/tmp/bench_main_candidate.csv"
+            output="/tmp/bench_main.out"
             log_dir="/tmp/flydsl_bench_${label}"
-            echo "Trying benchmark baseline ${label} (${commit})"
+            echo "Trying exact benchmark baseline ${BASE_REPO_NAME}@${commit}"
 
             if ! git worktree add --detach "${worktree}" "${commit}"; then
-              echo "Failed to create worktree for ${label}; trying older main commit."
-              idx=$((idx + 1))
-              continue
-            fi
-
-            (
-              set -e -o pipefail
-              cd "${worktree}"
-              export MLIR_PATH=/llvm-project/mlir_install
-              python3 -m pip install -e . --use-pep517 2>&1 | tail -5
-              export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
-              export AITER_REPO=/tmp/aiter
-              BENCH_LOG_DIR="${log_dir}" bash scripts/run_benchmark.sh 2>&1 | tee "${output}"
-              python3 /flydsl-test/scripts/benchmark_output_to_csv.py "${output}" "${csv}"
-            )
-            status=$?
-            if [ "${status}" -eq 0 ] && [ -s "${csv}" ]; then
-              cp "${csv}" /tmp/bench_main.csv
-              echo "${label}" >/tmp/bench_main_label
-              found_main=1
-              break
+              echo "Failed to create worktree for exact main baseline."
             else
-              echo "Benchmark baseline ${label} failed; trying older main commit."
+              (
+                set -e -o pipefail
+                cd "${worktree}"
+                export MLIR_PATH=/llvm-project/mlir_install
+                python3 -m pip install -e . --use-pep517 2>&1 | tail -5
+                export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
+                export AITER_REPO=/tmp/aiter
+                BENCH_LOG_DIR="${log_dir}" bash scripts/run_benchmark.sh 2>&1 | tee "${output}"
+                python3 /flydsl-test/scripts/benchmark_output_to_csv.py "${output}" "${csv}"
+              )
+              status=$?
+              if [ "${status}" -eq 0 ] && [ -s "${csv}" ]; then
+                cp "${csv}" /tmp/bench_main.csv
+                echo "${label}" >/tmp/bench_main_label
+              else
+                echo "Exact main benchmark baseline failed; not retrying older commits."
+              fi
             fi
-            idx=$((idx + 1))
-          done
-
-          if [ "${found_main}" -eq 0 ]; then
-            echo "No usable main benchmark baseline found."
+          else
+            echo "Failed to fetch exact main baseline ${BASE_REPO_NAME}@${BASE_COMMIT_SHA}."
           fi
 
-          if git fetch origin 'refs/tags/v*:refs/tags/v*' --force --depth=1; then
+          if [ ! -s /tmp/bench_main.csv ]; then
+            echo "::warning title=Benchmark baseline unavailable::No usable exact main baseline found; skipping main comparison."
+          fi
+
+          if git fetch "${base_repo_url}" 'refs/tags/v*:refs/tags/v*' --force --depth=1; then
             latest_tag="$(git tag --list 'v*' --sort=-v:refname | sed -n '1p')"
             if [ -n "${latest_tag}" ]; then
               worktree="/tmp/flydsl-bench-tag"
@@ -341,10 +340,10 @@ jobs:
                 echo "Failed to create worktree for ${latest_tag}; skipping latest-tag comparison."
               fi
             else
-              echo "No v* tags found; skipping latest-tag comparison."
+              echo "::warning title=Tag baseline unavailable::No v* tags found; skipping latest-tag comparison."
             fi
           else
-            echo "Failed to fetch tags; skipping latest-tag comparison."
+            echo "::warning title=Tag baseline unavailable::Failed to fetch tags; skipping latest-tag comparison."
           fi
           BASH
 
@@ -354,7 +353,7 @@ jobs:
         run: |
           docker exec flydsl_test bash -c "
             if [ ! -f /tmp/bench_main.csv ]; then
-              echo 'No usable main benchmark baseline found; skipping main comparison.'
+              echo '::warning title=Benchmark comparison skipped::No usable main benchmark baseline found.'
               exit 0
             fi
             cd /flydsl-test
@@ -369,7 +368,7 @@ jobs:
         run: |
           docker exec flydsl_test bash -c "
             if [ ! -f /tmp/bench_latest_tag.csv ]; then
-              echo 'No usable latest-tag benchmark baseline found; skipping latest-tag comparison.'
+              echo '::warning title=Benchmark comparison skipped::No usable latest-tag benchmark baseline found.'
               exit 0
             fi
             cd /flydsl-test
@@ -415,7 +414,7 @@ jobs:
     # Also gated on code_changed: docs-only changes skip this job (a
     # detect-changes failure falls back to running).
     if: |
-      always() &&
+      !cancelled() &&
       (needs.detect-changes.result != 'success' ||
        needs.detect-changes.outputs.code_changed == 'true') && (
         (github.event_name == 'pull_request' &&
@@ -557,10 +556,13 @@ jobs:
         timeout-minutes: 20
         continue-on-error: true
         run: |
-          docker exec flydsl_test bash -c "
+          docker exec \
+            -e BASE_REPO_NAME \
+            -e BASE_COMMIT_SHA \
+            flydsl_test bash -c "
             cd /flydsl-test
-            git fetch origin main --depth=1
-            git worktree add /tmp/flydsl-main origin/main
+            git fetch \"https://github.com/\${BASE_REPO_NAME}.git\" \"\${BASE_COMMIT_SHA}\" --no-tags --depth=1
+            git worktree add --detach /tmp/flydsl-main FETCH_HEAD
             cd /tmp/flydsl-main
             export MLIR_PATH=/llvm-project/mlir_install
             python3 -m pip install -e . --use-pep517 2>&1 | tail -5


### PR DESCRIPTION
## Summary

Make benchmark baseline selection deterministic for fork pull requests and prevent one unusable baseline from expanding into eight full benchmark runs.

Fixes #856.

## Motivation

The current workflow checks out the PR head repository and later fetches `origin/main`. For fork PRs, `origin` is the contributor fork rather than `ROCm/FlyDSL`.

In [run 29366839827](https://github.com/ROCm/FlyDSL/actions/runs/29366839827), the fork main was 11 commits behind the PR base. The same AITER API mismatch caused all eight fallback commits to fail, but every candidate still performed an editable install and almost the entire benchmark suite:

| Runner | Baseline time | Result |
|---|---:|---|
| MI355 | 76m06s | 8 failures; no comparison |
| MI325 | 57m23s | 8 failures; no comparison |

The workflow remained green after skipping both main and tag comparisons. Superseded GPU jobs could also continue because their job-level conditions used `always()` despite `cancel-in-progress: true`.

## Changes

- Resolve the canonical baseline repository from `pull_request.base.repo.full_name`.
- Fetch the exact `pull_request.base.sha` for PRs and `github.event.before` for main pushes; manual dispatch retains canonical `main` behavior.
- Run the main baseline exactly once instead of walking `main` through `main~7`.
- Fetch release tags from the base repository rather than the head fork.
- Apply the same exact-base selection to the label-triggered multi-GPU baseline.
- Reduce the combined baseline timeout from 180 to 45 minutes.
- Emit GitHub warning annotations when optional baseline comparisons cannot run.
- Replace job-level `always()` with `!cancelled()` on the real single- and multi-GPU jobs. Cleanup steps retain `always()`.
- Temporarily quarantine the unhealthy `linux-flydsl-navi-2` GPU 1 by running that job on proven healthy GPU 3; tracked for infrastructure repair in #858.
- Cap the single-GPU test step at 60 minutes so a bad device cannot occupy a runner for the default six-hour limit.
- Preserve the comparison label `main` for compatibility with the existing dashboard parser, while logging the exact repository and commit.

Baseline selection after this change:

| Event | Repository | Ref |
|---|---|---|
| Pull request | PR base repository | Exact `pull_request.base.sha` |
| Push to main | `github.repository` | Exact pre-push `github.event.before` |
| Manual dispatch | `github.repository` | `main` |

## Expected impact

For the observed failure mode, removing seven redundant retries should save roughly 65 minutes on MI355 and 50 minutes on MI325. It also makes the comparison target correct for every fork PR and allows concurrency cancellation to release GPU runners.

This intentionally remains a surgical workflow fix. AITER pinning, partial baseline CSV recovery, reusable main/release artifacts, test/performance workflow separation, and MLIR cache redesign are documented as follow-ups in #856.

## Testing

- [x] `git diff --check`
- [x] Parsed `.github/workflows/flydsl.yaml` with PyYAML
- [x] Ran `bash -n` over the modified embedded shell blocks
- [x] Ran `actionlint v1.7.7` (ignoring only the repository's known self-hosted runner labels)
- [x] Verified GitHub fetches both current and historical FlyDSL commits by exact SHA with `--depth=1`
- [x] Confirmed the eight-commit `rev-list` fallback and `git fetch origin main` are absent
- [x] Correlated 26 recent Navi jobs: GPU 1 hung 3/3 times; GPU 2 passed 6/6 and GPU 3 had 16 successful runs
- [x] Fork PR CI: confirm logs show `ROCm/FlyDSL@<base SHA>` and only one main attempt

No local GPU suite was run because the change is limited to GitHub Actions orchestration; this PR's fork CI is the functional integration test.

## Dependencies

- [x] No new third-party dependencies

## Breaking Changes

None.

## Related work

- #526 introduced the baseline comparison and eight-commit fallback.
- #597 added the latest-tag comparison while retaining that fallback.
- #840 and #842 fixed AITER-drift skip handling for current source but not stale fork baseline selection.
- #852 is an orthogonal open docs-only CI optimization. Its lightweight required-status shim intentionally retains `always()`; this PR only changes real GPU jobs and is compatible with it.


