### PR TITLE
[Kernel] Add CDNA SageAttention kernel

### DIFF
--- a/kernels/attention/sage_attn_cdna.py
+++ b/kernels/attention/sage_attn_cdna.py
@@ -3,817 +3,16 @@
 
 """SageAttention kernel for AMD MI308X (CDNA gfx942)."""
 
-import math as host_math
-import os
-
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
-from flydsl._mlir.dialects import llvm as _llvm
-from flydsl._mlir.dialects import memref as _memref
-from flydsl._mlir.dialects import scf as _scf
-from flydsl._mlir.dialects._rocdl_ops_gen import (
-    mfma_f32_32x32x16_fp8_fp8 as _ods_mfma_f32_32x32x16_fp8_fp8,
-)
-from flydsl._mlir.dialects._rocdl_ops_gen import (
-    mfma_i32_32x32x16_i8 as _ods_mfma_i32_32x32x16_i8,
-)
-from flydsl._mlir.dialects._rocdl_ops_gen import (
-    mfma_i32_32x32x32_i8 as _ods_mfma_i32_32x32x32_i8,
-)
-from flydsl._mlir.dialects._rocdl_ops_gen import (
-    mfma_scale_f32_32x32x64_f8f6f4 as _ods_mfma_scale_f32_32x32x64_f8f6f4,
-)
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl, vector
+from flydsl.expr import const_expr, gpu, range_constexpr
 from flydsl.expr.typing import T
 from flydsl.expr.typing import Vector as Vec
-from flydsl.expr.utils.arith import ArithValue
 from flydsl.expr.utils.arith import _to_raw as _raw
-from flydsl.runtime.device import get_rocm_arch as get_hip_arch
-from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
-from kernels.attention.sage_attn_utils import (
-    _LDS_CAP_BYTES,
-    _extract_aligned_pointer,
-    _llvm_value,
-    _pointer_load,
-    _pointer_store,
-)
-from kernels.attention.sage_attn_utils import _fadd as _u_fadd
-from kernels.attention.sage_attn_utils import _ffma as _u_ffma
-from kernels.attention.sage_attn_utils import _fmax as _u_fmax
-from kernels.attention.sage_attn_utils import _fmul as _u_fmul
-from kernels.attention.sage_attn_utils import _fsub as _u_fsub
-from kernels.common.kernels_common import _if_else, _if_then, get_warp_size
-
-
-class _SageTraits:
-    """Compile-time constants for one SageAttention CDNA launch config."""
-
-    def __init__(
-        self,
-        *,
-        BLOCK_M,
-        BLOCK_N,
-        BLOCK_SIZE,
-        CAUSAL,
-        D_CHUNKS,
-        GROUPS,
-        HEAD_DIM,
-        KV_STRIDE_TOKEN,
-        K_NEEDS_GUARD,
-        K_STEPS_QK,
-        K_STRIDE,
-        LDS_K_BYTES,
-        LDS_K_TOTAL_BYTES,
-        LDS_V_BYTES,
-        LDS_V_TOTAL_BYTES,
-        MFMA_K_FP8,
-        MFMA_K_INT8,
-        MFMA_M,
-        MFMA_N,
-        NUM_BATCHES_K,
-        NUM_BATCHES_V,
-        NUM_KV_HEADS,
-        NUM_PIPE_STAGES,
-        NUM_Q_HEADS,
-        PV_K_STEPS,
-        Q_SCALE_BLOCK_M,
-        ROWS_PER_BATCH_K,
-        ROWS_PER_BATCH_V,
-        ROWS_PER_WAVE,
-        STRIDE_TOKEN,
-        THREADS_PER_ROW_K,
-        THREADS_PER_ROW_V,
-        VEC_WIDTH_K,
-        VEC_WIDTH_V,
-        V_NEEDS_GUARD,
-        V_STRIDE,
-        V_TRANSPOSED,
-        WARP_SIZE,
-        _DEFER_SCALE,
-        _GFX942_W256,
-        _LPT_SCHED,
-        _dma_any,
-        _dma_k,
-        _dma_xor,
-        lds_base_offset,
-        use_bias,
-    ):
-        """Store all launch-config constants as attributes."""
-        self.BLOCK_M = BLOCK_M
-        self.BLOCK_N = BLOCK_N
-        self.BLOCK_SIZE = BLOCK_SIZE
-        self.CAUSAL = CAUSAL
-        self.D_CHUNKS = D_CHUNKS
-        self.GROUPS = GROUPS
-        self.HEAD_DIM = HEAD_DIM
-        self.KV_STRIDE_TOKEN = KV_STRIDE_TOKEN
-        self.K_NEEDS_GUARD = K_NEEDS_GUARD
-        self.K_STEPS_QK = K_STEPS_QK
-        self.K_STRIDE = K_STRIDE
-        self.LDS_K_BYTES = LDS_K_BYTES
-        self.LDS_K_TOTAL_BYTES = LDS_K_TOTAL_BYTES
-        self.LDS_V_BYTES = LDS_V_BYTES
-        self.LDS_V_TOTAL_BYTES = LDS_V_TOTAL_BYTES
-        self.MFMA_K_FP8 = MFMA_K_FP8
-        self.MFMA_K_INT8 = MFMA_K_INT8
-        self.MFMA_M = MFMA_M
-        self.MFMA_N = MFMA_N
-        self.NUM_BATCHES_K = NUM_BATCHES_K
-        self.NUM_BATCHES_V = NUM_BATCHES_V
-        self.NUM_KV_HEADS = NUM_KV_HEADS
-        self.NUM_PIPE_STAGES = NUM_PIPE_STAGES
-        self.NUM_Q_HEADS = NUM_Q_HEADS
-        self.PV_K_STEPS = PV_K_STEPS
-        self.Q_SCALE_BLOCK_M = Q_SCALE_BLOCK_M
-        self.ROWS_PER_BATCH_K = ROWS_PER_BATCH_K
-        self.ROWS_PER_BATCH_V = ROWS_PER_BATCH_V
-        self.ROWS_PER_WAVE = ROWS_PER_WAVE
-        self.STRIDE_TOKEN = STRIDE_TOKEN
-        self.THREADS_PER_ROW_K = THREADS_PER_ROW_K
-        self.THREADS_PER_ROW_V = THREADS_PER_ROW_V
-        self.VEC_WIDTH_K = VEC_WIDTH_K
-        self.VEC_WIDTH_V = VEC_WIDTH_V
-        self.V_NEEDS_GUARD = V_NEEDS_GUARD
-        self.V_STRIDE = V_STRIDE
-        self.V_TRANSPOSED = V_TRANSPOSED
-        self.WARP_SIZE = WARP_SIZE
-        self._DEFER_SCALE = _DEFER_SCALE
-        self._GFX942_W256 = _GFX942_W256
-        self._LPT_SCHED = _LPT_SCHED
-        self._dma_any = _dma_any
-        self._dma_k = _dma_k
-        self._dma_xor = _dma_xor
-        self.lds_base_offset = lds_base_offset
-        self.use_bias = use_bias
-
-
-class _SageKernel:
-    """SageAttention CDNA emitter: helpers, prologue, epilogue.
-
-    Methods read kernel SSA off ``self`` and constants off ``self.t``.
-    """
-
-    def __init__(self, t, allocator):
-        """Bind config traits and the shared-memory allocator."""
-        self.t = t
-        self.allocator = allocator
-
-    def mfma_i32_k32(self, result_type, operands):
-        a, b, c = (operands[0], operands[1], operands[2])
-        cbsz = operands[3] if len(operands) > 3 else 0
-        abid = operands[4] if len(operands) > 4 else 0
-        blgp = operands[5] if len(operands) > 5 else 0
-        a_v = _llvm_value(a)
-        b_v = _llvm_value(b)
-        c_v = _llvm_value(c)
-        if const_expr(self.t._GFX942_W256):
-            return _ods_mfma_i32_32x32x16_i8(
-                res=result_type, a=a_v, b=b_v, c=c_v, cbsz=cbsz, abid=abid, blgp=blgp
-            ).result
-        return _ods_mfma_i32_32x32x32_i8(res=result_type, a=a_v, b=b_v, c=c_v, cbsz=cbsz, abid=abid, blgp=blgp).result
-
-    def mfma_fp8_k16(self, result_type, operands):
-        a, b, c = (operands[0], operands[1], operands[2])
-        cbsz = operands[3] if len(operands) > 3 else 0
-        abid = operands[4] if len(operands) > 4 else 0
-        blgp = operands[5] if len(operands) > 5 else 0
-        a_v = _llvm_value(a)
-        b_v = _llvm_value(b)
-        c_v = _llvm_value(c)
-        return _ods_mfma_f32_32x32x16_fp8_fp8(
-            res=result_type, a=a_v, b=b_v, c=c_v, cbsz=cbsz, abid=abid, blgp=blgp
-        ).result
-
-    def mfma_fp8_k64(self, result_type, a, b, c, scale_a, scale_b):
-        """rocdl.mfma.scale.f32.32x32x64.f8f6f4 (fp8*fp8) wrapper.
-        a,b: vec<8xi32> per lane; c: vec<16xf32>; scale_a/b i32 e8m0 (127=1.0).
-        """
-        a_v = _llvm_value(a)
-        b_v = _llvm_value(b)
-        c_v = _llvm_value(c)
-        return _ods_mfma_scale_f32_32x32x64_f8f6f4(
-            res=result_type, a=a_v, b=b_v, c=c_v, cbsz=0, blgp=0, opselA=0, scaleA=scale_a, opselB=0, scaleB=scale_b
-        ).result
-
-    def _fadd(self, a, b):
-        return _u_fadd(a, b, self.fm_fast)
-
-    def _fsub(self, a, b):
-        return _u_fsub(a, b, self.fm_fast)
-
-    def _fmul(self, a, b):
-        return _u_fmul(a, b, self.fm_fast)
-
-    def _fmax(self, a, b):
-        return _u_fmax(a, b, self.fm_fast)
-
-    def _ffma(self, a, b, c):
-        return _u_ffma(a, b, c, self.fm_fast)
-
-    def q_global_idx(self, token_idx, col):
-        token = self.batch_idx * self.seq_len_q_v + token_idx
-        return token * self.t.STRIDE_TOKEN + self.head_q_idx * self.t.HEAD_DIM + col
-
-    def kv_global_idx(self, token_idx, col):
-        token = self.batch_idx * self.seq_len_k_v + token_idx
-        return token * self.t.KV_STRIDE_TOKEN + self.head_kv_idx * self.t.HEAD_DIM + col
-
-    def _load_ptr_i8_vec16(self, ptr, base_idx):
-        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.i8)
-        return _pointer_load(self.v16i8_type, gep)
-
-    def _load_ptr_i8_vec8(self, ptr, base_idx):
-        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.i8)
-        return _pointer_load(self.v8i8_type, gep)
-
-    def _load_ptr_i64(self, ptr, base_idx):
-        """Load 8 contiguous bytes from `ptr+base_idx` as a scalar i64
-        (8xi8 packed). Used for MFMA i8 operands which require packed i64.
-        """
-        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.i8)
-        return _pointer_load(T.i64, gep)
-
-    def _load_ptr_f8_vec8(self, ptr, base_idx):
-        return self._load_ptr_i8_vec8(ptr, base_idx)
-
-    def _store_ptr_bf16(self, ptr, base_idx, val):
-        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.bf16)
-        _pointer_store(val, gep)
-
-    def _load_ptr_f32(self, ptr, base_idx):
-        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.f32)
-        return _pointer_load(T.f32, gep)
-
-    def _load_ptr_f32_vec4(self, ptr, base_idx):
-        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.f32)
-        return _pointer_load(self.v4f32_type, gep)
-
-    def _bpermute_f32(self, value, src_lane):
-        value_i32 = arith.bitcast(T.i32, _raw(value))
-        lane_byte_idx = fx.Int32(arith.unwrap(arith.index_cast(T.i32, _raw(src_lane * 4))))
-        result_i32 = rocdl.ds_bpermute(T.i32, _raw(lane_byte_idx), value_i32)
-        return fx.Float32(arith.bitcast(T.f32, result_i32))
-
-    def reduction_peer32(self, v_f32):
-        return fx.Float32(v_f32).shuffle_xor(self.shuf32_i32, self.width_i32)
-
-    def row_max_reduce(self, local_max):
-        """Reduce max across the 2 klane halves within wave64."""
-        return self._fmax(local_max, self.reduction_peer32(local_max))
-
-    def row_sum_reduce(self, local_sum):
-        """Reduce sum across the 2 klane halves within wave64."""
-        return self._fadd(local_sum, self.reduction_peer32(local_sum))
-
-    def _coop_load_k_dma(self, tile_start, buf_off):
-        assert not self.t.K_NEEDS_GUARD, "K DMA path requires ROWS_PER_BATCH_K<=BLOCK_N"
-        DMA_BYTES_K = self.t.VEC_WIDTH_K
-        buf_off_i64 = arith.unwrap(arith.index_cast(T.i64, _raw(buf_off)))
-        wave_byte = rocdl.readfirstlane(
-            T.i64, arith.unwrap(arith.index_cast(T.i64, self.wave_id * fx.Index(self.t.WARP_SIZE * DMA_BYTES_K)))
-        )
-        base_ptr = self._lds_as3_base(self.lds)
-        base_ptr = buffer_ops.get_element_ptr(base_ptr, buf_off_i64)
-        base_ptr = buffer_ops.get_element_ptr(base_ptr, wave_byte)
-        size_i32 = arith.constant(DMA_BYTES_K, type=T.i32)
-        c0 = arith.constant(0, type=T.i32)
-        aux1 = arith.constant(1, type=T.i32)
-        _CPR_K = self.t.HEAD_DIM // self.t.VEC_WIDTH_K
-        _XMASK_K = _CPR_K - 1
-        for batch in range_constexpr(self.t.NUM_BATCHES_K):
-            row_offset = batch * self.t.ROWS_PER_BATCH_K
-            row_idx_raw = tile_start + self.load_row_k_batch + row_offset
-            if const_expr(self.t._dma_xor):
-                tile_row = self.load_row_k_batch + row_offset
-                phys_chunk = self.load_lane_k
-                g_chunk = ArithValue(phys_chunk) ^ ArithValue(tile_row) & fx.Index(_XMASK_K)
-                g_col = fx.Index(g_chunk) * fx.Index(self.t.VEC_WIDTH_K)
-                g_idx = self.kv_global_idx(row_idx_raw, g_col)
-            else:
-                g_idx = self.kv_global_idx(row_idx_raw, self.load_col_k_base)
-            voff = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx)))
-            if const_expr(batch == 0):
-                lds_ptr = base_ptr
-            else:
-                lds_ptr = buffer_ops.get_element_ptr(
-                    base_ptr, static_byte_offset=batch * self.t.BLOCK_SIZE * DMA_BYTES_K
-                )
-            rocdl.raw_ptr_buffer_load_lds(self.k_rsrc, lds_ptr, size_i32, voff, c0, c0, aux1)
-
-    def coop_load_k(self, tile_start, buf_off):
-        if const_expr(self.t._dma_k):
-            self._coop_load_k_dma(tile_start, buf_off)
-            return
-        for batch in range_constexpr(self.t.NUM_BATCHES_K):
-            row_offset = batch * self.t.ROWS_PER_BATCH_K
-            row_idx_raw = tile_start + self.load_row_k_batch + row_offset
-            if const_expr(self.t.K_NEEDS_GUARD):
-                row_valid = self.load_row_k_batch < fx.Index(self.t.BLOCK_N)
-                do_load = row_valid
-            else:
-                do_load = True
-            if do_load:
-                g_idx = self.kv_global_idx(row_idx_raw, self.load_col_k_base)
-                lds_row = self.load_row_k_batch + row_offset
-                lds_idx = buf_off + lds_row * self.t.K_STRIDE + self.load_col_k_base
-                g_dword_i32 = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx >> fx.Index(2))))
-                v4i32 = buffer_ops.buffer_load(self.k_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
-                vec = vector.bitcast(self.v16i8_type, v4i32)
-                Vec(vec).store(self.lds, [lds_idx])
-
-    def coop_load_v(self, tile_start, buf_off):
-        """Cooperatively load V (FP8 raw bytes) from global into LDS (gfx942 column-major)."""
-        for batch in range_constexpr(self.t.NUM_BATCHES_V):
-            row_offset = batch * self.t.ROWS_PER_BATCH_V
-            row_idx_raw = tile_start + self.load_row_v_batch + row_offset
-            if const_expr(self.t.V_NEEDS_GUARD):
-                row_valid = self.load_row_v_batch < fx.Index(self.t.BLOCK_N)
-                do_load = row_valid
-            else:
-                do_load = True
-            if do_load:
-                if const_expr(self.t.V_TRANSPOSED):
-                    d_idx = self.tid % fx.Index(self.t.HEAD_DIM)
-                    k_group = self.tid // fx.Index(self.t.HEAD_DIM)
-                    tile_idx = tile_start // fx.Index(self.t.BLOCK_N)
-                    g_byte_idx = (
-                        (
-                            (self.batch_idx * self.t.NUM_KV_HEADS + self.head_kv_idx) * self.num_k_blocks_per_head
-                            + tile_idx
-                        )
-                        * fx.Index(self.t.HEAD_DIM)
-                        + d_idx
-                    ) * fx.Index(self.t.BLOCK_N) + k_group * fx.Index(16)
-                    g_dword_i32 = arith.unwrap(arith.index_cast(T.i32, _raw(g_byte_idx >> fx.Index(2))))
-                    v4i32 = buffer_ops.buffer_load(self.v_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
-                    raw_v = vector.bitcast(self.v16i8_type, v4i32)
-                    v_off = buf_off + d_idx * self.t.V_STRIDE + k_group * fx.Index(16)
-                    Vec(raw_v).store(self.lds_v, [v_off])
-                else:
-                    g_idx = self.kv_global_idx(row_idx_raw, self.load_col_v_base)
-                    g_dword_i32 = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx >> fx.Index(2))))
-                    v4i32 = buffer_ops.buffer_load(self.v_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
-                    raw_v = vector.bitcast(self.v16i8_type, v4i32)
-                    lds_col = self.load_row_v_batch + row_offset
-                    for di in range_constexpr(self.t.VEC_WIDTH_V):
-                        d_idx = self.load_col_v_base + di
-                        v_off = buf_off + d_idx * self.t.V_STRIDE + lds_col
-                        b_i8 = vector.extract(raw_v, static_position=[di], dynamic_position=[])
-                        Vec.from_elements([b_i8], fx.Int8).store(self.lds_v, [v_off])
-
-    def load_k_frag(self, kv_block_row, ks, buf_off):
-        """Load K fragment from LDS for the QK MFMA."""
-        if const_expr(self.t._dma_xor):
-            _CPR_K = self.t.HEAD_DIM // self.t.VEC_WIDTH_K
-            _XMASK_K = _CPR_K - 1
-            if const_expr(self.t._GFX942_W256):
-                g_chunk = fx.Index(ks)
-                phys_chunk = ArithValue(g_chunk) ^ ArithValue(kv_block_row) & fx.Index(_XMASK_K)
-                k_col = fx.Index(phys_chunk) * fx.Index(self.t.VEC_WIDTH_K) + self.klane * fx.Index(8)
-            else:
-                g_chunk = fx.Index(ks * 2) + self.klane
-                phys_chunk = ArithValue(g_chunk) ^ ArithValue(kv_block_row) & fx.Index(_XMASK_K)
-                k_col = fx.Index(phys_chunk) * fx.Index(self.t.VEC_WIDTH_K)
-        elif const_expr(self.t._GFX942_W256):
-            k_col = fx.Index(ks * self.t.MFMA_K_INT8) + self.klane * 8
-        else:
-            k_col = fx.Index(ks * self.t.MFMA_K_INT8) + self.klane * 16
-        lds_idx = buf_off + fx.Index(kv_block_row * self.t.K_STRIDE) + k_col
-        if const_expr(self.t._GFX942_W256):
-            v8i8 = Vec.load(self.v8i8_type, self.lds, [lds_idx])
-            k_i64v = vector.bitcast(Vec.make_type(1, fx.Int64), v8i8)
-            return vector.extract(k_i64v, static_position=[0], dynamic_position=[])
-        v16i8 = Vec.load(self.v16i8_type, self.lds, [lds_idx])
-        return vector.bitcast(self.v4i32_type, v16i8)
-
-    def load_v_frag_fp8(self, pks, dc, buf_off, iter_lane_addr_i32):
-        """Load a V fragment (FP8) from LDS for the PV MFMA (gfx942 vector ds_read)."""
-        d_col = dc * self.t.MFMA_M + self.lane32
-        kv_k_start = fx.Index(pks * self.t.MFMA_K_FP8) + self.klane * fx.Index(self.t.MFMA_K_FP8 // 2)
-        v_off = buf_off + d_col * self.t.V_STRIDE + kv_k_start
-        if const_expr(self.t.MFMA_K_FP8 == 16):
-            v8i8 = Vec.load(self.v8i8_type, self.lds_v, [v_off])
-            v_i64v = vector.bitcast(Vec.make_type(1, fx.Int64), v8i8)
-            return vector.extract(v_i64v, static_position=[0], dynamic_position=[])
-        lo_v16i8 = Vec.load(self.v16i8_type, self.lds_v, [v_off])
-        hi_v16i8 = Vec.load(self.v16i8_type, self.lds_v, [v_off + 16])
-        lo_v4i32 = vector.bitcast(self.v4i32_type, lo_v16i8)
-        hi_v4i32 = vector.bitcast(self.v4i32_type, hi_v16i8)
-        elems = []
-        for w in range_constexpr(4):
-            elems.append(vector.extract(lo_v4i32, static_position=[w], dynamic_position=[]))
-        for w in range_constexpr(4):
-            elems.append(vector.extract(hi_v4i32, static_position=[w], dynamic_position=[]))
-        return Vec.from_elements(elems, fx.Int32).ir_value()
-
-    def f32_to_bf16_trunc(self, f32_raw):
-        """Bitwise f32 → bf16 truncation (upper 16 bits)."""
-        i32_val = arith.BitcastOp(T.i32, f32_raw).result
-        i16_val = arith.TruncIOp(T.i16, arith.ShRUIOp(i32_val, arith.constant(16, type=T.i32)).result).result
-        return arith.BitcastOp(T.bf16, i16_val).result
-
-    def _buf_off(self, buf_idx_i32, stride_index):
-        """buf_idx ∈ {0,1} → byte offset in {0, stride}, returned as fx.Index."""
-        is_one = ArithValue(fx.Int32(buf_idx_i32) == fx.Int32(1))
-        return fx.Index(is_one.select(stride_index, self.ZERO_INDEX))
-
-    def _i32_pair_to_i64(self, lo, hi):
-        lo64 = arith.extui(T.i64, _raw(lo))
-        hi64 = arith.shli(arith.extui(T.i64, _raw(hi)), arith.constant(32, type=T.i64))
-        return arith.ori(lo64, hi64)
-
-    def _gather_p_i64_from_pwords(self, p_words_2d, pks):
-        """Gather 8 fp8 bytes (i64 B operand) for mfma_f32_32x32x16_fp8."""
-        width_i32 = arith.constant(64, type=T.i32)
-        words = []
-        for j in range_constexpr(2):
-            selected = None
-            for k in range_constexpr(2):
-                k_pos = pks * self.t.MFMA_K_FP8 + k * 8 + j * 4
-                st = k_pos // self.t.MFMA_N
-                rem = k_pos % self.t.MFMA_N
-                sk = rem // 4 % 2
-                w_idx = rem // 8
-                xor_off = arith.constant((k ^ sk) * self.t.MFMA_M, type=T.i32)
-                w_cand = fx.Int32(p_words_2d[st][w_idx]).shuffle_xor(xor_off, width_i32)
-                if k == 0:
-                    selected = w_cand
-                else:
-                    is_k = arith.cmpi(arith.CmpIPredicate.eq, self.klane_i32, arith.constant(k, type=T.i32))
-                    selected = ArithValue(is_k).select(w_cand, selected)
-            words.append(selected)
-        return self._i32_pair_to_i64(words[0], words[1])
-
-    def _emit_qk_softmax_pquant(self, kv_block_start_arg, k_buf_off_arg, m_in, l_in):
-        """Emit QK MFMA + scale + mask + online softmax + P-quant for one KV tile.
-        Returns (m_new, l_new, corr, p_words_2d) as IR values.
-        """
-        s_accs_loc = [_raw(self.c_zero_v16i32) for _ in range(self.N_SUBTILES)]
-        for ks in range_constexpr(self.t.K_STEPS_QK):
-            for st in range_constexpr(self.N_SUBTILES):
-                kv_row_loc = self.lane32 + st * self.t.MFMA_N
-                k_frag = self.load_k_frag(kv_row_loc, ks, k_buf_off_arg)
-                if const_expr(self.t._GFX942_W256):
-                    s_accs_loc[st] = self.mfma_i32_k32(
-                        self.v16i32_type, [k_frag, self.q_packs[ks], s_accs_loc[st], 0, 0, 0]
-                    )
-                else:
-                    s_accs_loc[st] = self.mfma_i32_k32(
-                        self.v16i32_type, [k_frag, self.q_packs[ks], s_accs_loc[st], 0, 0, 0]
-                    )
-        kv_tile_idx_loc = kv_block_start_arg // self.t.BLOCK_N
-        max_kv_tile = self.num_k_blocks_per_head - fx.Index(1)
-        kv_tile_safe = fx.Index(
-            ArithValue(kv_tile_idx_loc < self.num_k_blocks_per_head).select(kv_tile_idx_loc, max_kv_tile)
-        )
-        k_descale_base_loc = (
-            self.batch_idx * self.t.NUM_KV_HEADS * self.num_k_blocks_per_head
-            + self.head_kv_idx * self.num_k_blocks_per_head
-            + kv_tile_safe
-        )
-        k_ds_loc = fx.Float32(self._load_ptr_f32(self.kds_ptr, k_descale_base_loc))
-        qk_scale_loc = self._fmul(self.q_ds, k_ds_loc)
-        s_f32_loc = []
-        if const_expr(self.t._DEFER_SCALE):
-            for st in range_constexpr(self.N_SUBTILES):
-                s_f32_vec = Vec(s_accs_loc[st]).to(fx.Float32)
-                for elem in range_constexpr(self.ELEMS_PER_TILE):
-                    s_f32_loc.append(s_f32_vec[elem])
-        else:
-            qk_scale_v16_loc = Vec.from_elements([qk_scale_loc], fx.Float32).broadcast_to(16)
-            for st in range_constexpr(self.N_SUBTILES):
-                s_f32_vec = Vec(s_accs_loc[st]).to(fx.Float32)
-                s_scaled_vec = Vec(arith.mulf(s_f32_vec, qk_scale_v16_loc, fastmath=self.fm_fast))
-                for elem in range_constexpr(self.ELEMS_PER_TILE):
-                    s_f32_loc.append(s_scaled_vec[elem])
-        if const_expr(self.t.use_bias):
-            s_biased = list(s_f32_loc)
-            bias_base = (
-                (self.batch_idx * self.t.NUM_Q_HEADS + self.head_q_idx) * self.q_scale_num_blocks
-                + self.q_scale_tile_idx
-            ) * self.seq_len_k_v
-            bias_col = kv_block_start_arg + self.lane
-            bias_col_safe = fx.Index(ArithValue(bias_col < self.seq_len_k_v).select(bias_col, fx.Index(0)))
-            bias_lane = fx.Float32(self._load_ptr_f32(self.bias_ptr, bias_base + bias_col_safe))
-            for st in range_constexpr(self.N_SUBTILES):
-                for elem in range_constexpr(self.ELEMS_PER_TILE):
-                    idx = st * self.ELEMS_PER_TILE + elem
-                    msub = elem // 4
-                    erem = elem % 4
-                    bias_src_lane = fx.Index(st * self.t.MFMA_N + msub * 8 + erem) + self.klane * 4
-                    bias = self._bpermute_f32(bias_lane, bias_src_lane)
-                    s_biased[idx] = self._fadd(s_biased[idx], bias)
-            s_f32_loc = s_biased
-        kv_start_i32_loc = fx.Int32(arith.unwrap(arith.index_cast(T.i32, _raw(kv_block_start_arg))))
-        if const_expr(self.t.CAUSAL):
-            s_named = list(s_f32_loc)
-            for st in range_constexpr(self.N_SUBTILES):
-                for elem in range_constexpr(self.ELEMS_PER_TILE):
-                    idx = st * self.ELEMS_PER_TILE + elem
-                    msub = elem // 4
-                    erem = elem % 4
-                    kv_col_i32 = (
-                        kv_start_i32_loc
-                        + fx.Int32(st * self.t.MFMA_N)
-                        + fx.Int32(msub * 8)
-                        + self.klane_off_i32
-                        + fx.Int32(erem)
-                    )
-                    out_of_range = ArithValue(kv_col_i32 >= self.seq_len_k_i32)
-                    out_of_range = out_of_range | ArithValue(kv_col_i32 > self.q_row_i32)
-                    s_named[idx] = out_of_range.select(self.c_neg_inf, s_named[idx])
-            s_f32_loc = s_named
-        else:
-            tile_end = kv_block_start_arg + fx.Index(self.t.BLOCK_N)
-            tile_oob_av = ArithValue(tile_end > self.seq_len_k_v)
-            cond_i1 = _raw(tile_oob_av)
-            f32_ty = ir.F32Type.get()
-            result_types = [f32_ty] * self.NUM_S_VALS
-            if_op = _scf.IfOp(cond_i1, result_types, has_else=True, loc=ir.Location.unknown())
-            with _if_then(if_op):
-                _llvm.inline_asm(None, [], "", "", has_side_effects=True)
-                masked = []
-                for st in range_constexpr(self.N_SUBTILES):
-                    for elem in range_constexpr(self.ELEMS_PER_TILE):
-                        idx = st * self.ELEMS_PER_TILE + elem
-                        msub = elem // 4
-                        erem = elem % 4
-                        kv_col_i32 = (
-                            kv_start_i32_loc
-                            + fx.Int32(st * self.t.MFMA_N)
-                            + fx.Int32(msub * 8)
-                            + self.klane_off_i32
-                            + fx.Int32(erem)
-                        )
-                        out_of_range = ArithValue(kv_col_i32 >= self.seq_len_k_i32)
-                        masked.append(_raw(out_of_range.select(self.c_neg_inf, s_f32_loc[idx])))
-                _scf.YieldOp(masked)
-            with _if_else(if_op):
-                _scf.YieldOp([_raw(v) for v in s_f32_loc])
-            s_f32_loc = list(if_op.results)
-        local_max_l = s_f32_loc[0]
-        for r in range_constexpr(self.NUM_S_VALS - 1):
-            local_max_l = self._fmax(local_max_l, s_f32_loc[r + 1])
-        row_max_l = self.row_max_reduce(local_max_l)
-        if const_expr(self.t._DEFER_SCALE):
-            row_max_l = self._fmul(row_max_l, qk_scale_loc)
-        m_new_l = self._fmax(m_in, row_max_l)
-        diff_m_l = self._fsub(m_in, m_new_l)
-        corr_l = rocdl.exp2(ir.F32Type.get(), _raw(diff_m_l))
-        neg_max_l = self._fsub(self.c_zero_f, m_new_l)
-        p_vals_l = []
-        local_sum_l = _raw(self.c_zero_f)
-        for r in range_constexpr(self.NUM_S_VALS):
-            if const_expr(self.t._DEFER_SCALE):
-                diff = self._ffma(s_f32_loc[r], qk_scale_loc, neg_max_l)
-            else:
-                diff = self._fadd(s_f32_loc[r], neg_max_l)
-            p = rocdl.exp2(ir.F32Type.get(), _raw(diff))
-            p_vals_l.append(p)
-            local_sum_l = self._fadd(local_sum_l, p)
-        tile_sum_l = self.row_sum_reduce(local_sum_l)
-        l_new_l = self._fadd(self._fmul(corr_l, l_in), tile_sum_l)
-        c0_i32_l = arith.constant(0, type=T.i32)
-        p_words_l = []
-        for st in range_constexpr(self.N_SUBTILES):
-            sub = []
-            for w in range_constexpr(4):
-                s0 = _raw(p_vals_l[st * self.ELEMS_PER_TILE + w * 4 + 0])
-                s1 = _raw(p_vals_l[st * self.ELEMS_PER_TILE + w * 4 + 1])
-                s2 = _raw(p_vals_l[st * self.ELEMS_PER_TILE + w * 4 + 2])
-                s3 = _raw(p_vals_l[st * self.ELEMS_PER_TILE + w * 4 + 3])
-                packed = c0_i32_l
-                packed = rocdl.cvt_pk_fp8_f32(T.i32, s0, s1, packed, 0)
-                packed = rocdl.cvt_pk_fp8_f32(T.i32, s2, s3, packed, 1)
-                sub.append(packed)
-            p_words_l.append(sub)
-        return (m_new_l, l_new_l, corr_l, p_words_l)
-
-    def _run_pv_mfma(self, p_words, cur_v_off, o_accs, v_iter_lane_addr_i32):
-        if const_expr(self.t._GFX942_W256):
-            for pks in range_constexpr(self.t.PV_K_STEPS):
-                p_i64 = self._gather_p_i64_from_pwords(p_words, pks)
-                for dc in range_constexpr(self.t.D_CHUNKS):
-                    v_i64 = self.load_v_frag_fp8(pks, dc, cur_v_off, v_iter_lane_addr_i32)
-                    o_accs[dc] = self.mfma_fp8_k16(self.v16f32_type, [v_i64, p_i64, o_accs[dc], 0, 0, 0])
-        else:
-            from flydsl._mlir.dialects._rocdl_ops_gen import permlane32_swap as _permlane32_swap_op
-
-            _struct_ty_2xi32 = ir.Type.parse("!llvm.struct<(i32, i32)>")
-            for pks in range_constexpr(self.t.PV_K_STEPS):
-                v8_elems = []
-                for w in range_constexpr(4):
-                    a_w = _raw(p_words[pks * 2][w])
-                    b_w = _raw(p_words[pks * 2 + 1][w])
-                    swapped = _permlane32_swap_op(_struct_ty_2xi32, old=a_w, src=b_w, fi=False, bound_control=True)
-                    lo_word = _llvm.extractvalue(T.i32, swapped, [0])
-                    hi_word = _llvm.extractvalue(T.i32, swapped, [1])
-                    v8_elems.append(lo_word)
-                    v8_elems.append(hi_word)
-                p_pack_v8i32 = Vec.from_elements(v8_elems, fx.Int32).ir_value()
-                scale_127 = arith.constant(127, type=T.i32)
-                for dc in range_constexpr(self.t.D_CHUNKS):
-                    v_frag = self.load_v_frag_fp8(pks, dc, cur_v_off, v_iter_lane_addr_i32)
-                    o_accs[dc] = self.mfma_fp8_k64(
-                        self.v16f32_type, v_frag, p_pack_v8i32, o_accs[dc], scale_127, scale_127
-                    )
-        return o_accs
-
-    def _lds_as3_base(self, lds_view):
-        base_idx = _memref.extract_aligned_pointer_as_index(_llvm_value(lds_view))
-        base_i64 = arith.unwrap(arith.index_cast(T.i64, base_idx))
-        return buffer_ops.create_llvm_ptr(base_i64, address_space=3)
-
-    def setup(
-        self,
-        Q,
-        K,
-        V,
-        O,  # noqa: E741
-        Q_descale,
-        K_descale,
-        V_descale,
-        Bias,
-        batch_size,
-        seq_len_q,
-        seq_len_k,
-        num_q_blocks,
-    ):
-        """Emit kernel prologue: pointers, LDS, tile indices, Q packs, constants."""
-        self.fm_fast = arith.FastMathFlags.fast
-        q_ptr = _extract_aligned_pointer(Q)
-        self.o_ptr = _extract_aligned_pointer(O)
-        qds_ptr = _extract_aligned_pointer(Q_descale)
-        self.kds_ptr = _extract_aligned_pointer(K_descale)
-        self.vds_ptr = _extract_aligned_pointer(V_descale)
-        if const_expr(self.t.use_bias):
-            self.bias_ptr = _extract_aligned_pointer(Bias)
-        bs_v_for_rsrc = fx.Index(batch_size)
-        slk_v_for_rsrc = fx.Index(seq_len_k)
-        num_k_blocks_for_rsrc = (slk_v_for_rsrc + fx.Index(self.t.BLOCK_N - 1)) // fx.Index(self.t.BLOCK_N)
-        kv_total_bytes = bs_v_for_rsrc * slk_v_for_rsrc * fx.Index(self.t.NUM_KV_HEADS * self.t.HEAD_DIM)
-        v_total_bytes = (
-            bs_v_for_rsrc
-            * fx.Index(self.t.NUM_KV_HEADS * self.t.HEAD_DIM)
-            * num_k_blocks_for_rsrc
-            * fx.Index(self.t.BLOCK_N)
-            if self.t.V_TRANSPOSED
-            else kv_total_bytes
-        )
-        self.k_rsrc = buffer_ops.create_buffer_resource(K, max_size=False, num_records_bytes=kv_total_bytes)
-        self.v_rsrc = buffer_ops.create_buffer_resource(V, max_size=False, num_records_bytes=v_total_bytes)
-        self.v4i32_type = Vec.make_type(4, fx.Int32)
-        self.v16i32_type = Vec.make_type(16, fx.Int32)
-        self.v16f32_type = Vec.make_type(16, fx.Float32)
-        self.v4f32_type = Vec.make_type(4, fx.Float32)
-        self.v8i8_type = Vec.make_type(8, fx.Int8)
-        self.v16i8_type = Vec.make_type(16, fx.Int8)
-        self.seq_len_q_v = fx.Index(seq_len_q)
-        self.seq_len_k_v = fx.Index(seq_len_k)
-        base_ptr = self.allocator.get_base()
-        self.lds = SmemPtr(base_ptr, self.t.lds_base_offset, T.i8, shape=(self.t.LDS_K_TOTAL_BYTES,)).get()
-        self.lds_v = SmemPtr(
-            base_ptr, self.t.lds_base_offset + self.t.LDS_K_TOTAL_BYTES, T.i8, shape=(self.t.LDS_V_TOTAL_BYTES,)
-        ).get()
-        block_id = fx.Index(gpu.block_idx.x)
-        self.tid = fx.Index(gpu.thread_idx.x)
-        self.wave_id = self.tid // self.t.WARP_SIZE
-        self.lane = self.tid % self.t.WARP_SIZE
-        self.lane32 = self.lane % self.t.MFMA_M
-        self.klane = self.lane // self.t.MFMA_M
-        wave_q_offset = self.wave_id * self.t.ROWS_PER_WAVE
-        self.head_q_idx = block_id % self.t.NUM_Q_HEADS
-        batch_q_tile_id = block_id // self.t.NUM_Q_HEADS
-        num_q_tiles = (self.seq_len_q_v + self.t.BLOCK_M - 1) // self.t.BLOCK_M
-        q_tile_raw = batch_q_tile_id % num_q_tiles
-        self.batch_idx = batch_q_tile_id // num_q_tiles
-        if const_expr(self.t._LPT_SCHED):
-            q_tile_idx = num_q_tiles - fx.Index(1) - q_tile_raw
-        else:
-            q_tile_idx = q_tile_raw
-        q_start = q_tile_idx * self.t.BLOCK_M
-        self.head_kv_idx = self.head_q_idx // self.t.GROUPS
-        self.load_row_k_batch = self.tid // self.t.THREADS_PER_ROW_K
-        self.load_lane_k = self.tid % self.t.THREADS_PER_ROW_K
-        self.load_col_k_base = self.load_lane_k * self.t.VEC_WIDTH_K
-        self.load_row_v_batch = self.tid // self.t.THREADS_PER_ROW_V
-        load_lane_v = self.tid % self.t.THREADS_PER_ROW_V
-        self.load_col_v_base = load_lane_v * self.t.VEC_WIDTH_V
-        self.q_row = q_start + wave_q_offset + self.lane32
-        self.q_row_i32 = fx.Int32(self.q_row)
-        self.q_in_bounds = arith.cmpi(arith.CmpIPredicate.slt, _raw(self.q_row), _raw(self.seq_len_q_v))
-        q_row_safe = fx.Index(ArithValue(self.q_in_bounds).select(self.q_row, fx.Index(0)))
-        _zero_v4i32_ir = Vec.filled(4, 0, fx.Int32).ir_value()
-        c_zero_i64 = arith.constant(0, type=T.i64)
-        self.q_packs = []
-        for ks in range_constexpr(self.t.K_STEPS_QK):
-            if const_expr(self.t._GFX942_W256):
-                q_col = fx.Index(ks * self.t.MFMA_K_INT8) + self.klane * 8
-                g_idx = self.q_global_idx(q_row_safe, q_col)
-                half = self._load_ptr_i64(q_ptr, g_idx)
-                self.q_packs.append(ArithValue(self.q_in_bounds).select(half, c_zero_i64))
-            else:
-                q_col = fx.Index(ks * self.t.MFMA_K_INT8) + self.klane * 16
-                g_idx = self.q_global_idx(q_row_safe, q_col)
-                v16i8 = self._load_ptr_i8_vec16(q_ptr, g_idx)
-                v4i32 = vector.bitcast(self.v4i32_type, v16i8)
-                self.q_packs.append(ArithValue(self.q_in_bounds).select(v4i32, _zero_v4i32_ir))
-        self.num_k_blocks_per_head = (self.seq_len_k_v + self.t.BLOCK_N - 1) // self.t.BLOCK_N
-        self.q_scale_num_blocks = fx.Index(num_q_blocks)
-        q_scale_tile_raw = (q_start + wave_q_offset) // self.t.Q_SCALE_BLOCK_M
-        self.q_scale_tile_idx = ArithValue(q_scale_tile_raw < self.q_scale_num_blocks).select(
-            q_scale_tile_raw, self.q_scale_num_blocks - fx.Index(1)
-        )
-        q_descale_base = (
-            self.batch_idx * self.t.NUM_Q_HEADS * self.q_scale_num_blocks
-            + self.head_q_idx * self.q_scale_num_blocks
-            + self.q_scale_tile_idx
-        )
-        self.q_ds = fx.Float32(self._load_ptr_f32(qds_ptr, q_descale_base))
-        self.v_descale_base = (self.batch_idx * self.t.NUM_KV_HEADS + self.head_kv_idx) * self.t.HEAD_DIM
-        self.c_neg_inf = fx.Float32(float("-inf"))
-        self.c_zero_f = fx.Float32(0.0)
-        self.c_one_f = fx.Float32(1.0)
-        self.c_zero_v16f32 = Vec.filled(16, 0.0, fx.Float32)
-        self.c_zero_v16i32 = Vec.filled(16, 0, fx.Int32)
-        self.shuf32_i32 = fx.Int32(32)
-        self.width_i32 = fx.Int32(self.t.WARP_SIZE)
-        _q_end = q_start + self.t.BLOCK_M
-        if const_expr(self.t.CAUSAL):
-            self.kv_upper = fx.Index(ArithValue(_q_end < self.seq_len_k_v).select(_q_end, self.seq_len_k_v))
-        else:
-            self.kv_upper = self.seq_len_k_v
-        self.K_BUF1_OFF = fx.Index(self.t.LDS_K_BYTES)
-        self.V_BUF1_OFF = fx.Index(self.t.LDS_V_BYTES)
-        self.ZERO_INDEX = fx.Index(0)
-        self.N_SUBTILES = self.t.BLOCK_N // self.t.MFMA_N
-        self.ELEMS_PER_TILE = 16
-        self.NUM_S_VALS = self.N_SUBTILES * self.ELEMS_PER_TILE
-        self.klane_i32 = fx.Int32(self.klane)
-        self.klane_off_i32 = self.klane_i32 * fx.Int32(4)
-        self.seq_len_k_i32 = fx.Int32(self.seq_len_k_v)
-
-    def write_output(self, loop_results, _FINAL_OFF_L, _FINAL_OFF_O_ACCS):
-        """Normalize accumulators by 1/l and apply V descale; store guarded by caller."""
-        l_final = loop_results[_FINAL_OFF_L]
-        o_finals = [loop_results[_FINAL_OFF_O_ACCS + dc] for dc in range_constexpr(self.t.D_CHUNKS)]
-        inv_l = arith.divf(_raw(self.c_one_f), _raw(l_final), fastmath=self.fm_fast)
-        inv_l_fp8 = _raw(inv_l)
-        for dc in range_constexpr(self.t.D_CHUNKS):
-            for msub in range_constexpr(4):
-                d_col_base = fx.Index(dc * self.t.MFMA_M) + fx.Index(msub * 8) + self.klane * 4
-                v_ds_vec = Vec(
-                    self._load_ptr_f32_vec4(
-                        self.vds_ptr,
-                        self.v_descale_base + fx.Index(dc * self.t.MFMA_M) + fx.Index(msub * 8) + self.klane * 4,
-                    )
-                )
-                bf16_elems = []
-                for erem in range_constexpr(4):
-                    i_pos = msub * 4 + erem
-                    v_ds = v_ds_vec[erem]
-                    o_elem = vector.extract(o_finals[dc], static_position=[i_pos], dynamic_position=[])
-                    scale = arith.mulf(_raw(inv_l_fp8), _raw(v_ds), fastmath=self.fm_fast)
-                    o_norm = arith.mulf(o_elem, scale, fastmath=self.fm_fast)
-                    bf16_elems.append(self.f32_to_bf16_trunc(o_norm))
-                o_vec = Vec.from_elements(bf16_elems, fx.BFloat16).ir_value()
-                o_global = self.q_global_idx(self.q_row, d_col_base)
-                self._store_ptr_bf16(self.o_ptr, o_global, o_vec)
-
-
-def _detect_gpu_name():
-    """Return the GPU marketing name (e.g. 'AMD Instinct MI308X') or ''."""
-    try:
-        import torch
-
-        if torch.cuda.is_available():
-            return torch.cuda.get_device_name(0) or ""
-    except Exception:
-        pass
-    try:
-        import subprocess
-
-        out = subprocess.run(["rocminfo"], capture_output=True, text=True, timeout=10).stdout
-        for line in out.splitlines():
-            if "Marketing Name" in line and "MI" in line:
-                return line.split(":", 1)[1].strip()
-    except Exception:
-        pass
-    return ""
-
-
-def _require_mi308x(gpu_arch):
-    """Raise unless running on an AMD MI308X (gfx942); this kernel targets MI308X only."""
-    gpu_name = _detect_gpu_name()
-    is_gfx942 = isinstance(gpu_arch, str) and gpu_arch.startswith("gfx942")
-    is_mi308x = "MI308" in gpu_name.upper()
-    if not (is_gfx942 and is_mi308x):
-        raise RuntimeError(
-            f"SageAttention CDNA kernel supports only AMD MI308X (gfx942); "
-            f"got arch={gpu_arch!r} name={gpu_name!r}. Other hardware is not supported."
-        )
+from kernels.attention.sage_attn_helpers import SageKernelFacade, _make_sage_launch_config
+from kernels.common.tensor_shim import _run_compiled
 
 
 def build_sage_attn_cdna_module(
@@ -831,222 +30,36 @@ def build_sage_attn_cdna_module(
     daz=True,
     path_tag="auto",
     use_bias=False,
-    use_fp8_pv=False,
-    split_k: int = 1,
-    gfx942_w256: bool | None = None,
     v_transposed: bool = False,
     bias_block_m: int | None = None,
+    gfx942_w256=True,
 ):
-    """Build FlyDSL sage attention kernel for AMD MI308X (CDNA gfx942).
-
-    Uses Int8 MFMA for QK^T and BF16 MFMA for PV, matching triton sage v1 precision.
-    """
-    gpu_arch = get_hip_arch()
-    _require_mi308x(gpu_arch)
-    _IS_GFX942 = gpu_arch.startswith("gfx942")
-    _GFX942_COMPACT = False
-    _w256_env = os.environ.get("SAGE_GFX942_W256", "auto")
-    if gfx942_w256 is None:
-        if _w256_env == "auto":
-            _GFX942_W256 = True
-        elif _w256_env in ("compact", "c256"):
-            _GFX942_W256 = False
-            _GFX942_COMPACT = True
-        else:
-            _GFX942_W256 = _IS_GFX942 and _w256_env not in ("0", "")
-            _GFX942_COMPACT = False
-    else:
-        _GFX942_W256 = _IS_GFX942 and bool(gfx942_w256)
-        _GFX942_COMPACT = False
-    if _IS_GFX942 and (not _GFX942_W256):
-        raise ValueError("gfx942 requires the w256 SageAttention path")
-    WARP_SIZE = get_warp_size(gpu_arch)
-    MFMA_M = 32
-    MFMA_N = 32
-    if _GFX942_W256:
-        path_tag = f"{path_tag}_w256"
-        MFMA_K_INT8 = 16
-        MFMA_K_FP8 = 16
-    else:
-        MFMA_K_INT8 = 32
-        MFMA_K_FP8 = 64
-    ROWS_PER_WAVE = MFMA_M
-    BLOCK_M = block_m if block_m is not None else 256
-    BLOCK_N = block_n if block_n is not None else 128
-    Q_SCALE_BLOCK_M = bias_block_m if bias_block_m is not None else BLOCK_M
-    SPLIT_K = max(1, int(split_k))
-    IS_SPLIT_K = SPLIT_K > 1
-    V_TRANSPOSED = bool(v_transposed)
-    NUM_WAVES = BLOCK_M // ROWS_PER_WAVE
-    if flat_work_group_size is None:
-        flat_work_group_size = NUM_WAVES * WARP_SIZE
-    BLOCK_SIZE = flat_work_group_size
-    K_STEPS_QK = head_dim // MFMA_K_INT8
-    D_CHUNK = MFMA_N
-    D_CHUNKS = head_dim // D_CHUNK
-    PV_K_STEPS = BLOCK_N // MFMA_K_FP8
-    assert head_dim % MFMA_K_INT8 == 0, f"head_dim {head_dim} must be divisible by {MFMA_K_INT8}"
-    assert BLOCK_M % ROWS_PER_WAVE == 0
-    assert BLOCK_N % MFMA_K_FP8 == 0
-    if sm_scale is None:
-        sm_scale = 1.0 / host_math.sqrt(head_dim)
-    NUM_Q_HEADS = num_q_heads
-    NUM_KV_HEADS = num_kv_heads
-    HEAD_DIM = head_dim
-    CAUSAL = causal
-    GROUPS = num_q_heads // num_kv_heads
-    STRIDE_TOKEN = NUM_Q_HEADS * HEAD_DIM
-    KV_STRIDE_TOKEN = NUM_KV_HEADS * HEAD_DIM
-    _dma_env = os.environ.get("SAGE_LDS_DMA", "auto")
-    if _dma_env == "auto":
-        _dma_env = "0"
-    _dma_k = _dma_env in ("1", "k", "kv")
-    _dma_any = _dma_k
-    _cpr_k_host = head_dim // 16
-    _cpr_k_is_p2 = _cpr_k_host > 0 and _cpr_k_host & _cpr_k_host - 1 == 0
-    _dma_xor = _dma_any and _cpr_k_is_p2 and (os.environ.get("SAGE_LDS_DMA_XOR", "1") not in ("0", ""))
-    if const_expr(_dma_any):
-        path_tag = f"{path_tag}_dma{_dma_env}" + ("x" if _dma_xor else "")
-    _defer_env = os.environ.get("SAGE_DEFER_SCALE", "auto")
-    if _defer_env in ("0", ""):
-        _DEFER_SCALE = False
-    elif _defer_env == "force":
-        _DEFER_SCALE = True
-    else:
-        _DEFER_SCALE = not CAUSAL or BLOCK_M <= 128
-    if use_bias:
-        _DEFER_SCALE = False
-    if const_expr(_DEFER_SCALE):
-        path_tag = f"{path_tag}_ds"
-    _lpt_env = os.environ.get("SAGE_LPT_SCHED", "auto")
-    _LPT_SCHED = _lpt_env not in ("0", "")
-    if const_expr(_LPT_SCHED):
-        path_tag = f"{path_tag}_lpt"
-    _default_lds_pad = "8" if _IS_GFX942 and V_TRANSPOSED else "4" if _IS_GFX942 else "16"
-    _LDS_PAD = int(os.environ.get("SAGE_LDS_PAD", _default_lds_pad))
-    if _LDS_PAD < 0 or _LDS_PAD % 4 != 0:
-        raise ValueError("SAGE_LDS_PAD must be a non-negative multiple of 4")
-    path_tag = f"{path_tag}_pad{_LDS_PAD}"
-    if const_expr(_dma_k):
-        K_STRIDE = HEAD_DIM
-    else:
-        K_STRIDE = HEAD_DIM + _LDS_PAD
-    V_STRIDE = BLOCK_N + _LDS_PAD
-    VEC_WIDTH_K = 16
-    VEC_WIDTH_V = 16
-    THREADS_PER_ROW_K = HEAD_DIM // VEC_WIDTH_K
-    THREADS_PER_ROW_V = HEAD_DIM // VEC_WIDTH_V
-    ROWS_PER_BATCH_K = BLOCK_SIZE // THREADS_PER_ROW_K
-    ROWS_PER_BATCH_V = BLOCK_SIZE // THREADS_PER_ROW_V
-    if ROWS_PER_BATCH_K >= BLOCK_N:
-        NUM_BATCHES_K = 1
-        K_NEEDS_GUARD = ROWS_PER_BATCH_K > BLOCK_N
-    else:
-        NUM_BATCHES_K = BLOCK_N // ROWS_PER_BATCH_K
-        K_NEEDS_GUARD = False
-    if V_TRANSPOSED:
-        NUM_BATCHES_V = 1
-        V_NEEDS_GUARD = False
-    elif ROWS_PER_BATCH_V >= BLOCK_N:
-        NUM_BATCHES_V = 1
-        V_NEEDS_GUARD = ROWS_PER_BATCH_V > BLOCK_N
-    else:
-        NUM_BATCHES_V = BLOCK_N // ROWS_PER_BATCH_V
-        V_NEEDS_GUARD = False
-    LDS_K_BYTES = BLOCK_N * K_STRIDE * 1
-    LDS_V_BYTES = HEAD_DIM * V_STRIDE * 1
-    _pipe_env = os.environ.get("SAGE_PIPE_STAGES", "2")
-    NUM_PIPE_STAGES = 1 if _pipe_env in ("0", "1") or IS_SPLIT_K else 2
-    LDS_K_TOTAL_BYTES = LDS_K_BYTES * NUM_PIPE_STAGES
-    LDS_V_TOTAL_BYTES = LDS_V_BYTES * NUM_PIPE_STAGES
-    LDS_TOTAL_BYTES = LDS_K_TOTAL_BYTES + LDS_V_TOTAL_BYTES
-    if NUM_PIPE_STAGES == 2 and LDS_TOTAL_BYTES > _LDS_CAP_BYTES:
-        NUM_PIPE_STAGES = 1
-        LDS_K_TOTAL_BYTES = LDS_K_BYTES
-        LDS_V_TOTAL_BYTES = LDS_V_BYTES
-        LDS_TOTAL_BYTES = LDS_K_TOTAL_BYTES + LDS_V_TOTAL_BYTES
-    if NUM_PIPE_STAGES == 2:
-        path_tag = f"{path_tag}_pipe2"
-    else:
-        path_tag = f"{path_tag}_pipe1"
-    if IS_SPLIT_K:
-        path_tag = f"{path_tag}_sk{SPLIT_K}"
-    LDS_TOTAL_I8_ELEMS = LDS_TOTAL_BYTES
-    allocator = SmemAllocator(
-        None, arch=gpu_arch, global_sym_name=f"sage_attn_cdna_smem_M{BLOCK_M}N{BLOCK_N}_{path_tag}"
-    )
-    lds_base_offset = allocator._align(allocator.ptr, 16)
-    allocator.ptr = lds_base_offset + LDS_TOTAL_I8_ELEMS
-
-    t = _SageTraits(
-        BLOCK_M=BLOCK_M,
-        BLOCK_N=BLOCK_N,
-        BLOCK_SIZE=BLOCK_SIZE,
-        CAUSAL=CAUSAL,
-        D_CHUNKS=D_CHUNKS,
-        GROUPS=GROUPS,
-        HEAD_DIM=HEAD_DIM,
-        KV_STRIDE_TOKEN=KV_STRIDE_TOKEN,
-        K_NEEDS_GUARD=K_NEEDS_GUARD,
-        K_STEPS_QK=K_STEPS_QK,
-        K_STRIDE=K_STRIDE,
-        LDS_K_BYTES=LDS_K_BYTES,
-        LDS_K_TOTAL_BYTES=LDS_K_TOTAL_BYTES,
-        LDS_V_BYTES=LDS_V_BYTES,
-        LDS_V_TOTAL_BYTES=LDS_V_TOTAL_BYTES,
-        MFMA_K_FP8=MFMA_K_FP8,
-        MFMA_K_INT8=MFMA_K_INT8,
-        MFMA_M=MFMA_M,
-        MFMA_N=MFMA_N,
-        NUM_BATCHES_K=NUM_BATCHES_K,
-        NUM_BATCHES_V=NUM_BATCHES_V,
-        NUM_KV_HEADS=NUM_KV_HEADS,
-        NUM_PIPE_STAGES=NUM_PIPE_STAGES,
-        NUM_Q_HEADS=NUM_Q_HEADS,
-        PV_K_STEPS=PV_K_STEPS,
-        Q_SCALE_BLOCK_M=Q_SCALE_BLOCK_M,
-        ROWS_PER_BATCH_K=ROWS_PER_BATCH_K,
-        ROWS_PER_BATCH_V=ROWS_PER_BATCH_V,
-        ROWS_PER_WAVE=ROWS_PER_WAVE,
-        STRIDE_TOKEN=STRIDE_TOKEN,
-        THREADS_PER_ROW_K=THREADS_PER_ROW_K,
-        THREADS_PER_ROW_V=THREADS_PER_ROW_V,
-        VEC_WIDTH_K=VEC_WIDTH_K,
-        VEC_WIDTH_V=VEC_WIDTH_V,
-        V_NEEDS_GUARD=V_NEEDS_GUARD,
-        V_STRIDE=V_STRIDE,
-        V_TRANSPOSED=V_TRANSPOSED,
-        WARP_SIZE=WARP_SIZE,
-        _DEFER_SCALE=_DEFER_SCALE,
-        _GFX942_W256=_GFX942_W256,
-        _LPT_SCHED=_LPT_SCHED,
-        _dma_any=_dma_any,
-        _dma_k=_dma_k,
-        _dma_xor=_dma_xor,
-        lds_base_offset=lds_base_offset,
+    """Build FlyDSL sage attention kernel for AMD MI308X (CDNA gfx942)."""
+    del gfx942_w256  # MI308X path is always 32x32x16 w256; kept for harness/API compat
+    cfg = _make_sage_launch_config(
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        causal=causal,
+        block_m=block_m,
+        block_n=block_n,
+        flat_work_group_size=flat_work_group_size,
         use_bias=use_bias,
+        v_transposed=v_transposed,
+        bias_block_m=bias_block_m,
+        path_tag=path_tag,
     )
-    _impl = _SageKernel(t, allocator)
-    _cache_tag = (
-        gpu_arch,
-        BLOCK_M,
-        BLOCK_N,
-        CAUSAL,
-        HEAD_DIM,
-        NUM_Q_HEADS,
-        NUM_KV_HEADS,
-        _DEFER_SCALE,
-        _LPT_SCHED,
-        _GFX942_W256,
-        _dma_k,
-        _dma_xor,
-        V_TRANSPOSED,
-        use_bias,
-        use_fp8_pv,
-        NUM_PIPE_STAGES,
-        SPLIT_K,
-        path_tag,
-    )
+    t = cfg["t"]
+    allocator = cfg["allocator"]
+    BLOCK_M = cfg["BLOCK_M"]
+    BLOCK_SIZE = cfg["BLOCK_SIZE"]
+    NUM_Q_HEADS = cfg["NUM_Q_HEADS"]
+    impl = SageKernelFacade(t, allocator)
+    k_loader = impl.k_loader
+    v_loader = impl.v_loader
+    qk_softmax = impl.qk_softmax
+    pv_gemm = impl.pv_gemm
+    store = impl.store
 
     @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
     def sage_attn_kernel(
@@ -1063,79 +76,79 @@ def build_sage_attn_cdna_module(
         seq_len_k: fx.Int32,
         num_q_blocks: fx.Int32,
     ):
-        const_expr(_cache_tag)
-        _impl.setup(Q, K, V, O, Q_descale, K_descale, V_descale, Bias, batch_size, seq_len_q, seq_len_k, num_q_blocks)
-        if const_expr(_impl.t.NUM_PIPE_STAGES == 2):
-            _impl.coop_load_k(_impl.ZERO_INDEX, _impl.ZERO_INDEX)
-            _impl.coop_load_v(_impl.ZERO_INDEX, _impl.ZERO_INDEX)
-            _impl.coop_load_k(fx.Index(_impl.t.BLOCK_N), _impl.K_BUF1_OFF)
-            _impl.coop_load_v(fx.Index(_impl.t.BLOCK_N), _impl.V_BUF1_OFF)
+        const_expr(cfg["cache_tag"])
+        impl.setup(Q, K, V, O, Q_descale, K_descale, V_descale, Bias, batch_size, seq_len_q, seq_len_k, num_q_blocks)
+        if const_expr(impl.t.NUM_PIPE_STAGES == 2):
+            k_loader.coop_load_k(impl.ZERO_INDEX, impl.ZERO_INDEX)
+            v_loader.coop_load_v(impl.ZERO_INDEX, impl.ZERO_INDEX)
+            k_loader.coop_load_k(fx.Int64(impl.t.BLOCK_N), impl.K_BUF1_OFF)
+            v_loader.coop_load_v(fx.Int64(impl.t.BLOCK_N), impl.V_BUF1_OFF)
             gpu.barrier()
-            c0_i32_init = arith.constant(0, type=T.i32)
-            init_args = [c0_i32_init, _raw(_impl.c_neg_inf), _raw(_impl.c_zero_f)]
-            for _ in range_constexpr(_impl.t.D_CHUNKS):
-                init_args.append(_raw(_impl.c_zero_v16f32))
+            c0_i32_init = fx.Int32(0).ir_value()
+            init_args = [c0_i32_init, _raw(impl.c_neg_inf), _raw(impl.c_zero_f)]
+            for _ in range_constexpr(impl.t.D_CHUNKS):
+                init_args.append(_raw(impl.c_zero_v16f32))
             _OFF_CUR_BUF = 0
             _OFF_M = 1
             _OFF_L = 2
             _OFF_O_ACCS = 3
             loop_results = init_args
-            for kv_block_start, inner_iter_args in range(0, _impl.kv_upper, _impl.t.BLOCK_N, init=init_args):
+            for kv_block_start, inner_iter_args in range(0, impl.kv_upper, impl.t.BLOCK_N, init=init_args):
                 cur_buf_i32 = inner_iter_args[_OFF_CUR_BUF]
                 m_running = inner_iter_args[_OFF_M]
                 l_running = inner_iter_args[_OFF_L]
-                o_accs = [inner_iter_args[_OFF_O_ACCS + i] for i in range_constexpr(_impl.t.D_CHUNKS)]
-                cur_k_off = _impl._buf_off(cur_buf_i32, _impl.K_BUF1_OFF)
-                cur_v_off = _impl._buf_off(cur_buf_i32, _impl.V_BUF1_OFF)
-                next_buf_i32 = arith.XOrIOp(_raw(cur_buf_i32), arith.constant(1, type=T.i32)).result
-                m_new, l_new, corr, p_words = _impl._emit_qk_softmax_pquant(
+                o_accs = [inner_iter_args[_OFF_O_ACCS + i] for i in range_constexpr(impl.t.D_CHUNKS)]
+                cur_k_off = impl._buf_off(cur_buf_i32, impl.K_BUF1_OFF)
+                cur_v_off = impl._buf_off(cur_buf_i32, impl.V_BUF1_OFF)
+                next_buf_i32 = (fx.Int32(cur_buf_i32) ^ fx.Int32(1)).ir_value()
+                m_new, l_new, corr, p_words = qk_softmax.emit_qk_softmax_pquant(
                     kv_block_start, cur_k_off, m_running, l_running
                 )
                 corr_vec16 = Vec.from_elements([corr], fx.Float32).broadcast_to(16).ir_value()
-                for dc in range_constexpr(_impl.t.D_CHUNKS):
-                    o_accs[dc] = _impl._fmul(o_accs[dc], corr_vec16)
-                kv_block_after_next = kv_block_start + fx.Index(2 * _impl.t.BLOCK_N)
-                o_accs = _impl._run_pv_mfma(p_words, cur_v_off, o_accs, None)
+                for dc in range_constexpr(impl.t.D_CHUNKS):
+                    o_accs[dc] = impl._fmul(o_accs[dc], corr_vec16)
+                kv_block_after_next = fx.Int64(kv_block_start) + fx.Int64(2 * impl.t.BLOCK_N)
+                o_accs = pv_gemm.run_pv_mfma(p_words, cur_v_off, o_accs)
                 gpu.barrier()
-                _impl.coop_load_k(kv_block_after_next, cur_k_off)
-                _impl.coop_load_v(kv_block_after_next, cur_v_off)
+                k_loader.coop_load_k(kv_block_after_next, cur_k_off)
+                v_loader.coop_load_v(kv_block_after_next, cur_v_off)
                 _yield_args = [next_buf_i32, _raw(m_new), _raw(l_new)]
-                for dc in range_constexpr(_impl.t.D_CHUNKS):
+                for dc in range_constexpr(impl.t.D_CHUNKS):
                     _yield_args.append(o_accs[dc])
                 loop_results = yield _yield_args
             _FINAL_OFF_L = _OFF_L
             _FINAL_OFF_O_ACCS = _OFF_O_ACCS
         else:
-            init_args = [_raw(_impl.c_neg_inf), _raw(_impl.c_zero_f)]
-            for _ in range_constexpr(_impl.t.D_CHUNKS):
-                init_args.append(_raw(_impl.c_zero_v16f32))
+            init_args = [_raw(impl.c_neg_inf), _raw(impl.c_zero_f)]
+            for _ in range_constexpr(impl.t.D_CHUNKS):
+                init_args.append(_raw(impl.c_zero_v16f32))
             _OFF_M = 0
             _OFF_L = 1
             _OFF_O_ACCS = 2
             loop_results = init_args
-            for kv_block_start, inner_iter_args in range(0, _impl.kv_upper, _impl.t.BLOCK_N, init=init_args):
+            for kv_block_start, inner_iter_args in range(0, impl.kv_upper, impl.t.BLOCK_N, init=init_args):
                 m_running = inner_iter_args[_OFF_M]
                 l_running = inner_iter_args[_OFF_L]
-                o_accs = [inner_iter_args[_OFF_O_ACCS + i] for i in range_constexpr(_impl.t.D_CHUNKS)]
-                _impl.coop_load_k(kv_block_start, _impl.ZERO_INDEX)
-                _impl.coop_load_v(kv_block_start, _impl.ZERO_INDEX)
+                o_accs = [inner_iter_args[_OFF_O_ACCS + i] for i in range_constexpr(impl.t.D_CHUNKS)]
+                k_loader.coop_load_k(kv_block_start, impl.ZERO_INDEX)
+                v_loader.coop_load_v(kv_block_start, impl.ZERO_INDEX)
                 gpu.barrier()
-                m_new, l_new, corr, p_words = _impl._emit_qk_softmax_pquant(
-                    kv_block_start, _impl.ZERO_INDEX, m_running, l_running
+                m_new, l_new, corr, p_words = qk_softmax.emit_qk_softmax_pquant(
+                    kv_block_start, impl.ZERO_INDEX, m_running, l_running
                 )
                 corr_vec16 = Vec.from_elements([corr], fx.Float32).broadcast_to(16).ir_value()
-                for dc in range_constexpr(_impl.t.D_CHUNKS):
-                    o_accs[dc] = _impl._fmul(o_accs[dc], corr_vec16)
-                o_accs = _impl._run_pv_mfma(p_words, _impl.ZERO_INDEX, o_accs, None)
+                for dc in range_constexpr(impl.t.D_CHUNKS):
+                    o_accs[dc] = impl._fmul(o_accs[dc], corr_vec16)
+                o_accs = pv_gemm.run_pv_mfma(p_words, impl.ZERO_INDEX, o_accs)
                 gpu.barrier()
                 _yield_args = [_raw(m_new), _raw(l_new)]
-                for dc in range_constexpr(_impl.t.D_CHUNKS):
+                for dc in range_constexpr(impl.t.D_CHUNKS):
                     _yield_args.append(o_accs[dc])
                 loop_results = yield _yield_args
             _FINAL_OFF_L = _OFF_L
             _FINAL_OFF_O_ACCS = _OFF_O_ACCS
-        if _impl.q_in_bounds:
-            _impl.write_output(loop_results, _FINAL_OFF_L, _FINAL_OFF_O_ACCS)
+        if impl.q_in_bounds:
+            store.write_output(loop_results, _FINAL_OFF_L, _FINAL_OFF_O_ACCS)
 
     @flyc.jit
     def launch_sage_attn(
@@ -1147,9 +160,6 @@ def build_sage_attn_cdna_module(
         K_descale: fx.Tensor,
         V_descale: fx.Tensor,
         Bias: fx.Tensor,
-        O_acc: fx.Tensor,
-        M_out: fx.Tensor,
-        L_out: fx.Tensor,
         batch_size: fx.Int32,
         seq_len_q: fx.Int32,
         seq_len_k: fx.Int32,
@@ -1160,8 +170,8 @@ def build_sage_attn_cdna_module(
         ctx = CompilationContext.get_current()
         with ir.InsertionPoint(ctx.gpu_module_body):
             allocator.finalize()
-        bs_idx = fx.Index(batch_size)
-        slq_idx = fx.Index(seq_len_q)
+        bs_idx = fx.Int64(batch_size)
+        slq_idx = fx.Int64(seq_len_q)
         num_q_tiles = (slq_idx + BLOCK_M - 1) // BLOCK_M
         grid_x = bs_idx * num_q_tiles * NUM_Q_HEADS
         launcher = sage_attn_kernel(
@@ -1204,9 +214,38 @@ def build_sage_attn_cdna_module(
         "llvm_options": {"enable-post-misched": True, "lsr-drop-solution": True},
     }
 
-    def _launch(*args, **kwargs):
+    def _launch(
+        Q,
+        K,
+        V,
+        O,  # noqa: E741
+        Q_descale,
+        K_descale,
+        V_descale,
+        Bias,
+        batch_size,
+        seq_len_q,
+        seq_len_k,
+        num_q_blocks,
+        stream=None,
+    ):
         with CompilationContext.compile_hints(_compile_hints):
-            return launch_sage_attn(*args, **kwargs)
+            return _run_compiled(
+                launch_sage_attn,
+                Q,
+                K,
+                V,
+                O,
+                Q_descale,
+                K_descale,
+                V_descale,
+                Bias,
+                batch_size,
+                seq_len_q,
+                seq_len_k,
+                num_q_blocks,
+                stream,
+            )
 
     def _compile(
         Q,

--- a/kernels/attention/sage_attn_cdna.py
+++ b/kernels/attention/sage_attn_cdna.py
@@ -1,0 +1,1701 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""FlyDSL Sage Attention kernel for CDNA (gfx942/gfx950).
+
+Implements Int8 Q/K × FP8 V flash attention using MFMA instructions:
+  - GEMM1 (Q×K^T): mfma_i32_32x32x32_i8 → Int32 accum → scale to Float32
+  - GEMM2 (P×V):   mfma_f32_32x32x16_bf16 → Float32 accum
+
+Architecture: gfx942 (MI300X) and gfx950 (MI350)
+  - wave64 (64 threads/wave)
+  - MFMA 32x32x32 for Int8, 32x32x16 for BF16 (gfx950 binding)
+  - Block: (BLOCK_M // ROWS_PER_WAVE) waves × 64 threads = total threads
+
+Layout: Q/K/V/O are 1D-flattened from BSHD.
+Grid:   (batch * num_q_tiles * num_q_heads,)
+Block:  (NUM_WAVES * 64,) -- default 8 waves → 512 threads
+
+Supports:
+  - Causal masking
+  - GQA / MQA (num_q_heads divisible by num_kv_heads)
+"""
+
+import math as host_math
+import os
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import (
+    fly as _fly,
+)
+from flydsl._mlir.dialects import (
+    llvm as _llvm,
+)
+from flydsl._mlir.dialects import (
+    math as _math,
+)
+from flydsl._mlir.dialects import (
+    memref as _memref,
+)
+from flydsl._mlir.dialects import (
+    scf as _scf,
+)
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import (
+    arith,
+    buffer_ops,
+    const_expr,
+    gpu,
+    range_constexpr,
+    rocdl,
+    vector,
+)
+from flydsl.expr.typing import T
+from flydsl.expr.typing import Vector as Vec
+from flydsl.expr.utils.arith import ArithValue
+from flydsl.expr.utils.arith import _to_raw as _raw
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+from kernels.common.kernels_common import get_warp_size
+
+_LOG2E = host_math.log2(host_math.e)
+_LDS_CAP_BYTES = 65536
+
+
+def _llvm_value(value):
+    if hasattr(value, "ir_value") and not isinstance(value, ir.Value):
+        return value.ir_value()
+    return value
+
+
+def _llvm_ptr_ty():
+    return ir.Type.parse("!llvm.ptr")
+
+
+def _extract_aligned_pointer(tensor) -> ir.Value:
+    return _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), _llvm_value(tensor))
+
+
+def _pointer_load(result_type: ir.Type, ptr: ir.Value) -> ir.Value:
+    return _llvm.LoadOp(result_type, _llvm_value(ptr)).result
+
+
+def _pointer_store(value: ir.Value, ptr: ir.Value):
+    return _llvm.StoreOp(_llvm_value(value), _llvm_value(ptr))
+
+
+def build_sage_attn_cdna_module(
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    causal=False,
+    sm_scale=None,
+    waves_per_eu=2,
+    flat_work_group_size=None,
+    block_m=None,
+    block_n=None,
+    unsafe_fp_math=True,
+    fast_fp_math=True,
+    daz=True,
+    path_tag="auto",
+    use_bias=False,
+    use_fp8_pv=False,
+    split_k: int = 1,
+    gfx942_w256: bool | None = None,
+    v_transposed: bool = False,
+    bias_block_m: int | None = None,
+):
+    """Build FlyDSL sage attention kernel for CDNA (gfx942/gfx950).
+
+    Uses Int8 MFMA for QK^T and BF16 MFMA for PV, matching triton sage v1 precision.
+    """
+    gpu_arch = get_hip_arch()
+    _IS_GFX942 = gpu_arch.startswith("gfx942")
+    _GFX942_COMPACT = False
+    _w256_env = os.environ.get("SAGE_GFX942_W256", "auto")
+    if gfx942_w256 is None:
+        if _w256_env == "auto":
+            # Default: try true 32x32 MFMA w256 path (256 thr, 32 rows/wave).
+            _GFX942_W256 = True
+        elif _w256_env in ("compact", "c256"):
+            _GFX942_W256 = False
+            _GFX942_COMPACT = True
+        else:
+            _GFX942_W256 = _IS_GFX942 and _w256_env not in ("0", "")
+            _GFX942_COMPACT = False
+    else:
+        _GFX942_W256 = _IS_GFX942 and bool(gfx942_w256)
+        _GFX942_COMPACT = False
+    if _IS_GFX942 and not _GFX942_W256:
+        raise ValueError("gfx942 requires the w256 SageAttention path")
+
+    WARP_SIZE = get_warp_size(gpu_arch)  # 64 for CDNA
+
+    # MFMA 32x32 tile dimensions (Stage A: both QK and PV use 32x32)
+    MFMA_M = 32
+    MFMA_N = 32
+
+    if _GFX942_W256:
+        path_tag = f"{path_tag}_w256"
+        # gfx942: LLVM lowers 32x32x16_i8 / 32x32x16_fp8.
+        MFMA_K_INT8 = 16
+        MFMA_K_FP8 = 16
+    else:
+        # For Int8 MFMA: mfma_i32_32x32x32_i8 accumulates K=32 per call
+        MFMA_K_INT8 = 32
+        # For FP8 K=64 MFMA: mfma_scale_f32_32x32x64_f8f6f4 accumulates K=64.
+        MFMA_K_FP8 = 64
+
+    ROWS_PER_WAVE = MFMA_M  # 32 output rows per wave
+
+    BLOCK_M = block_m if block_m is not None else 256
+    BLOCK_N = block_n if block_n is not None else 128
+    Q_SCALE_BLOCK_M = bias_block_m if bias_block_m is not None else BLOCK_M
+
+    SPLIT_K = max(1, int(split_k))
+    IS_SPLIT_K = SPLIT_K > 1
+    V_TRANSPOSED = bool(v_transposed)
+
+    NUM_WAVES = BLOCK_M // ROWS_PER_WAVE  # e.g. 256//32 = 8 (PR1818-style w256)
+    if flat_work_group_size is None:
+        flat_work_group_size = NUM_WAVES * WARP_SIZE
+    BLOCK_SIZE = flat_work_group_size
+
+    # K steps for GEMM1 (QK): head_dim // MFMA_K_INT8
+    K_STEPS_QK = head_dim // MFMA_K_INT8
+
+    # D chunks for GEMM2 (PV): head_dim / MFMA_N output columns per chunk
+    D_CHUNK = MFMA_N  # 16 columns per MFMA output fragment
+    D_CHUNKS = head_dim // D_CHUNK
+
+    # K steps for GEMM2 per BLOCK_N tile: BLOCK_N // MFMA_K_FP8
+    PV_K_STEPS = BLOCK_N // MFMA_K_FP8
+
+    assert head_dim % MFMA_K_INT8 == 0, f"head_dim {head_dim} must be divisible by {MFMA_K_INT8}"
+    assert BLOCK_M % ROWS_PER_WAVE == 0
+    assert BLOCK_N % MFMA_K_FP8 == 0
+
+    if sm_scale is None:
+        sm_scale = 1.0 / host_math.sqrt(head_dim)
+
+    NUM_Q_HEADS = num_q_heads
+    NUM_KV_HEADS = num_kv_heads
+    HEAD_DIM = head_dim
+    CAUSAL = causal
+    GROUPS = num_q_heads // num_kv_heads  # GQA group size
+
+    STRIDE_TOKEN = NUM_Q_HEADS * HEAD_DIM
+    KV_STRIDE_TOKEN = NUM_KV_HEADS * HEAD_DIM
+
+    # LDS layout
+    # K: row-major BLOCK_N × HEAD_DIM (Int8, 1 byte/elem). +8 byte pad per row.
+    # V on gfx942: COLUMN-MAJOR HEAD_DIM × BLOCK_N (FP8 raw bytes, 1 byte/elem).
+    #    +8 byte pad per V "row" (= V "column" in the original BLOCK_N×HEAD_DIM
+    #    view). Storing V transposed makes per-lane PV reads contiguous in K
+    #    (32 contiguous bytes at fixed d), enabling 2× ds_read_b128 instead of
+    #    32× ds_read_u8.
+    # V on gfx950 (Stage IV-c): ROW-MAJOR BLOCK_N × HEAD_DIM (matches global
+    #    layout). Cooperative load is 1× ds_write_b128 per row instead of 16×
+    #    scattered ds_write_b8. PV per-lane gather uses ds_read_tr8_b64 (CDNA4-
+    #    only; performs a 16-lane in-instruction transpose) to deliver the
+    #    32 K-contiguous bytes per lane that the f8f6f4 MFMA expects.
+    _is_gfx950_kv = "gfx950" in gpu_arch
+
+    # ---- Direct global→LDS DMA staging (experimental memory-staging lever) ----
+    # Default coop loads stage K/V through the VGPR file: buffer_load (global→
+    # VGPR) then ds_write (VGPR→LDS) — a two-hop copy that pins staging VGPRs
+    # per outstanding load and emits a ds_write stripe per KV tile. The CDNA
+    # `buffer_load_lds` path moves global→LDS directly, bypassing the register
+    # file. The hardware writes are LANE-CONTIGUOUS within a wave, so the K/V
+    # LDS strides MUST be packed (no +16 pad / XOR) and the destination is a
+    # per-wave-uniform pointer (HW adds lane*size). gfx950 supports a 16 B/lane
+    # DMA (one buffer_load_dwordx4-to-LDS); gfx942 is 4 B/lane. V on gfx942 is
+    # column-major (scatter-transpose) which the DMA cannot express, so V-DMA
+    # is gfx950-only.
+    # Auto gate: the only measured net win is K-only DMA + XOR swizzle on causal
+    # gfx950 (~3-4.7%); non-causal is ~flat and V/kv modes regress (see
+    # sage_attn_memstage/). So "auto" (default) turns on K-DMA exactly there and
+    # stays byte-identical to baseline everywhere else. Explicit values still
+    # force a specific arm for A/B: 0/""=off, k/v/kv/1=that mode unconditionally.
+    _dma_env = os.environ.get("SAGE_LDS_DMA", "auto")
+    if _dma_env == "auto":
+        _dma_env = "k" if (CAUSAL and _is_gfx950_kv) else "0"
+    _dma_k = _dma_env in ("1", "k", "kv")
+    _dma_v = _dma_env in ("1", "v", "kv") and _is_gfx950_kv
+    _dma_any = _dma_k or _dma_v
+    # DMA forces a packed (no-pad) stride, which aliases every KV row onto the
+    # same 32-bank set (HEAD_DIM=128 B = 32 banks × 4 B) → 32-way ds_read
+    # conflicts. The pad is unavailable (the lane-contiguous DMA destination is
+    # not a per-lane address), but an XOR swizzle CAN be carried purely in
+    # ADDRESS ARITHMETIC: permute which 16-B chunk each lane fetches on the
+    # global side (write) and apply the inverse permute on the LDS read index.
+    # chunk' = chunk ^ (row & (CHUNKS_PER_ROW-1)) is self-inverse and in-row
+    # (16-B aligned), so global reads stay fully coalesced (same 128-B rows,
+    # only lane↔chunk assignment permutes) and the QK ds_read sees rows scattered
+    # across distinct banks. Default ON whenever DMA is on (set SAGE_LDS_DMA_XOR=0
+    # to reproduce the un-swizzled packed baseline for A/B).
+    # The in-row XOR is only self-inverse when CHUNKS_PER_ROW is a power of two
+    # (so `& mask` selects a within-row chunk). HEAD_DIM 64/128/256 → 4/8/16
+    # chunks (all p2); guard non-p2 head_dims by falling back to no-xor.
+    _cpr_k_host = head_dim // 16  # VEC_WIDTH_K = 16 B chunks per K row
+    _cpr_k_is_p2 = _cpr_k_host > 0 and (_cpr_k_host & (_cpr_k_host - 1)) == 0
+    _dma_xor = _dma_any and _cpr_k_is_p2 and os.environ.get("SAGE_LDS_DMA_XOR", "1") not in ("0", "")
+    # `buffer_load_lds` completion is tracked by the global `vmcnt`, not
+    # `lgkmcnt`, so the LDS data is only guaranteed visible after a `vmcnt`
+    # drain — which `gpu.barrier()`'s implicit `lgkmcnt(0)` does NOT provide.
+    # An explicit `s_waitcnt vmcnt(0)` before the gating barrier is therefore
+    # required *unless* something else already drains vmcnt there. In single-
+    # tensor DMA modes (`k` or `v`) the OTHER tensor is still register-staged,
+    # and its coop-load issues its own `s_waitcnt vmcnt(0)` before its
+    # `ds_write` (the VGPR→LDS store needs the loaded VGPRs) — a full drain that
+    # also lands the sibling DMA. So the explicit fence is only needed when BOTH
+    # K and V are DMA (`kv`/`1`), where no register path forces a drain. Skipping
+    # the redundant fence in single-tensor modes removes a per-iter critical-path
+    # stall that the lean, high-occupancy non-causal iters could not hide
+    # (causal iters hid it under the per-element mask compute). Verified
+    # bit-identical with the fence gated off in K-only mode.
+    _need_dma_fence = _dma_k and _dma_v
+    if const_expr(_dma_any):
+        path_tag = f"{path_tag}_dma{_dma_env}" + ("x" if _dma_xor else "")
+        if const_expr(_need_dma_fence):
+            path_tag = f"{path_tag}f"
+
+    # ---- Deferred-scale softmax ("gate the scale") ----
+    # Defer the QK descale out of the per-element score path and fold it into the
+    # softmax exp as one FMA (see section 2/4 in the kernel body). Removes the 32
+    # per-element `v_pk_mul_f32` per iter — the dominant non-exp VALU op in this
+    # VALU(exp)-bound loop. The per-iter ISA histogram confirms deferral is a pure
+    # win on op count (96 vs 129 exposed VALU, 181 vs 192 VGPR), yet whether it
+    # nets faster depends on whether eager's scale-muls were *already hidden*:
+    #   - non-causal (any block_m): deferral wins (−5–7%), bit-identical cosine.
+    #   - causal, block_m<=128: deferral wins too (−5%) — the smaller MFMA shadow
+    #     and higher occupancy leave eager's muls exposed, so removing them pays.
+    #   - causal, block_m=256: deferral REGRESSES (+7–9%). The big-tile MFMA shadow
+    #     plus the per-element mask compute (64 cndmask+cmp) already swallow eager's
+    #     muls for free, so deferral removes nothing but still adds a serial
+    #     post-reduction `row_max*scale` on the exp critical path. Nothing to recoup
+    #     here — the cost is structural, not an op-count problem.
+    # So gate ON for non-causal OR (causal AND block_m<=128) — a compile-time
+    # per-shape branch (the dispatcher is a perf lever). Env `SAGE_DEFER_SCALE`
+    # overrides for A/B: `auto`/`1` = the gate above, `0` = always eager, `force` =
+    # always deferred.
+    _defer_env = os.environ.get("SAGE_DEFER_SCALE", "auto")
+    if _defer_env in ("0", ""):
+        _DEFER_SCALE = False
+    elif _defer_env == "force":
+        _DEFER_SCALE = True
+    else:  # "auto" / "1": non-causal always; causal only at block_m<=128
+        _DEFER_SCALE = (not CAUSAL) or (BLOCK_M <= 128)
+    if use_bias:
+        # Bias is already in log2 score units and is added after QK descale.
+        _DEFER_SCALE = False
+    if const_expr(_DEFER_SCALE):
+        path_tag = f"{path_tag}_ds"
+
+    # ---- Reverse Q-tile scheduling ----
+    # Reverse the Q-tile assignment so concurrently launched workgroups do not
+    # march through identical K/V regions in lockstep. This remains required for
+    # causal LPT balancing and is also a small, repeatable cache-distribution win
+    # for non-causal long sequences. It is a pure workgroup permutation, so each
+    # output tile's computation and numerics are unchanged.
+    # Env `SAGE_LPT_SCHED`: `auto`/`1` (default on) · `0` (naive order) ·
+    # `force` (on, retained for existing A/B commands).
+    _lpt_env = os.environ.get("SAGE_LPT_SCHED", "auto")
+    _LPT_SCHED = _lpt_env not in ("0", "")
+    if const_expr(_LPT_SCHED):
+        path_tag = f"{path_tag}_lpt"
+
+    _default_lds_pad = "8" if (_IS_GFX942 and V_TRANSPOSED) else ("4" if _IS_GFX942 else "16")
+    _LDS_PAD = int(os.environ.get("SAGE_LDS_PAD", _default_lds_pad))
+    if _LDS_PAD < 0 or _LDS_PAD % 4 != 0:
+        raise ValueError("SAGE_LDS_PAD must be a non-negative multiple of 4")
+    path_tag = f"{path_tag}_pad{_LDS_PAD}"
+
+    if const_expr(_dma_k):
+        K_STRIDE = HEAD_DIM
+    else:
+        K_STRIDE = HEAD_DIM + _LDS_PAD
+    if _is_gfx950_kv and const_expr(_dma_v):
+        V_STRIDE = HEAD_DIM
+    else:
+        V_STRIDE = (HEAD_DIM if _is_gfx950_kv else BLOCK_N) + _LDS_PAD
+
+    # Cooperative load parameters
+    VEC_WIDTH_K = 16  # 16 Int8 elements = 16 bytes per thread
+    # V coop load (gfx942): each thread reads 16 contiguous FP8 bytes from one
+    # global V row (16 d-positions) and SCATTERS them as 16 separate bytes
+    # into column-major LDS at 16 different LDS rows (the d-positions), same
+    # LDS column (the kv_row).
+    # V coop load (gfx950): each thread reads 16 contiguous FP8 bytes and
+    # WRITES them contiguously into row-major LDS as one ds_write_b128.
+    VEC_WIDTH_V = 16  # 16 FP8 bytes per thread (one global vec load)
+    THREADS_PER_ROW_K = HEAD_DIM // VEC_WIDTH_K
+    THREADS_PER_ROW_V = HEAD_DIM // VEC_WIDTH_V
+    ROWS_PER_BATCH_K = BLOCK_SIZE // THREADS_PER_ROW_K
+    ROWS_PER_BATCH_V = BLOCK_SIZE // THREADS_PER_ROW_V
+
+    if ROWS_PER_BATCH_K >= BLOCK_N:
+        NUM_BATCHES_K = 1
+        K_NEEDS_GUARD = ROWS_PER_BATCH_K > BLOCK_N
+    else:
+        NUM_BATCHES_K = BLOCK_N // ROWS_PER_BATCH_K
+        K_NEEDS_GUARD = False
+    if V_TRANSPOSED and not _is_gfx950_kv:
+        # Native [B,H,D,S] mapping uses all 512 threads as
+        # 128 d-columns × four 16-token segments: one pass covers BLOCK_N=64.
+        NUM_BATCHES_V = 1
+        V_NEEDS_GUARD = False
+    elif ROWS_PER_BATCH_V >= BLOCK_N:
+        NUM_BATCHES_V = 1
+        V_NEEDS_GUARD = ROWS_PER_BATCH_V > BLOCK_N
+    else:
+        NUM_BATCHES_V = BLOCK_N // ROWS_PER_BATCH_V
+        V_NEEDS_GUARD = False
+
+    # V LDS section.
+    # gfx942 (column-major): HEAD_DIM rows × V_STRIDE bytes per row.
+    # gfx950 (row-major):    BLOCK_N rows × V_STRIDE (=HEAD_DIM) bytes per row.
+    LDS_K_BYTES = BLOCK_N * K_STRIDE * 1  # 1 byte per Int8
+    if _is_gfx950_kv:
+        LDS_V_BYTES = BLOCK_N * V_STRIDE * 1  # row-major: BLOCK_N × HEAD_DIM
+    else:
+        LDS_V_BYTES = HEAD_DIM * V_STRIDE * 1  # column-major: HEAD_DIM × V_STRIDE
+    # Stage III: software pipeline (1 or 2 stages). Double-buffer K/V overlaps
+    # the next tile's loads with the current tile's MFMAs, but BLOCK_N=128 on
+    # gfx942 exceeds 64 KiB LDS — auto-fallback to single buffer (see legacy512).
+    # Layout pipe2: [K0 | K1 | V0 | V1]; pipe1: [K | V].
+    _pipe_env = os.environ.get("SAGE_PIPE_STAGES", "2")
+    NUM_PIPE_STAGES = 1 if (_pipe_env in ("0", "1") or IS_SPLIT_K) else 2
+    LDS_K_TOTAL_BYTES = LDS_K_BYTES * NUM_PIPE_STAGES
+    LDS_V_TOTAL_BYTES = LDS_V_BYTES * NUM_PIPE_STAGES
+    LDS_TOTAL_BYTES = LDS_K_TOTAL_BYTES + LDS_V_TOTAL_BYTES
+    if NUM_PIPE_STAGES == 2 and LDS_TOTAL_BYTES > _LDS_CAP_BYTES:
+        NUM_PIPE_STAGES = 1
+        LDS_K_TOTAL_BYTES = LDS_K_BYTES
+        LDS_V_TOTAL_BYTES = LDS_V_BYTES
+        LDS_TOTAL_BYTES = LDS_K_TOTAL_BYTES + LDS_V_TOTAL_BYTES
+    if NUM_PIPE_STAGES == 2:
+        path_tag = f"{path_tag}_pipe2"
+    else:
+        path_tag = f"{path_tag}_pipe1"
+    if IS_SPLIT_K:
+        path_tag = f"{path_tag}_sk{SPLIT_K}"
+
+    # We store K as i8 and V as bf16. Because the SmemAllocator works in elements
+    # and we share one LDS array, we allocate in Int8 units and use byte offsets.
+    # K section: LDS_K_TOTAL_BYTES bytes starting at lds_offset
+    # V section: LDS_V_TOTAL_BYTES bytes starting at lds_offset + LDS_K_TOTAL_BYTES
+    LDS_TOTAL_I8_ELEMS = LDS_TOTAL_BYTES  # 1:1 byte mapping for i8 allocator
+
+    allocator = SmemAllocator(
+        None,
+        arch=gpu_arch,
+        global_sym_name=f"sage_attn_cdna_smem_M{BLOCK_M}N{BLOCK_N}_{path_tag}",
+    )
+    lds_base_offset = allocator._align(allocator.ptr, 16)
+    allocator.ptr = lds_base_offset + LDS_TOTAL_I8_ELEMS
+
+    # Architecture-specific FP8 type (gfx942: fnuz, gfx950: fn)
+    # Deferred: MLIR types must be constructed inside an active MLIR Context,
+    # which only exists inside the @flyc.kernel scope.
+    _is_gfx950 = "gfx950" in gpu_arch
+    _fp8_mlir_type_cls = ir.Float8E4M3FNType if _is_gfx950 else ir.Float8E4M3FNUZType
+
+    # The 32x32 MFMA variants don't have a flydsl.expr.rocdl wrapper, so we
+    # call the raw ODS class directly with positional arguments.
+    from flydsl._mlir.dialects._rocdl_ops_gen import (
+        ds_read_tr8_b64 as _ods_ds_read_tr8_b64,
+    )
+    from flydsl._mlir.dialects._rocdl_ops_gen import (
+        mfma_f32_32x32x16_fp8_fp8 as _ods_mfma_f32_32x32x16_fp8_fp8,
+    )
+    from flydsl._mlir.dialects._rocdl_ops_gen import (
+        mfma_i32_32x32x16_i8 as _ods_mfma_i32_32x32x16_i8,
+    )
+    from flydsl._mlir.dialects._rocdl_ops_gen import (
+        mfma_i32_32x32x32_i8 as _ods_mfma_i32_32x32x32_i8,
+    )
+    from flydsl._mlir.dialects._rocdl_ops_gen import (
+        mfma_scale_f32_32x32x64_f8f6f4 as _ods_mfma_scale_f32_32x32x64_f8f6f4,
+    )
+
+    def mfma_i32_k32(result_type, operands):
+        a, b, c = operands[0], operands[1], operands[2]
+        cbsz = operands[3] if len(operands) > 3 else 0
+        abid = operands[4] if len(operands) > 4 else 0
+        blgp = operands[5] if len(operands) > 5 else 0
+        a_v = a.ir_value() if hasattr(a, "ir_value") and not isinstance(a, ir.Value) else a
+        b_v = b.ir_value() if hasattr(b, "ir_value") and not isinstance(b, ir.Value) else b
+        c_v = c.ir_value() if hasattr(c, "ir_value") and not isinstance(c, ir.Value) else c
+        if const_expr(_GFX942_W256):
+            return _ods_mfma_i32_32x32x16_i8(
+                res=result_type,
+                a=a_v,
+                b=b_v,
+                c=c_v,
+                cbsz=cbsz,
+                abid=abid,
+                blgp=blgp,
+            ).result
+        return _ods_mfma_i32_32x32x32_i8(
+            res=result_type,
+            a=a_v,
+            b=b_v,
+            c=c_v,
+            cbsz=cbsz,
+            abid=abid,
+            blgp=blgp,
+        ).result
+
+    def mfma_fp8_k16(result_type, operands):
+        a, b, c = operands[0], operands[1], operands[2]
+        cbsz = operands[3] if len(operands) > 3 else 0
+        abid = operands[4] if len(operands) > 4 else 0
+        blgp = operands[5] if len(operands) > 5 else 0
+        a_v = a.ir_value() if hasattr(a, "ir_value") and not isinstance(a, ir.Value) else a
+        b_v = b.ir_value() if hasattr(b, "ir_value") and not isinstance(b, ir.Value) else b
+        c_v = c.ir_value() if hasattr(c, "ir_value") and not isinstance(c, ir.Value) else c
+        return _ods_mfma_f32_32x32x16_fp8_fp8(
+            res=result_type,
+            a=a_v,
+            b=b_v,
+            c=c_v,
+            cbsz=cbsz,
+            abid=abid,
+            blgp=blgp,
+        ).result
+
+    def mfma_fp8_k64(result_type, a, b, c, scale_a, scale_b):
+        """rocdl.mfma.scale.f32.32x32x64.f8f6f4 (fp8 * fp8) wrapper.
+
+        a, b: vector<8xi32> per lane (= 32 fp8 bytes per lane).
+        c: vector<16xf32> per lane (accumulator; same layout as 32x32x16_bf16).
+        scale_a, scale_b: i32 (e8m0). Pass 127 for "no scaling" (1.0 multiplier).
+        opselA=opselB=0 selects the FP8 path.
+        """
+        a_v = a.ir_value() if hasattr(a, "ir_value") and not isinstance(a, ir.Value) else a
+        b_v = b.ir_value() if hasattr(b, "ir_value") and not isinstance(b, ir.Value) else b
+        c_v = c.ir_value() if hasattr(c, "ir_value") and not isinstance(c, ir.Value) else c
+        return _ods_mfma_scale_f32_32x32x64_f8f6f4(
+            res=result_type,
+            a=a_v,
+            b=b_v,
+            c=c_v,
+            cbsz=0,
+            blgp=0,
+            opselA=0,
+            scaleA=scale_a,
+            opselB=0,
+            scaleB=scale_b,
+        ).result
+
+    @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
+    def sage_attn_kernel(
+        Q: fx.Tensor,  # Int8, 1D flattened BSHD
+        K: fx.Tensor,  # Int8, 1D flattened BSHD (num_kv_heads)
+        V: fx.Tensor,  # FP8, 1D flattened BSHD (num_kv_heads)
+        O: fx.Tensor,  # BF16 output, 1D flattened BSHD  # noqa: E741
+        Q_descale: fx.Tensor,  # f32, shape [batch, num_q_heads, num_q_blocks]
+        K_descale: fx.Tensor,  # f32, shape [batch, num_kv_heads, num_k_blocks]
+        V_descale: fx.Tensor,  # f32, shape [batch, num_kv_heads, head_dim] (per-element)
+        Bias: fx.Tensor,  # f32 [batch, num_q_heads, num_q_blocks, seq_len_k]
+        batch_size: fx.Int32,
+        seq_len_q: fx.Int32,
+        seq_len_k: fx.Int32,
+        num_q_blocks: fx.Int32,
+    ):
+        fm_fast = arith.FastMathFlags.fast
+
+        def _fadd(a, b):
+            return arith.addf(_raw(a), _raw(b), fastmath=fm_fast)
+
+        def _fsub(a, b):
+            return arith.subf(_raw(a), _raw(b), fastmath=fm_fast)
+
+        def _fmul(a, b):
+            return arith.mulf(_raw(a), _raw(b), fastmath=fm_fast)
+
+        def _fmax(a, b):
+            return arith.MaxNumFOp(_raw(a), _raw(b), fastmath=fm_fast).result
+
+        def _ffma(a, b, c):
+            # fused a*b + c (single rounding); used to fold the QK descale into
+            # the exp argument so the 32 per-element scale-muls collapse.
+            return _math.fma(_raw(a), _raw(b), _raw(c), fastmath=fm_fast)
+
+        def _sitofp(v):
+            return arith.SIToFPOp(T.f32, _raw(v)).result
+
+        q_ptr = _extract_aligned_pointer(Q)
+        o_ptr = _extract_aligned_pointer(O)
+        qds_ptr = _extract_aligned_pointer(Q_descale)
+        kds_ptr = _extract_aligned_pointer(K_descale)
+        vds_ptr = _extract_aligned_pointer(V_descale)
+        if const_expr(use_bias):
+            bias_ptr = _extract_aligned_pointer(Bias)
+
+        # Buffer descriptors for K/V global loads.
+        # Tight num_records_bytes = B*S*Hk*HEAD_DIM lets the hardware return
+        # 0 for OOB lanes past tensor end, so we can drop the row-clamp +
+        # V zero-fill selects in coop_load_k/v. Score masking already pins
+        # P=0 for KV columns past seq_len_k, so even inner-batch overflow
+        # rows that fall into a neighboring batch's bytes contribute 0 to
+        # the PV MFMA (0 * any-fp8 = 0; sage_quant outputs are NaN-free).
+        bs_v_for_rsrc = fx.Index(batch_size)
+        slk_v_for_rsrc = fx.Index(seq_len_k)
+        num_k_blocks_for_rsrc = (slk_v_for_rsrc + fx.Index(BLOCK_N - 1)) // fx.Index(BLOCK_N)
+        kv_total_bytes = bs_v_for_rsrc * slk_v_for_rsrc * fx.Index(NUM_KV_HEADS * HEAD_DIM)
+        v_total_bytes = (
+            bs_v_for_rsrc * fx.Index(NUM_KV_HEADS * HEAD_DIM) * num_k_blocks_for_rsrc * fx.Index(BLOCK_N)
+            if V_TRANSPOSED
+            else kv_total_bytes
+        )
+        k_rsrc = buffer_ops.create_buffer_resource(
+            K,
+            max_size=False,
+            num_records_bytes=kv_total_bytes,
+        )
+        v_rsrc = buffer_ops.create_buffer_resource(
+            V,
+            max_size=False,
+            num_records_bytes=v_total_bytes,
+        )
+
+        v4i32_type = Vec.make_type(4, fx.Int32)
+        v16i32_type = Vec.make_type(16, fx.Int32)
+        v16f32_type = Vec.make_type(16, fx.Float32)
+        v4f32_type = Vec.make_type(4, fx.Float32)
+        # MFMA 32x32x32_i8: A/B = v4i32 (=16xi8 per lane), C/D = v16i32 per lane (wave64)
+        v8i8_type = Vec.make_type(8, fx.Int8)
+        v16i8_type = Vec.make_type(16, fx.Int8)
+
+        seq_len_q_v = fx.Index(seq_len_q)
+        seq_len_k_v = fx.Index(seq_len_k)
+
+        base_ptr = allocator.get_base()
+        # Shared LDS as Int8 view: covers BOTH K ping-pong buffers (K0 | K1).
+        # Buffer index is a runtime value; per-buffer LDS index = base_idx +
+        # buf_idx * LDS_K_BYTES.
+        lds = SmemPtr(
+            base_ptr,
+            lds_base_offset,
+            T.i8,
+            shape=(LDS_K_TOTAL_BYTES,),
+        ).get()
+        # Separate, statically-shaped view for V — gives the LLVM backend a
+        # tight bound that helps prove 16-byte alignment for vector loads, so
+        # they can lower to ds_read_b128 instead of 32× ds_read_u8. Covers
+        # BOTH V ping-pong buffers (V0 | V1).
+        lds_v = SmemPtr(
+            base_ptr,
+            lds_base_offset + LDS_K_TOTAL_BYTES,
+            T.i8,
+            shape=(LDS_V_TOTAL_BYTES,),
+        ).get()
+
+        block_id = fx.Index(gpu.block_idx.x)
+        tid = fx.Index(gpu.thread_idx.x)
+
+        wave_id = tid // WARP_SIZE
+        lane = tid % WARP_SIZE
+
+        # MFMA 32x32 wave64 layout:
+        # lane32 = lane % 32  (row index in A operand, col index in B/output)
+        # klane  = lane // 32 (K-block selector, 0 or 1 for wave64)
+        lane32 = lane % MFMA_M
+        klane = lane // MFMA_M  # 0 or 1 for wave64
+
+        wave_q_offset = wave_id * ROWS_PER_WAVE
+
+        head_q_idx = block_id % NUM_Q_HEADS
+        batch_q_tile_id = block_id // NUM_Q_HEADS
+        num_q_tiles = (seq_len_q_v + BLOCK_M - 1) // BLOCK_M
+        q_tile_raw = batch_q_tile_id % num_q_tiles
+        batch_idx = batch_q_tile_id // num_q_tiles
+        # Causal LPT/SPT remap: reverse the Q-tile order so workgroup 0 (drawn
+        # first) processes the LAST (longest-work) causal tile. Pure scheduling
+        # permutation — every Q-tile's computation is independent and unchanged,
+        # so output is bit-identical to the naive-order baseline. No-op (off) for
+        # non-causal where tile work is uniform.
+        if const_expr(_LPT_SCHED):
+            q_tile_idx = (num_q_tiles - fx.Index(1)) - q_tile_raw
+        else:
+            q_tile_idx = q_tile_raw
+        q_start = q_tile_idx * BLOCK_M
+
+        # KV head for this Q head (GQA)
+        head_kv_idx = head_q_idx // GROUPS
+
+        load_row_k_batch = tid // THREADS_PER_ROW_K
+        load_lane_k = tid % THREADS_PER_ROW_K
+        load_col_k_base = load_lane_k * VEC_WIDTH_K
+
+        load_row_v_batch = tid // THREADS_PER_ROW_V
+        load_lane_v = tid % THREADS_PER_ROW_V
+        load_col_v_base = load_lane_v * VEC_WIDTH_V
+
+        def q_global_idx(token_idx, col):
+            token = batch_idx * seq_len_q_v + token_idx
+            return token * STRIDE_TOKEN + head_q_idx * HEAD_DIM + col
+
+        def kv_global_idx(token_idx, col):
+            token = batch_idx * seq_len_k_v + token_idx
+            return token * KV_STRIDE_TOKEN + head_kv_idx * HEAD_DIM + col
+
+        def _load_ptr_i8_vec16(ptr, base_idx):
+            gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.i8)
+            return _pointer_load(v16i8_type, gep)
+
+        def _load_ptr_i8_vec8(ptr, base_idx):
+            gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.i8)
+            return _pointer_load(v8i8_type, gep)
+
+        def _load_ptr_i64(ptr, base_idx):
+            """Load 8 contiguous bytes from `ptr+base_idx` as a scalar i64
+            (8xi8 packed). Used for MFMA i8 operands which require packed i64.
+            """
+            gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.i8)
+            return _pointer_load(T.i64, gep)
+
+        def _load_ptr_f8_vec8(ptr, base_idx):
+            # FP8 is loaded as raw bytes and bitcast; the actual ExtFOp uses the
+            # arch-specific FP8 type (FNUZ on gfx942, FN on gfx950).
+            return _load_ptr_i8_vec8(ptr, base_idx)
+
+        def _store_ptr_bf16(ptr, base_idx, val):
+            gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.bf16)
+            _pointer_store(val, gep)
+
+        def _load_ptr_f32(ptr, base_idx):
+            gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.f32)
+            return _pointer_load(T.f32, gep)
+
+        def _load_ptr_f32_vec4(ptr, base_idx):
+            gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.f32)
+            return _pointer_load(v4f32_type, gep)
+
+        def _bpermute_f32(value, src_lane):
+            value_i32 = arith.bitcast(T.i32, _raw(value))
+            # ds_bpermute addresses lanes in bytes, despite operating entirely
+            # on VGPRs: lane N is selected with index N * sizeof(i32).
+            lane_byte_idx = fx.Int32(arith.unwrap(arith.index_cast(T.i32, _raw(src_lane * 4))))
+            result_i32 = rocdl.ds_bpermute(T.i32, _raw(lane_byte_idx), value_i32)
+            return fx.Float32(arith.bitcast(T.f32, result_i32))
+
+        # ---- Preload Q to registers (Int8, v4i32 = 16xi8 packs for MFMA) ----
+        # Each wave owns ROWS_PER_WAVE=32 Q rows.
+        # For mfma_i32_32x32x32_i8: A operand is vector<4xi32> = 16 i8 per lane.
+        # lane32 = q_row within the 32-row tile (0..31)
+        # klane (0,1) selects the 16-byte half of the 32-wide K dimension.
+        # We preload K_STEPS_QK packs per lane (each = 16 i8 = v4i32).
+        q_row = q_start + wave_q_offset + lane32
+        q_row_i32 = fx.Int32(q_row)
+        q_in_bounds = arith.cmpi(arith.CmpIPredicate.slt, _raw(q_row), _raw(seq_len_q_v))
+        q_row_safe = fx.Index(ArithValue(q_in_bounds).select(q_row, fx.Index(0)))
+
+        _zero_v4i32_ir = Vec.filled(4, 0, fx.Int32).ir_value()
+        c_zero_i64 = arith.constant(0, type=T.i64)
+        q_packs = []
+        for ks in range_constexpr(K_STEPS_QK):
+            if const_expr(_GFX942_W256):
+                # 32x32x16_i8: each lane holds 8 i8 (packed i64); klane picks
+                # the 8-byte half of the 16-wide K chunk for this MFMA step.
+                q_col = fx.Index(ks * MFMA_K_INT8) + klane * 8
+                g_idx = q_global_idx(q_row_safe, q_col)
+                half = _load_ptr_i64(q_ptr, g_idx)
+                q_packs.append(ArithValue(q_in_bounds).select(half, c_zero_i64))
+            else:
+                # klane in {0,1} picks the 16-byte K sub-pack (K=k_block*16 + 0..15).
+                q_col = fx.Index(ks * MFMA_K_INT8) + klane * 16
+                g_idx = q_global_idx(q_row_safe, q_col)
+                v16i8 = _load_ptr_i8_vec16(q_ptr, g_idx)
+                v4i32 = vector.bitcast(v4i32_type, v16i8)
+                q_packs.append(ArithValue(q_in_bounds).select(v4i32, _zero_v4i32_ir))
+
+        # ---- Descale factors ----
+        # q_descale and SmoothQ bias use Q_SCALE_BLOCK_M.
+        # k_descale: [batch, num_kv_heads, num_k_blocks]
+        # v_descale: [batch, num_kv_heads] (per head, broadcast over k-blocks)
+        num_k_blocks_per_head = (seq_len_k_v + BLOCK_N - 1) // BLOCK_N
+
+        q_scale_num_blocks = fx.Index(num_q_blocks)
+        q_scale_tile_raw = (q_start + wave_q_offset) // Q_SCALE_BLOCK_M
+        q_scale_tile_idx = ArithValue(q_scale_tile_raw < q_scale_num_blocks).select(
+            q_scale_tile_raw, q_scale_num_blocks - fx.Index(1)
+        )
+        q_descale_base = (
+            batch_idx * NUM_Q_HEADS * q_scale_num_blocks + head_q_idx * q_scale_num_blocks + q_scale_tile_idx
+        )
+        q_ds = fx.Float32(_load_ptr_f32(qds_ptr, q_descale_base))
+
+        v_descale_base = (batch_idx * NUM_KV_HEADS + head_kv_idx) * HEAD_DIM
+
+        # ---- Constants ----
+        c_neg_inf = fx.Float32(float("-inf"))
+        c_zero_f = fx.Float32(0.0)
+        c_one_f = fx.Float32(1.0)
+        c_zero_v16f32 = Vec.filled(16, 0.0, fx.Float32)
+        c_zero_v16i32 = Vec.filled(16, 0, fx.Int32)
+
+        # Warp shuffle for reduction: wave64 has 64 lanes; with 32x32 MFMA the
+        # only cross-lane partner of a (klane, lane32) is the lane at the same
+        # lane32 with the other klane (XOR distance = 32).
+        shuf32_i32 = fx.Int32(32)
+        width_i32 = fx.Int32(WARP_SIZE)
+
+        def reduction_peer32(v_f32):
+            return fx.Float32(v_f32).shuffle_xor(shuf32_i32, width_i32)
+
+        def row_max_reduce(local_max):
+            """Reduce max across the 2 klane halves within wave64."""
+            return _fmax(local_max, reduction_peer32(local_max))
+
+        def row_sum_reduce(local_sum):
+            """Reduce sum across the 2 klane halves within wave64."""
+            return _fadd(local_sum, reduction_peer32(local_sum))
+
+        _q_end = q_start + BLOCK_M
+        if const_expr(CAUSAL):
+            kv_upper = fx.Index(ArithValue(_q_end < seq_len_k_v).select(_q_end, seq_len_k_v))
+        else:
+            kv_upper = seq_len_k_v
+
+        # ---- Direct global→LDS DMA helpers (experimental) ----
+        # raw_ptr_buffer_load_lds moves `size` bytes/lane straight from a buffer
+        # resource into LDS, bypassing the VGPR file. The HW LDS write is
+        # lane-contiguous within a wave: lane l of wave w lands at
+        #   lds_ptr_base + w*WARP_SIZE*size + l*size
+        # so the caller passes a WAVE-UNIFORM destination pointer (the per-lane
+        # stride is implicit) and the full per-lane address goes on the GLOBAL
+        # side via `voffset` (byte offset into the resource). With packed
+        # K/V strides this reproduces the row-major LDS tile bit-for-bit, since
+        # load_row*STRIDE + load_col == tid*size for THREADS_PER_ROW*VEC==STRIDE.
+        if const_expr(_dma_any):
+            from flydsl.expr import rocdl as _rocdl_dma
+
+            def _dma_fence():
+                # buffer_load_lds completion is tracked by vmcnt, NOT lgkmcnt,
+                # so gpu.barrier()'s implicit lgkmcnt(0) does not guarantee the
+                # LDS data has landed. Drain vmcnt before the gating barrier.
+                _llvm.inline_asm(None, [], "s_waitcnt vmcnt(0)", "", has_side_effects=True)
+
+            def _lds_as3_base(lds_view):
+                base_idx = _memref.extract_aligned_pointer_as_index(_llvm_value(lds_view))
+                base_i64 = arith.unwrap(arith.index_cast(T.i64, base_idx))
+                return buffer_ops.create_llvm_ptr(base_i64, address_space=3)
+
+        def _coop_load_k_dma(tile_start, buf_off):
+            # K DMA: packed row-major LDS, DMA_BYTES = VEC_WIDTH_K (16 on gfx950,
+            # one buffer_load_dwordx4-to-LDS). guard never fires for shipped
+            # tile configs (ROWS_PER_BATCH_K <= BLOCK_N); asserted at build.
+            assert not K_NEEDS_GUARD, "K DMA path requires ROWS_PER_BATCH_K<=BLOCK_N"
+            DMA_BYTES_K = VEC_WIDTH_K
+            buf_off_i64 = arith.unwrap(arith.index_cast(T.i64, _raw(buf_off)))
+            wave_byte = _rocdl_dma.readfirstlane(
+                T.i64,
+                arith.unwrap(arith.index_cast(T.i64, wave_id * fx.Index(WARP_SIZE * DMA_BYTES_K))),
+            )
+            base_ptr = _lds_as3_base(lds)
+            base_ptr = buffer_ops.get_element_ptr(base_ptr, buf_off_i64)
+            base_ptr = buffer_ops.get_element_ptr(base_ptr, wave_byte)
+            size_i32 = arith.constant(DMA_BYTES_K, type=T.i32)
+            c0 = arith.constant(0, type=T.i32)
+            aux1 = arith.constant(1, type=T.i32)
+            # CHUNKS_PER_ROW = HEAD_DIM / VEC_WIDTH_K = number of 16-B chunks per
+            # K row; the XOR period is the next-lower power of two so the permute
+            # stays in-row. K row = HEAD_DIM(128)/16 = 8 chunks → period 8.
+            _CPR_K = HEAD_DIM // VEC_WIDTH_K
+            _XMASK_K = _CPR_K - 1  # 7 for HEAD_DIM=128
+            for batch in range_constexpr(NUM_BATCHES_K):
+                row_offset = batch * ROWS_PER_BATCH_K
+                row_idx_raw = tile_start + load_row_k_batch + row_offset
+                if const_expr(_dma_xor):
+                    # Physical chunk this lane owns in LDS = load_col_k_base/16;
+                    # fetch the XOR-permuted chunk from GLOBAL so that, combined
+                    # with the inverse permute on the QK read, each LDS row lands
+                    # on a distinct bank set. tile_row = LDS row within the tile.
+                    tile_row = load_row_k_batch + row_offset
+                    phys_chunk = load_lane_k  # = load_col_k_base // VEC_WIDTH_K
+                    g_chunk = ArithValue(phys_chunk) ^ (ArithValue(tile_row) & fx.Index(_XMASK_K))
+                    g_col = fx.Index(g_chunk) * fx.Index(VEC_WIDTH_K)
+                    g_idx = kv_global_idx(row_idx_raw, g_col)
+                else:
+                    g_idx = kv_global_idx(row_idx_raw, load_col_k_base)
+                voff = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx)))
+                if const_expr(batch == 0):
+                    lds_ptr = base_ptr
+                else:
+                    lds_ptr = buffer_ops.get_element_ptr(
+                        base_ptr,
+                        static_byte_offset=batch * BLOCK_SIZE * DMA_BYTES_K,
+                    )
+                _rocdl_dma.raw_ptr_buffer_load_lds(k_rsrc, lds_ptr, size_i32, voff, c0, c0, aux1)
+
+        def _coop_load_v_dma(tile_start, buf_off):
+            # gfx950 row-major V: structurally identical to K DMA. Packed
+            # V stride, DMA_BYTES = VEC_WIDTH_V = 16. global voffset = byte
+            # index into V resource; HW write lands lane-contiguous == the
+            # row-major LDS tile. gfx942 column-major (transpose) cannot be a
+            # DMA — _dma_v is forced False there.
+            assert not V_NEEDS_GUARD, "V DMA path requires ROWS_PER_BATCH_V<=BLOCK_N"
+            DMA_BYTES_V = VEC_WIDTH_V
+            buf_off_i64 = arith.unwrap(arith.index_cast(T.i64, _raw(buf_off)))
+            wave_byte = _rocdl_dma.readfirstlane(
+                T.i64,
+                arith.unwrap(arith.index_cast(T.i64, wave_id * fx.Index(WARP_SIZE * DMA_BYTES_V))),
+            )
+            base_ptr = _lds_as3_base(lds_v)
+            base_ptr = buffer_ops.get_element_ptr(base_ptr, buf_off_i64)
+            base_ptr = buffer_ops.get_element_ptr(base_ptr, wave_byte)
+            size_i32 = arith.constant(DMA_BYTES_V, type=T.i32)
+            c0 = arith.constant(0, type=T.i32)
+            aux1 = arith.constant(1, type=T.i32)
+            for batch in range_constexpr(NUM_BATCHES_V):
+                row_offset = batch * ROWS_PER_BATCH_V
+                row_idx_raw = tile_start + load_row_v_batch + row_offset
+                g_idx = kv_global_idx(row_idx_raw, load_col_v_base)
+                voff = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx)))
+                if const_expr(batch == 0):
+                    lds_ptr = base_ptr
+                else:
+                    lds_ptr = buffer_ops.get_element_ptr(
+                        base_ptr,
+                        static_byte_offset=batch * BLOCK_SIZE * DMA_BYTES_V,
+                    )
+                _rocdl_dma.raw_ptr_buffer_load_lds(v_rsrc, lds_ptr, size_i32, voff, c0, c0, aux1)
+
+        # ---- Cooperative load helpers for K (Int8) ----
+        # buf_off: byte offset into the K-side LDS that selects the ping-pong
+        # buffer. 0 = buffer 0, LDS_K_BYTES = buffer 1.
+        def coop_load_k(tile_start, buf_off):
+            if const_expr(_dma_k):
+                _coop_load_k_dma(tile_start, buf_off)
+                return
+            for batch in range_constexpr(NUM_BATCHES_K):
+                row_offset = batch * ROWS_PER_BATCH_K
+                row_idx_raw = tile_start + load_row_k_batch + row_offset
+                # Tight buffer descriptor (num_records_bytes=B*S*Hk*HEAD_DIM)
+                # makes hardware return 0 for OOB lanes past tensor end. For
+                # inner-batch tail rows that overflow into a neighbouring
+                # batch the score mask still pins P=0 for those columns, so
+                # the PV contribution is 0 regardless. No row-clamp select
+                # needed.
+                if const_expr(K_NEEDS_GUARD):
+                    row_valid = load_row_k_batch < fx.Index(BLOCK_N)
+                    do_load = row_valid
+                else:
+                    do_load = True
+                if do_load:
+                    g_idx = kv_global_idx(row_idx_raw, load_col_k_base)
+                    lds_row = load_row_k_batch + row_offset
+                    lds_idx = buf_off + lds_row * K_STRIDE + load_col_k_base
+                    # buffer_load_dwordx4: g_idx is in i8 elements (=bytes); divide
+                    # by 4 to get the dword index buffer_load expects when dtype=i32.
+                    g_dword_i32 = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx >> fx.Index(2))))
+                    v4i32 = buffer_ops.buffer_load(k_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
+                    vec = vector.bitcast(v16i8_type, v4i32)
+                    Vec(vec).store(lds, [lds_idx])
+
+        # V is stored in the upper half of LDS, COLUMN-MAJOR (transposed):
+        # the LDS V section is HEAD_DIM rows × V_STRIDE bytes per row, where
+        # row index = d (0..HEAD_DIM-1) and the first BLOCK_N bytes of each row
+        # hold consecutive kv positions (column = kv_row).
+        # Storing V transposed makes per-lane PV reads be 32 contiguous bytes
+        # (one ds_read_b256 = 2 ds_read_b128) at fixed d, kv_row=k_start..+31.
+
+        def coop_load_v(tile_start, buf_off):
+            """Load V from global (FP8 raw bytes) into LDS.
+
+            gfx942 (column-major LDS): each thread reads VEC_WIDTH_V=16
+              contiguous FP8 bytes from one global V row and SCATTERS them as
+              16 individual byte writes to 16 different LDS rows.
+            gfx950 (row-major LDS): each thread reads VEC_WIDTH_V=16 contiguous
+              FP8 bytes and writes them contiguously as one ds_write_b128 —
+              same shape as global, no transpose. Reduces ~2048 ds_write_b8
+              transactions per KV iter down to ~128 ds_write_b128 transactions.
+
+            Tight buffer descriptor (num_records_bytes=B*S*Hk*HEAD_DIM) makes
+            hardware return 0 for OOB lanes past tensor end. For inner-batch
+            tail rows that overflow into a neighbouring batch the score mask
+            pins P=0 for those columns, so 0 * (whatever V byte) = 0 in the
+            PV MFMA. sage_quant outputs are NaN-free, so no NaN propagation.
+
+            buf_off: byte offset into lds_v selecting the ping-pong V buffer.
+            """
+            if const_expr(_dma_v):
+                _coop_load_v_dma(tile_start, buf_off)
+                return
+            for batch in range_constexpr(NUM_BATCHES_V):
+                row_offset = batch * ROWS_PER_BATCH_V
+                row_idx_raw = tile_start + load_row_v_batch + row_offset
+                if const_expr(V_NEEDS_GUARD):
+                    row_valid = load_row_v_batch < fx.Index(BLOCK_N)
+                    do_load = row_valid
+                else:
+                    do_load = True
+                if do_load:
+                    if const_expr(V_TRANSPOSED and not _is_gfx950_kv):
+                        # Quant output is [B,H,D,S]. Each lane owns one d-row
+                        # and loads 16 consecutive K positions, matching the
+                        d_idx = tid % fx.Index(HEAD_DIM)
+                        k_group = tid // fx.Index(HEAD_DIM)
+                        tile_idx = tile_start // fx.Index(BLOCK_N)
+                        g_byte_idx = (
+                            ((batch_idx * NUM_KV_HEADS + head_kv_idx) * num_k_blocks_per_head + tile_idx)
+                            * fx.Index(HEAD_DIM)
+                            + d_idx
+                        ) * fx.Index(BLOCK_N) + k_group * fx.Index(16)
+                        g_dword_i32 = arith.unwrap(arith.index_cast(T.i32, _raw(g_byte_idx >> fx.Index(2))))
+                        v4i32 = buffer_ops.buffer_load(v_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
+                        raw_v = vector.bitcast(v16i8_type, v4i32)
+                        v_off = buf_off + d_idx * V_STRIDE + k_group * fx.Index(16)
+                        Vec(raw_v).store(lds_v, [v_off])
+                    else:
+                        g_idx = kv_global_idx(row_idx_raw, load_col_v_base)
+                        g_dword_i32 = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx >> fx.Index(2))))
+                        v4i32 = buffer_ops.buffer_load(v_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
+                        raw_v = vector.bitcast(v16i8_type, v4i32)
+
+                        if const_expr(_is_gfx950_kv):
+                            lds_row = load_row_v_batch + row_offset
+                            v_off = buf_off + lds_row * V_STRIDE + load_col_v_base
+                            Vec(raw_v).store(lds_v, [v_off])
+                        else:
+                            lds_col = load_row_v_batch + row_offset
+                            for di in range_constexpr(VEC_WIDTH_V):
+                                d_idx = load_col_v_base + di
+                                v_off = buf_off + d_idx * V_STRIDE + lds_col
+                                b_i8 = vector.extract(raw_v, static_position=[di], dynamic_position=[])
+                                Vec.from_elements([b_i8], fx.Int8).store(lds_v, [v_off])
+
+        def load_k_frag(kv_block_row, ks, buf_off):
+            """Load K fragment from LDS for QK MFMA.
+
+            gfx950 / gfx942-legacy32: v4i32 (=16xi8) for mfma_i32_32x32x32_i8.
+            gfx942 w256: i64 (=8xi8) for mfma_i32_32x32x16_i8.
+            """
+            if const_expr(_dma_xor):
+                # Inverse of the write-side permute: QK wants global 16-B chunk
+                # g = ks*2 + klane of this kv row; it physically lives at chunk
+                # g ^ (row & (CHUNKS_PER_ROW-1)) in the packed LDS tile.
+                _CPR_K = HEAD_DIM // VEC_WIDTH_K
+                _XMASK_K = _CPR_K - 1
+                if const_expr(_GFX942_W256):
+                    g_chunk = fx.Index(ks)
+                    phys_chunk = ArithValue(g_chunk) ^ (ArithValue(kv_block_row) & fx.Index(_XMASK_K))
+                    k_col = fx.Index(phys_chunk) * fx.Index(VEC_WIDTH_K) + klane * fx.Index(8)
+                else:
+                    g_chunk = fx.Index(ks * 2) + klane  # 16-B chunk QK needs
+                    phys_chunk = ArithValue(g_chunk) ^ (ArithValue(kv_block_row) & fx.Index(_XMASK_K))
+                    k_col = fx.Index(phys_chunk) * fx.Index(VEC_WIDTH_K)
+            else:
+                if const_expr(_GFX942_W256):
+                    k_col = fx.Index(ks * MFMA_K_INT8) + klane * 8
+                else:
+                    k_col = fx.Index(ks * MFMA_K_INT8) + klane * 16
+            lds_idx = buf_off + fx.Index(kv_block_row * K_STRIDE) + k_col
+            if const_expr(_GFX942_W256):
+                v8i8 = Vec.load(v8i8_type, lds, [lds_idx])
+                k_i64v = vector.bitcast(Vec.make_type(1, fx.Int64), v8i8)
+                return vector.extract(k_i64v, static_position=[0], dynamic_position=[])
+            v16i8 = Vec.load(v16i8_type, lds, [lds_idx])
+            return vector.bitcast(v4i32_type, v16i8)
+
+        def load_v_frag_fp8(pks, dc, buf_off, iter_lane_addr_i32):
+            """Load v8i32 (=32xi8 fp8) V fragment from LDS for mfma_scale_f32_32x32x64.
+
+            For lane (klane, lane32) at PV step `pks` and D chunk `dc`, the A
+            operand needs V[d=dc*32+lane32, k=pks*64+klane*32 .. +31].
+
+            gfx942 path (column-major LDS, V_STRIDE = BLOCK_N+16):
+              LDS layout has d as the row index and k_v as the column index, so
+              the 32 K-bytes per lane are 32 LDS-contiguous bytes. Issue as
+              two 16-byte vector loads (compiler lowers to 2× ds_read_b128).
+
+            gfx950 path (row-major LDS, V_STRIDE = HEAD_DIM):
+              Use 4× ds_read_tr8_b64 (CDNA4-only). Each instruction is a
+              SIMD-64 op composed of 4 independent 16-lane sub-ops; within
+              each 16-lane group the instruction does an in-tile transpose so
+              that physical lane t outputs 8 K-bytes at fixed d=base_d + (t%16).
+
+              Per-lane LDS address (verified by /tmp/probe_ds_read_tr8_b64.py
+              against the Triton emitter at MemoryOpToLLVM.cpp:140-330):
+                g       = lane // 16    # which 16-lane sub-group
+                i       = lane %  16    # output position within sub-group
+                base_kv = pks*64 + (g//2)*32 + k_idx*8     # k_idx ∈ {0,1,2,3}
+                base_d  = dc*32  + (g%2)*16
+                addr    = (base_kv + i//2) * V_STRIDE + (base_d + (i%2)*8)
+              4 calls (k_idx 0..3) per lane gather 32 contiguous K-bytes.
+
+              `iter_lane_addr_i32` (gfx950): precomputed per-iter, per-lane
+              i32 LDS address holding (lds_v_base + cur_v_off + lane-invariant
+              part). The (pks, dc, k_idx)-dependent part is added per call as
+              a compile-time literal so the AMDGPU backend folds it into
+              `ds_read offset:LIT`, eliminating per-call `v_or_b32`.
+            """
+            if const_expr(_is_gfx950):
+                lds_ptr_ty = ir.Type.parse("!llvm.ptr<3>")
+                v2i32_type = Vec.make_type(2, fx.Int32)
+
+                words = []
+                for k_idx in range_constexpr(4):
+                    # Compile-time-constant byte offset for this (pks, dc, k_idx).
+                    lit_bytes = (pks * MFMA_K_FP8 + k_idx * 8) * V_STRIDE + dc * MFMA_M
+                    addr_i32 = arith.AddIOp(
+                        iter_lane_addr_i32,
+                        arith.constant(lit_bytes, type=T.i32),
+                    ).result
+                    ptr_val = _llvm.inttoptr(lds_ptr_ty, addr_i32)
+                    v2i32 = _ods_ds_read_tr8_b64(res=v2i32_type, ptr=ptr_val).result
+                    words.append(v2i32)
+
+                # Pack 4× v2i32 → v8i32 (= 32 fp8 bytes per lane).
+                elems = []
+                for w_idx in range_constexpr(4):
+                    for sub in range_constexpr(2):
+                        elems.append(vector.extract(words[w_idx], static_position=[sub], dynamic_position=[]))
+                return Vec.from_elements(elems, fx.Int32).ir_value()
+
+            # gfx942 column-major path.
+            d_col = dc * MFMA_M + lane32
+            kv_k_start = fx.Index(pks * MFMA_K_FP8) + klane * fx.Index(MFMA_K_FP8 // 2)
+            v_off = buf_off + d_col * V_STRIDE + kv_k_start
+            if const_expr(MFMA_K_FP8 == 16):
+                v8i8 = Vec.load(v8i8_type, lds_v, [v_off])
+                v_i64v = vector.bitcast(Vec.make_type(1, fx.Int64), v8i8)
+                return vector.extract(v_i64v, static_position=[0], dynamic_position=[])
+            lo_v16i8 = Vec.load(v16i8_type, lds_v, [v_off])
+            hi_v16i8 = Vec.load(v16i8_type, lds_v, [v_off + 16])
+            lo_v4i32 = vector.bitcast(v4i32_type, lo_v16i8)
+            hi_v4i32 = vector.bitcast(v4i32_type, hi_v16i8)
+            elems = []
+            for w in range_constexpr(4):
+                elems.append(vector.extract(lo_v4i32, static_position=[w], dynamic_position=[]))
+            for w in range_constexpr(4):
+                elems.append(vector.extract(hi_v4i32, static_position=[w], dynamic_position=[]))
+            return Vec.from_elements(elems, fx.Int32).ir_value()
+
+        def f32_to_bf16_trunc(f32_raw):
+            """Bitwise f32 → bf16 truncation (upper 16 bits)."""
+            i32_val = arith.BitcastOp(T.i32, f32_raw).result
+            i16_val = arith.TruncIOp(
+                T.i16,
+                arith.ShRUIOp(i32_val, arith.constant(16, type=T.i32)).result,
+            ).result
+            return arith.BitcastOp(T.bf16, i16_val).result
+
+        # ---- Main loop: iterate over KV tiles ----
+        # Stage III: 2-stage software pipeline.
+        #   Prologue: prefetch KV block 0 into buffer 0.
+        #   Iter i:   barrier; if not last, prefetch block (i+1) into buf (i+1)%2;
+        #             then QK MFMA + softmax + PV MFMA on buf (i%2).
+        # Buffer parity is carried as a loop-state i32 (0 or 1) to keep the LDS
+        # offset on the fast scalar-broadcast path (no integer division by
+        # BLOCK_N inside the hot loop).
+        K_BUF1_OFF = fx.Index(LDS_K_BYTES)
+        V_BUF1_OFF = fx.Index(LDS_V_BYTES)
+        ZERO_INDEX = fx.Index(0)
+
+        def _buf_off(buf_idx_i32, stride_index):
+            """buf_idx ∈ {0,1} → byte offset in {0, stride}, returned as fx.Index."""
+            is_one = ArithValue(fx.Int32(buf_idx_i32) == fx.Int32(1))
+            return fx.Index(is_one.select(stride_index, ZERO_INDEX))
+
+        # Per-lane V LDS base address (gfx950 fast path): hoist the lane-
+        # invariant component once so per-iter ds_reads only need to ADD
+        # cur_v_off and a compile-time literal for (pks, dc, k_idx). This
+        # eliminates the per-ds_read `v_or_b32 vXX, s4, vYY` pattern that
+        # accounted for ~33 instr/iter vs Triton.
+        if const_expr(_is_gfx950):
+            from flydsl.expr.utils.arith import ArithValue as _AV
+
+            _g = lane // fx.Index(16)
+            _i = lane % fx.Index(16)
+            _klane_g = _g // fx.Index(2)
+            _d_group = _g % fx.Index(2)
+            _row_off_within = _i // fx.Index(2)
+            _col_extra_within = (_i % fx.Index(2)) * fx.Index(8)
+            _per_lane_v_inv = (
+                (_klane_g * fx.Index(32) + _row_off_within) * fx.Index(V_STRIDE)
+                + _d_group * fx.Index(16)
+                + _col_extra_within
+            )
+            _lds_v_base = _memref.extract_aligned_pointer_as_index(_llvm_value(lds_v))
+            _v_lane_base_index = _AV(_lds_v_base) + _per_lane_v_inv
+            v_lane_base_i32 = arith.unwrap(arith.index_cast(T.i32, _v_lane_base_index))
+
+        # ===== Straight QK→softmax→PV per iter (Attack #3 2026-05-11) =====
+        # Cross-iter softmax pipelining was tried and added scf.for yield
+        # pressure for p_words+corr (16 i32 + 1 f32 across the boundary)
+        # without a measured win at long-S vs Triton. Triton uses straight
+        # QK→softmax→PV per iter and wins. Restoring that simpler structure
+        # to (a) shrink loop-carried state by ~17 vregs and (b) let the JIT
+        # scheduler interleave softmax VALU into PV MFMA shadow naturally
+        # within a single iter rather than across the yield boundary.
+        N_SUBTILES = BLOCK_N // MFMA_N
+        ELEMS_PER_TILE = 16
+        NUM_S_VALS = N_SUBTILES * ELEMS_PER_TILE
+
+        # Hoist constants used by the softmax helper from inside-loop scope.
+        klane_i32 = fx.Int32(klane)
+        klane_off_i32 = klane_i32 * fx.Int32(4)
+        seq_len_k_i32 = fx.Int32(seq_len_k_v)
+
+        def _i32_pair_to_i64(lo, hi):
+            lo64 = arith.extui(T.i64, _raw(lo))
+            hi64 = arith.shli(
+                arith.extui(T.i64, _raw(hi)),
+                arith.constant(32, type=T.i64),
+            )
+            return arith.ori(lo64, hi64)
+
+        def _gather_p_i64_from_pwords(p_words_2d, pks):
+            """Gather 8 fp8 bytes (i64 B operand) for mfma_f32_32x32x16_fp8."""
+            width_i32 = arith.constant(64, type=T.i32)
+            words = []
+            for j in range_constexpr(2):
+                selected = None
+                for k in range_constexpr(2):
+                    k_pos = pks * MFMA_K_FP8 + k * 8 + j * 4
+                    st = k_pos // MFMA_N
+                    rem = k_pos % MFMA_N
+                    sk = (rem // 4) % 2
+                    w_idx = rem // 8
+                    xor_off = arith.constant((k ^ sk) * MFMA_M, type=T.i32)
+                    w_cand = fx.Int32(p_words_2d[st][w_idx]).shuffle_xor(xor_off, width_i32)
+                    if k == 0:
+                        selected = w_cand
+                    else:
+                        is_k = arith.cmpi(
+                            arith.CmpIPredicate.eq,
+                            klane_i32,
+                            arith.constant(k, type=T.i32),
+                        )
+                        selected = ArithValue(is_k).select(w_cand, selected)
+                words.append(selected)
+            return _i32_pair_to_i64(words[0], words[1])
+
+        def _emit_qk_softmax_pquant(kv_block_start_arg, k_buf_off_arg, m_in, l_in):
+            """Emit QK MFMA + scale + mask + softmax + p-quant for the KV tile
+            at kv_block_start_arg, using K loaded into LDS at k_buf_off_arg.
+
+            Returns (m_new, l_new, corr, p_words_2d) — IR values.
+            """
+            # 1) QK MFMA
+            s_accs_loc = [_raw(c_zero_v16i32) for _ in range(N_SUBTILES)]
+            for ks in range_constexpr(K_STEPS_QK):
+                for st in range_constexpr(N_SUBTILES):
+                    kv_row_loc = lane32 + st * MFMA_N
+                    k_frag = load_k_frag(kv_row_loc, ks, k_buf_off_arg)
+                    if const_expr(_GFX942_W256):
+                        s_accs_loc[st] = mfma_i32_k32(
+                            v16i32_type,
+                            [k_frag, q_packs[ks], s_accs_loc[st], 0, 0, 0],
+                        )
+                    else:
+                        s_accs_loc[st] = mfma_i32_k32(
+                            v16i32_type,
+                            [k_frag, q_packs[ks], s_accs_loc[st], 0, 0, 0],
+                        )
+
+            # 2) Scale (descale-index clamp for the last-iter OOB tile).
+            # "Gate the scale": when _DEFER_SCALE, carry RAW f32 scores and fold
+            # the (strictly positive, amax-based) descale into the softmax exp as
+            # one FMA per element — max commutes with a positive scale, so
+            # max(scale*s)==scale*max(s). This dissolves the 32 per-element
+            # `v_pk_mul_f32` the eager scale emits, the dominant non-exp VALU in
+            # this VALU-bound loop. Deferral wins on non-causal and on causal
+            # block_m<=128, but REGRESSES causal+block_m=256 (the big-tile MFMA
+            # shadow + per-element mask compute already hide the eager muls, so
+            # deferral only adds a serial post-reduction scale on the exp critical
+            # path). Gated accordingly at build time — a per-shape branch.
+            kv_tile_idx_loc = kv_block_start_arg // BLOCK_N
+            max_kv_tile = num_k_blocks_per_head - fx.Index(1)
+            kv_tile_safe = fx.Index(
+                ArithValue(kv_tile_idx_loc < num_k_blocks_per_head).select(kv_tile_idx_loc, max_kv_tile)
+            )
+            k_descale_base_loc = (
+                batch_idx * NUM_KV_HEADS * num_k_blocks_per_head + head_kv_idx * num_k_blocks_per_head + kv_tile_safe
+            )
+            k_ds_loc = fx.Float32(_load_ptr_f32(kds_ptr, k_descale_base_loc))
+            qk_scale_loc = _fmul(q_ds, k_ds_loc)
+            s_f32_loc = []
+            if const_expr(_DEFER_SCALE):
+                for st in range_constexpr(N_SUBTILES):
+                    s_f32_vec = Vec(s_accs_loc[st]).to(fx.Float32)
+                    for elem in range_constexpr(ELEMS_PER_TILE):
+                        s_f32_loc.append(s_f32_vec[elem])
+            else:
+                qk_scale_v16_loc = Vec.from_elements([qk_scale_loc], fx.Float32).broadcast_to(16)
+                for st in range_constexpr(N_SUBTILES):
+                    s_f32_vec = Vec(s_accs_loc[st]).to(fx.Float32)
+                    s_scaled_vec = Vec(arith.mulf(s_f32_vec, qk_scale_v16_loc, fastmath=fm_fast))
+                    for elem in range_constexpr(ELEMS_PER_TILE):
+                        s_f32_loc.append(s_scaled_vec[elem])
+
+            # SmoothQ correction is constant for every Q row in a Q block.
+            # This code only exists in the use_bias=True specialization; the
+            # ordinary Sage kernel retains its original score loop.
+            if const_expr(use_bias):
+                s_biased = list(s_f32_loc)
+                bias_base = (
+                    (batch_idx * NUM_Q_HEADS + head_q_idx) * q_scale_num_blocks + q_scale_tile_idx
+                ) * seq_len_k_v
+                # Every score column is shared by 32 output rows in the wave.
+                # Load one bias per lane, then broadcast it from the lane whose
+                # id equals the column within this 64-wide KV tile. This keeps
+                # scalar alignment and the exact column mapping while replacing
+                # 32 duplicate global loads per bias with readlane shuffles.
+                bias_col = kv_block_start_arg + lane
+                bias_col_safe = fx.Index(ArithValue(bias_col < seq_len_k_v).select(bias_col, fx.Index(0)))
+                bias_lane = fx.Float32(_load_ptr_f32(bias_ptr, bias_base + bias_col_safe))
+                for st in range_constexpr(N_SUBTILES):
+                    for elem in range_constexpr(ELEMS_PER_TILE):
+                        idx = st * ELEMS_PER_TILE + elem
+                        msub = elem // 4
+                        erem = elem % 4
+                        bias_src_lane = fx.Index(st * MFMA_N + msub * 8 + erem) + klane * 4
+                        bias = _bpermute_f32(bias_lane, bias_src_lane)
+                        s_biased[idx] = _fadd(s_biased[idx], bias)
+                s_f32_loc = s_biased
+
+            # 3) Mask
+            kv_start_i32_loc = fx.Int32(arith.unwrap(arith.index_cast(T.i32, _raw(kv_block_start_arg))))
+            if const_expr(CAUSAL):
+                s_named = list(s_f32_loc)
+                for st in range_constexpr(N_SUBTILES):
+                    for elem in range_constexpr(ELEMS_PER_TILE):
+                        idx = st * ELEMS_PER_TILE + elem
+                        msub = elem // 4
+                        erem = elem % 4
+                        kv_col_i32 = (
+                            kv_start_i32_loc
+                            + fx.Int32(st * MFMA_N)
+                            + fx.Int32(msub * 8)
+                            + klane_off_i32
+                            + fx.Int32(erem)
+                        )
+                        out_of_range = ArithValue(kv_col_i32 >= seq_len_k_i32)
+                        out_of_range = out_of_range | ArithValue(kv_col_i32 > q_row_i32)
+                        s_named[idx] = out_of_range.select(c_neg_inf, s_named[idx])
+                s_f32_loc = s_named
+            else:
+                tile_end = kv_block_start_arg + fx.Index(BLOCK_N)
+                tile_oob_av = ArithValue(tile_end > seq_len_k_v)
+                cond_i1 = _raw(tile_oob_av)
+                f32_ty = ir.F32Type.get()
+                result_types = [f32_ty] * NUM_S_VALS
+                if_op = _scf.IfOp(
+                    cond_i1,
+                    result_types,
+                    has_else=True,
+                    loc=ir.Location.unknown(),
+                )
+                with ir.InsertionPoint(if_op.then_block):
+                    _llvm.inline_asm(
+                        None,
+                        [],
+                        "",
+                        "",
+                        has_side_effects=True,
+                    )
+                    masked = []
+                    for st in range_constexpr(N_SUBTILES):
+                        for elem in range_constexpr(ELEMS_PER_TILE):
+                            idx = st * ELEMS_PER_TILE + elem
+                            msub = elem // 4
+                            erem = elem % 4
+                            kv_col_i32 = (
+                                kv_start_i32_loc
+                                + fx.Int32(st * MFMA_N)
+                                + fx.Int32(msub * 8)
+                                + klane_off_i32
+                                + fx.Int32(erem)
+                            )
+                            out_of_range = ArithValue(kv_col_i32 >= seq_len_k_i32)
+                            masked.append(_raw(out_of_range.select(c_neg_inf, s_f32_loc[idx])))
+                    _scf.YieldOp(masked)
+                with ir.InsertionPoint(if_op.else_block):
+                    _scf.YieldOp([_raw(v) for v in s_f32_loc])
+                s_f32_loc = list(if_op.results)
+
+            # 4) Softmax. When deferring, the running max/corr stay in SCALED
+            # space (the descale varies per KV-tile, so cross-tile comparison
+            # must be post-scale): max over RAW scores, scale the single reduced
+            # row-max by qk_scale (one scalar mul vs 32 per-element), and fold
+            # the scale into each exp argument as one FMA (scale*s_raw - m_new).
+            # When not deferring, scores are already scaled (section 2).
+            local_max_l = s_f32_loc[0]
+            for r in range_constexpr(NUM_S_VALS - 1):
+                local_max_l = _fmax(local_max_l, s_f32_loc[r + 1])
+            row_max_l = row_max_reduce(local_max_l)
+            if const_expr(_DEFER_SCALE):
+                row_max_l = _fmul(row_max_l, qk_scale_loc)
+            m_new_l = _fmax(m_in, row_max_l)
+            diff_m_l = _fsub(m_in, m_new_l)
+            corr_l = rocdl.exp2(ir.F32Type.get(), _raw(diff_m_l))
+            neg_max_l = _fsub(c_zero_f, m_new_l)
+            p_vals_l = []
+            local_sum_l = _raw(c_zero_f)
+            for r in range_constexpr(NUM_S_VALS):
+                if const_expr(_DEFER_SCALE):
+                    diff = _ffma(s_f32_loc[r], qk_scale_loc, neg_max_l)
+                else:
+                    diff = _fadd(s_f32_loc[r], neg_max_l)
+                p = rocdl.exp2(ir.F32Type.get(), _raw(diff))
+                p_vals_l.append(p)
+                local_sum_l = _fadd(local_sum_l, p)
+            tile_sum_l = row_sum_reduce(local_sum_l)
+            l_new_l = _fadd(_fmul(corr_l, l_in), tile_sum_l)
+
+            # 5) P-quant → p_words[st][w] : i32
+            c0_i32_l = arith.constant(0, type=T.i32)
+            p_words_l = []
+            for st in range_constexpr(N_SUBTILES):
+                sub = []
+                for w in range_constexpr(4):
+                    s0 = _raw(p_vals_l[st * ELEMS_PER_TILE + w * 4 + 0])
+                    s1 = _raw(p_vals_l[st * ELEMS_PER_TILE + w * 4 + 1])
+                    s2 = _raw(p_vals_l[st * ELEMS_PER_TILE + w * 4 + 2])
+                    s3 = _raw(p_vals_l[st * ELEMS_PER_TILE + w * 4 + 3])
+                    packed = c0_i32_l
+                    packed = rocdl.cvt_pk_fp8_f32(T.i32, s0, s1, packed, 0)
+                    packed = rocdl.cvt_pk_fp8_f32(T.i32, s2, s3, packed, 1)
+                    sub.append(packed)
+                p_words_l.append(sub)
+            return m_new_l, l_new_l, corr_l, p_words_l
+
+        def _run_pv_mfma(p_words, cur_v_off, o_accs, v_iter_lane_addr_i32):
+            if const_expr(_GFX942_W256):
+                for pks in range_constexpr(PV_K_STEPS):
+                    p_i64 = _gather_p_i64_from_pwords(p_words, pks)
+                    for dc in range_constexpr(D_CHUNKS):
+                        v_i64 = load_v_frag_fp8(pks, dc, cur_v_off, v_iter_lane_addr_i32)
+                        o_accs[dc] = mfma_fp8_k16(
+                            v16f32_type,
+                            [v_i64, p_i64, o_accs[dc], 0, 0, 0],
+                        )
+            else:
+                from flydsl._mlir.dialects._rocdl_ops_gen import (
+                    permlane32_swap as _permlane32_swap_op,
+                )
+
+                _struct_ty_2xi32 = ir.Type.parse("!llvm.struct<(i32, i32)>")
+                for pks in range_constexpr(PV_K_STEPS):
+                    v8_elems = []
+                    for w in range_constexpr(4):
+                        a_w = _raw(p_words[pks * 2][w])
+                        b_w = _raw(p_words[pks * 2 + 1][w])
+                        swapped = _permlane32_swap_op(
+                            _struct_ty_2xi32,
+                            old=a_w,
+                            src=b_w,
+                            fi=False,
+                            bound_control=True,
+                        )
+                        lo_word = _llvm.extractvalue(T.i32, swapped, [0])
+                        hi_word = _llvm.extractvalue(T.i32, swapped, [1])
+                        v8_elems.append(lo_word)
+                        v8_elems.append(hi_word)
+                    p_pack_v8i32 = Vec.from_elements(v8_elems, fx.Int32).ir_value()
+                    scale_127 = arith.constant(127, type=T.i32)
+                    for dc in range_constexpr(D_CHUNKS):
+                        v_frag = load_v_frag_fp8(pks, dc, cur_v_off, v_iter_lane_addr_i32)
+                        o_accs[dc] = mfma_fp8_k64(
+                            v16f32_type,
+                            v_frag,
+                            p_pack_v8i32,
+                            o_accs[dc],
+                            scale_127,
+                            scale_127,
+                        )
+            return o_accs
+
+        if const_expr(NUM_PIPE_STAGES == 2):
+            # ---- Prologue (pipe2) ----
+            # Prefetch buf 0 (K[0]/V[0]) AND buf 1 (K[1]/V[1] — harmless if num_iters<2;
+            # coop loaders clamp OOB rows to row 0). Then barrier; iter 0 computes
+            # softmax[0] from buf 0 in-line.
+            coop_load_k(ZERO_INDEX, ZERO_INDEX)
+            coop_load_v(ZERO_INDEX, ZERO_INDEX)
+            coop_load_k(fx.Index(BLOCK_N), K_BUF1_OFF)
+            coop_load_v(fx.Index(BLOCK_N), V_BUF1_OFF)
+            if const_expr(_need_dma_fence):
+                _dma_fence()
+            gpu.barrier()
+
+            # i32 0 — current buffer index for iter 0 (buf 0 holds K[0]/V[0]).
+            c0_i32_init = arith.constant(0, type=T.i32)
+
+            # Iter args layout (Attack #3 — no cross-iter softmax):
+            #   [cur_buf (i32), m (f32), l (f32), *o_accs (D_CHUNKS × v16f32)]
+            init_args = [c0_i32_init, _raw(c_neg_inf), _raw(c_zero_f)]
+            for _ in range_constexpr(D_CHUNKS):
+                init_args.append(_raw(c_zero_v16f32))
+
+            _OFF_CUR_BUF = 0
+            _OFF_M = 1
+            _OFF_L = 2
+            _OFF_O_ACCS = 3
+
+            loop_results = init_args
+            for kv_block_start, inner_iter_args in range(0, kv_upper, BLOCK_N, init=init_args):
+                cur_buf_i32 = inner_iter_args[_OFF_CUR_BUF]
+                m_running = inner_iter_args[_OFF_M]
+                l_running = inner_iter_args[_OFF_L]
+                o_accs = [inner_iter_args[_OFF_O_ACCS + i] for i in range_constexpr(D_CHUNKS)]
+
+                cur_k_off = _buf_off(cur_buf_i32, K_BUF1_OFF)
+                cur_v_off = _buf_off(cur_buf_i32, V_BUF1_OFF)
+                if const_expr(_is_gfx950):
+                    cur_v_off_i32 = arith.unwrap(arith.index_cast(T.i32, cur_v_off))
+                    v_iter_lane_addr_i32 = arith.AddIOp(v_lane_base_i32, cur_v_off_i32).result
+                else:
+                    v_iter_lane_addr_i32 = None
+                next_buf_i32 = arith.XOrIOp(_raw(cur_buf_i32), arith.constant(1, type=T.i32)).result
+
+                m_new, l_new, corr, p_words = _emit_qk_softmax_pquant(kv_block_start, cur_k_off, m_running, l_running)
+
+                corr_vec16 = Vec.from_elements([corr], fx.Float32).broadcast_to(16).ir_value()
+                for dc in range_constexpr(D_CHUNKS):
+                    o_accs[dc] = _fmul(o_accs[dc], corr_vec16)
+
+                kv_block_after_next = kv_block_start + fx.Index(2 * BLOCK_N)
+                o_accs = _run_pv_mfma(p_words, cur_v_off, o_accs, v_iter_lane_addr_i32)
+                if const_expr(_need_dma_fence):
+                    _dma_fence()
+                gpu.barrier()
+
+                coop_load_k(kv_block_after_next, cur_k_off)
+                coop_load_v(kv_block_after_next, cur_v_off)
+
+                _yield_args = [next_buf_i32, _raw(m_new), _raw(l_new)]
+                for dc in range_constexpr(D_CHUNKS):
+                    _yield_args.append(o_accs[dc])
+                loop_results = yield _yield_args
+
+            _FINAL_OFF_L = _OFF_L
+            _FINAL_OFF_O_ACCS = _OFF_O_ACCS
+        else:
+            # ---- Single-buffer main loop (pipe1) ----
+            init_args = [_raw(c_neg_inf), _raw(c_zero_f)]
+            for _ in range_constexpr(D_CHUNKS):
+                init_args.append(_raw(c_zero_v16f32))
+
+            _OFF_M = 0
+            _OFF_L = 1
+            _OFF_O_ACCS = 2
+
+            loop_results = init_args
+            for kv_block_start, inner_iter_args in range(0, kv_upper, BLOCK_N, init=init_args):
+                m_running = inner_iter_args[_OFF_M]
+                l_running = inner_iter_args[_OFF_L]
+                o_accs = [inner_iter_args[_OFF_O_ACCS + i] for i in range_constexpr(D_CHUNKS)]
+
+                coop_load_k(kv_block_start, ZERO_INDEX)
+                coop_load_v(kv_block_start, ZERO_INDEX)
+                if const_expr(_need_dma_fence):
+                    _dma_fence()
+                gpu.barrier()
+
+                m_new, l_new, corr, p_words = _emit_qk_softmax_pquant(kv_block_start, ZERO_INDEX, m_running, l_running)
+
+                corr_vec16 = Vec.from_elements([corr], fx.Float32).broadcast_to(16).ir_value()
+                for dc in range_constexpr(D_CHUNKS):
+                    o_accs[dc] = _fmul(o_accs[dc], corr_vec16)
+
+                o_accs = _run_pv_mfma(p_words, ZERO_INDEX, o_accs, None)
+
+                # Single-buffer WAR barrier: PV above reads K/V from LDS; the
+                # next iter's coop_load overwrites the SAME LDS buffer. Without
+                # this, fast waves clobber LDS while straggler waves (higher
+                # wave-ids) are still reading it — manifests only past ~6-8 kv
+                # iters and corrupts the upper wave-group's output rows.
+                gpu.barrier()
+
+                _yield_args = [_raw(m_new), _raw(l_new)]
+                for dc in range_constexpr(D_CHUNKS):
+                    _yield_args.append(o_accs[dc])
+                loop_results = yield _yield_args
+
+            _FINAL_OFF_L = _OFF_L
+            _FINAL_OFF_O_ACCS = _OFF_O_ACCS
+
+        # ---- Normalize and store O ----
+        l_final = loop_results[_FINAL_OFF_L]
+        o_finals = [loop_results[_FINAL_OFF_O_ACCS + dc] for dc in range_constexpr(D_CHUNKS)]
+
+        inv_l = arith.divf(_raw(c_one_f), _raw(l_final), fastmath=fm_fast)
+        # No FP8_MAX compensation needed: P-quant casts P∈[0,1] directly without
+        # the FP8_MAX pre-scale (matches Triton).
+        inv_l_fp8 = _raw(inv_l)
+
+        if q_in_bounds:
+            # MFMA 32x32 C/D layout (wave64): lane (klane, lane32) holds 16 f32
+            # outputs covering 16 distinct M positions (d positions in PV output)
+            # at one fixed N position = lane32 (= q_row within wave).
+            # Vector index i ∈ 0..15:
+            #   d_offset = (i // 4) * 8 + klane * 4 + (i % 4)
+            # Each group of 4 consecutive i (i.e. msub=0..3) gives 4 contiguous
+            # d positions, so we can do 4 v4bf16 stores per dc instead of 16
+            # scalar stores.
+
+            for dc in range_constexpr(D_CHUNKS):
+                for msub in range_constexpr(4):
+                    d_col_base = fx.Index(dc * MFMA_M) + fx.Index(msub * 8) + klane * 4
+                    v_ds_vec = Vec(
+                        _load_ptr_f32_vec4(
+                            vds_ptr,
+                            v_descale_base + fx.Index(dc * MFMA_M) + fx.Index(msub * 8) + klane * 4,
+                        )
+                    )
+                    bf16_elems = []
+                    for erem in range_constexpr(4):
+                        i_pos = msub * 4 + erem
+                        v_ds = v_ds_vec[erem]
+                        o_elem = vector.extract(o_finals[dc], static_position=[i_pos], dynamic_position=[])
+                        scale = arith.mulf(_raw(inv_l_fp8), _raw(v_ds), fastmath=fm_fast)
+                        o_norm = arith.mulf(o_elem, scale, fastmath=fm_fast)
+                        bf16_elems.append(f32_to_bf16_trunc(o_norm))
+                    o_vec = Vec.from_elements(bf16_elems, fx.BFloat16).ir_value()
+                    o_global = q_global_idx(q_row, d_col_base)
+                    _store_ptr_bf16(o_ptr, o_global, o_vec)
+
+    @flyc.jit
+    def launch_sage_attn(
+        Q: fx.Tensor,
+        K: fx.Tensor,
+        V: fx.Tensor,
+        O: fx.Tensor,  # noqa: E741
+        Q_descale: fx.Tensor,
+        K_descale: fx.Tensor,
+        V_descale: fx.Tensor,
+        Bias: fx.Tensor,
+        O_acc: fx.Tensor,
+        M_out: fx.Tensor,
+        L_out: fx.Tensor,
+        batch_size: fx.Int32,
+        seq_len_q: fx.Int32,
+        seq_len_k: fx.Int32,
+        num_q_blocks: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        bs_idx = fx.Index(batch_size)
+        slq_idx = fx.Index(seq_len_q)
+        num_q_tiles = (slq_idx + BLOCK_M - 1) // BLOCK_M
+        grid_x = bs_idx * num_q_tiles * NUM_Q_HEADS
+
+        launcher = sage_attn_kernel(
+            Q,
+            K,
+            V,
+            O,
+            Q_descale,
+            K_descale,
+            V_descale,
+            Bias,
+            batch_size,
+            seq_len_q,
+            seq_len_k,
+            num_q_blocks,
+        )
+
+        if const_expr(waves_per_eu is not None):
+            _wpe = int(waves_per_eu)
+            if const_expr(_wpe >= 1):
+                for op in ctx.gpu_module_body.operations:
+                    if const_expr(getattr(op, "OPERATION_NAME", None) == "gpu.func"):
+                        op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(T.i32, _wpe)
+
+        if const_expr(flat_work_group_size is not None):
+            _fwgs = int(flat_work_group_size)
+            if const_expr(_fwgs >= 1):
+                flat_wg_attr = ir.StringAttr.get(f"{_fwgs},{_fwgs}")
+                for op in ctx.gpu_module_body.operations:
+                    if const_expr(getattr(op, "OPERATION_NAME", None) == "gpu.func"):
+                        op.attributes["rocdl.flat_work_group_size"] = flat_wg_attr
+
+        passthrough_entries = []
+        if const_expr(daz):
+            passthrough_entries.append(
+                ir.ArrayAttr.get(
+                    [
+                        ir.StringAttr.get("denormal-fp-math-f32"),
+                        ir.StringAttr.get("preserve-sign,preserve-sign"),
+                    ]
+                )
+            )
+            passthrough_entries.append(
+                ir.ArrayAttr.get(
+                    [
+                        ir.StringAttr.get("no-nans-fp-math"),
+                        ir.StringAttr.get("true"),
+                    ]
+                )
+            )
+            passthrough_entries.append(
+                ir.ArrayAttr.get(
+                    [
+                        ir.StringAttr.get("unsafe-fp-math"),
+                        ir.StringAttr.get("true"),
+                    ]
+                )
+            )
+        for op in ctx.gpu_module_body.operations:
+            if const_expr(getattr(op, "OPERATION_NAME", None) == "gpu.func"):
+                op.attributes["passthrough"] = ir.ArrayAttr.get(passthrough_entries)
+
+        launcher.launch(grid=(grid_x, 1, 1), block=(BLOCK_SIZE, 1, 1), stream=stream)
+
+    _compile_hints = {
+        "fast_fp_math": fast_fp_math,
+        "unsafe_fp_math": unsafe_fp_math,
+        "llvm_options": {"enable-post-misched": True, "lsr-drop-solution": True},
+    }
+
+    def _launch(*args, **kwargs):
+        with CompilationContext.compile_hints(_compile_hints):
+            return launch_sage_attn(*args, **kwargs)
+
+    def _compile(
+        Q,
+        K,
+        V,
+        O,  # noqa: E741
+        Q_descale,
+        K_descale,
+        V_descale,
+        Bias,
+        batch_size,
+        seq_len_q,
+        seq_len_k,
+        num_q_blocks,
+        stream=None,
+    ):
+        with CompilationContext.compile_hints(_compile_hints):
+            return flyc.compile(
+                launch_sage_attn,
+                Q,
+                K,
+                V,
+                O,
+                Q_descale,
+                K_descale,
+                V_descale,
+                Bias,
+                batch_size,
+                seq_len_q,
+                seq_len_k,
+                num_q_blocks,
+                fx.Stream(stream),
+            )
+
+    _launch.compile = _compile
+    return _launch

--- a/kernels/attention/sage_attn_cdna.py
+++ b/kernels/attention/sage_attn_cdna.py
@@ -1,25 +1,7 @@
-# SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2025 FlyDSL Project Contributors
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-"""FlyDSL Sage Attention kernel for CDNA (gfx942/gfx950).
-
-Implements Int8 Q/K × FP8 V flash attention using MFMA instructions:
-  - GEMM1 (Q×K^T): mfma_i32_32x32x32_i8 → Int32 accum → scale to Float32
-  - GEMM2 (P×V):   mfma_f32_32x32x16_bf16 → Float32 accum
-
-Architecture: gfx942 (MI300X) and gfx950 (MI350)
-  - wave64 (64 threads/wave)
-  - MFMA 32x32x32 for Int8, 32x32x16 for BF16 (gfx950 binding)
-  - Block: (BLOCK_M // ROWS_PER_WAVE) waves × 64 threads = total threads
-
-Layout: Q/K/V/O are 1D-flattened from BSHD.
-Grid:   (batch * num_q_tiles * num_q_heads,)
-Block:  (NUM_WAVES * 64,) -- default 8 waves → 512 threads
-
-Supports:
-  - Causal masking
-  - GQA / MQA (num_q_heads divisible by num_kv_heads)
-"""
+"""SageAttention kernel for AMD MI308X (CDNA gfx942)."""
 
 import math as host_math
 import os
@@ -27,63 +9,811 @@ import os
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
-from flydsl._mlir.dialects import (
-    fly as _fly,
+from flydsl._mlir.dialects import llvm as _llvm
+from flydsl._mlir.dialects import memref as _memref
+from flydsl._mlir.dialects import scf as _scf
+from flydsl._mlir.dialects._rocdl_ops_gen import (
+    mfma_f32_32x32x16_fp8_fp8 as _ods_mfma_f32_32x32x16_fp8_fp8,
 )
-from flydsl._mlir.dialects import (
-    llvm as _llvm,
+from flydsl._mlir.dialects._rocdl_ops_gen import (
+    mfma_i32_32x32x16_i8 as _ods_mfma_i32_32x32x16_i8,
 )
-from flydsl._mlir.dialects import (
-    math as _math,
+from flydsl._mlir.dialects._rocdl_ops_gen import (
+    mfma_i32_32x32x32_i8 as _ods_mfma_i32_32x32x32_i8,
 )
-from flydsl._mlir.dialects import (
-    memref as _memref,
-)
-from flydsl._mlir.dialects import (
-    scf as _scf,
+from flydsl._mlir.dialects._rocdl_ops_gen import (
+    mfma_scale_f32_32x32x64_f8f6f4 as _ods_mfma_scale_f32_32x32x64_f8f6f4,
 )
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import (
-    arith,
-    buffer_ops,
-    const_expr,
-    gpu,
-    range_constexpr,
-    rocdl,
-    vector,
-)
+from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl, vector
 from flydsl.expr.typing import T
 from flydsl.expr.typing import Vector as Vec
 from flydsl.expr.utils.arith import ArithValue
 from flydsl.expr.utils.arith import _to_raw as _raw
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
-from kernels.common.kernels_common import get_warp_size
-
-_LOG2E = host_math.log2(host_math.e)
-_LDS_CAP_BYTES = 65536
-
-
-def _llvm_value(value):
-    if hasattr(value, "ir_value") and not isinstance(value, ir.Value):
-        return value.ir_value()
-    return value
-
-
-def _llvm_ptr_ty():
-    return ir.Type.parse("!llvm.ptr")
-
-
-def _extract_aligned_pointer(tensor) -> ir.Value:
-    return _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), _llvm_value(tensor))
+from kernels.attention.sage_attn_utils import (
+    _LDS_CAP_BYTES,
+    _extract_aligned_pointer,
+    _llvm_value,
+    _pointer_load,
+    _pointer_store,
+)
+from kernels.attention.sage_attn_utils import _fadd as _u_fadd
+from kernels.attention.sage_attn_utils import _ffma as _u_ffma
+from kernels.attention.sage_attn_utils import _fmax as _u_fmax
+from kernels.attention.sage_attn_utils import _fmul as _u_fmul
+from kernels.attention.sage_attn_utils import _fsub as _u_fsub
+from kernels.common.kernels_common import _if_else, _if_then, get_warp_size
 
 
-def _pointer_load(result_type: ir.Type, ptr: ir.Value) -> ir.Value:
-    return _llvm.LoadOp(result_type, _llvm_value(ptr)).result
+class _SageTraits:
+    """Compile-time constants for one SageAttention CDNA launch config."""
+
+    def __init__(
+        self,
+        *,
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_SIZE,
+        CAUSAL,
+        D_CHUNKS,
+        GROUPS,
+        HEAD_DIM,
+        KV_STRIDE_TOKEN,
+        K_NEEDS_GUARD,
+        K_STEPS_QK,
+        K_STRIDE,
+        LDS_K_BYTES,
+        LDS_K_TOTAL_BYTES,
+        LDS_V_BYTES,
+        LDS_V_TOTAL_BYTES,
+        MFMA_K_FP8,
+        MFMA_K_INT8,
+        MFMA_M,
+        MFMA_N,
+        NUM_BATCHES_K,
+        NUM_BATCHES_V,
+        NUM_KV_HEADS,
+        NUM_PIPE_STAGES,
+        NUM_Q_HEADS,
+        PV_K_STEPS,
+        Q_SCALE_BLOCK_M,
+        ROWS_PER_BATCH_K,
+        ROWS_PER_BATCH_V,
+        ROWS_PER_WAVE,
+        STRIDE_TOKEN,
+        THREADS_PER_ROW_K,
+        THREADS_PER_ROW_V,
+        VEC_WIDTH_K,
+        VEC_WIDTH_V,
+        V_NEEDS_GUARD,
+        V_STRIDE,
+        V_TRANSPOSED,
+        WARP_SIZE,
+        _DEFER_SCALE,
+        _GFX942_W256,
+        _LPT_SCHED,
+        _dma_any,
+        _dma_k,
+        _dma_xor,
+        lds_base_offset,
+        use_bias,
+    ):
+        """Store all launch-config constants as attributes."""
+        self.BLOCK_M = BLOCK_M
+        self.BLOCK_N = BLOCK_N
+        self.BLOCK_SIZE = BLOCK_SIZE
+        self.CAUSAL = CAUSAL
+        self.D_CHUNKS = D_CHUNKS
+        self.GROUPS = GROUPS
+        self.HEAD_DIM = HEAD_DIM
+        self.KV_STRIDE_TOKEN = KV_STRIDE_TOKEN
+        self.K_NEEDS_GUARD = K_NEEDS_GUARD
+        self.K_STEPS_QK = K_STEPS_QK
+        self.K_STRIDE = K_STRIDE
+        self.LDS_K_BYTES = LDS_K_BYTES
+        self.LDS_K_TOTAL_BYTES = LDS_K_TOTAL_BYTES
+        self.LDS_V_BYTES = LDS_V_BYTES
+        self.LDS_V_TOTAL_BYTES = LDS_V_TOTAL_BYTES
+        self.MFMA_K_FP8 = MFMA_K_FP8
+        self.MFMA_K_INT8 = MFMA_K_INT8
+        self.MFMA_M = MFMA_M
+        self.MFMA_N = MFMA_N
+        self.NUM_BATCHES_K = NUM_BATCHES_K
+        self.NUM_BATCHES_V = NUM_BATCHES_V
+        self.NUM_KV_HEADS = NUM_KV_HEADS
+        self.NUM_PIPE_STAGES = NUM_PIPE_STAGES
+        self.NUM_Q_HEADS = NUM_Q_HEADS
+        self.PV_K_STEPS = PV_K_STEPS
+        self.Q_SCALE_BLOCK_M = Q_SCALE_BLOCK_M
+        self.ROWS_PER_BATCH_K = ROWS_PER_BATCH_K
+        self.ROWS_PER_BATCH_V = ROWS_PER_BATCH_V
+        self.ROWS_PER_WAVE = ROWS_PER_WAVE
+        self.STRIDE_TOKEN = STRIDE_TOKEN
+        self.THREADS_PER_ROW_K = THREADS_PER_ROW_K
+        self.THREADS_PER_ROW_V = THREADS_PER_ROW_V
+        self.VEC_WIDTH_K = VEC_WIDTH_K
+        self.VEC_WIDTH_V = VEC_WIDTH_V
+        self.V_NEEDS_GUARD = V_NEEDS_GUARD
+        self.V_STRIDE = V_STRIDE
+        self.V_TRANSPOSED = V_TRANSPOSED
+        self.WARP_SIZE = WARP_SIZE
+        self._DEFER_SCALE = _DEFER_SCALE
+        self._GFX942_W256 = _GFX942_W256
+        self._LPT_SCHED = _LPT_SCHED
+        self._dma_any = _dma_any
+        self._dma_k = _dma_k
+        self._dma_xor = _dma_xor
+        self.lds_base_offset = lds_base_offset
+        self.use_bias = use_bias
 
 
-def _pointer_store(value: ir.Value, ptr: ir.Value):
-    return _llvm.StoreOp(_llvm_value(value), _llvm_value(ptr))
+class _SageKernel:
+    """SageAttention CDNA emitter: helpers, prologue, epilogue.
+
+    Methods read kernel SSA off ``self`` and constants off ``self.t``.
+    """
+
+    def __init__(self, t, allocator):
+        """Bind config traits and the shared-memory allocator."""
+        self.t = t
+        self.allocator = allocator
+
+    def mfma_i32_k32(self, result_type, operands):
+        a, b, c = (operands[0], operands[1], operands[2])
+        cbsz = operands[3] if len(operands) > 3 else 0
+        abid = operands[4] if len(operands) > 4 else 0
+        blgp = operands[5] if len(operands) > 5 else 0
+        a_v = _llvm_value(a)
+        b_v = _llvm_value(b)
+        c_v = _llvm_value(c)
+        if const_expr(self.t._GFX942_W256):
+            return _ods_mfma_i32_32x32x16_i8(
+                res=result_type, a=a_v, b=b_v, c=c_v, cbsz=cbsz, abid=abid, blgp=blgp
+            ).result
+        return _ods_mfma_i32_32x32x32_i8(res=result_type, a=a_v, b=b_v, c=c_v, cbsz=cbsz, abid=abid, blgp=blgp).result
+
+    def mfma_fp8_k16(self, result_type, operands):
+        a, b, c = (operands[0], operands[1], operands[2])
+        cbsz = operands[3] if len(operands) > 3 else 0
+        abid = operands[4] if len(operands) > 4 else 0
+        blgp = operands[5] if len(operands) > 5 else 0
+        a_v = _llvm_value(a)
+        b_v = _llvm_value(b)
+        c_v = _llvm_value(c)
+        return _ods_mfma_f32_32x32x16_fp8_fp8(
+            res=result_type, a=a_v, b=b_v, c=c_v, cbsz=cbsz, abid=abid, blgp=blgp
+        ).result
+
+    def mfma_fp8_k64(self, result_type, a, b, c, scale_a, scale_b):
+        """rocdl.mfma.scale.f32.32x32x64.f8f6f4 (fp8*fp8) wrapper.
+        a,b: vec<8xi32> per lane; c: vec<16xf32>; scale_a/b i32 e8m0 (127=1.0).
+        """
+        a_v = _llvm_value(a)
+        b_v = _llvm_value(b)
+        c_v = _llvm_value(c)
+        return _ods_mfma_scale_f32_32x32x64_f8f6f4(
+            res=result_type, a=a_v, b=b_v, c=c_v, cbsz=0, blgp=0, opselA=0, scaleA=scale_a, opselB=0, scaleB=scale_b
+        ).result
+
+    def _fadd(self, a, b):
+        return _u_fadd(a, b, self.fm_fast)
+
+    def _fsub(self, a, b):
+        return _u_fsub(a, b, self.fm_fast)
+
+    def _fmul(self, a, b):
+        return _u_fmul(a, b, self.fm_fast)
+
+    def _fmax(self, a, b):
+        return _u_fmax(a, b, self.fm_fast)
+
+    def _ffma(self, a, b, c):
+        return _u_ffma(a, b, c, self.fm_fast)
+
+    def q_global_idx(self, token_idx, col):
+        token = self.batch_idx * self.seq_len_q_v + token_idx
+        return token * self.t.STRIDE_TOKEN + self.head_q_idx * self.t.HEAD_DIM + col
+
+    def kv_global_idx(self, token_idx, col):
+        token = self.batch_idx * self.seq_len_k_v + token_idx
+        return token * self.t.KV_STRIDE_TOKEN + self.head_kv_idx * self.t.HEAD_DIM + col
+
+    def _load_ptr_i8_vec16(self, ptr, base_idx):
+        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.i8)
+        return _pointer_load(self.v16i8_type, gep)
+
+    def _load_ptr_i8_vec8(self, ptr, base_idx):
+        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.i8)
+        return _pointer_load(self.v8i8_type, gep)
+
+    def _load_ptr_i64(self, ptr, base_idx):
+        """Load 8 contiguous bytes from `ptr+base_idx` as a scalar i64
+        (8xi8 packed). Used for MFMA i8 operands which require packed i64.
+        """
+        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.i8)
+        return _pointer_load(T.i64, gep)
+
+    def _load_ptr_f8_vec8(self, ptr, base_idx):
+        return self._load_ptr_i8_vec8(ptr, base_idx)
+
+    def _store_ptr_bf16(self, ptr, base_idx, val):
+        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.bf16)
+        _pointer_store(val, gep)
+
+    def _load_ptr_f32(self, ptr, base_idx):
+        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.f32)
+        return _pointer_load(T.f32, gep)
+
+    def _load_ptr_f32_vec4(self, ptr, base_idx):
+        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.f32)
+        return _pointer_load(self.v4f32_type, gep)
+
+    def _bpermute_f32(self, value, src_lane):
+        value_i32 = arith.bitcast(T.i32, _raw(value))
+        lane_byte_idx = fx.Int32(arith.unwrap(arith.index_cast(T.i32, _raw(src_lane * 4))))
+        result_i32 = rocdl.ds_bpermute(T.i32, _raw(lane_byte_idx), value_i32)
+        return fx.Float32(arith.bitcast(T.f32, result_i32))
+
+    def reduction_peer32(self, v_f32):
+        return fx.Float32(v_f32).shuffle_xor(self.shuf32_i32, self.width_i32)
+
+    def row_max_reduce(self, local_max):
+        """Reduce max across the 2 klane halves within wave64."""
+        return self._fmax(local_max, self.reduction_peer32(local_max))
+
+    def row_sum_reduce(self, local_sum):
+        """Reduce sum across the 2 klane halves within wave64."""
+        return self._fadd(local_sum, self.reduction_peer32(local_sum))
+
+    def _coop_load_k_dma(self, tile_start, buf_off):
+        assert not self.t.K_NEEDS_GUARD, "K DMA path requires ROWS_PER_BATCH_K<=BLOCK_N"
+        DMA_BYTES_K = self.t.VEC_WIDTH_K
+        buf_off_i64 = arith.unwrap(arith.index_cast(T.i64, _raw(buf_off)))
+        wave_byte = rocdl.readfirstlane(
+            T.i64, arith.unwrap(arith.index_cast(T.i64, self.wave_id * fx.Index(self.t.WARP_SIZE * DMA_BYTES_K)))
+        )
+        base_ptr = self._lds_as3_base(self.lds)
+        base_ptr = buffer_ops.get_element_ptr(base_ptr, buf_off_i64)
+        base_ptr = buffer_ops.get_element_ptr(base_ptr, wave_byte)
+        size_i32 = arith.constant(DMA_BYTES_K, type=T.i32)
+        c0 = arith.constant(0, type=T.i32)
+        aux1 = arith.constant(1, type=T.i32)
+        _CPR_K = self.t.HEAD_DIM // self.t.VEC_WIDTH_K
+        _XMASK_K = _CPR_K - 1
+        for batch in range_constexpr(self.t.NUM_BATCHES_K):
+            row_offset = batch * self.t.ROWS_PER_BATCH_K
+            row_idx_raw = tile_start + self.load_row_k_batch + row_offset
+            if const_expr(self.t._dma_xor):
+                tile_row = self.load_row_k_batch + row_offset
+                phys_chunk = self.load_lane_k
+                g_chunk = ArithValue(phys_chunk) ^ ArithValue(tile_row) & fx.Index(_XMASK_K)
+                g_col = fx.Index(g_chunk) * fx.Index(self.t.VEC_WIDTH_K)
+                g_idx = self.kv_global_idx(row_idx_raw, g_col)
+            else:
+                g_idx = self.kv_global_idx(row_idx_raw, self.load_col_k_base)
+            voff = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx)))
+            if const_expr(batch == 0):
+                lds_ptr = base_ptr
+            else:
+                lds_ptr = buffer_ops.get_element_ptr(
+                    base_ptr, static_byte_offset=batch * self.t.BLOCK_SIZE * DMA_BYTES_K
+                )
+            rocdl.raw_ptr_buffer_load_lds(self.k_rsrc, lds_ptr, size_i32, voff, c0, c0, aux1)
+
+    def coop_load_k(self, tile_start, buf_off):
+        if const_expr(self.t._dma_k):
+            self._coop_load_k_dma(tile_start, buf_off)
+            return
+        for batch in range_constexpr(self.t.NUM_BATCHES_K):
+            row_offset = batch * self.t.ROWS_PER_BATCH_K
+            row_idx_raw = tile_start + self.load_row_k_batch + row_offset
+            if const_expr(self.t.K_NEEDS_GUARD):
+                row_valid = self.load_row_k_batch < fx.Index(self.t.BLOCK_N)
+                do_load = row_valid
+            else:
+                do_load = True
+            if do_load:
+                g_idx = self.kv_global_idx(row_idx_raw, self.load_col_k_base)
+                lds_row = self.load_row_k_batch + row_offset
+                lds_idx = buf_off + lds_row * self.t.K_STRIDE + self.load_col_k_base
+                g_dword_i32 = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx >> fx.Index(2))))
+                v4i32 = buffer_ops.buffer_load(self.k_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
+                vec = vector.bitcast(self.v16i8_type, v4i32)
+                Vec(vec).store(self.lds, [lds_idx])
+
+    def coop_load_v(self, tile_start, buf_off):
+        """Cooperatively load V (FP8 raw bytes) from global into LDS (gfx942 column-major)."""
+        for batch in range_constexpr(self.t.NUM_BATCHES_V):
+            row_offset = batch * self.t.ROWS_PER_BATCH_V
+            row_idx_raw = tile_start + self.load_row_v_batch + row_offset
+            if const_expr(self.t.V_NEEDS_GUARD):
+                row_valid = self.load_row_v_batch < fx.Index(self.t.BLOCK_N)
+                do_load = row_valid
+            else:
+                do_load = True
+            if do_load:
+                if const_expr(self.t.V_TRANSPOSED):
+                    d_idx = self.tid % fx.Index(self.t.HEAD_DIM)
+                    k_group = self.tid // fx.Index(self.t.HEAD_DIM)
+                    tile_idx = tile_start // fx.Index(self.t.BLOCK_N)
+                    g_byte_idx = (
+                        (
+                            (self.batch_idx * self.t.NUM_KV_HEADS + self.head_kv_idx) * self.num_k_blocks_per_head
+                            + tile_idx
+                        )
+                        * fx.Index(self.t.HEAD_DIM)
+                        + d_idx
+                    ) * fx.Index(self.t.BLOCK_N) + k_group * fx.Index(16)
+                    g_dword_i32 = arith.unwrap(arith.index_cast(T.i32, _raw(g_byte_idx >> fx.Index(2))))
+                    v4i32 = buffer_ops.buffer_load(self.v_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
+                    raw_v = vector.bitcast(self.v16i8_type, v4i32)
+                    v_off = buf_off + d_idx * self.t.V_STRIDE + k_group * fx.Index(16)
+                    Vec(raw_v).store(self.lds_v, [v_off])
+                else:
+                    g_idx = self.kv_global_idx(row_idx_raw, self.load_col_v_base)
+                    g_dword_i32 = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx >> fx.Index(2))))
+                    v4i32 = buffer_ops.buffer_load(self.v_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
+                    raw_v = vector.bitcast(self.v16i8_type, v4i32)
+                    lds_col = self.load_row_v_batch + row_offset
+                    for di in range_constexpr(self.t.VEC_WIDTH_V):
+                        d_idx = self.load_col_v_base + di
+                        v_off = buf_off + d_idx * self.t.V_STRIDE + lds_col
+                        b_i8 = vector.extract(raw_v, static_position=[di], dynamic_position=[])
+                        Vec.from_elements([b_i8], fx.Int8).store(self.lds_v, [v_off])
+
+    def load_k_frag(self, kv_block_row, ks, buf_off):
+        """Load K fragment from LDS for the QK MFMA."""
+        if const_expr(self.t._dma_xor):
+            _CPR_K = self.t.HEAD_DIM // self.t.VEC_WIDTH_K
+            _XMASK_K = _CPR_K - 1
+            if const_expr(self.t._GFX942_W256):
+                g_chunk = fx.Index(ks)
+                phys_chunk = ArithValue(g_chunk) ^ ArithValue(kv_block_row) & fx.Index(_XMASK_K)
+                k_col = fx.Index(phys_chunk) * fx.Index(self.t.VEC_WIDTH_K) + self.klane * fx.Index(8)
+            else:
+                g_chunk = fx.Index(ks * 2) + self.klane
+                phys_chunk = ArithValue(g_chunk) ^ ArithValue(kv_block_row) & fx.Index(_XMASK_K)
+                k_col = fx.Index(phys_chunk) * fx.Index(self.t.VEC_WIDTH_K)
+        elif const_expr(self.t._GFX942_W256):
+            k_col = fx.Index(ks * self.t.MFMA_K_INT8) + self.klane * 8
+        else:
+            k_col = fx.Index(ks * self.t.MFMA_K_INT8) + self.klane * 16
+        lds_idx = buf_off + fx.Index(kv_block_row * self.t.K_STRIDE) + k_col
+        if const_expr(self.t._GFX942_W256):
+            v8i8 = Vec.load(self.v8i8_type, self.lds, [lds_idx])
+            k_i64v = vector.bitcast(Vec.make_type(1, fx.Int64), v8i8)
+            return vector.extract(k_i64v, static_position=[0], dynamic_position=[])
+        v16i8 = Vec.load(self.v16i8_type, self.lds, [lds_idx])
+        return vector.bitcast(self.v4i32_type, v16i8)
+
+    def load_v_frag_fp8(self, pks, dc, buf_off, iter_lane_addr_i32):
+        """Load a V fragment (FP8) from LDS for the PV MFMA (gfx942 vector ds_read)."""
+        d_col = dc * self.t.MFMA_M + self.lane32
+        kv_k_start = fx.Index(pks * self.t.MFMA_K_FP8) + self.klane * fx.Index(self.t.MFMA_K_FP8 // 2)
+        v_off = buf_off + d_col * self.t.V_STRIDE + kv_k_start
+        if const_expr(self.t.MFMA_K_FP8 == 16):
+            v8i8 = Vec.load(self.v8i8_type, self.lds_v, [v_off])
+            v_i64v = vector.bitcast(Vec.make_type(1, fx.Int64), v8i8)
+            return vector.extract(v_i64v, static_position=[0], dynamic_position=[])
+        lo_v16i8 = Vec.load(self.v16i8_type, self.lds_v, [v_off])
+        hi_v16i8 = Vec.load(self.v16i8_type, self.lds_v, [v_off + 16])
+        lo_v4i32 = vector.bitcast(self.v4i32_type, lo_v16i8)
+        hi_v4i32 = vector.bitcast(self.v4i32_type, hi_v16i8)
+        elems = []
+        for w in range_constexpr(4):
+            elems.append(vector.extract(lo_v4i32, static_position=[w], dynamic_position=[]))
+        for w in range_constexpr(4):
+            elems.append(vector.extract(hi_v4i32, static_position=[w], dynamic_position=[]))
+        return Vec.from_elements(elems, fx.Int32).ir_value()
+
+    def f32_to_bf16_trunc(self, f32_raw):
+        """Bitwise f32 → bf16 truncation (upper 16 bits)."""
+        i32_val = arith.BitcastOp(T.i32, f32_raw).result
+        i16_val = arith.TruncIOp(T.i16, arith.ShRUIOp(i32_val, arith.constant(16, type=T.i32)).result).result
+        return arith.BitcastOp(T.bf16, i16_val).result
+
+    def _buf_off(self, buf_idx_i32, stride_index):
+        """buf_idx ∈ {0,1} → byte offset in {0, stride}, returned as fx.Index."""
+        is_one = ArithValue(fx.Int32(buf_idx_i32) == fx.Int32(1))
+        return fx.Index(is_one.select(stride_index, self.ZERO_INDEX))
+
+    def _i32_pair_to_i64(self, lo, hi):
+        lo64 = arith.extui(T.i64, _raw(lo))
+        hi64 = arith.shli(arith.extui(T.i64, _raw(hi)), arith.constant(32, type=T.i64))
+        return arith.ori(lo64, hi64)
+
+    def _gather_p_i64_from_pwords(self, p_words_2d, pks):
+        """Gather 8 fp8 bytes (i64 B operand) for mfma_f32_32x32x16_fp8."""
+        width_i32 = arith.constant(64, type=T.i32)
+        words = []
+        for j in range_constexpr(2):
+            selected = None
+            for k in range_constexpr(2):
+                k_pos = pks * self.t.MFMA_K_FP8 + k * 8 + j * 4
+                st = k_pos // self.t.MFMA_N
+                rem = k_pos % self.t.MFMA_N
+                sk = rem // 4 % 2
+                w_idx = rem // 8
+                xor_off = arith.constant((k ^ sk) * self.t.MFMA_M, type=T.i32)
+                w_cand = fx.Int32(p_words_2d[st][w_idx]).shuffle_xor(xor_off, width_i32)
+                if k == 0:
+                    selected = w_cand
+                else:
+                    is_k = arith.cmpi(arith.CmpIPredicate.eq, self.klane_i32, arith.constant(k, type=T.i32))
+                    selected = ArithValue(is_k).select(w_cand, selected)
+            words.append(selected)
+        return self._i32_pair_to_i64(words[0], words[1])
+
+    def _emit_qk_softmax_pquant(self, kv_block_start_arg, k_buf_off_arg, m_in, l_in):
+        """Emit QK MFMA + scale + mask + online softmax + P-quant for one KV tile.
+        Returns (m_new, l_new, corr, p_words_2d) as IR values.
+        """
+        s_accs_loc = [_raw(self.c_zero_v16i32) for _ in range(self.N_SUBTILES)]
+        for ks in range_constexpr(self.t.K_STEPS_QK):
+            for st in range_constexpr(self.N_SUBTILES):
+                kv_row_loc = self.lane32 + st * self.t.MFMA_N
+                k_frag = self.load_k_frag(kv_row_loc, ks, k_buf_off_arg)
+                if const_expr(self.t._GFX942_W256):
+                    s_accs_loc[st] = self.mfma_i32_k32(
+                        self.v16i32_type, [k_frag, self.q_packs[ks], s_accs_loc[st], 0, 0, 0]
+                    )
+                else:
+                    s_accs_loc[st] = self.mfma_i32_k32(
+                        self.v16i32_type, [k_frag, self.q_packs[ks], s_accs_loc[st], 0, 0, 0]
+                    )
+        kv_tile_idx_loc = kv_block_start_arg // self.t.BLOCK_N
+        max_kv_tile = self.num_k_blocks_per_head - fx.Index(1)
+        kv_tile_safe = fx.Index(
+            ArithValue(kv_tile_idx_loc < self.num_k_blocks_per_head).select(kv_tile_idx_loc, max_kv_tile)
+        )
+        k_descale_base_loc = (
+            self.batch_idx * self.t.NUM_KV_HEADS * self.num_k_blocks_per_head
+            + self.head_kv_idx * self.num_k_blocks_per_head
+            + kv_tile_safe
+        )
+        k_ds_loc = fx.Float32(self._load_ptr_f32(self.kds_ptr, k_descale_base_loc))
+        qk_scale_loc = self._fmul(self.q_ds, k_ds_loc)
+        s_f32_loc = []
+        if const_expr(self.t._DEFER_SCALE):
+            for st in range_constexpr(self.N_SUBTILES):
+                s_f32_vec = Vec(s_accs_loc[st]).to(fx.Float32)
+                for elem in range_constexpr(self.ELEMS_PER_TILE):
+                    s_f32_loc.append(s_f32_vec[elem])
+        else:
+            qk_scale_v16_loc = Vec.from_elements([qk_scale_loc], fx.Float32).broadcast_to(16)
+            for st in range_constexpr(self.N_SUBTILES):
+                s_f32_vec = Vec(s_accs_loc[st]).to(fx.Float32)
+                s_scaled_vec = Vec(arith.mulf(s_f32_vec, qk_scale_v16_loc, fastmath=self.fm_fast))
+                for elem in range_constexpr(self.ELEMS_PER_TILE):
+                    s_f32_loc.append(s_scaled_vec[elem])
+        if const_expr(self.t.use_bias):
+            s_biased = list(s_f32_loc)
+            bias_base = (
+                (self.batch_idx * self.t.NUM_Q_HEADS + self.head_q_idx) * self.q_scale_num_blocks
+                + self.q_scale_tile_idx
+            ) * self.seq_len_k_v
+            bias_col = kv_block_start_arg + self.lane
+            bias_col_safe = fx.Index(ArithValue(bias_col < self.seq_len_k_v).select(bias_col, fx.Index(0)))
+            bias_lane = fx.Float32(self._load_ptr_f32(self.bias_ptr, bias_base + bias_col_safe))
+            for st in range_constexpr(self.N_SUBTILES):
+                for elem in range_constexpr(self.ELEMS_PER_TILE):
+                    idx = st * self.ELEMS_PER_TILE + elem
+                    msub = elem // 4
+                    erem = elem % 4
+                    bias_src_lane = fx.Index(st * self.t.MFMA_N + msub * 8 + erem) + self.klane * 4
+                    bias = self._bpermute_f32(bias_lane, bias_src_lane)
+                    s_biased[idx] = self._fadd(s_biased[idx], bias)
+            s_f32_loc = s_biased
+        kv_start_i32_loc = fx.Int32(arith.unwrap(arith.index_cast(T.i32, _raw(kv_block_start_arg))))
+        if const_expr(self.t.CAUSAL):
+            s_named = list(s_f32_loc)
+            for st in range_constexpr(self.N_SUBTILES):
+                for elem in range_constexpr(self.ELEMS_PER_TILE):
+                    idx = st * self.ELEMS_PER_TILE + elem
+                    msub = elem // 4
+                    erem = elem % 4
+                    kv_col_i32 = (
+                        kv_start_i32_loc
+                        + fx.Int32(st * self.t.MFMA_N)
+                        + fx.Int32(msub * 8)
+                        + self.klane_off_i32
+                        + fx.Int32(erem)
+                    )
+                    out_of_range = ArithValue(kv_col_i32 >= self.seq_len_k_i32)
+                    out_of_range = out_of_range | ArithValue(kv_col_i32 > self.q_row_i32)
+                    s_named[idx] = out_of_range.select(self.c_neg_inf, s_named[idx])
+            s_f32_loc = s_named
+        else:
+            tile_end = kv_block_start_arg + fx.Index(self.t.BLOCK_N)
+            tile_oob_av = ArithValue(tile_end > self.seq_len_k_v)
+            cond_i1 = _raw(tile_oob_av)
+            f32_ty = ir.F32Type.get()
+            result_types = [f32_ty] * self.NUM_S_VALS
+            if_op = _scf.IfOp(cond_i1, result_types, has_else=True, loc=ir.Location.unknown())
+            with _if_then(if_op):
+                _llvm.inline_asm(None, [], "", "", has_side_effects=True)
+                masked = []
+                for st in range_constexpr(self.N_SUBTILES):
+                    for elem in range_constexpr(self.ELEMS_PER_TILE):
+                        idx = st * self.ELEMS_PER_TILE + elem
+                        msub = elem // 4
+                        erem = elem % 4
+                        kv_col_i32 = (
+                            kv_start_i32_loc
+                            + fx.Int32(st * self.t.MFMA_N)
+                            + fx.Int32(msub * 8)
+                            + self.klane_off_i32
+                            + fx.Int32(erem)
+                        )
+                        out_of_range = ArithValue(kv_col_i32 >= self.seq_len_k_i32)
+                        masked.append(_raw(out_of_range.select(self.c_neg_inf, s_f32_loc[idx])))
+                _scf.YieldOp(masked)
+            with _if_else(if_op):
+                _scf.YieldOp([_raw(v) for v in s_f32_loc])
+            s_f32_loc = list(if_op.results)
+        local_max_l = s_f32_loc[0]
+        for r in range_constexpr(self.NUM_S_VALS - 1):
+            local_max_l = self._fmax(local_max_l, s_f32_loc[r + 1])
+        row_max_l = self.row_max_reduce(local_max_l)
+        if const_expr(self.t._DEFER_SCALE):
+            row_max_l = self._fmul(row_max_l, qk_scale_loc)
+        m_new_l = self._fmax(m_in, row_max_l)
+        diff_m_l = self._fsub(m_in, m_new_l)
+        corr_l = rocdl.exp2(ir.F32Type.get(), _raw(diff_m_l))
+        neg_max_l = self._fsub(self.c_zero_f, m_new_l)
+        p_vals_l = []
+        local_sum_l = _raw(self.c_zero_f)
+        for r in range_constexpr(self.NUM_S_VALS):
+            if const_expr(self.t._DEFER_SCALE):
+                diff = self._ffma(s_f32_loc[r], qk_scale_loc, neg_max_l)
+            else:
+                diff = self._fadd(s_f32_loc[r], neg_max_l)
+            p = rocdl.exp2(ir.F32Type.get(), _raw(diff))
+            p_vals_l.append(p)
+            local_sum_l = self._fadd(local_sum_l, p)
+        tile_sum_l = self.row_sum_reduce(local_sum_l)
+        l_new_l = self._fadd(self._fmul(corr_l, l_in), tile_sum_l)
+        c0_i32_l = arith.constant(0, type=T.i32)
+        p_words_l = []
+        for st in range_constexpr(self.N_SUBTILES):
+            sub = []
+            for w in range_constexpr(4):
+                s0 = _raw(p_vals_l[st * self.ELEMS_PER_TILE + w * 4 + 0])
+                s1 = _raw(p_vals_l[st * self.ELEMS_PER_TILE + w * 4 + 1])
+                s2 = _raw(p_vals_l[st * self.ELEMS_PER_TILE + w * 4 + 2])
+                s3 = _raw(p_vals_l[st * self.ELEMS_PER_TILE + w * 4 + 3])
+                packed = c0_i32_l
+                packed = rocdl.cvt_pk_fp8_f32(T.i32, s0, s1, packed, 0)
+                packed = rocdl.cvt_pk_fp8_f32(T.i32, s2, s3, packed, 1)
+                sub.append(packed)
+            p_words_l.append(sub)
+        return (m_new_l, l_new_l, corr_l, p_words_l)
+
+    def _run_pv_mfma(self, p_words, cur_v_off, o_accs, v_iter_lane_addr_i32):
+        if const_expr(self.t._GFX942_W256):
+            for pks in range_constexpr(self.t.PV_K_STEPS):
+                p_i64 = self._gather_p_i64_from_pwords(p_words, pks)
+                for dc in range_constexpr(self.t.D_CHUNKS):
+                    v_i64 = self.load_v_frag_fp8(pks, dc, cur_v_off, v_iter_lane_addr_i32)
+                    o_accs[dc] = self.mfma_fp8_k16(self.v16f32_type, [v_i64, p_i64, o_accs[dc], 0, 0, 0])
+        else:
+            from flydsl._mlir.dialects._rocdl_ops_gen import permlane32_swap as _permlane32_swap_op
+
+            _struct_ty_2xi32 = ir.Type.parse("!llvm.struct<(i32, i32)>")
+            for pks in range_constexpr(self.t.PV_K_STEPS):
+                v8_elems = []
+                for w in range_constexpr(4):
+                    a_w = _raw(p_words[pks * 2][w])
+                    b_w = _raw(p_words[pks * 2 + 1][w])
+                    swapped = _permlane32_swap_op(_struct_ty_2xi32, old=a_w, src=b_w, fi=False, bound_control=True)
+                    lo_word = _llvm.extractvalue(T.i32, swapped, [0])
+                    hi_word = _llvm.extractvalue(T.i32, swapped, [1])
+                    v8_elems.append(lo_word)
+                    v8_elems.append(hi_word)
+                p_pack_v8i32 = Vec.from_elements(v8_elems, fx.Int32).ir_value()
+                scale_127 = arith.constant(127, type=T.i32)
+                for dc in range_constexpr(self.t.D_CHUNKS):
+                    v_frag = self.load_v_frag_fp8(pks, dc, cur_v_off, v_iter_lane_addr_i32)
+                    o_accs[dc] = self.mfma_fp8_k64(
+                        self.v16f32_type, v_frag, p_pack_v8i32, o_accs[dc], scale_127, scale_127
+                    )
+        return o_accs
+
+    def _lds_as3_base(self, lds_view):
+        base_idx = _memref.extract_aligned_pointer_as_index(_llvm_value(lds_view))
+        base_i64 = arith.unwrap(arith.index_cast(T.i64, base_idx))
+        return buffer_ops.create_llvm_ptr(base_i64, address_space=3)
+
+    def setup(
+        self,
+        Q,
+        K,
+        V,
+        O,  # noqa: E741
+        Q_descale,
+        K_descale,
+        V_descale,
+        Bias,
+        batch_size,
+        seq_len_q,
+        seq_len_k,
+        num_q_blocks,
+    ):
+        """Emit kernel prologue: pointers, LDS, tile indices, Q packs, constants."""
+        self.fm_fast = arith.FastMathFlags.fast
+        q_ptr = _extract_aligned_pointer(Q)
+        self.o_ptr = _extract_aligned_pointer(O)
+        qds_ptr = _extract_aligned_pointer(Q_descale)
+        self.kds_ptr = _extract_aligned_pointer(K_descale)
+        self.vds_ptr = _extract_aligned_pointer(V_descale)
+        if const_expr(self.t.use_bias):
+            self.bias_ptr = _extract_aligned_pointer(Bias)
+        bs_v_for_rsrc = fx.Index(batch_size)
+        slk_v_for_rsrc = fx.Index(seq_len_k)
+        num_k_blocks_for_rsrc = (slk_v_for_rsrc + fx.Index(self.t.BLOCK_N - 1)) // fx.Index(self.t.BLOCK_N)
+        kv_total_bytes = bs_v_for_rsrc * slk_v_for_rsrc * fx.Index(self.t.NUM_KV_HEADS * self.t.HEAD_DIM)
+        v_total_bytes = (
+            bs_v_for_rsrc
+            * fx.Index(self.t.NUM_KV_HEADS * self.t.HEAD_DIM)
+            * num_k_blocks_for_rsrc
+            * fx.Index(self.t.BLOCK_N)
+            if self.t.V_TRANSPOSED
+            else kv_total_bytes
+        )
+        self.k_rsrc = buffer_ops.create_buffer_resource(K, max_size=False, num_records_bytes=kv_total_bytes)
+        self.v_rsrc = buffer_ops.create_buffer_resource(V, max_size=False, num_records_bytes=v_total_bytes)
+        self.v4i32_type = Vec.make_type(4, fx.Int32)
+        self.v16i32_type = Vec.make_type(16, fx.Int32)
+        self.v16f32_type = Vec.make_type(16, fx.Float32)
+        self.v4f32_type = Vec.make_type(4, fx.Float32)
+        self.v8i8_type = Vec.make_type(8, fx.Int8)
+        self.v16i8_type = Vec.make_type(16, fx.Int8)
+        self.seq_len_q_v = fx.Index(seq_len_q)
+        self.seq_len_k_v = fx.Index(seq_len_k)
+        base_ptr = self.allocator.get_base()
+        self.lds = SmemPtr(base_ptr, self.t.lds_base_offset, T.i8, shape=(self.t.LDS_K_TOTAL_BYTES,)).get()
+        self.lds_v = SmemPtr(
+            base_ptr, self.t.lds_base_offset + self.t.LDS_K_TOTAL_BYTES, T.i8, shape=(self.t.LDS_V_TOTAL_BYTES,)
+        ).get()
+        block_id = fx.Index(gpu.block_idx.x)
+        self.tid = fx.Index(gpu.thread_idx.x)
+        self.wave_id = self.tid // self.t.WARP_SIZE
+        self.lane = self.tid % self.t.WARP_SIZE
+        self.lane32 = self.lane % self.t.MFMA_M
+        self.klane = self.lane // self.t.MFMA_M
+        wave_q_offset = self.wave_id * self.t.ROWS_PER_WAVE
+        self.head_q_idx = block_id % self.t.NUM_Q_HEADS
+        batch_q_tile_id = block_id // self.t.NUM_Q_HEADS
+        num_q_tiles = (self.seq_len_q_v + self.t.BLOCK_M - 1) // self.t.BLOCK_M
+        q_tile_raw = batch_q_tile_id % num_q_tiles
+        self.batch_idx = batch_q_tile_id // num_q_tiles
+        if const_expr(self.t._LPT_SCHED):
+            q_tile_idx = num_q_tiles - fx.Index(1) - q_tile_raw
+        else:
+            q_tile_idx = q_tile_raw
+        q_start = q_tile_idx * self.t.BLOCK_M
+        self.head_kv_idx = self.head_q_idx // self.t.GROUPS
+        self.load_row_k_batch = self.tid // self.t.THREADS_PER_ROW_K
+        self.load_lane_k = self.tid % self.t.THREADS_PER_ROW_K
+        self.load_col_k_base = self.load_lane_k * self.t.VEC_WIDTH_K
+        self.load_row_v_batch = self.tid // self.t.THREADS_PER_ROW_V
+        load_lane_v = self.tid % self.t.THREADS_PER_ROW_V
+        self.load_col_v_base = load_lane_v * self.t.VEC_WIDTH_V
+        self.q_row = q_start + wave_q_offset + self.lane32
+        self.q_row_i32 = fx.Int32(self.q_row)
+        self.q_in_bounds = arith.cmpi(arith.CmpIPredicate.slt, _raw(self.q_row), _raw(self.seq_len_q_v))
+        q_row_safe = fx.Index(ArithValue(self.q_in_bounds).select(self.q_row, fx.Index(0)))
+        _zero_v4i32_ir = Vec.filled(4, 0, fx.Int32).ir_value()
+        c_zero_i64 = arith.constant(0, type=T.i64)
+        self.q_packs = []
+        for ks in range_constexpr(self.t.K_STEPS_QK):
+            if const_expr(self.t._GFX942_W256):
+                q_col = fx.Index(ks * self.t.MFMA_K_INT8) + self.klane * 8
+                g_idx = self.q_global_idx(q_row_safe, q_col)
+                half = self._load_ptr_i64(q_ptr, g_idx)
+                self.q_packs.append(ArithValue(self.q_in_bounds).select(half, c_zero_i64))
+            else:
+                q_col = fx.Index(ks * self.t.MFMA_K_INT8) + self.klane * 16
+                g_idx = self.q_global_idx(q_row_safe, q_col)
+                v16i8 = self._load_ptr_i8_vec16(q_ptr, g_idx)
+                v4i32 = vector.bitcast(self.v4i32_type, v16i8)
+                self.q_packs.append(ArithValue(self.q_in_bounds).select(v4i32, _zero_v4i32_ir))
+        self.num_k_blocks_per_head = (self.seq_len_k_v + self.t.BLOCK_N - 1) // self.t.BLOCK_N
+        self.q_scale_num_blocks = fx.Index(num_q_blocks)
+        q_scale_tile_raw = (q_start + wave_q_offset) // self.t.Q_SCALE_BLOCK_M
+        self.q_scale_tile_idx = ArithValue(q_scale_tile_raw < self.q_scale_num_blocks).select(
+            q_scale_tile_raw, self.q_scale_num_blocks - fx.Index(1)
+        )
+        q_descale_base = (
+            self.batch_idx * self.t.NUM_Q_HEADS * self.q_scale_num_blocks
+            + self.head_q_idx * self.q_scale_num_blocks
+            + self.q_scale_tile_idx
+        )
+        self.q_ds = fx.Float32(self._load_ptr_f32(qds_ptr, q_descale_base))
+        self.v_descale_base = (self.batch_idx * self.t.NUM_KV_HEADS + self.head_kv_idx) * self.t.HEAD_DIM
+        self.c_neg_inf = fx.Float32(float("-inf"))
+        self.c_zero_f = fx.Float32(0.0)
+        self.c_one_f = fx.Float32(1.0)
+        self.c_zero_v16f32 = Vec.filled(16, 0.0, fx.Float32)
+        self.c_zero_v16i32 = Vec.filled(16, 0, fx.Int32)
+        self.shuf32_i32 = fx.Int32(32)
+        self.width_i32 = fx.Int32(self.t.WARP_SIZE)
+        _q_end = q_start + self.t.BLOCK_M
+        if const_expr(self.t.CAUSAL):
+            self.kv_upper = fx.Index(ArithValue(_q_end < self.seq_len_k_v).select(_q_end, self.seq_len_k_v))
+        else:
+            self.kv_upper = self.seq_len_k_v
+        self.K_BUF1_OFF = fx.Index(self.t.LDS_K_BYTES)
+        self.V_BUF1_OFF = fx.Index(self.t.LDS_V_BYTES)
+        self.ZERO_INDEX = fx.Index(0)
+        self.N_SUBTILES = self.t.BLOCK_N // self.t.MFMA_N
+        self.ELEMS_PER_TILE = 16
+        self.NUM_S_VALS = self.N_SUBTILES * self.ELEMS_PER_TILE
+        self.klane_i32 = fx.Int32(self.klane)
+        self.klane_off_i32 = self.klane_i32 * fx.Int32(4)
+        self.seq_len_k_i32 = fx.Int32(self.seq_len_k_v)
+
+    def write_output(self, loop_results, _FINAL_OFF_L, _FINAL_OFF_O_ACCS):
+        """Normalize accumulators by 1/l and apply V descale; store guarded by caller."""
+        l_final = loop_results[_FINAL_OFF_L]
+        o_finals = [loop_results[_FINAL_OFF_O_ACCS + dc] for dc in range_constexpr(self.t.D_CHUNKS)]
+        inv_l = arith.divf(_raw(self.c_one_f), _raw(l_final), fastmath=self.fm_fast)
+        inv_l_fp8 = _raw(inv_l)
+        for dc in range_constexpr(self.t.D_CHUNKS):
+            for msub in range_constexpr(4):
+                d_col_base = fx.Index(dc * self.t.MFMA_M) + fx.Index(msub * 8) + self.klane * 4
+                v_ds_vec = Vec(
+                    self._load_ptr_f32_vec4(
+                        self.vds_ptr,
+                        self.v_descale_base + fx.Index(dc * self.t.MFMA_M) + fx.Index(msub * 8) + self.klane * 4,
+                    )
+                )
+                bf16_elems = []
+                for erem in range_constexpr(4):
+                    i_pos = msub * 4 + erem
+                    v_ds = v_ds_vec[erem]
+                    o_elem = vector.extract(o_finals[dc], static_position=[i_pos], dynamic_position=[])
+                    scale = arith.mulf(_raw(inv_l_fp8), _raw(v_ds), fastmath=self.fm_fast)
+                    o_norm = arith.mulf(o_elem, scale, fastmath=self.fm_fast)
+                    bf16_elems.append(self.f32_to_bf16_trunc(o_norm))
+                o_vec = Vec.from_elements(bf16_elems, fx.BFloat16).ir_value()
+                o_global = self.q_global_idx(self.q_row, d_col_base)
+                self._store_ptr_bf16(self.o_ptr, o_global, o_vec)
+
+
+def _detect_gpu_name():
+    """Return the GPU marketing name (e.g. 'AMD Instinct MI308X') or ''."""
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return torch.cuda.get_device_name(0) or ""
+    except Exception:
+        pass
+    try:
+        import subprocess
+
+        out = subprocess.run(["rocminfo"], capture_output=True, text=True, timeout=10).stdout
+        for line in out.splitlines():
+            if "Marketing Name" in line and "MI" in line:
+                return line.split(":", 1)[1].strip()
+    except Exception:
+        pass
+    return ""
+
+
+def _require_mi308x(gpu_arch):
+    """Raise unless running on an AMD MI308X (gfx942); this kernel targets MI308X only."""
+    gpu_name = _detect_gpu_name()
+    is_gfx942 = isinstance(gpu_arch, str) and gpu_arch.startswith("gfx942")
+    is_mi308x = "MI308" in gpu_name.upper()
+    if not (is_gfx942 and is_mi308x):
+        raise RuntimeError(
+            f"SageAttention CDNA kernel supports only AMD MI308X (gfx942); "
+            f"got arch={gpu_arch!r} name={gpu_name!r}. Other hardware is not supported."
+        )
 
 
 def build_sage_attn_cdna_module(
@@ -107,17 +837,17 @@ def build_sage_attn_cdna_module(
     v_transposed: bool = False,
     bias_block_m: int | None = None,
 ):
-    """Build FlyDSL sage attention kernel for CDNA (gfx942/gfx950).
+    """Build FlyDSL sage attention kernel for AMD MI308X (CDNA gfx942).
 
     Uses Int8 MFMA for QK^T and BF16 MFMA for PV, matching triton sage v1 precision.
     """
     gpu_arch = get_hip_arch()
+    _require_mi308x(gpu_arch)
     _IS_GFX942 = gpu_arch.startswith("gfx942")
     _GFX942_COMPACT = False
     _w256_env = os.environ.get("SAGE_GFX942_W256", "auto")
     if gfx942_w256 is None:
         if _w256_env == "auto":
-            # Default: try true 32x32 MFMA w256 path (256 thr, 32 rows/wave).
             _GFX942_W256 = True
         elif _w256_env in ("compact", "c256"):
             _GFX942_W256 = False
@@ -128,223 +858,93 @@ def build_sage_attn_cdna_module(
     else:
         _GFX942_W256 = _IS_GFX942 and bool(gfx942_w256)
         _GFX942_COMPACT = False
-    if _IS_GFX942 and not _GFX942_W256:
+    if _IS_GFX942 and (not _GFX942_W256):
         raise ValueError("gfx942 requires the w256 SageAttention path")
-
-    WARP_SIZE = get_warp_size(gpu_arch)  # 64 for CDNA
-
-    # MFMA 32x32 tile dimensions (Stage A: both QK and PV use 32x32)
+    WARP_SIZE = get_warp_size(gpu_arch)
     MFMA_M = 32
     MFMA_N = 32
-
     if _GFX942_W256:
         path_tag = f"{path_tag}_w256"
-        # gfx942: LLVM lowers 32x32x16_i8 / 32x32x16_fp8.
         MFMA_K_INT8 = 16
         MFMA_K_FP8 = 16
     else:
-        # For Int8 MFMA: mfma_i32_32x32x32_i8 accumulates K=32 per call
         MFMA_K_INT8 = 32
-        # For FP8 K=64 MFMA: mfma_scale_f32_32x32x64_f8f6f4 accumulates K=64.
         MFMA_K_FP8 = 64
-
-    ROWS_PER_WAVE = MFMA_M  # 32 output rows per wave
-
+    ROWS_PER_WAVE = MFMA_M
     BLOCK_M = block_m if block_m is not None else 256
     BLOCK_N = block_n if block_n is not None else 128
     Q_SCALE_BLOCK_M = bias_block_m if bias_block_m is not None else BLOCK_M
-
     SPLIT_K = max(1, int(split_k))
     IS_SPLIT_K = SPLIT_K > 1
     V_TRANSPOSED = bool(v_transposed)
-
-    NUM_WAVES = BLOCK_M // ROWS_PER_WAVE  # e.g. 256//32 = 8 (PR1818-style w256)
+    NUM_WAVES = BLOCK_M // ROWS_PER_WAVE
     if flat_work_group_size is None:
         flat_work_group_size = NUM_WAVES * WARP_SIZE
     BLOCK_SIZE = flat_work_group_size
-
-    # K steps for GEMM1 (QK): head_dim // MFMA_K_INT8
     K_STEPS_QK = head_dim // MFMA_K_INT8
-
-    # D chunks for GEMM2 (PV): head_dim / MFMA_N output columns per chunk
-    D_CHUNK = MFMA_N  # 16 columns per MFMA output fragment
+    D_CHUNK = MFMA_N
     D_CHUNKS = head_dim // D_CHUNK
-
-    # K steps for GEMM2 per BLOCK_N tile: BLOCK_N // MFMA_K_FP8
     PV_K_STEPS = BLOCK_N // MFMA_K_FP8
-
     assert head_dim % MFMA_K_INT8 == 0, f"head_dim {head_dim} must be divisible by {MFMA_K_INT8}"
     assert BLOCK_M % ROWS_PER_WAVE == 0
     assert BLOCK_N % MFMA_K_FP8 == 0
-
     if sm_scale is None:
         sm_scale = 1.0 / host_math.sqrt(head_dim)
-
     NUM_Q_HEADS = num_q_heads
     NUM_KV_HEADS = num_kv_heads
     HEAD_DIM = head_dim
     CAUSAL = causal
-    GROUPS = num_q_heads // num_kv_heads  # GQA group size
-
+    GROUPS = num_q_heads // num_kv_heads
     STRIDE_TOKEN = NUM_Q_HEADS * HEAD_DIM
     KV_STRIDE_TOKEN = NUM_KV_HEADS * HEAD_DIM
-
-    # LDS layout
-    # K: row-major BLOCK_N × HEAD_DIM (Int8, 1 byte/elem). +8 byte pad per row.
-    # V on gfx942: COLUMN-MAJOR HEAD_DIM × BLOCK_N (FP8 raw bytes, 1 byte/elem).
-    #    +8 byte pad per V "row" (= V "column" in the original BLOCK_N×HEAD_DIM
-    #    view). Storing V transposed makes per-lane PV reads contiguous in K
-    #    (32 contiguous bytes at fixed d), enabling 2× ds_read_b128 instead of
-    #    32× ds_read_u8.
-    # V on gfx950 (Stage IV-c): ROW-MAJOR BLOCK_N × HEAD_DIM (matches global
-    #    layout). Cooperative load is 1× ds_write_b128 per row instead of 16×
-    #    scattered ds_write_b8. PV per-lane gather uses ds_read_tr8_b64 (CDNA4-
-    #    only; performs a 16-lane in-instruction transpose) to deliver the
-    #    32 K-contiguous bytes per lane that the f8f6f4 MFMA expects.
-    _is_gfx950_kv = "gfx950" in gpu_arch
-
-    # ---- Direct global→LDS DMA staging (experimental memory-staging lever) ----
-    # Default coop loads stage K/V through the VGPR file: buffer_load (global→
-    # VGPR) then ds_write (VGPR→LDS) — a two-hop copy that pins staging VGPRs
-    # per outstanding load and emits a ds_write stripe per KV tile. The CDNA
-    # `buffer_load_lds` path moves global→LDS directly, bypassing the register
-    # file. The hardware writes are LANE-CONTIGUOUS within a wave, so the K/V
-    # LDS strides MUST be packed (no +16 pad / XOR) and the destination is a
-    # per-wave-uniform pointer (HW adds lane*size). gfx950 supports a 16 B/lane
-    # DMA (one buffer_load_dwordx4-to-LDS); gfx942 is 4 B/lane. V on gfx942 is
-    # column-major (scatter-transpose) which the DMA cannot express, so V-DMA
-    # is gfx950-only.
-    # Auto gate: the only measured net win is K-only DMA + XOR swizzle on causal
-    # gfx950 (~3-4.7%); non-causal is ~flat and V/kv modes regress (see
-    # sage_attn_memstage/). So "auto" (default) turns on K-DMA exactly there and
-    # stays byte-identical to baseline everywhere else. Explicit values still
-    # force a specific arm for A/B: 0/""=off, k/v/kv/1=that mode unconditionally.
     _dma_env = os.environ.get("SAGE_LDS_DMA", "auto")
     if _dma_env == "auto":
-        _dma_env = "k" if (CAUSAL and _is_gfx950_kv) else "0"
+        _dma_env = "0"
     _dma_k = _dma_env in ("1", "k", "kv")
-    _dma_v = _dma_env in ("1", "v", "kv") and _is_gfx950_kv
-    _dma_any = _dma_k or _dma_v
-    # DMA forces a packed (no-pad) stride, which aliases every KV row onto the
-    # same 32-bank set (HEAD_DIM=128 B = 32 banks × 4 B) → 32-way ds_read
-    # conflicts. The pad is unavailable (the lane-contiguous DMA destination is
-    # not a per-lane address), but an XOR swizzle CAN be carried purely in
-    # ADDRESS ARITHMETIC: permute which 16-B chunk each lane fetches on the
-    # global side (write) and apply the inverse permute on the LDS read index.
-    # chunk' = chunk ^ (row & (CHUNKS_PER_ROW-1)) is self-inverse and in-row
-    # (16-B aligned), so global reads stay fully coalesced (same 128-B rows,
-    # only lane↔chunk assignment permutes) and the QK ds_read sees rows scattered
-    # across distinct banks. Default ON whenever DMA is on (set SAGE_LDS_DMA_XOR=0
-    # to reproduce the un-swizzled packed baseline for A/B).
-    # The in-row XOR is only self-inverse when CHUNKS_PER_ROW is a power of two
-    # (so `& mask` selects a within-row chunk). HEAD_DIM 64/128/256 → 4/8/16
-    # chunks (all p2); guard non-p2 head_dims by falling back to no-xor.
-    _cpr_k_host = head_dim // 16  # VEC_WIDTH_K = 16 B chunks per K row
-    _cpr_k_is_p2 = _cpr_k_host > 0 and (_cpr_k_host & (_cpr_k_host - 1)) == 0
-    _dma_xor = _dma_any and _cpr_k_is_p2 and os.environ.get("SAGE_LDS_DMA_XOR", "1") not in ("0", "")
-    # `buffer_load_lds` completion is tracked by the global `vmcnt`, not
-    # `lgkmcnt`, so the LDS data is only guaranteed visible after a `vmcnt`
-    # drain — which `gpu.barrier()`'s implicit `lgkmcnt(0)` does NOT provide.
-    # An explicit `s_waitcnt vmcnt(0)` before the gating barrier is therefore
-    # required *unless* something else already drains vmcnt there. In single-
-    # tensor DMA modes (`k` or `v`) the OTHER tensor is still register-staged,
-    # and its coop-load issues its own `s_waitcnt vmcnt(0)` before its
-    # `ds_write` (the VGPR→LDS store needs the loaded VGPRs) — a full drain that
-    # also lands the sibling DMA. So the explicit fence is only needed when BOTH
-    # K and V are DMA (`kv`/`1`), where no register path forces a drain. Skipping
-    # the redundant fence in single-tensor modes removes a per-iter critical-path
-    # stall that the lean, high-occupancy non-causal iters could not hide
-    # (causal iters hid it under the per-element mask compute). Verified
-    # bit-identical with the fence gated off in K-only mode.
-    _need_dma_fence = _dma_k and _dma_v
+    _dma_any = _dma_k
+    _cpr_k_host = head_dim // 16
+    _cpr_k_is_p2 = _cpr_k_host > 0 and _cpr_k_host & _cpr_k_host - 1 == 0
+    _dma_xor = _dma_any and _cpr_k_is_p2 and (os.environ.get("SAGE_LDS_DMA_XOR", "1") not in ("0", ""))
     if const_expr(_dma_any):
         path_tag = f"{path_tag}_dma{_dma_env}" + ("x" if _dma_xor else "")
-        if const_expr(_need_dma_fence):
-            path_tag = f"{path_tag}f"
-
-    # ---- Deferred-scale softmax ("gate the scale") ----
-    # Defer the QK descale out of the per-element score path and fold it into the
-    # softmax exp as one FMA (see section 2/4 in the kernel body). Removes the 32
-    # per-element `v_pk_mul_f32` per iter — the dominant non-exp VALU op in this
-    # VALU(exp)-bound loop. The per-iter ISA histogram confirms deferral is a pure
-    # win on op count (96 vs 129 exposed VALU, 181 vs 192 VGPR), yet whether it
-    # nets faster depends on whether eager's scale-muls were *already hidden*:
-    #   - non-causal (any block_m): deferral wins (−5–7%), bit-identical cosine.
-    #   - causal, block_m<=128: deferral wins too (−5%) — the smaller MFMA shadow
-    #     and higher occupancy leave eager's muls exposed, so removing them pays.
-    #   - causal, block_m=256: deferral REGRESSES (+7–9%). The big-tile MFMA shadow
-    #     plus the per-element mask compute (64 cndmask+cmp) already swallow eager's
-    #     muls for free, so deferral removes nothing but still adds a serial
-    #     post-reduction `row_max*scale` on the exp critical path. Nothing to recoup
-    #     here — the cost is structural, not an op-count problem.
-    # So gate ON for non-causal OR (causal AND block_m<=128) — a compile-time
-    # per-shape branch (the dispatcher is a perf lever). Env `SAGE_DEFER_SCALE`
-    # overrides for A/B: `auto`/`1` = the gate above, `0` = always eager, `force` =
-    # always deferred.
     _defer_env = os.environ.get("SAGE_DEFER_SCALE", "auto")
     if _defer_env in ("0", ""):
         _DEFER_SCALE = False
     elif _defer_env == "force":
         _DEFER_SCALE = True
-    else:  # "auto" / "1": non-causal always; causal only at block_m<=128
-        _DEFER_SCALE = (not CAUSAL) or (BLOCK_M <= 128)
+    else:
+        _DEFER_SCALE = not CAUSAL or BLOCK_M <= 128
     if use_bias:
-        # Bias is already in log2 score units and is added after QK descale.
         _DEFER_SCALE = False
     if const_expr(_DEFER_SCALE):
         path_tag = f"{path_tag}_ds"
-
-    # ---- Reverse Q-tile scheduling ----
-    # Reverse the Q-tile assignment so concurrently launched workgroups do not
-    # march through identical K/V regions in lockstep. This remains required for
-    # causal LPT balancing and is also a small, repeatable cache-distribution win
-    # for non-causal long sequences. It is a pure workgroup permutation, so each
-    # output tile's computation and numerics are unchanged.
-    # Env `SAGE_LPT_SCHED`: `auto`/`1` (default on) · `0` (naive order) ·
-    # `force` (on, retained for existing A/B commands).
     _lpt_env = os.environ.get("SAGE_LPT_SCHED", "auto")
     _LPT_SCHED = _lpt_env not in ("0", "")
     if const_expr(_LPT_SCHED):
         path_tag = f"{path_tag}_lpt"
-
-    _default_lds_pad = "8" if (_IS_GFX942 and V_TRANSPOSED) else ("4" if _IS_GFX942 else "16")
+    _default_lds_pad = "8" if _IS_GFX942 and V_TRANSPOSED else "4" if _IS_GFX942 else "16"
     _LDS_PAD = int(os.environ.get("SAGE_LDS_PAD", _default_lds_pad))
     if _LDS_PAD < 0 or _LDS_PAD % 4 != 0:
         raise ValueError("SAGE_LDS_PAD must be a non-negative multiple of 4")
     path_tag = f"{path_tag}_pad{_LDS_PAD}"
-
     if const_expr(_dma_k):
         K_STRIDE = HEAD_DIM
     else:
         K_STRIDE = HEAD_DIM + _LDS_PAD
-    if _is_gfx950_kv and const_expr(_dma_v):
-        V_STRIDE = HEAD_DIM
-    else:
-        V_STRIDE = (HEAD_DIM if _is_gfx950_kv else BLOCK_N) + _LDS_PAD
-
-    # Cooperative load parameters
-    VEC_WIDTH_K = 16  # 16 Int8 elements = 16 bytes per thread
-    # V coop load (gfx942): each thread reads 16 contiguous FP8 bytes from one
-    # global V row (16 d-positions) and SCATTERS them as 16 separate bytes
-    # into column-major LDS at 16 different LDS rows (the d-positions), same
-    # LDS column (the kv_row).
-    # V coop load (gfx950): each thread reads 16 contiguous FP8 bytes and
-    # WRITES them contiguously into row-major LDS as one ds_write_b128.
-    VEC_WIDTH_V = 16  # 16 FP8 bytes per thread (one global vec load)
+    V_STRIDE = BLOCK_N + _LDS_PAD
+    VEC_WIDTH_K = 16
+    VEC_WIDTH_V = 16
     THREADS_PER_ROW_K = HEAD_DIM // VEC_WIDTH_K
     THREADS_PER_ROW_V = HEAD_DIM // VEC_WIDTH_V
     ROWS_PER_BATCH_K = BLOCK_SIZE // THREADS_PER_ROW_K
     ROWS_PER_BATCH_V = BLOCK_SIZE // THREADS_PER_ROW_V
-
     if ROWS_PER_BATCH_K >= BLOCK_N:
         NUM_BATCHES_K = 1
         K_NEEDS_GUARD = ROWS_PER_BATCH_K > BLOCK_N
     else:
         NUM_BATCHES_K = BLOCK_N // ROWS_PER_BATCH_K
         K_NEEDS_GUARD = False
-    if V_TRANSPOSED and not _is_gfx950_kv:
-        # Native [B,H,D,S] mapping uses all 512 threads as
-        # 128 d-columns × four 16-token segments: one pass covers BLOCK_N=64.
+    if V_TRANSPOSED:
         NUM_BATCHES_V = 1
         V_NEEDS_GUARD = False
     elif ROWS_PER_BATCH_V >= BLOCK_N:
@@ -353,21 +953,10 @@ def build_sage_attn_cdna_module(
     else:
         NUM_BATCHES_V = BLOCK_N // ROWS_PER_BATCH_V
         V_NEEDS_GUARD = False
-
-    # V LDS section.
-    # gfx942 (column-major): HEAD_DIM rows × V_STRIDE bytes per row.
-    # gfx950 (row-major):    BLOCK_N rows × V_STRIDE (=HEAD_DIM) bytes per row.
-    LDS_K_BYTES = BLOCK_N * K_STRIDE * 1  # 1 byte per Int8
-    if _is_gfx950_kv:
-        LDS_V_BYTES = BLOCK_N * V_STRIDE * 1  # row-major: BLOCK_N × HEAD_DIM
-    else:
-        LDS_V_BYTES = HEAD_DIM * V_STRIDE * 1  # column-major: HEAD_DIM × V_STRIDE
-    # Stage III: software pipeline (1 or 2 stages). Double-buffer K/V overlaps
-    # the next tile's loads with the current tile's MFMAs, but BLOCK_N=128 on
-    # gfx942 exceeds 64 KiB LDS — auto-fallback to single buffer (see legacy512).
-    # Layout pipe2: [K0 | K1 | V0 | V1]; pipe1: [K | V].
+    LDS_K_BYTES = BLOCK_N * K_STRIDE * 1
+    LDS_V_BYTES = HEAD_DIM * V_STRIDE * 1
     _pipe_env = os.environ.get("SAGE_PIPE_STAGES", "2")
-    NUM_PIPE_STAGES = 1 if (_pipe_env in ("0", "1") or IS_SPLIT_K) else 2
+    NUM_PIPE_STAGES = 1 if _pipe_env in ("0", "1") or IS_SPLIT_K else 2
     LDS_K_TOTAL_BYTES = LDS_K_BYTES * NUM_PIPE_STAGES
     LDS_V_TOTAL_BYTES = LDS_V_BYTES * NUM_PIPE_STAGES
     LDS_TOTAL_BYTES = LDS_K_TOTAL_BYTES + LDS_V_TOTAL_BYTES
@@ -382,1186 +971,171 @@ def build_sage_attn_cdna_module(
         path_tag = f"{path_tag}_pipe1"
     if IS_SPLIT_K:
         path_tag = f"{path_tag}_sk{SPLIT_K}"
-
-    # We store K as i8 and V as bf16. Because the SmemAllocator works in elements
-    # and we share one LDS array, we allocate in Int8 units and use byte offsets.
-    # K section: LDS_K_TOTAL_BYTES bytes starting at lds_offset
-    # V section: LDS_V_TOTAL_BYTES bytes starting at lds_offset + LDS_K_TOTAL_BYTES
-    LDS_TOTAL_I8_ELEMS = LDS_TOTAL_BYTES  # 1:1 byte mapping for i8 allocator
-
+    LDS_TOTAL_I8_ELEMS = LDS_TOTAL_BYTES
     allocator = SmemAllocator(
-        None,
-        arch=gpu_arch,
-        global_sym_name=f"sage_attn_cdna_smem_M{BLOCK_M}N{BLOCK_N}_{path_tag}",
+        None, arch=gpu_arch, global_sym_name=f"sage_attn_cdna_smem_M{BLOCK_M}N{BLOCK_N}_{path_tag}"
     )
     lds_base_offset = allocator._align(allocator.ptr, 16)
     allocator.ptr = lds_base_offset + LDS_TOTAL_I8_ELEMS
 
-    # Architecture-specific FP8 type (gfx942: fnuz, gfx950: fn)
-    # Deferred: MLIR types must be constructed inside an active MLIR Context,
-    # which only exists inside the @flyc.kernel scope.
-    _is_gfx950 = "gfx950" in gpu_arch
-    _fp8_mlir_type_cls = ir.Float8E4M3FNType if _is_gfx950 else ir.Float8E4M3FNUZType
-
-    # The 32x32 MFMA variants don't have a flydsl.expr.rocdl wrapper, so we
-    # call the raw ODS class directly with positional arguments.
-    from flydsl._mlir.dialects._rocdl_ops_gen import (
-        ds_read_tr8_b64 as _ods_ds_read_tr8_b64,
+    t = _SageTraits(
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_SIZE=BLOCK_SIZE,
+        CAUSAL=CAUSAL,
+        D_CHUNKS=D_CHUNKS,
+        GROUPS=GROUPS,
+        HEAD_DIM=HEAD_DIM,
+        KV_STRIDE_TOKEN=KV_STRIDE_TOKEN,
+        K_NEEDS_GUARD=K_NEEDS_GUARD,
+        K_STEPS_QK=K_STEPS_QK,
+        K_STRIDE=K_STRIDE,
+        LDS_K_BYTES=LDS_K_BYTES,
+        LDS_K_TOTAL_BYTES=LDS_K_TOTAL_BYTES,
+        LDS_V_BYTES=LDS_V_BYTES,
+        LDS_V_TOTAL_BYTES=LDS_V_TOTAL_BYTES,
+        MFMA_K_FP8=MFMA_K_FP8,
+        MFMA_K_INT8=MFMA_K_INT8,
+        MFMA_M=MFMA_M,
+        MFMA_N=MFMA_N,
+        NUM_BATCHES_K=NUM_BATCHES_K,
+        NUM_BATCHES_V=NUM_BATCHES_V,
+        NUM_KV_HEADS=NUM_KV_HEADS,
+        NUM_PIPE_STAGES=NUM_PIPE_STAGES,
+        NUM_Q_HEADS=NUM_Q_HEADS,
+        PV_K_STEPS=PV_K_STEPS,
+        Q_SCALE_BLOCK_M=Q_SCALE_BLOCK_M,
+        ROWS_PER_BATCH_K=ROWS_PER_BATCH_K,
+        ROWS_PER_BATCH_V=ROWS_PER_BATCH_V,
+        ROWS_PER_WAVE=ROWS_PER_WAVE,
+        STRIDE_TOKEN=STRIDE_TOKEN,
+        THREADS_PER_ROW_K=THREADS_PER_ROW_K,
+        THREADS_PER_ROW_V=THREADS_PER_ROW_V,
+        VEC_WIDTH_K=VEC_WIDTH_K,
+        VEC_WIDTH_V=VEC_WIDTH_V,
+        V_NEEDS_GUARD=V_NEEDS_GUARD,
+        V_STRIDE=V_STRIDE,
+        V_TRANSPOSED=V_TRANSPOSED,
+        WARP_SIZE=WARP_SIZE,
+        _DEFER_SCALE=_DEFER_SCALE,
+        _GFX942_W256=_GFX942_W256,
+        _LPT_SCHED=_LPT_SCHED,
+        _dma_any=_dma_any,
+        _dma_k=_dma_k,
+        _dma_xor=_dma_xor,
+        lds_base_offset=lds_base_offset,
+        use_bias=use_bias,
     )
-    from flydsl._mlir.dialects._rocdl_ops_gen import (
-        mfma_f32_32x32x16_fp8_fp8 as _ods_mfma_f32_32x32x16_fp8_fp8,
+    _impl = _SageKernel(t, allocator)
+    _cache_tag = (
+        gpu_arch,
+        BLOCK_M,
+        BLOCK_N,
+        CAUSAL,
+        HEAD_DIM,
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        _DEFER_SCALE,
+        _LPT_SCHED,
+        _GFX942_W256,
+        _dma_k,
+        _dma_xor,
+        V_TRANSPOSED,
+        use_bias,
+        use_fp8_pv,
+        NUM_PIPE_STAGES,
+        SPLIT_K,
+        path_tag,
     )
-    from flydsl._mlir.dialects._rocdl_ops_gen import (
-        mfma_i32_32x32x16_i8 as _ods_mfma_i32_32x32x16_i8,
-    )
-    from flydsl._mlir.dialects._rocdl_ops_gen import (
-        mfma_i32_32x32x32_i8 as _ods_mfma_i32_32x32x32_i8,
-    )
-    from flydsl._mlir.dialects._rocdl_ops_gen import (
-        mfma_scale_f32_32x32x64_f8f6f4 as _ods_mfma_scale_f32_32x32x64_f8f6f4,
-    )
-
-    def mfma_i32_k32(result_type, operands):
-        a, b, c = operands[0], operands[1], operands[2]
-        cbsz = operands[3] if len(operands) > 3 else 0
-        abid = operands[4] if len(operands) > 4 else 0
-        blgp = operands[5] if len(operands) > 5 else 0
-        a_v = a.ir_value() if hasattr(a, "ir_value") and not isinstance(a, ir.Value) else a
-        b_v = b.ir_value() if hasattr(b, "ir_value") and not isinstance(b, ir.Value) else b
-        c_v = c.ir_value() if hasattr(c, "ir_value") and not isinstance(c, ir.Value) else c
-        if const_expr(_GFX942_W256):
-            return _ods_mfma_i32_32x32x16_i8(
-                res=result_type,
-                a=a_v,
-                b=b_v,
-                c=c_v,
-                cbsz=cbsz,
-                abid=abid,
-                blgp=blgp,
-            ).result
-        return _ods_mfma_i32_32x32x32_i8(
-            res=result_type,
-            a=a_v,
-            b=b_v,
-            c=c_v,
-            cbsz=cbsz,
-            abid=abid,
-            blgp=blgp,
-        ).result
-
-    def mfma_fp8_k16(result_type, operands):
-        a, b, c = operands[0], operands[1], operands[2]
-        cbsz = operands[3] if len(operands) > 3 else 0
-        abid = operands[4] if len(operands) > 4 else 0
-        blgp = operands[5] if len(operands) > 5 else 0
-        a_v = a.ir_value() if hasattr(a, "ir_value") and not isinstance(a, ir.Value) else a
-        b_v = b.ir_value() if hasattr(b, "ir_value") and not isinstance(b, ir.Value) else b
-        c_v = c.ir_value() if hasattr(c, "ir_value") and not isinstance(c, ir.Value) else c
-        return _ods_mfma_f32_32x32x16_fp8_fp8(
-            res=result_type,
-            a=a_v,
-            b=b_v,
-            c=c_v,
-            cbsz=cbsz,
-            abid=abid,
-            blgp=blgp,
-        ).result
-
-    def mfma_fp8_k64(result_type, a, b, c, scale_a, scale_b):
-        """rocdl.mfma.scale.f32.32x32x64.f8f6f4 (fp8 * fp8) wrapper.
-
-        a, b: vector<8xi32> per lane (= 32 fp8 bytes per lane).
-        c: vector<16xf32> per lane (accumulator; same layout as 32x32x16_bf16).
-        scale_a, scale_b: i32 (e8m0). Pass 127 for "no scaling" (1.0 multiplier).
-        opselA=opselB=0 selects the FP8 path.
-        """
-        a_v = a.ir_value() if hasattr(a, "ir_value") and not isinstance(a, ir.Value) else a
-        b_v = b.ir_value() if hasattr(b, "ir_value") and not isinstance(b, ir.Value) else b
-        c_v = c.ir_value() if hasattr(c, "ir_value") and not isinstance(c, ir.Value) else c
-        return _ods_mfma_scale_f32_32x32x64_f8f6f4(
-            res=result_type,
-            a=a_v,
-            b=b_v,
-            c=c_v,
-            cbsz=0,
-            blgp=0,
-            opselA=0,
-            scaleA=scale_a,
-            opselB=0,
-            scaleB=scale_b,
-        ).result
 
     @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
     def sage_attn_kernel(
-        Q: fx.Tensor,  # Int8, 1D flattened BSHD
-        K: fx.Tensor,  # Int8, 1D flattened BSHD (num_kv_heads)
-        V: fx.Tensor,  # FP8, 1D flattened BSHD (num_kv_heads)
-        O: fx.Tensor,  # BF16 output, 1D flattened BSHD  # noqa: E741
-        Q_descale: fx.Tensor,  # f32, shape [batch, num_q_heads, num_q_blocks]
-        K_descale: fx.Tensor,  # f32, shape [batch, num_kv_heads, num_k_blocks]
-        V_descale: fx.Tensor,  # f32, shape [batch, num_kv_heads, head_dim] (per-element)
-        Bias: fx.Tensor,  # f32 [batch, num_q_heads, num_q_blocks, seq_len_k]
+        Q: fx.Tensor,
+        K: fx.Tensor,
+        V: fx.Tensor,
+        O: fx.Tensor,  # noqa: E741
+        Q_descale: fx.Tensor,
+        K_descale: fx.Tensor,
+        V_descale: fx.Tensor,
+        Bias: fx.Tensor,
         batch_size: fx.Int32,
         seq_len_q: fx.Int32,
         seq_len_k: fx.Int32,
         num_q_blocks: fx.Int32,
     ):
-        fm_fast = arith.FastMathFlags.fast
-
-        def _fadd(a, b):
-            return arith.addf(_raw(a), _raw(b), fastmath=fm_fast)
-
-        def _fsub(a, b):
-            return arith.subf(_raw(a), _raw(b), fastmath=fm_fast)
-
-        def _fmul(a, b):
-            return arith.mulf(_raw(a), _raw(b), fastmath=fm_fast)
-
-        def _fmax(a, b):
-            return arith.MaxNumFOp(_raw(a), _raw(b), fastmath=fm_fast).result
-
-        def _ffma(a, b, c):
-            # fused a*b + c (single rounding); used to fold the QK descale into
-            # the exp argument so the 32 per-element scale-muls collapse.
-            return _math.fma(_raw(a), _raw(b), _raw(c), fastmath=fm_fast)
-
-        def _sitofp(v):
-            return arith.SIToFPOp(T.f32, _raw(v)).result
-
-        q_ptr = _extract_aligned_pointer(Q)
-        o_ptr = _extract_aligned_pointer(O)
-        qds_ptr = _extract_aligned_pointer(Q_descale)
-        kds_ptr = _extract_aligned_pointer(K_descale)
-        vds_ptr = _extract_aligned_pointer(V_descale)
-        if const_expr(use_bias):
-            bias_ptr = _extract_aligned_pointer(Bias)
-
-        # Buffer descriptors for K/V global loads.
-        # Tight num_records_bytes = B*S*Hk*HEAD_DIM lets the hardware return
-        # 0 for OOB lanes past tensor end, so we can drop the row-clamp +
-        # V zero-fill selects in coop_load_k/v. Score masking already pins
-        # P=0 for KV columns past seq_len_k, so even inner-batch overflow
-        # rows that fall into a neighboring batch's bytes contribute 0 to
-        # the PV MFMA (0 * any-fp8 = 0; sage_quant outputs are NaN-free).
-        bs_v_for_rsrc = fx.Index(batch_size)
-        slk_v_for_rsrc = fx.Index(seq_len_k)
-        num_k_blocks_for_rsrc = (slk_v_for_rsrc + fx.Index(BLOCK_N - 1)) // fx.Index(BLOCK_N)
-        kv_total_bytes = bs_v_for_rsrc * slk_v_for_rsrc * fx.Index(NUM_KV_HEADS * HEAD_DIM)
-        v_total_bytes = (
-            bs_v_for_rsrc * fx.Index(NUM_KV_HEADS * HEAD_DIM) * num_k_blocks_for_rsrc * fx.Index(BLOCK_N)
-            if V_TRANSPOSED
-            else kv_total_bytes
-        )
-        k_rsrc = buffer_ops.create_buffer_resource(
-            K,
-            max_size=False,
-            num_records_bytes=kv_total_bytes,
-        )
-        v_rsrc = buffer_ops.create_buffer_resource(
-            V,
-            max_size=False,
-            num_records_bytes=v_total_bytes,
-        )
-
-        v4i32_type = Vec.make_type(4, fx.Int32)
-        v16i32_type = Vec.make_type(16, fx.Int32)
-        v16f32_type = Vec.make_type(16, fx.Float32)
-        v4f32_type = Vec.make_type(4, fx.Float32)
-        # MFMA 32x32x32_i8: A/B = v4i32 (=16xi8 per lane), C/D = v16i32 per lane (wave64)
-        v8i8_type = Vec.make_type(8, fx.Int8)
-        v16i8_type = Vec.make_type(16, fx.Int8)
-
-        seq_len_q_v = fx.Index(seq_len_q)
-        seq_len_k_v = fx.Index(seq_len_k)
-
-        base_ptr = allocator.get_base()
-        # Shared LDS as Int8 view: covers BOTH K ping-pong buffers (K0 | K1).
-        # Buffer index is a runtime value; per-buffer LDS index = base_idx +
-        # buf_idx * LDS_K_BYTES.
-        lds = SmemPtr(
-            base_ptr,
-            lds_base_offset,
-            T.i8,
-            shape=(LDS_K_TOTAL_BYTES,),
-        ).get()
-        # Separate, statically-shaped view for V — gives the LLVM backend a
-        # tight bound that helps prove 16-byte alignment for vector loads, so
-        # they can lower to ds_read_b128 instead of 32× ds_read_u8. Covers
-        # BOTH V ping-pong buffers (V0 | V1).
-        lds_v = SmemPtr(
-            base_ptr,
-            lds_base_offset + LDS_K_TOTAL_BYTES,
-            T.i8,
-            shape=(LDS_V_TOTAL_BYTES,),
-        ).get()
-
-        block_id = fx.Index(gpu.block_idx.x)
-        tid = fx.Index(gpu.thread_idx.x)
-
-        wave_id = tid // WARP_SIZE
-        lane = tid % WARP_SIZE
-
-        # MFMA 32x32 wave64 layout:
-        # lane32 = lane % 32  (row index in A operand, col index in B/output)
-        # klane  = lane // 32 (K-block selector, 0 or 1 for wave64)
-        lane32 = lane % MFMA_M
-        klane = lane // MFMA_M  # 0 or 1 for wave64
-
-        wave_q_offset = wave_id * ROWS_PER_WAVE
-
-        head_q_idx = block_id % NUM_Q_HEADS
-        batch_q_tile_id = block_id // NUM_Q_HEADS
-        num_q_tiles = (seq_len_q_v + BLOCK_M - 1) // BLOCK_M
-        q_tile_raw = batch_q_tile_id % num_q_tiles
-        batch_idx = batch_q_tile_id // num_q_tiles
-        # Causal LPT/SPT remap: reverse the Q-tile order so workgroup 0 (drawn
-        # first) processes the LAST (longest-work) causal tile. Pure scheduling
-        # permutation — every Q-tile's computation is independent and unchanged,
-        # so output is bit-identical to the naive-order baseline. No-op (off) for
-        # non-causal where tile work is uniform.
-        if const_expr(_LPT_SCHED):
-            q_tile_idx = (num_q_tiles - fx.Index(1)) - q_tile_raw
-        else:
-            q_tile_idx = q_tile_raw
-        q_start = q_tile_idx * BLOCK_M
-
-        # KV head for this Q head (GQA)
-        head_kv_idx = head_q_idx // GROUPS
-
-        load_row_k_batch = tid // THREADS_PER_ROW_K
-        load_lane_k = tid % THREADS_PER_ROW_K
-        load_col_k_base = load_lane_k * VEC_WIDTH_K
-
-        load_row_v_batch = tid // THREADS_PER_ROW_V
-        load_lane_v = tid % THREADS_PER_ROW_V
-        load_col_v_base = load_lane_v * VEC_WIDTH_V
-
-        def q_global_idx(token_idx, col):
-            token = batch_idx * seq_len_q_v + token_idx
-            return token * STRIDE_TOKEN + head_q_idx * HEAD_DIM + col
-
-        def kv_global_idx(token_idx, col):
-            token = batch_idx * seq_len_k_v + token_idx
-            return token * KV_STRIDE_TOKEN + head_kv_idx * HEAD_DIM + col
-
-        def _load_ptr_i8_vec16(ptr, base_idx):
-            gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.i8)
-            return _pointer_load(v16i8_type, gep)
-
-        def _load_ptr_i8_vec8(ptr, base_idx):
-            gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.i8)
-            return _pointer_load(v8i8_type, gep)
-
-        def _load_ptr_i64(ptr, base_idx):
-            """Load 8 contiguous bytes from `ptr+base_idx` as a scalar i64
-            (8xi8 packed). Used for MFMA i8 operands which require packed i64.
-            """
-            gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.i8)
-            return _pointer_load(T.i64, gep)
-
-        def _load_ptr_f8_vec8(ptr, base_idx):
-            # FP8 is loaded as raw bytes and bitcast; the actual ExtFOp uses the
-            # arch-specific FP8 type (FNUZ on gfx942, FN on gfx950).
-            return _load_ptr_i8_vec8(ptr, base_idx)
-
-        def _store_ptr_bf16(ptr, base_idx, val):
-            gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.bf16)
-            _pointer_store(val, gep)
-
-        def _load_ptr_f32(ptr, base_idx):
-            gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.f32)
-            return _pointer_load(T.f32, gep)
-
-        def _load_ptr_f32_vec4(ptr, base_idx):
-            gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.f32)
-            return _pointer_load(v4f32_type, gep)
-
-        def _bpermute_f32(value, src_lane):
-            value_i32 = arith.bitcast(T.i32, _raw(value))
-            # ds_bpermute addresses lanes in bytes, despite operating entirely
-            # on VGPRs: lane N is selected with index N * sizeof(i32).
-            lane_byte_idx = fx.Int32(arith.unwrap(arith.index_cast(T.i32, _raw(src_lane * 4))))
-            result_i32 = rocdl.ds_bpermute(T.i32, _raw(lane_byte_idx), value_i32)
-            return fx.Float32(arith.bitcast(T.f32, result_i32))
-
-        # ---- Preload Q to registers (Int8, v4i32 = 16xi8 packs for MFMA) ----
-        # Each wave owns ROWS_PER_WAVE=32 Q rows.
-        # For mfma_i32_32x32x32_i8: A operand is vector<4xi32> = 16 i8 per lane.
-        # lane32 = q_row within the 32-row tile (0..31)
-        # klane (0,1) selects the 16-byte half of the 32-wide K dimension.
-        # We preload K_STEPS_QK packs per lane (each = 16 i8 = v4i32).
-        q_row = q_start + wave_q_offset + lane32
-        q_row_i32 = fx.Int32(q_row)
-        q_in_bounds = arith.cmpi(arith.CmpIPredicate.slt, _raw(q_row), _raw(seq_len_q_v))
-        q_row_safe = fx.Index(ArithValue(q_in_bounds).select(q_row, fx.Index(0)))
-
-        _zero_v4i32_ir = Vec.filled(4, 0, fx.Int32).ir_value()
-        c_zero_i64 = arith.constant(0, type=T.i64)
-        q_packs = []
-        for ks in range_constexpr(K_STEPS_QK):
-            if const_expr(_GFX942_W256):
-                # 32x32x16_i8: each lane holds 8 i8 (packed i64); klane picks
-                # the 8-byte half of the 16-wide K chunk for this MFMA step.
-                q_col = fx.Index(ks * MFMA_K_INT8) + klane * 8
-                g_idx = q_global_idx(q_row_safe, q_col)
-                half = _load_ptr_i64(q_ptr, g_idx)
-                q_packs.append(ArithValue(q_in_bounds).select(half, c_zero_i64))
-            else:
-                # klane in {0,1} picks the 16-byte K sub-pack (K=k_block*16 + 0..15).
-                q_col = fx.Index(ks * MFMA_K_INT8) + klane * 16
-                g_idx = q_global_idx(q_row_safe, q_col)
-                v16i8 = _load_ptr_i8_vec16(q_ptr, g_idx)
-                v4i32 = vector.bitcast(v4i32_type, v16i8)
-                q_packs.append(ArithValue(q_in_bounds).select(v4i32, _zero_v4i32_ir))
-
-        # ---- Descale factors ----
-        # q_descale and SmoothQ bias use Q_SCALE_BLOCK_M.
-        # k_descale: [batch, num_kv_heads, num_k_blocks]
-        # v_descale: [batch, num_kv_heads] (per head, broadcast over k-blocks)
-        num_k_blocks_per_head = (seq_len_k_v + BLOCK_N - 1) // BLOCK_N
-
-        q_scale_num_blocks = fx.Index(num_q_blocks)
-        q_scale_tile_raw = (q_start + wave_q_offset) // Q_SCALE_BLOCK_M
-        q_scale_tile_idx = ArithValue(q_scale_tile_raw < q_scale_num_blocks).select(
-            q_scale_tile_raw, q_scale_num_blocks - fx.Index(1)
-        )
-        q_descale_base = (
-            batch_idx * NUM_Q_HEADS * q_scale_num_blocks + head_q_idx * q_scale_num_blocks + q_scale_tile_idx
-        )
-        q_ds = fx.Float32(_load_ptr_f32(qds_ptr, q_descale_base))
-
-        v_descale_base = (batch_idx * NUM_KV_HEADS + head_kv_idx) * HEAD_DIM
-
-        # ---- Constants ----
-        c_neg_inf = fx.Float32(float("-inf"))
-        c_zero_f = fx.Float32(0.0)
-        c_one_f = fx.Float32(1.0)
-        c_zero_v16f32 = Vec.filled(16, 0.0, fx.Float32)
-        c_zero_v16i32 = Vec.filled(16, 0, fx.Int32)
-
-        # Warp shuffle for reduction: wave64 has 64 lanes; with 32x32 MFMA the
-        # only cross-lane partner of a (klane, lane32) is the lane at the same
-        # lane32 with the other klane (XOR distance = 32).
-        shuf32_i32 = fx.Int32(32)
-        width_i32 = fx.Int32(WARP_SIZE)
-
-        def reduction_peer32(v_f32):
-            return fx.Float32(v_f32).shuffle_xor(shuf32_i32, width_i32)
-
-        def row_max_reduce(local_max):
-            """Reduce max across the 2 klane halves within wave64."""
-            return _fmax(local_max, reduction_peer32(local_max))
-
-        def row_sum_reduce(local_sum):
-            """Reduce sum across the 2 klane halves within wave64."""
-            return _fadd(local_sum, reduction_peer32(local_sum))
-
-        _q_end = q_start + BLOCK_M
-        if const_expr(CAUSAL):
-            kv_upper = fx.Index(ArithValue(_q_end < seq_len_k_v).select(_q_end, seq_len_k_v))
-        else:
-            kv_upper = seq_len_k_v
-
-        # ---- Direct global→LDS DMA helpers (experimental) ----
-        # raw_ptr_buffer_load_lds moves `size` bytes/lane straight from a buffer
-        # resource into LDS, bypassing the VGPR file. The HW LDS write is
-        # lane-contiguous within a wave: lane l of wave w lands at
-        #   lds_ptr_base + w*WARP_SIZE*size + l*size
-        # so the caller passes a WAVE-UNIFORM destination pointer (the per-lane
-        # stride is implicit) and the full per-lane address goes on the GLOBAL
-        # side via `voffset` (byte offset into the resource). With packed
-        # K/V strides this reproduces the row-major LDS tile bit-for-bit, since
-        # load_row*STRIDE + load_col == tid*size for THREADS_PER_ROW*VEC==STRIDE.
-        if const_expr(_dma_any):
-            from flydsl.expr import rocdl as _rocdl_dma
-
-            def _dma_fence():
-                # buffer_load_lds completion is tracked by vmcnt, NOT lgkmcnt,
-                # so gpu.barrier()'s implicit lgkmcnt(0) does not guarantee the
-                # LDS data has landed. Drain vmcnt before the gating barrier.
-                _llvm.inline_asm(None, [], "s_waitcnt vmcnt(0)", "", has_side_effects=True)
-
-            def _lds_as3_base(lds_view):
-                base_idx = _memref.extract_aligned_pointer_as_index(_llvm_value(lds_view))
-                base_i64 = arith.unwrap(arith.index_cast(T.i64, base_idx))
-                return buffer_ops.create_llvm_ptr(base_i64, address_space=3)
-
-        def _coop_load_k_dma(tile_start, buf_off):
-            # K DMA: packed row-major LDS, DMA_BYTES = VEC_WIDTH_K (16 on gfx950,
-            # one buffer_load_dwordx4-to-LDS). guard never fires for shipped
-            # tile configs (ROWS_PER_BATCH_K <= BLOCK_N); asserted at build.
-            assert not K_NEEDS_GUARD, "K DMA path requires ROWS_PER_BATCH_K<=BLOCK_N"
-            DMA_BYTES_K = VEC_WIDTH_K
-            buf_off_i64 = arith.unwrap(arith.index_cast(T.i64, _raw(buf_off)))
-            wave_byte = _rocdl_dma.readfirstlane(
-                T.i64,
-                arith.unwrap(arith.index_cast(T.i64, wave_id * fx.Index(WARP_SIZE * DMA_BYTES_K))),
-            )
-            base_ptr = _lds_as3_base(lds)
-            base_ptr = buffer_ops.get_element_ptr(base_ptr, buf_off_i64)
-            base_ptr = buffer_ops.get_element_ptr(base_ptr, wave_byte)
-            size_i32 = arith.constant(DMA_BYTES_K, type=T.i32)
-            c0 = arith.constant(0, type=T.i32)
-            aux1 = arith.constant(1, type=T.i32)
-            # CHUNKS_PER_ROW = HEAD_DIM / VEC_WIDTH_K = number of 16-B chunks per
-            # K row; the XOR period is the next-lower power of two so the permute
-            # stays in-row. K row = HEAD_DIM(128)/16 = 8 chunks → period 8.
-            _CPR_K = HEAD_DIM // VEC_WIDTH_K
-            _XMASK_K = _CPR_K - 1  # 7 for HEAD_DIM=128
-            for batch in range_constexpr(NUM_BATCHES_K):
-                row_offset = batch * ROWS_PER_BATCH_K
-                row_idx_raw = tile_start + load_row_k_batch + row_offset
-                if const_expr(_dma_xor):
-                    # Physical chunk this lane owns in LDS = load_col_k_base/16;
-                    # fetch the XOR-permuted chunk from GLOBAL so that, combined
-                    # with the inverse permute on the QK read, each LDS row lands
-                    # on a distinct bank set. tile_row = LDS row within the tile.
-                    tile_row = load_row_k_batch + row_offset
-                    phys_chunk = load_lane_k  # = load_col_k_base // VEC_WIDTH_K
-                    g_chunk = ArithValue(phys_chunk) ^ (ArithValue(tile_row) & fx.Index(_XMASK_K))
-                    g_col = fx.Index(g_chunk) * fx.Index(VEC_WIDTH_K)
-                    g_idx = kv_global_idx(row_idx_raw, g_col)
-                else:
-                    g_idx = kv_global_idx(row_idx_raw, load_col_k_base)
-                voff = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx)))
-                if const_expr(batch == 0):
-                    lds_ptr = base_ptr
-                else:
-                    lds_ptr = buffer_ops.get_element_ptr(
-                        base_ptr,
-                        static_byte_offset=batch * BLOCK_SIZE * DMA_BYTES_K,
-                    )
-                _rocdl_dma.raw_ptr_buffer_load_lds(k_rsrc, lds_ptr, size_i32, voff, c0, c0, aux1)
-
-        def _coop_load_v_dma(tile_start, buf_off):
-            # gfx950 row-major V: structurally identical to K DMA. Packed
-            # V stride, DMA_BYTES = VEC_WIDTH_V = 16. global voffset = byte
-            # index into V resource; HW write lands lane-contiguous == the
-            # row-major LDS tile. gfx942 column-major (transpose) cannot be a
-            # DMA — _dma_v is forced False there.
-            assert not V_NEEDS_GUARD, "V DMA path requires ROWS_PER_BATCH_V<=BLOCK_N"
-            DMA_BYTES_V = VEC_WIDTH_V
-            buf_off_i64 = arith.unwrap(arith.index_cast(T.i64, _raw(buf_off)))
-            wave_byte = _rocdl_dma.readfirstlane(
-                T.i64,
-                arith.unwrap(arith.index_cast(T.i64, wave_id * fx.Index(WARP_SIZE * DMA_BYTES_V))),
-            )
-            base_ptr = _lds_as3_base(lds_v)
-            base_ptr = buffer_ops.get_element_ptr(base_ptr, buf_off_i64)
-            base_ptr = buffer_ops.get_element_ptr(base_ptr, wave_byte)
-            size_i32 = arith.constant(DMA_BYTES_V, type=T.i32)
-            c0 = arith.constant(0, type=T.i32)
-            aux1 = arith.constant(1, type=T.i32)
-            for batch in range_constexpr(NUM_BATCHES_V):
-                row_offset = batch * ROWS_PER_BATCH_V
-                row_idx_raw = tile_start + load_row_v_batch + row_offset
-                g_idx = kv_global_idx(row_idx_raw, load_col_v_base)
-                voff = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx)))
-                if const_expr(batch == 0):
-                    lds_ptr = base_ptr
-                else:
-                    lds_ptr = buffer_ops.get_element_ptr(
-                        base_ptr,
-                        static_byte_offset=batch * BLOCK_SIZE * DMA_BYTES_V,
-                    )
-                _rocdl_dma.raw_ptr_buffer_load_lds(v_rsrc, lds_ptr, size_i32, voff, c0, c0, aux1)
-
-        # ---- Cooperative load helpers for K (Int8) ----
-        # buf_off: byte offset into the K-side LDS that selects the ping-pong
-        # buffer. 0 = buffer 0, LDS_K_BYTES = buffer 1.
-        def coop_load_k(tile_start, buf_off):
-            if const_expr(_dma_k):
-                _coop_load_k_dma(tile_start, buf_off)
-                return
-            for batch in range_constexpr(NUM_BATCHES_K):
-                row_offset = batch * ROWS_PER_BATCH_K
-                row_idx_raw = tile_start + load_row_k_batch + row_offset
-                # Tight buffer descriptor (num_records_bytes=B*S*Hk*HEAD_DIM)
-                # makes hardware return 0 for OOB lanes past tensor end. For
-                # inner-batch tail rows that overflow into a neighbouring
-                # batch the score mask still pins P=0 for those columns, so
-                # the PV contribution is 0 regardless. No row-clamp select
-                # needed.
-                if const_expr(K_NEEDS_GUARD):
-                    row_valid = load_row_k_batch < fx.Index(BLOCK_N)
-                    do_load = row_valid
-                else:
-                    do_load = True
-                if do_load:
-                    g_idx = kv_global_idx(row_idx_raw, load_col_k_base)
-                    lds_row = load_row_k_batch + row_offset
-                    lds_idx = buf_off + lds_row * K_STRIDE + load_col_k_base
-                    # buffer_load_dwordx4: g_idx is in i8 elements (=bytes); divide
-                    # by 4 to get the dword index buffer_load expects when dtype=i32.
-                    g_dword_i32 = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx >> fx.Index(2))))
-                    v4i32 = buffer_ops.buffer_load(k_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
-                    vec = vector.bitcast(v16i8_type, v4i32)
-                    Vec(vec).store(lds, [lds_idx])
-
-        # V is stored in the upper half of LDS, COLUMN-MAJOR (transposed):
-        # the LDS V section is HEAD_DIM rows × V_STRIDE bytes per row, where
-        # row index = d (0..HEAD_DIM-1) and the first BLOCK_N bytes of each row
-        # hold consecutive kv positions (column = kv_row).
-        # Storing V transposed makes per-lane PV reads be 32 contiguous bytes
-        # (one ds_read_b256 = 2 ds_read_b128) at fixed d, kv_row=k_start..+31.
-
-        def coop_load_v(tile_start, buf_off):
-            """Load V from global (FP8 raw bytes) into LDS.
-
-            gfx942 (column-major LDS): each thread reads VEC_WIDTH_V=16
-              contiguous FP8 bytes from one global V row and SCATTERS them as
-              16 individual byte writes to 16 different LDS rows.
-            gfx950 (row-major LDS): each thread reads VEC_WIDTH_V=16 contiguous
-              FP8 bytes and writes them contiguously as one ds_write_b128 —
-              same shape as global, no transpose. Reduces ~2048 ds_write_b8
-              transactions per KV iter down to ~128 ds_write_b128 transactions.
-
-            Tight buffer descriptor (num_records_bytes=B*S*Hk*HEAD_DIM) makes
-            hardware return 0 for OOB lanes past tensor end. For inner-batch
-            tail rows that overflow into a neighbouring batch the score mask
-            pins P=0 for those columns, so 0 * (whatever V byte) = 0 in the
-            PV MFMA. sage_quant outputs are NaN-free, so no NaN propagation.
-
-            buf_off: byte offset into lds_v selecting the ping-pong V buffer.
-            """
-            if const_expr(_dma_v):
-                _coop_load_v_dma(tile_start, buf_off)
-                return
-            for batch in range_constexpr(NUM_BATCHES_V):
-                row_offset = batch * ROWS_PER_BATCH_V
-                row_idx_raw = tile_start + load_row_v_batch + row_offset
-                if const_expr(V_NEEDS_GUARD):
-                    row_valid = load_row_v_batch < fx.Index(BLOCK_N)
-                    do_load = row_valid
-                else:
-                    do_load = True
-                if do_load:
-                    if const_expr(V_TRANSPOSED and not _is_gfx950_kv):
-                        # Quant output is [B,H,D,S]. Each lane owns one d-row
-                        # and loads 16 consecutive K positions, matching the
-                        d_idx = tid % fx.Index(HEAD_DIM)
-                        k_group = tid // fx.Index(HEAD_DIM)
-                        tile_idx = tile_start // fx.Index(BLOCK_N)
-                        g_byte_idx = (
-                            ((batch_idx * NUM_KV_HEADS + head_kv_idx) * num_k_blocks_per_head + tile_idx)
-                            * fx.Index(HEAD_DIM)
-                            + d_idx
-                        ) * fx.Index(BLOCK_N) + k_group * fx.Index(16)
-                        g_dword_i32 = arith.unwrap(arith.index_cast(T.i32, _raw(g_byte_idx >> fx.Index(2))))
-                        v4i32 = buffer_ops.buffer_load(v_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
-                        raw_v = vector.bitcast(v16i8_type, v4i32)
-                        v_off = buf_off + d_idx * V_STRIDE + k_group * fx.Index(16)
-                        Vec(raw_v).store(lds_v, [v_off])
-                    else:
-                        g_idx = kv_global_idx(row_idx_raw, load_col_v_base)
-                        g_dword_i32 = arith.unwrap(arith.index_cast(T.i32, _raw(g_idx >> fx.Index(2))))
-                        v4i32 = buffer_ops.buffer_load(v_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
-                        raw_v = vector.bitcast(v16i8_type, v4i32)
-
-                        if const_expr(_is_gfx950_kv):
-                            lds_row = load_row_v_batch + row_offset
-                            v_off = buf_off + lds_row * V_STRIDE + load_col_v_base
-                            Vec(raw_v).store(lds_v, [v_off])
-                        else:
-                            lds_col = load_row_v_batch + row_offset
-                            for di in range_constexpr(VEC_WIDTH_V):
-                                d_idx = load_col_v_base + di
-                                v_off = buf_off + d_idx * V_STRIDE + lds_col
-                                b_i8 = vector.extract(raw_v, static_position=[di], dynamic_position=[])
-                                Vec.from_elements([b_i8], fx.Int8).store(lds_v, [v_off])
-
-        def load_k_frag(kv_block_row, ks, buf_off):
-            """Load K fragment from LDS for QK MFMA.
-
-            gfx950 / gfx942-legacy32: v4i32 (=16xi8) for mfma_i32_32x32x32_i8.
-            gfx942 w256: i64 (=8xi8) for mfma_i32_32x32x16_i8.
-            """
-            if const_expr(_dma_xor):
-                # Inverse of the write-side permute: QK wants global 16-B chunk
-                # g = ks*2 + klane of this kv row; it physically lives at chunk
-                # g ^ (row & (CHUNKS_PER_ROW-1)) in the packed LDS tile.
-                _CPR_K = HEAD_DIM // VEC_WIDTH_K
-                _XMASK_K = _CPR_K - 1
-                if const_expr(_GFX942_W256):
-                    g_chunk = fx.Index(ks)
-                    phys_chunk = ArithValue(g_chunk) ^ (ArithValue(kv_block_row) & fx.Index(_XMASK_K))
-                    k_col = fx.Index(phys_chunk) * fx.Index(VEC_WIDTH_K) + klane * fx.Index(8)
-                else:
-                    g_chunk = fx.Index(ks * 2) + klane  # 16-B chunk QK needs
-                    phys_chunk = ArithValue(g_chunk) ^ (ArithValue(kv_block_row) & fx.Index(_XMASK_K))
-                    k_col = fx.Index(phys_chunk) * fx.Index(VEC_WIDTH_K)
-            else:
-                if const_expr(_GFX942_W256):
-                    k_col = fx.Index(ks * MFMA_K_INT8) + klane * 8
-                else:
-                    k_col = fx.Index(ks * MFMA_K_INT8) + klane * 16
-            lds_idx = buf_off + fx.Index(kv_block_row * K_STRIDE) + k_col
-            if const_expr(_GFX942_W256):
-                v8i8 = Vec.load(v8i8_type, lds, [lds_idx])
-                k_i64v = vector.bitcast(Vec.make_type(1, fx.Int64), v8i8)
-                return vector.extract(k_i64v, static_position=[0], dynamic_position=[])
-            v16i8 = Vec.load(v16i8_type, lds, [lds_idx])
-            return vector.bitcast(v4i32_type, v16i8)
-
-        def load_v_frag_fp8(pks, dc, buf_off, iter_lane_addr_i32):
-            """Load v8i32 (=32xi8 fp8) V fragment from LDS for mfma_scale_f32_32x32x64.
-
-            For lane (klane, lane32) at PV step `pks` and D chunk `dc`, the A
-            operand needs V[d=dc*32+lane32, k=pks*64+klane*32 .. +31].
-
-            gfx942 path (column-major LDS, V_STRIDE = BLOCK_N+16):
-              LDS layout has d as the row index and k_v as the column index, so
-              the 32 K-bytes per lane are 32 LDS-contiguous bytes. Issue as
-              two 16-byte vector loads (compiler lowers to 2× ds_read_b128).
-
-            gfx950 path (row-major LDS, V_STRIDE = HEAD_DIM):
-              Use 4× ds_read_tr8_b64 (CDNA4-only). Each instruction is a
-              SIMD-64 op composed of 4 independent 16-lane sub-ops; within
-              each 16-lane group the instruction does an in-tile transpose so
-              that physical lane t outputs 8 K-bytes at fixed d=base_d + (t%16).
-
-              Per-lane LDS address (verified by /tmp/probe_ds_read_tr8_b64.py
-              against the Triton emitter at MemoryOpToLLVM.cpp:140-330):
-                g       = lane // 16    # which 16-lane sub-group
-                i       = lane %  16    # output position within sub-group
-                base_kv = pks*64 + (g//2)*32 + k_idx*8     # k_idx ∈ {0,1,2,3}
-                base_d  = dc*32  + (g%2)*16
-                addr    = (base_kv + i//2) * V_STRIDE + (base_d + (i%2)*8)
-              4 calls (k_idx 0..3) per lane gather 32 contiguous K-bytes.
-
-              `iter_lane_addr_i32` (gfx950): precomputed per-iter, per-lane
-              i32 LDS address holding (lds_v_base + cur_v_off + lane-invariant
-              part). The (pks, dc, k_idx)-dependent part is added per call as
-              a compile-time literal so the AMDGPU backend folds it into
-              `ds_read offset:LIT`, eliminating per-call `v_or_b32`.
-            """
-            if const_expr(_is_gfx950):
-                lds_ptr_ty = ir.Type.parse("!llvm.ptr<3>")
-                v2i32_type = Vec.make_type(2, fx.Int32)
-
-                words = []
-                for k_idx in range_constexpr(4):
-                    # Compile-time-constant byte offset for this (pks, dc, k_idx).
-                    lit_bytes = (pks * MFMA_K_FP8 + k_idx * 8) * V_STRIDE + dc * MFMA_M
-                    addr_i32 = arith.AddIOp(
-                        iter_lane_addr_i32,
-                        arith.constant(lit_bytes, type=T.i32),
-                    ).result
-                    ptr_val = _llvm.inttoptr(lds_ptr_ty, addr_i32)
-                    v2i32 = _ods_ds_read_tr8_b64(res=v2i32_type, ptr=ptr_val).result
-                    words.append(v2i32)
-
-                # Pack 4× v2i32 → v8i32 (= 32 fp8 bytes per lane).
-                elems = []
-                for w_idx in range_constexpr(4):
-                    for sub in range_constexpr(2):
-                        elems.append(vector.extract(words[w_idx], static_position=[sub], dynamic_position=[]))
-                return Vec.from_elements(elems, fx.Int32).ir_value()
-
-            # gfx942 column-major path.
-            d_col = dc * MFMA_M + lane32
-            kv_k_start = fx.Index(pks * MFMA_K_FP8) + klane * fx.Index(MFMA_K_FP8 // 2)
-            v_off = buf_off + d_col * V_STRIDE + kv_k_start
-            if const_expr(MFMA_K_FP8 == 16):
-                v8i8 = Vec.load(v8i8_type, lds_v, [v_off])
-                v_i64v = vector.bitcast(Vec.make_type(1, fx.Int64), v8i8)
-                return vector.extract(v_i64v, static_position=[0], dynamic_position=[])
-            lo_v16i8 = Vec.load(v16i8_type, lds_v, [v_off])
-            hi_v16i8 = Vec.load(v16i8_type, lds_v, [v_off + 16])
-            lo_v4i32 = vector.bitcast(v4i32_type, lo_v16i8)
-            hi_v4i32 = vector.bitcast(v4i32_type, hi_v16i8)
-            elems = []
-            for w in range_constexpr(4):
-                elems.append(vector.extract(lo_v4i32, static_position=[w], dynamic_position=[]))
-            for w in range_constexpr(4):
-                elems.append(vector.extract(hi_v4i32, static_position=[w], dynamic_position=[]))
-            return Vec.from_elements(elems, fx.Int32).ir_value()
-
-        def f32_to_bf16_trunc(f32_raw):
-            """Bitwise f32 → bf16 truncation (upper 16 bits)."""
-            i32_val = arith.BitcastOp(T.i32, f32_raw).result
-            i16_val = arith.TruncIOp(
-                T.i16,
-                arith.ShRUIOp(i32_val, arith.constant(16, type=T.i32)).result,
-            ).result
-            return arith.BitcastOp(T.bf16, i16_val).result
-
-        # ---- Main loop: iterate over KV tiles ----
-        # Stage III: 2-stage software pipeline.
-        #   Prologue: prefetch KV block 0 into buffer 0.
-        #   Iter i:   barrier; if not last, prefetch block (i+1) into buf (i+1)%2;
-        #             then QK MFMA + softmax + PV MFMA on buf (i%2).
-        # Buffer parity is carried as a loop-state i32 (0 or 1) to keep the LDS
-        # offset on the fast scalar-broadcast path (no integer division by
-        # BLOCK_N inside the hot loop).
-        K_BUF1_OFF = fx.Index(LDS_K_BYTES)
-        V_BUF1_OFF = fx.Index(LDS_V_BYTES)
-        ZERO_INDEX = fx.Index(0)
-
-        def _buf_off(buf_idx_i32, stride_index):
-            """buf_idx ∈ {0,1} → byte offset in {0, stride}, returned as fx.Index."""
-            is_one = ArithValue(fx.Int32(buf_idx_i32) == fx.Int32(1))
-            return fx.Index(is_one.select(stride_index, ZERO_INDEX))
-
-        # Per-lane V LDS base address (gfx950 fast path): hoist the lane-
-        # invariant component once so per-iter ds_reads only need to ADD
-        # cur_v_off and a compile-time literal for (pks, dc, k_idx). This
-        # eliminates the per-ds_read `v_or_b32 vXX, s4, vYY` pattern that
-        # accounted for ~33 instr/iter vs Triton.
-        if const_expr(_is_gfx950):
-            from flydsl.expr.utils.arith import ArithValue as _AV
-
-            _g = lane // fx.Index(16)
-            _i = lane % fx.Index(16)
-            _klane_g = _g // fx.Index(2)
-            _d_group = _g % fx.Index(2)
-            _row_off_within = _i // fx.Index(2)
-            _col_extra_within = (_i % fx.Index(2)) * fx.Index(8)
-            _per_lane_v_inv = (
-                (_klane_g * fx.Index(32) + _row_off_within) * fx.Index(V_STRIDE)
-                + _d_group * fx.Index(16)
-                + _col_extra_within
-            )
-            _lds_v_base = _memref.extract_aligned_pointer_as_index(_llvm_value(lds_v))
-            _v_lane_base_index = _AV(_lds_v_base) + _per_lane_v_inv
-            v_lane_base_i32 = arith.unwrap(arith.index_cast(T.i32, _v_lane_base_index))
-
-        # ===== Straight QK→softmax→PV per iter (Attack #3 2026-05-11) =====
-        # Cross-iter softmax pipelining was tried and added scf.for yield
-        # pressure for p_words+corr (16 i32 + 1 f32 across the boundary)
-        # without a measured win at long-S vs Triton. Triton uses straight
-        # QK→softmax→PV per iter and wins. Restoring that simpler structure
-        # to (a) shrink loop-carried state by ~17 vregs and (b) let the JIT
-        # scheduler interleave softmax VALU into PV MFMA shadow naturally
-        # within a single iter rather than across the yield boundary.
-        N_SUBTILES = BLOCK_N // MFMA_N
-        ELEMS_PER_TILE = 16
-        NUM_S_VALS = N_SUBTILES * ELEMS_PER_TILE
-
-        # Hoist constants used by the softmax helper from inside-loop scope.
-        klane_i32 = fx.Int32(klane)
-        klane_off_i32 = klane_i32 * fx.Int32(4)
-        seq_len_k_i32 = fx.Int32(seq_len_k_v)
-
-        def _i32_pair_to_i64(lo, hi):
-            lo64 = arith.extui(T.i64, _raw(lo))
-            hi64 = arith.shli(
-                arith.extui(T.i64, _raw(hi)),
-                arith.constant(32, type=T.i64),
-            )
-            return arith.ori(lo64, hi64)
-
-        def _gather_p_i64_from_pwords(p_words_2d, pks):
-            """Gather 8 fp8 bytes (i64 B operand) for mfma_f32_32x32x16_fp8."""
-            width_i32 = arith.constant(64, type=T.i32)
-            words = []
-            for j in range_constexpr(2):
-                selected = None
-                for k in range_constexpr(2):
-                    k_pos = pks * MFMA_K_FP8 + k * 8 + j * 4
-                    st = k_pos // MFMA_N
-                    rem = k_pos % MFMA_N
-                    sk = (rem // 4) % 2
-                    w_idx = rem // 8
-                    xor_off = arith.constant((k ^ sk) * MFMA_M, type=T.i32)
-                    w_cand = fx.Int32(p_words_2d[st][w_idx]).shuffle_xor(xor_off, width_i32)
-                    if k == 0:
-                        selected = w_cand
-                    else:
-                        is_k = arith.cmpi(
-                            arith.CmpIPredicate.eq,
-                            klane_i32,
-                            arith.constant(k, type=T.i32),
-                        )
-                        selected = ArithValue(is_k).select(w_cand, selected)
-                words.append(selected)
-            return _i32_pair_to_i64(words[0], words[1])
-
-        def _emit_qk_softmax_pquant(kv_block_start_arg, k_buf_off_arg, m_in, l_in):
-            """Emit QK MFMA + scale + mask + softmax + p-quant for the KV tile
-            at kv_block_start_arg, using K loaded into LDS at k_buf_off_arg.
-
-            Returns (m_new, l_new, corr, p_words_2d) — IR values.
-            """
-            # 1) QK MFMA
-            s_accs_loc = [_raw(c_zero_v16i32) for _ in range(N_SUBTILES)]
-            for ks in range_constexpr(K_STEPS_QK):
-                for st in range_constexpr(N_SUBTILES):
-                    kv_row_loc = lane32 + st * MFMA_N
-                    k_frag = load_k_frag(kv_row_loc, ks, k_buf_off_arg)
-                    if const_expr(_GFX942_W256):
-                        s_accs_loc[st] = mfma_i32_k32(
-                            v16i32_type,
-                            [k_frag, q_packs[ks], s_accs_loc[st], 0, 0, 0],
-                        )
-                    else:
-                        s_accs_loc[st] = mfma_i32_k32(
-                            v16i32_type,
-                            [k_frag, q_packs[ks], s_accs_loc[st], 0, 0, 0],
-                        )
-
-            # 2) Scale (descale-index clamp for the last-iter OOB tile).
-            # "Gate the scale": when _DEFER_SCALE, carry RAW f32 scores and fold
-            # the (strictly positive, amax-based) descale into the softmax exp as
-            # one FMA per element — max commutes with a positive scale, so
-            # max(scale*s)==scale*max(s). This dissolves the 32 per-element
-            # `v_pk_mul_f32` the eager scale emits, the dominant non-exp VALU in
-            # this VALU-bound loop. Deferral wins on non-causal and on causal
-            # block_m<=128, but REGRESSES causal+block_m=256 (the big-tile MFMA
-            # shadow + per-element mask compute already hide the eager muls, so
-            # deferral only adds a serial post-reduction scale on the exp critical
-            # path). Gated accordingly at build time — a per-shape branch.
-            kv_tile_idx_loc = kv_block_start_arg // BLOCK_N
-            max_kv_tile = num_k_blocks_per_head - fx.Index(1)
-            kv_tile_safe = fx.Index(
-                ArithValue(kv_tile_idx_loc < num_k_blocks_per_head).select(kv_tile_idx_loc, max_kv_tile)
-            )
-            k_descale_base_loc = (
-                batch_idx * NUM_KV_HEADS * num_k_blocks_per_head + head_kv_idx * num_k_blocks_per_head + kv_tile_safe
-            )
-            k_ds_loc = fx.Float32(_load_ptr_f32(kds_ptr, k_descale_base_loc))
-            qk_scale_loc = _fmul(q_ds, k_ds_loc)
-            s_f32_loc = []
-            if const_expr(_DEFER_SCALE):
-                for st in range_constexpr(N_SUBTILES):
-                    s_f32_vec = Vec(s_accs_loc[st]).to(fx.Float32)
-                    for elem in range_constexpr(ELEMS_PER_TILE):
-                        s_f32_loc.append(s_f32_vec[elem])
-            else:
-                qk_scale_v16_loc = Vec.from_elements([qk_scale_loc], fx.Float32).broadcast_to(16)
-                for st in range_constexpr(N_SUBTILES):
-                    s_f32_vec = Vec(s_accs_loc[st]).to(fx.Float32)
-                    s_scaled_vec = Vec(arith.mulf(s_f32_vec, qk_scale_v16_loc, fastmath=fm_fast))
-                    for elem in range_constexpr(ELEMS_PER_TILE):
-                        s_f32_loc.append(s_scaled_vec[elem])
-
-            # SmoothQ correction is constant for every Q row in a Q block.
-            # This code only exists in the use_bias=True specialization; the
-            # ordinary Sage kernel retains its original score loop.
-            if const_expr(use_bias):
-                s_biased = list(s_f32_loc)
-                bias_base = (
-                    (batch_idx * NUM_Q_HEADS + head_q_idx) * q_scale_num_blocks + q_scale_tile_idx
-                ) * seq_len_k_v
-                # Every score column is shared by 32 output rows in the wave.
-                # Load one bias per lane, then broadcast it from the lane whose
-                # id equals the column within this 64-wide KV tile. This keeps
-                # scalar alignment and the exact column mapping while replacing
-                # 32 duplicate global loads per bias with readlane shuffles.
-                bias_col = kv_block_start_arg + lane
-                bias_col_safe = fx.Index(ArithValue(bias_col < seq_len_k_v).select(bias_col, fx.Index(0)))
-                bias_lane = fx.Float32(_load_ptr_f32(bias_ptr, bias_base + bias_col_safe))
-                for st in range_constexpr(N_SUBTILES):
-                    for elem in range_constexpr(ELEMS_PER_TILE):
-                        idx = st * ELEMS_PER_TILE + elem
-                        msub = elem // 4
-                        erem = elem % 4
-                        bias_src_lane = fx.Index(st * MFMA_N + msub * 8 + erem) + klane * 4
-                        bias = _bpermute_f32(bias_lane, bias_src_lane)
-                        s_biased[idx] = _fadd(s_biased[idx], bias)
-                s_f32_loc = s_biased
-
-            # 3) Mask
-            kv_start_i32_loc = fx.Int32(arith.unwrap(arith.index_cast(T.i32, _raw(kv_block_start_arg))))
-            if const_expr(CAUSAL):
-                s_named = list(s_f32_loc)
-                for st in range_constexpr(N_SUBTILES):
-                    for elem in range_constexpr(ELEMS_PER_TILE):
-                        idx = st * ELEMS_PER_TILE + elem
-                        msub = elem // 4
-                        erem = elem % 4
-                        kv_col_i32 = (
-                            kv_start_i32_loc
-                            + fx.Int32(st * MFMA_N)
-                            + fx.Int32(msub * 8)
-                            + klane_off_i32
-                            + fx.Int32(erem)
-                        )
-                        out_of_range = ArithValue(kv_col_i32 >= seq_len_k_i32)
-                        out_of_range = out_of_range | ArithValue(kv_col_i32 > q_row_i32)
-                        s_named[idx] = out_of_range.select(c_neg_inf, s_named[idx])
-                s_f32_loc = s_named
-            else:
-                tile_end = kv_block_start_arg + fx.Index(BLOCK_N)
-                tile_oob_av = ArithValue(tile_end > seq_len_k_v)
-                cond_i1 = _raw(tile_oob_av)
-                f32_ty = ir.F32Type.get()
-                result_types = [f32_ty] * NUM_S_VALS
-                if_op = _scf.IfOp(
-                    cond_i1,
-                    result_types,
-                    has_else=True,
-                    loc=ir.Location.unknown(),
-                )
-                with ir.InsertionPoint(if_op.then_block):
-                    _llvm.inline_asm(
-                        None,
-                        [],
-                        "",
-                        "",
-                        has_side_effects=True,
-                    )
-                    masked = []
-                    for st in range_constexpr(N_SUBTILES):
-                        for elem in range_constexpr(ELEMS_PER_TILE):
-                            idx = st * ELEMS_PER_TILE + elem
-                            msub = elem // 4
-                            erem = elem % 4
-                            kv_col_i32 = (
-                                kv_start_i32_loc
-                                + fx.Int32(st * MFMA_N)
-                                + fx.Int32(msub * 8)
-                                + klane_off_i32
-                                + fx.Int32(erem)
-                            )
-                            out_of_range = ArithValue(kv_col_i32 >= seq_len_k_i32)
-                            masked.append(_raw(out_of_range.select(c_neg_inf, s_f32_loc[idx])))
-                    _scf.YieldOp(masked)
-                with ir.InsertionPoint(if_op.else_block):
-                    _scf.YieldOp([_raw(v) for v in s_f32_loc])
-                s_f32_loc = list(if_op.results)
-
-            # 4) Softmax. When deferring, the running max/corr stay in SCALED
-            # space (the descale varies per KV-tile, so cross-tile comparison
-            # must be post-scale): max over RAW scores, scale the single reduced
-            # row-max by qk_scale (one scalar mul vs 32 per-element), and fold
-            # the scale into each exp argument as one FMA (scale*s_raw - m_new).
-            # When not deferring, scores are already scaled (section 2).
-            local_max_l = s_f32_loc[0]
-            for r in range_constexpr(NUM_S_VALS - 1):
-                local_max_l = _fmax(local_max_l, s_f32_loc[r + 1])
-            row_max_l = row_max_reduce(local_max_l)
-            if const_expr(_DEFER_SCALE):
-                row_max_l = _fmul(row_max_l, qk_scale_loc)
-            m_new_l = _fmax(m_in, row_max_l)
-            diff_m_l = _fsub(m_in, m_new_l)
-            corr_l = rocdl.exp2(ir.F32Type.get(), _raw(diff_m_l))
-            neg_max_l = _fsub(c_zero_f, m_new_l)
-            p_vals_l = []
-            local_sum_l = _raw(c_zero_f)
-            for r in range_constexpr(NUM_S_VALS):
-                if const_expr(_DEFER_SCALE):
-                    diff = _ffma(s_f32_loc[r], qk_scale_loc, neg_max_l)
-                else:
-                    diff = _fadd(s_f32_loc[r], neg_max_l)
-                p = rocdl.exp2(ir.F32Type.get(), _raw(diff))
-                p_vals_l.append(p)
-                local_sum_l = _fadd(local_sum_l, p)
-            tile_sum_l = row_sum_reduce(local_sum_l)
-            l_new_l = _fadd(_fmul(corr_l, l_in), tile_sum_l)
-
-            # 5) P-quant → p_words[st][w] : i32
-            c0_i32_l = arith.constant(0, type=T.i32)
-            p_words_l = []
-            for st in range_constexpr(N_SUBTILES):
-                sub = []
-                for w in range_constexpr(4):
-                    s0 = _raw(p_vals_l[st * ELEMS_PER_TILE + w * 4 + 0])
-                    s1 = _raw(p_vals_l[st * ELEMS_PER_TILE + w * 4 + 1])
-                    s2 = _raw(p_vals_l[st * ELEMS_PER_TILE + w * 4 + 2])
-                    s3 = _raw(p_vals_l[st * ELEMS_PER_TILE + w * 4 + 3])
-                    packed = c0_i32_l
-                    packed = rocdl.cvt_pk_fp8_f32(T.i32, s0, s1, packed, 0)
-                    packed = rocdl.cvt_pk_fp8_f32(T.i32, s2, s3, packed, 1)
-                    sub.append(packed)
-                p_words_l.append(sub)
-            return m_new_l, l_new_l, corr_l, p_words_l
-
-        def _run_pv_mfma(p_words, cur_v_off, o_accs, v_iter_lane_addr_i32):
-            if const_expr(_GFX942_W256):
-                for pks in range_constexpr(PV_K_STEPS):
-                    p_i64 = _gather_p_i64_from_pwords(p_words, pks)
-                    for dc in range_constexpr(D_CHUNKS):
-                        v_i64 = load_v_frag_fp8(pks, dc, cur_v_off, v_iter_lane_addr_i32)
-                        o_accs[dc] = mfma_fp8_k16(
-                            v16f32_type,
-                            [v_i64, p_i64, o_accs[dc], 0, 0, 0],
-                        )
-            else:
-                from flydsl._mlir.dialects._rocdl_ops_gen import (
-                    permlane32_swap as _permlane32_swap_op,
-                )
-
-                _struct_ty_2xi32 = ir.Type.parse("!llvm.struct<(i32, i32)>")
-                for pks in range_constexpr(PV_K_STEPS):
-                    v8_elems = []
-                    for w in range_constexpr(4):
-                        a_w = _raw(p_words[pks * 2][w])
-                        b_w = _raw(p_words[pks * 2 + 1][w])
-                        swapped = _permlane32_swap_op(
-                            _struct_ty_2xi32,
-                            old=a_w,
-                            src=b_w,
-                            fi=False,
-                            bound_control=True,
-                        )
-                        lo_word = _llvm.extractvalue(T.i32, swapped, [0])
-                        hi_word = _llvm.extractvalue(T.i32, swapped, [1])
-                        v8_elems.append(lo_word)
-                        v8_elems.append(hi_word)
-                    p_pack_v8i32 = Vec.from_elements(v8_elems, fx.Int32).ir_value()
-                    scale_127 = arith.constant(127, type=T.i32)
-                    for dc in range_constexpr(D_CHUNKS):
-                        v_frag = load_v_frag_fp8(pks, dc, cur_v_off, v_iter_lane_addr_i32)
-                        o_accs[dc] = mfma_fp8_k64(
-                            v16f32_type,
-                            v_frag,
-                            p_pack_v8i32,
-                            o_accs[dc],
-                            scale_127,
-                            scale_127,
-                        )
-            return o_accs
-
-        if const_expr(NUM_PIPE_STAGES == 2):
-            # ---- Prologue (pipe2) ----
-            # Prefetch buf 0 (K[0]/V[0]) AND buf 1 (K[1]/V[1] — harmless if num_iters<2;
-            # coop loaders clamp OOB rows to row 0). Then barrier; iter 0 computes
-            # softmax[0] from buf 0 in-line.
-            coop_load_k(ZERO_INDEX, ZERO_INDEX)
-            coop_load_v(ZERO_INDEX, ZERO_INDEX)
-            coop_load_k(fx.Index(BLOCK_N), K_BUF1_OFF)
-            coop_load_v(fx.Index(BLOCK_N), V_BUF1_OFF)
-            if const_expr(_need_dma_fence):
-                _dma_fence()
+        const_expr(_cache_tag)
+        _impl.setup(Q, K, V, O, Q_descale, K_descale, V_descale, Bias, batch_size, seq_len_q, seq_len_k, num_q_blocks)
+        if const_expr(_impl.t.NUM_PIPE_STAGES == 2):
+            _impl.coop_load_k(_impl.ZERO_INDEX, _impl.ZERO_INDEX)
+            _impl.coop_load_v(_impl.ZERO_INDEX, _impl.ZERO_INDEX)
+            _impl.coop_load_k(fx.Index(_impl.t.BLOCK_N), _impl.K_BUF1_OFF)
+            _impl.coop_load_v(fx.Index(_impl.t.BLOCK_N), _impl.V_BUF1_OFF)
             gpu.barrier()
-
-            # i32 0 — current buffer index for iter 0 (buf 0 holds K[0]/V[0]).
             c0_i32_init = arith.constant(0, type=T.i32)
-
-            # Iter args layout (Attack #3 — no cross-iter softmax):
-            #   [cur_buf (i32), m (f32), l (f32), *o_accs (D_CHUNKS × v16f32)]
-            init_args = [c0_i32_init, _raw(c_neg_inf), _raw(c_zero_f)]
-            for _ in range_constexpr(D_CHUNKS):
-                init_args.append(_raw(c_zero_v16f32))
-
+            init_args = [c0_i32_init, _raw(_impl.c_neg_inf), _raw(_impl.c_zero_f)]
+            for _ in range_constexpr(_impl.t.D_CHUNKS):
+                init_args.append(_raw(_impl.c_zero_v16f32))
             _OFF_CUR_BUF = 0
             _OFF_M = 1
             _OFF_L = 2
             _OFF_O_ACCS = 3
-
             loop_results = init_args
-            for kv_block_start, inner_iter_args in range(0, kv_upper, BLOCK_N, init=init_args):
+            for kv_block_start, inner_iter_args in range(0, _impl.kv_upper, _impl.t.BLOCK_N, init=init_args):
                 cur_buf_i32 = inner_iter_args[_OFF_CUR_BUF]
                 m_running = inner_iter_args[_OFF_M]
                 l_running = inner_iter_args[_OFF_L]
-                o_accs = [inner_iter_args[_OFF_O_ACCS + i] for i in range_constexpr(D_CHUNKS)]
-
-                cur_k_off = _buf_off(cur_buf_i32, K_BUF1_OFF)
-                cur_v_off = _buf_off(cur_buf_i32, V_BUF1_OFF)
-                if const_expr(_is_gfx950):
-                    cur_v_off_i32 = arith.unwrap(arith.index_cast(T.i32, cur_v_off))
-                    v_iter_lane_addr_i32 = arith.AddIOp(v_lane_base_i32, cur_v_off_i32).result
-                else:
-                    v_iter_lane_addr_i32 = None
+                o_accs = [inner_iter_args[_OFF_O_ACCS + i] for i in range_constexpr(_impl.t.D_CHUNKS)]
+                cur_k_off = _impl._buf_off(cur_buf_i32, _impl.K_BUF1_OFF)
+                cur_v_off = _impl._buf_off(cur_buf_i32, _impl.V_BUF1_OFF)
                 next_buf_i32 = arith.XOrIOp(_raw(cur_buf_i32), arith.constant(1, type=T.i32)).result
-
-                m_new, l_new, corr, p_words = _emit_qk_softmax_pquant(kv_block_start, cur_k_off, m_running, l_running)
-
+                m_new, l_new, corr, p_words = _impl._emit_qk_softmax_pquant(
+                    kv_block_start, cur_k_off, m_running, l_running
+                )
                 corr_vec16 = Vec.from_elements([corr], fx.Float32).broadcast_to(16).ir_value()
-                for dc in range_constexpr(D_CHUNKS):
-                    o_accs[dc] = _fmul(o_accs[dc], corr_vec16)
-
-                kv_block_after_next = kv_block_start + fx.Index(2 * BLOCK_N)
-                o_accs = _run_pv_mfma(p_words, cur_v_off, o_accs, v_iter_lane_addr_i32)
-                if const_expr(_need_dma_fence):
-                    _dma_fence()
+                for dc in range_constexpr(_impl.t.D_CHUNKS):
+                    o_accs[dc] = _impl._fmul(o_accs[dc], corr_vec16)
+                kv_block_after_next = kv_block_start + fx.Index(2 * _impl.t.BLOCK_N)
+                o_accs = _impl._run_pv_mfma(p_words, cur_v_off, o_accs, None)
                 gpu.barrier()
-
-                coop_load_k(kv_block_after_next, cur_k_off)
-                coop_load_v(kv_block_after_next, cur_v_off)
-
+                _impl.coop_load_k(kv_block_after_next, cur_k_off)
+                _impl.coop_load_v(kv_block_after_next, cur_v_off)
                 _yield_args = [next_buf_i32, _raw(m_new), _raw(l_new)]
-                for dc in range_constexpr(D_CHUNKS):
+                for dc in range_constexpr(_impl.t.D_CHUNKS):
                     _yield_args.append(o_accs[dc])
                 loop_results = yield _yield_args
-
             _FINAL_OFF_L = _OFF_L
             _FINAL_OFF_O_ACCS = _OFF_O_ACCS
         else:
-            # ---- Single-buffer main loop (pipe1) ----
-            init_args = [_raw(c_neg_inf), _raw(c_zero_f)]
-            for _ in range_constexpr(D_CHUNKS):
-                init_args.append(_raw(c_zero_v16f32))
-
+            init_args = [_raw(_impl.c_neg_inf), _raw(_impl.c_zero_f)]
+            for _ in range_constexpr(_impl.t.D_CHUNKS):
+                init_args.append(_raw(_impl.c_zero_v16f32))
             _OFF_M = 0
             _OFF_L = 1
             _OFF_O_ACCS = 2
-
             loop_results = init_args
-            for kv_block_start, inner_iter_args in range(0, kv_upper, BLOCK_N, init=init_args):
+            for kv_block_start, inner_iter_args in range(0, _impl.kv_upper, _impl.t.BLOCK_N, init=init_args):
                 m_running = inner_iter_args[_OFF_M]
                 l_running = inner_iter_args[_OFF_L]
-                o_accs = [inner_iter_args[_OFF_O_ACCS + i] for i in range_constexpr(D_CHUNKS)]
-
-                coop_load_k(kv_block_start, ZERO_INDEX)
-                coop_load_v(kv_block_start, ZERO_INDEX)
-                if const_expr(_need_dma_fence):
-                    _dma_fence()
+                o_accs = [inner_iter_args[_OFF_O_ACCS + i] for i in range_constexpr(_impl.t.D_CHUNKS)]
+                _impl.coop_load_k(kv_block_start, _impl.ZERO_INDEX)
+                _impl.coop_load_v(kv_block_start, _impl.ZERO_INDEX)
                 gpu.barrier()
-
-                m_new, l_new, corr, p_words = _emit_qk_softmax_pquant(kv_block_start, ZERO_INDEX, m_running, l_running)
-
+                m_new, l_new, corr, p_words = _impl._emit_qk_softmax_pquant(
+                    kv_block_start, _impl.ZERO_INDEX, m_running, l_running
+                )
                 corr_vec16 = Vec.from_elements([corr], fx.Float32).broadcast_to(16).ir_value()
-                for dc in range_constexpr(D_CHUNKS):
-                    o_accs[dc] = _fmul(o_accs[dc], corr_vec16)
-
-                o_accs = _run_pv_mfma(p_words, ZERO_INDEX, o_accs, None)
-
-                # Single-buffer WAR barrier: PV above reads K/V from LDS; the
-                # next iter's coop_load overwrites the SAME LDS buffer. Without
-                # this, fast waves clobber LDS while straggler waves (higher
-                # wave-ids) are still reading it — manifests only past ~6-8 kv
-                # iters and corrupts the upper wave-group's output rows.
+                for dc in range_constexpr(_impl.t.D_CHUNKS):
+                    o_accs[dc] = _impl._fmul(o_accs[dc], corr_vec16)
+                o_accs = _impl._run_pv_mfma(p_words, _impl.ZERO_INDEX, o_accs, None)
                 gpu.barrier()
-
                 _yield_args = [_raw(m_new), _raw(l_new)]
-                for dc in range_constexpr(D_CHUNKS):
+                for dc in range_constexpr(_impl.t.D_CHUNKS):
                     _yield_args.append(o_accs[dc])
                 loop_results = yield _yield_args
-
             _FINAL_OFF_L = _OFF_L
             _FINAL_OFF_O_ACCS = _OFF_O_ACCS
-
-        # ---- Normalize and store O ----
-        l_final = loop_results[_FINAL_OFF_L]
-        o_finals = [loop_results[_FINAL_OFF_O_ACCS + dc] for dc in range_constexpr(D_CHUNKS)]
-
-        inv_l = arith.divf(_raw(c_one_f), _raw(l_final), fastmath=fm_fast)
-        # No FP8_MAX compensation needed: P-quant casts P∈[0,1] directly without
-        # the FP8_MAX pre-scale (matches Triton).
-        inv_l_fp8 = _raw(inv_l)
-
-        if q_in_bounds:
-            # MFMA 32x32 C/D layout (wave64): lane (klane, lane32) holds 16 f32
-            # outputs covering 16 distinct M positions (d positions in PV output)
-            # at one fixed N position = lane32 (= q_row within wave).
-            # Vector index i ∈ 0..15:
-            #   d_offset = (i // 4) * 8 + klane * 4 + (i % 4)
-            # Each group of 4 consecutive i (i.e. msub=0..3) gives 4 contiguous
-            # d positions, so we can do 4 v4bf16 stores per dc instead of 16
-            # scalar stores.
-
-            for dc in range_constexpr(D_CHUNKS):
-                for msub in range_constexpr(4):
-                    d_col_base = fx.Index(dc * MFMA_M) + fx.Index(msub * 8) + klane * 4
-                    v_ds_vec = Vec(
-                        _load_ptr_f32_vec4(
-                            vds_ptr,
-                            v_descale_base + fx.Index(dc * MFMA_M) + fx.Index(msub * 8) + klane * 4,
-                        )
-                    )
-                    bf16_elems = []
-                    for erem in range_constexpr(4):
-                        i_pos = msub * 4 + erem
-                        v_ds = v_ds_vec[erem]
-                        o_elem = vector.extract(o_finals[dc], static_position=[i_pos], dynamic_position=[])
-                        scale = arith.mulf(_raw(inv_l_fp8), _raw(v_ds), fastmath=fm_fast)
-                        o_norm = arith.mulf(o_elem, scale, fastmath=fm_fast)
-                        bf16_elems.append(f32_to_bf16_trunc(o_norm))
-                    o_vec = Vec.from_elements(bf16_elems, fx.BFloat16).ir_value()
-                    o_global = q_global_idx(q_row, d_col_base)
-                    _store_ptr_bf16(o_ptr, o_global, o_vec)
+        if _impl.q_in_bounds:
+            _impl.write_output(loop_results, _FINAL_OFF_L, _FINAL_OFF_O_ACCS)
 
     @flyc.jit
     def launch_sage_attn(
@@ -1586,34 +1160,19 @@ def build_sage_attn_cdna_module(
         ctx = CompilationContext.get_current()
         with ir.InsertionPoint(ctx.gpu_module_body):
             allocator.finalize()
-
         bs_idx = fx.Index(batch_size)
         slq_idx = fx.Index(seq_len_q)
         num_q_tiles = (slq_idx + BLOCK_M - 1) // BLOCK_M
         grid_x = bs_idx * num_q_tiles * NUM_Q_HEADS
-
         launcher = sage_attn_kernel(
-            Q,
-            K,
-            V,
-            O,
-            Q_descale,
-            K_descale,
-            V_descale,
-            Bias,
-            batch_size,
-            seq_len_q,
-            seq_len_k,
-            num_q_blocks,
+            Q, K, V, O, Q_descale, K_descale, V_descale, Bias, batch_size, seq_len_q, seq_len_k, num_q_blocks
         )
-
         if const_expr(waves_per_eu is not None):
             _wpe = int(waves_per_eu)
             if const_expr(_wpe >= 1):
                 for op in ctx.gpu_module_body.operations:
                     if const_expr(getattr(op, "OPERATION_NAME", None) == "gpu.func"):
                         op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(T.i32, _wpe)
-
         if const_expr(flat_work_group_size is not None):
             _fwgs = int(flat_work_group_size)
             if const_expr(_fwgs >= 1):
@@ -1621,37 +1180,22 @@ def build_sage_attn_cdna_module(
                 for op in ctx.gpu_module_body.operations:
                     if const_expr(getattr(op, "OPERATION_NAME", None) == "gpu.func"):
                         op.attributes["rocdl.flat_work_group_size"] = flat_wg_attr
-
         passthrough_entries = []
         if const_expr(daz):
             passthrough_entries.append(
                 ir.ArrayAttr.get(
-                    [
-                        ir.StringAttr.get("denormal-fp-math-f32"),
-                        ir.StringAttr.get("preserve-sign,preserve-sign"),
-                    ]
+                    [ir.StringAttr.get("denormal-fp-math-f32"), ir.StringAttr.get("preserve-sign,preserve-sign")]
                 )
             )
             passthrough_entries.append(
-                ir.ArrayAttr.get(
-                    [
-                        ir.StringAttr.get("no-nans-fp-math"),
-                        ir.StringAttr.get("true"),
-                    ]
-                )
+                ir.ArrayAttr.get([ir.StringAttr.get("no-nans-fp-math"), ir.StringAttr.get("true")])
             )
             passthrough_entries.append(
-                ir.ArrayAttr.get(
-                    [
-                        ir.StringAttr.get("unsafe-fp-math"),
-                        ir.StringAttr.get("true"),
-                    ]
-                )
+                ir.ArrayAttr.get([ir.StringAttr.get("unsafe-fp-math"), ir.StringAttr.get("true")])
             )
         for op in ctx.gpu_module_body.operations:
             if const_expr(getattr(op, "OPERATION_NAME", None) == "gpu.func"):
                 op.attributes["passthrough"] = ir.ArrayAttr.get(passthrough_entries)
-
         launcher.launch(grid=(grid_x, 1, 1), block=(BLOCK_SIZE, 1, 1), stream=stream)
 
     _compile_hints = {
@@ -1677,7 +1221,7 @@ def build_sage_attn_cdna_module(
         seq_len_q,
         seq_len_k,
         num_q_blocks,
-        stream=None,
+        stream=None,  # noqa: E741
     ):
         with CompilationContext.compile_hints(_compile_hints):
             return flyc.compile(

--- a/kernels/attention/sage_attn_helpers.py
+++ b/kernels/attention/sage_attn_helpers.py
@@ -1,0 +1,1006 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""SageAttention CDNA helpers: traits, context, loaders, GEMM, softmax, store."""
+
+import os
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import fly
+from flydsl._mlir.dialects import llvm as _llvm
+from flydsl._mlir.dialects import memref as _memref
+from flydsl._mlir.dialects._rocdl_ops_gen import (
+    mfma_f32_32x32x16_fp8_fp8 as _ods_mfma_f32_32x32x16_fp8_fp8,
+)
+from flydsl._mlir.dialects._rocdl_ops_gen import (
+    mfma_i32_32x32x16_i8 as _ods_mfma_i32_32x32x16_i8,
+)
+from flydsl.expr import arith, buffer_ops, const_expr, gpu, math, range_constexpr, rocdl
+from flydsl.expr.typing import T
+from flydsl.expr.typing import Vector as Vec
+from flydsl.expr.utils.arith import _to_raw as _raw
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+from kernels.attention.sage_attn_utils import (
+    _LDS_CAP_BYTES,
+    _extract_aligned_pointer,
+    _f32_to_bf16_trunc,
+    _i32_pair_to_i64,
+    _lds_vec_load,
+    _lds_vec_store,
+    _lds_vec_store_elem,
+    _pointer_load,
+)
+from kernels.common.kernels_common import get_warp_size
+
+
+def _llvm_value(value):
+    if hasattr(value, "ir_value") and not isinstance(value, ir.Value):
+        return value.ir_value()
+    return value
+
+
+class _SageTraits:
+    """Compile-time constants for one SageAttention CDNA launch config."""
+
+    def __init__(
+        self,
+        *,
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_SIZE,
+        CAUSAL,
+        D_CHUNKS,
+        GROUPS,
+        HEAD_DIM,
+        KV_STRIDE_TOKEN,
+        K_NEEDS_GUARD,
+        K_STEPS_QK,
+        K_STRIDE,
+        LDS_K_BYTES,
+        LDS_K_TOTAL_BYTES,
+        LDS_V_BYTES,
+        LDS_V_TOTAL_BYTES,
+        MFMA_K_FP8,
+        MFMA_K_INT8,
+        MFMA_M,
+        MFMA_N,
+        NUM_BATCHES_K,
+        NUM_BATCHES_V,
+        NUM_KV_HEADS,
+        NUM_PIPE_STAGES,
+        NUM_Q_HEADS,
+        PV_K_STEPS,
+        Q_SCALE_BLOCK_M,
+        ROWS_PER_BATCH_K,
+        ROWS_PER_BATCH_V,
+        ROWS_PER_WAVE,
+        STRIDE_TOKEN,
+        THREADS_PER_ROW_K,
+        THREADS_PER_ROW_V,
+        VEC_WIDTH_K,
+        VEC_WIDTH_V,
+        V_NEEDS_GUARD,
+        V_STRIDE,
+        V_TRANSPOSED,
+        WARP_SIZE,
+        _DEFER_SCALE,
+        _LPT_SCHED,
+        _dma_any,
+        _dma_k,
+        _dma_xor,
+        lds_base_offset,
+        use_bias,
+    ):
+        """Store all launch-config constants as attributes."""
+        self.BLOCK_M = BLOCK_M
+        self.BLOCK_N = BLOCK_N
+        self.BLOCK_SIZE = BLOCK_SIZE
+        self.CAUSAL = CAUSAL
+        self.D_CHUNKS = D_CHUNKS
+        self.GROUPS = GROUPS
+        self.HEAD_DIM = HEAD_DIM
+        self.KV_STRIDE_TOKEN = KV_STRIDE_TOKEN
+        self.K_NEEDS_GUARD = K_NEEDS_GUARD
+        self.K_STEPS_QK = K_STEPS_QK
+        self.K_STRIDE = K_STRIDE
+        self.LDS_K_BYTES = LDS_K_BYTES
+        self.LDS_K_TOTAL_BYTES = LDS_K_TOTAL_BYTES
+        self.LDS_V_BYTES = LDS_V_BYTES
+        self.LDS_V_TOTAL_BYTES = LDS_V_TOTAL_BYTES
+        self.MFMA_K_FP8 = MFMA_K_FP8
+        self.MFMA_K_INT8 = MFMA_K_INT8
+        self.MFMA_M = MFMA_M
+        self.MFMA_N = MFMA_N
+        self.NUM_BATCHES_K = NUM_BATCHES_K
+        self.NUM_BATCHES_V = NUM_BATCHES_V
+        self.NUM_KV_HEADS = NUM_KV_HEADS
+        self.NUM_PIPE_STAGES = NUM_PIPE_STAGES
+        self.NUM_Q_HEADS = NUM_Q_HEADS
+        self.PV_K_STEPS = PV_K_STEPS
+        self.Q_SCALE_BLOCK_M = Q_SCALE_BLOCK_M
+        self.ROWS_PER_BATCH_K = ROWS_PER_BATCH_K
+        self.ROWS_PER_BATCH_V = ROWS_PER_BATCH_V
+        self.ROWS_PER_WAVE = ROWS_PER_WAVE
+        self.STRIDE_TOKEN = STRIDE_TOKEN
+        self.THREADS_PER_ROW_K = THREADS_PER_ROW_K
+        self.THREADS_PER_ROW_V = THREADS_PER_ROW_V
+        self.VEC_WIDTH_K = VEC_WIDTH_K
+        self.VEC_WIDTH_V = VEC_WIDTH_V
+        self.V_NEEDS_GUARD = V_NEEDS_GUARD
+        self.V_STRIDE = V_STRIDE
+        self.V_TRANSPOSED = V_TRANSPOSED
+        self.WARP_SIZE = WARP_SIZE
+        self._DEFER_SCALE = _DEFER_SCALE
+        self._LPT_SCHED = _LPT_SCHED
+        self._dma_any = _dma_any
+        self._dma_k = _dma_k
+        self._dma_xor = _dma_xor
+        self.lds_base_offset = lds_base_offset
+        self.use_bias = use_bias
+
+
+class _SageKernel:
+    """SageAttention CDNA emitter: helpers, prologue, epilogue.
+
+    Methods read kernel SSA off ``self`` and constants off ``self.t``.
+    """
+
+    def __init__(self, t, allocator):
+        """Bind config traits and the shared-memory allocator."""
+        self.t = t
+        self.allocator = allocator
+
+    def mfma_i32_k16(self, result_type, operands):
+        a, b, c = operands[:3]
+        cbsz = operands[3] if len(operands) > 3 else 0
+        abid = operands[4] if len(operands) > 4 else 0
+        blgp = operands[5] if len(operands) > 5 else 0
+        return _ods_mfma_i32_32x32x16_i8(
+            res=result_type,
+            a=_llvm_value(a),
+            b=_llvm_value(b),
+            c=_llvm_value(c),
+            cbsz=cbsz,
+            abid=abid,
+            blgp=blgp,
+        ).result
+
+    def mfma_fp8_k16(self, result_type, operands):
+        a, b, c = (operands[0], operands[1], operands[2])
+        cbsz = operands[3] if len(operands) > 3 else 0
+        abid = operands[4] if len(operands) > 4 else 0
+        blgp = operands[5] if len(operands) > 5 else 0
+        a_v = _llvm_value(a)
+        b_v = _llvm_value(b)
+        c_v = _llvm_value(c)
+        return _ods_mfma_f32_32x32x16_fp8_fp8(
+            res=result_type, a=a_v, b=b_v, c=c_v, cbsz=cbsz, abid=abid, blgp=blgp
+        ).result
+
+    def _fadd(self, a, b):
+        return arith.addf(_raw(a), _raw(b), fastmath=self.fm_fast)
+
+    def _fsub(self, a, b):
+        return arith.subf(_raw(a), _raw(b), fastmath=self.fm_fast)
+
+    def _fmul(self, a, b):
+        return arith.mulf(_raw(a), _raw(b), fastmath=self.fm_fast)
+
+    def _fmax(self, a, b):
+        return arith.MaxNumFOp(_raw(a), _raw(b), fastmath=self.fm_fast).result
+
+    def _ffma(self, a, b, c):
+        return math.fma(_raw(a), _raw(b), _raw(c), fastmath=self.fm_fast)
+
+    def _fdiv(self, a, b):
+        return arith.divf(_raw(a), _raw(b), fastmath=self.fm_fast)
+
+    def q_global_idx(self, token_idx, col):
+        token = self.batch_idx * self.seq_len_q_v + token_idx
+        return token * self.t.STRIDE_TOKEN + self.head_q_idx * self.t.HEAD_DIM + col
+
+    def kv_global_idx(self, token_idx, col):
+        token = self.batch_idx * self.seq_len_k_v + token_idx
+        return token * self.t.KV_STRIDE_TOKEN + self.head_kv_idx * self.t.HEAD_DIM + col
+
+    def _load_gm_i64(self, div, elem_idx):
+        v8i8 = fly.copy_atom_call_ssa([self.v8i8_type], self.load_atom_64_i8, fx.slice(div, (None, fx.Int32(elem_idx))))
+        return fx.Vector(v8i8).bitcast(fx.Int64)[0]
+
+    def _load_ptr_f32(self, ptr, base_idx):
+        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.f32)
+        return _pointer_load(T.f32, gep)
+
+    def _load_ptr_f32_vec4(self, ptr, base_idx):
+        gep = buffer_ops.get_element_ptr(ptr, fx.Int64(base_idx), elem_type=T.f32)
+        return _pointer_load(self.v4f32_type, gep)
+
+    def _store_gm_bf16x4(self, div, elem_idx, bf16_vec):
+        pack = Vec(bf16_vec).bitcast(fx.Int32)
+        fx.memref_store_vec(pack, self.o_store_reg)
+        fx.copy(self.store_atom_64, self.o_store_reg, fx.slice(div, (None, fx.Int32(elem_idx))))
+
+    def _bpermute_f32(self, value, src_lane):
+        value_i32 = arith.bitcast(T.i32, _raw(value))
+        lane_byte_idx = fx.Int32(src_lane * 4)
+        result_i32 = rocdl.ds_bpermute(T.i32, _raw(lane_byte_idx), value_i32)
+        return arith.bitcast(T.f32, result_i32)
+
+    def reduction_peer32(self, v_f32):
+        return fx.Float32(v_f32).shuffle_xor(self.shuf32_i32, self.width_i32)
+
+    def row_max_reduce(self, local_max):
+        """Reduce max across the 2 klane halves within wave64."""
+        return self._fmax(local_max, self.reduction_peer32(local_max))
+
+    def row_sum_reduce(self, local_sum):
+        """Reduce sum across the 2 klane halves within wave64."""
+        return self._fadd(local_sum, self.reduction_peer32(local_sum))
+
+    def _coop_load_k_dma(self, tile_start, buf_off):
+        assert not self.t.K_NEEDS_GUARD, "K DMA path requires ROWS_PER_BATCH_K<=BLOCK_N"
+        DMA_BYTES_K = self.t.VEC_WIDTH_K
+        buf_off_i64 = fx.Int64(buf_off).ir_value()
+        wave_byte = rocdl.readfirstlane(T.i64, fx.Int64(self.wave_id * (self.t.WARP_SIZE * DMA_BYTES_K)).ir_value())
+        base_ptr = self._lds_as3_base(self.lds)
+        base_ptr = buffer_ops.get_element_ptr(base_ptr, buf_off_i64)
+        base_ptr = buffer_ops.get_element_ptr(base_ptr, wave_byte)
+        size_i32 = fx.Int32(DMA_BYTES_K).ir_value()
+        c0 = fx.Int32(0).ir_value()
+        aux1 = fx.Int32(1).ir_value()
+        _CPR_K = self.t.HEAD_DIM // self.t.VEC_WIDTH_K
+        _XMASK_K = _CPR_K - 1
+        for batch in range_constexpr(self.t.NUM_BATCHES_K):
+            row_offset = batch * self.t.ROWS_PER_BATCH_K
+            row_idx_raw = tile_start + self.load_row_k_batch + row_offset
+            if const_expr(self.t._dma_xor):
+                tile_row = self.load_row_k_batch + row_offset
+                phys_chunk = self.load_lane_k
+                g_chunk = fx.Int64(phys_chunk) ^ fx.Int64(tile_row) & fx.Int64(_XMASK_K)
+                g_col = g_chunk * self.t.VEC_WIDTH_K
+                g_idx = self.kv_global_idx(row_idx_raw, g_col)
+            else:
+                g_idx = self.kv_global_idx(row_idx_raw, self.load_col_k_base)
+            voff = fx.Int32(g_idx).ir_value()
+            if const_expr(batch == 0):
+                lds_ptr = base_ptr
+            else:
+                lds_ptr = buffer_ops.get_element_ptr(
+                    base_ptr, static_byte_offset=batch * self.t.BLOCK_SIZE * DMA_BYTES_K
+                )
+            rocdl.raw_ptr_buffer_load_lds(self.k_rsrc, lds_ptr, size_i32, voff, c0, c0, aux1)
+
+    def coop_load_k(self, tile_start, buf_off):
+        tile_start = fx.Int64(tile_start)
+        if const_expr(self.t._dma_k):
+            self._coop_load_k_dma(tile_start, buf_off)
+            return
+        for batch in range_constexpr(self.t.NUM_BATCHES_K):
+            row_offset = batch * self.t.ROWS_PER_BATCH_K
+            row_idx_raw = tile_start + self.load_row_k_batch + row_offset
+            if const_expr(self.t.K_NEEDS_GUARD):
+                row_valid = self.load_row_k_batch < self.t.BLOCK_N
+                do_load = row_valid
+            else:
+                do_load = True
+            if do_load:
+                g_idx = self.kv_global_idx(row_idx_raw, self.load_col_k_base)
+                lds_row = self.load_row_k_batch + row_offset
+                lds_idx = buf_off + lds_row * self.t.K_STRIDE + self.load_col_k_base
+                v4i32 = fly.copy_atom_call_ssa(
+                    [self.v4i32_type], self.load_atom_128, fx.slice(self.k_div, (None, fx.Int32(g_idx)))
+                )
+                vec = fx.Vector(v4i32).bitcast(fx.Int8)
+                _lds_vec_store(vec, self.lds, lds_idx)
+
+    def coop_load_v(self, tile_start, buf_off):
+        """Cooperatively load V (FP8 raw bytes) from global into LDS (gfx942 column-major)."""
+        tile_start = fx.Int64(tile_start)
+        for batch in range_constexpr(self.t.NUM_BATCHES_V):
+            row_offset = batch * self.t.ROWS_PER_BATCH_V
+            row_idx_raw = tile_start + self.load_row_v_batch + row_offset
+            if const_expr(self.t.V_NEEDS_GUARD):
+                row_valid = self.load_row_v_batch < self.t.BLOCK_N
+                do_load = row_valid
+            else:
+                do_load = True
+            if do_load:
+                if const_expr(self.t.V_TRANSPOSED):
+                    d_idx = self.tid % self.t.HEAD_DIM
+                    k_group = self.tid // self.t.HEAD_DIM
+                    tile_idx = tile_start // self.t.BLOCK_N
+                    g_byte_idx = (
+                        (
+                            (self.batch_idx * self.t.NUM_KV_HEADS + self.head_kv_idx) * self.num_k_blocks_per_head
+                            + tile_idx
+                        )
+                        * self.t.HEAD_DIM
+                        + d_idx
+                    ) * self.t.BLOCK_N + k_group * 16
+                    g_dword_i32 = fx.Int32(g_byte_idx >> 2).ir_value()
+                    v4i32 = buffer_ops.buffer_load(self.v_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
+                    raw_v = fx.Vector(v4i32).bitcast(fx.Int8)
+                    v_off = buf_off + d_idx * self.t.V_STRIDE + k_group * 16
+                    _lds_vec_store(raw_v, self.lds_v, v_off)
+                else:
+                    g_idx = self.kv_global_idx(row_idx_raw, self.load_col_v_base)
+                    g_dword_i32 = fx.Int32(g_idx >> 2).ir_value()
+                    v4i32 = buffer_ops.buffer_load(self.v_rsrc, g_dword_i32, vec_width=4, dtype=T.i32)
+                    raw_v = fx.Vector(v4i32).bitcast(fx.Int8)
+                    lds_col = self.load_row_v_batch + row_offset
+                    for di in range_constexpr(self.t.VEC_WIDTH_V):
+                        d_idx = self.load_col_v_base + di
+                        v_off = buf_off + d_idx * self.t.V_STRIDE + lds_col
+                        b_i8 = fx.Vector(raw_v)[di]
+                        _lds_vec_store_elem(b_i8, self.lds_v, v_off, fx.Int8)
+
+    def load_k_frag(self, kv_block_row, ks, buf_off):
+        """Load K fragment from LDS for the QK MFMA."""
+        if const_expr(self.t._dma_xor):
+            _CPR_K = self.t.HEAD_DIM // self.t.VEC_WIDTH_K
+            _XMASK_K = _CPR_K - 1
+            g_chunk = fx.Int64(ks)
+            phys_chunk = g_chunk ^ fx.Int64(kv_block_row) & fx.Int64(_XMASK_K)
+            k_col = phys_chunk * self.t.VEC_WIDTH_K + self.klane * 8
+        else:
+            k_col = fx.Int64(ks * self.t.MFMA_K_INT8) + self.klane * 8
+        lds_idx = buf_off + kv_block_row * self.t.K_STRIDE + k_col
+        v8i8 = _lds_vec_load(self.v8i8_type, self.lds, lds_idx)
+        k_i64v = fx.Vector(v8i8).bitcast(fx.Int64)
+        return fx.Vector(k_i64v)[0]
+
+    def load_v_frag_fp8(self, pks, dc, buf_off):
+        """Load a V fragment (FP8) from LDS for the PV MFMA."""
+        d_col = dc * self.t.MFMA_M + self.lane32
+        kv_k_start = fx.Int64(pks * self.t.MFMA_K_FP8) + self.klane * (self.t.MFMA_K_FP8 // 2)
+        v_off = buf_off + d_col * self.t.V_STRIDE + kv_k_start
+        v8i8 = _lds_vec_load(self.v8i8_type, self.lds_v, v_off)
+        v_i64v = fx.Vector(v8i8).bitcast(fx.Int64)
+        return fx.Vector(v_i64v)[0]
+
+    def f32_to_bf16_trunc(self, f32_raw):
+        """Bitwise f32 → bf16 truncation (upper 16 bits)."""
+        return _f32_to_bf16_trunc(f32_raw)
+
+    def _buf_off(self, buf_idx_i32, stride_index):
+        """Return byte offset zero or stride for the selected pipeline buffer."""
+        is_one = fx.Int32(buf_idx_i32) == 1
+        return fx.Int64(is_one.select(stride_index, self.ZERO_INDEX))
+
+    def _gather_p_i64_from_pwords(self, p_words_2d, pks):
+        """Gather 8 fp8 bytes (i64 B operand) for mfma_f32_32x32x16_fp8."""
+        width_i32 = fx.Int32(64).ir_value()
+        words = []
+        for j in range_constexpr(2):
+            selected = None
+            for k in range_constexpr(2):
+                k_pos = pks * self.t.MFMA_K_FP8 + k * 8 + j * 4
+                st = k_pos // self.t.MFMA_N
+                rem = k_pos % self.t.MFMA_N
+                sk = rem // 4 % 2
+                w_idx = rem // 8
+                xor_off = fx.Int32((k ^ sk) * self.t.MFMA_M).ir_value()
+                w_cand = fx.Int32(p_words_2d[st][w_idx]).shuffle_xor(xor_off, width_i32)
+                if k == 0:
+                    selected = w_cand
+                else:
+                    is_k = self.klane_i32 == k
+                    selected = is_k.select(w_cand, selected)
+            words.append(selected)
+        return _i32_pair_to_i64(words[0], words[1])
+
+    def _emit_qk_softmax_pquant(self, kv_block_start_arg, k_buf_off_arg, m_in, l_in):
+        """Emit QK MFMA + scale + mask + online softmax + P-quant for one KV tile.
+        Returns (m_new, l_new, corr, p_words_2d) as IR values.
+        """
+        kv_block_start_arg = fx.Int64(kv_block_start_arg)
+        s_accs_loc = [_raw(self.c_zero_v16i32) for _ in range(self.N_SUBTILES)]
+        for ks in range_constexpr(self.t.K_STEPS_QK):
+            for st in range_constexpr(self.N_SUBTILES):
+                kv_row_loc = self.lane32 + st * self.t.MFMA_N
+                k_frag = self.load_k_frag(kv_row_loc, ks, k_buf_off_arg)
+                s_accs_loc[st] = self.mfma_i32_k16(
+                    self.v16i32_type, [k_frag, self.q_packs[ks], s_accs_loc[st], 0, 0, 0]
+                )
+        kv_tile_idx_loc = kv_block_start_arg // self.t.BLOCK_N
+        max_kv_tile = self.num_k_blocks_per_head - 1
+        kv_tile_safe = (kv_tile_idx_loc < self.num_k_blocks_per_head).select(kv_tile_idx_loc, max_kv_tile)
+        k_descale_base_loc = (
+            self.batch_idx * self.t.NUM_KV_HEADS * self.num_k_blocks_per_head
+            + self.head_kv_idx * self.num_k_blocks_per_head
+            + kv_tile_safe
+        )
+        k_ds_loc = fx.Float32(self._load_ptr_f32(self.kds_ptr, k_descale_base_loc))
+        qk_scale_loc = self._fmul(self.q_ds, k_ds_loc)
+        s_f32_loc = []
+        if const_expr(self.t._DEFER_SCALE):
+            for st in range_constexpr(self.N_SUBTILES):
+                s_f32_vec = Vec(s_accs_loc[st]).to(fx.Float32)
+                for elem in range_constexpr(self.ELEMS_PER_TILE):
+                    s_f32_loc.append(s_f32_vec[elem])
+        else:
+            qk_scale_v16_loc = Vec.from_elements([qk_scale_loc], fx.Float32).broadcast_to(16)
+            for st in range_constexpr(self.N_SUBTILES):
+                s_f32_vec = Vec(s_accs_loc[st]).to(fx.Float32)
+                s_scaled_vec = Vec(arith.mulf(s_f32_vec, qk_scale_v16_loc, fastmath=self.fm_fast))
+                for elem in range_constexpr(self.ELEMS_PER_TILE):
+                    s_f32_loc.append(s_scaled_vec[elem])
+        if const_expr(self.t.use_bias):
+            s_biased = list(s_f32_loc)
+            bias_base = (
+                (self.batch_idx * self.t.NUM_Q_HEADS + self.head_q_idx) * self.q_scale_num_blocks
+                + self.q_scale_tile_idx
+            ) * self.seq_len_k_v
+            bias_col = kv_block_start_arg + self.lane
+            bias_col_safe = (bias_col < self.seq_len_k_v).select(bias_col, fx.Int64(0))
+            bias_lane = fx.Float32(self._load_ptr_f32(self.bias_ptr, bias_base + bias_col_safe))
+            for st in range_constexpr(self.N_SUBTILES):
+                for elem in range_constexpr(self.ELEMS_PER_TILE):
+                    idx = st * self.ELEMS_PER_TILE + elem
+                    msub = elem // 4
+                    erem = elem % 4
+                    bias_src_lane = fx.Int64(st * self.t.MFMA_N + msub * 8 + erem) + self.klane * 4
+                    bias = self._bpermute_f32(bias_lane, bias_src_lane)
+                    s_biased[idx] = self._fadd(s_biased[idx], bias)
+            s_f32_loc = s_biased
+        kv_start_i32_loc = fx.Int32(kv_block_start_arg)
+        if const_expr(self.t.CAUSAL):
+            s_named = list(s_f32_loc)
+            for st in range_constexpr(self.N_SUBTILES):
+                for elem in range_constexpr(self.ELEMS_PER_TILE):
+                    idx = st * self.ELEMS_PER_TILE + elem
+                    msub = elem // 4
+                    erem = elem % 4
+                    kv_col_i32 = (
+                        kv_start_i32_loc
+                        + fx.Int32(st * self.t.MFMA_N)
+                        + fx.Int32(msub * 8)
+                        + self.klane_off_i32
+                        + fx.Int32(erem)
+                    )
+                    out_of_range = kv_col_i32 >= self.seq_len_k_i32
+                    out_of_range = out_of_range | (kv_col_i32 > self.q_row_i32)
+                    s_named[idx] = out_of_range.select(self.c_neg_inf, s_named[idx])
+            s_f32_loc = s_named
+        else:
+            tile_end = kv_block_start_arg + self.t.BLOCK_N
+            tile_oob = tile_end > self.seq_len_k_v
+            s_base = s_f32_loc
+
+            def _mask_oob_values():
+                _llvm.inline_asm(None, [], "", "", has_side_effects=True)
+                masked = []
+                for st in range_constexpr(self.N_SUBTILES):
+                    for elem in range_constexpr(self.ELEMS_PER_TILE):
+                        idx = st * self.ELEMS_PER_TILE + elem
+                        msub = elem // 4
+                        erem = elem % 4
+                        kv_col_i32 = (
+                            kv_start_i32_loc
+                            + fx.Int32(st * self.t.MFMA_N)
+                            + fx.Int32(msub * 8)
+                            + self.klane_off_i32
+                            + fx.Int32(erem)
+                        )
+                        out_of_range = kv_col_i32 >= self.seq_len_k_i32
+                        masked.append(_raw(out_of_range.select(self.c_neg_inf, s_base[idx])))
+                return masked
+
+            @flyc.jit
+            def _apply_seq_mask():
+                if tile_oob:
+                    return _mask_oob_values()
+                return [_raw(v) for v in s_base]
+
+            s_f32_loc = list(_apply_seq_mask())
+        local_max_l = s_f32_loc[0]
+        for r in range_constexpr(self.NUM_S_VALS - 1):
+            local_max_l = self._fmax(local_max_l, s_f32_loc[r + 1])
+        row_max_l = self.row_max_reduce(local_max_l)
+        if const_expr(self.t._DEFER_SCALE):
+            row_max_l = self._fmul(row_max_l, qk_scale_loc)
+        m_new_l = self._fmax(m_in, row_max_l)
+        diff_m_l = self._fsub(m_in, m_new_l)
+        corr_l = rocdl.exp2(ir.F32Type.get(), _raw(diff_m_l))
+        neg_max_l = self._fsub(self.c_zero_f, m_new_l)
+        p_vals_l = []
+        local_sum_l = _raw(self.c_zero_f)
+        for r in range_constexpr(self.NUM_S_VALS):
+            if const_expr(self.t._DEFER_SCALE):
+                diff = self._ffma(s_f32_loc[r], qk_scale_loc, neg_max_l)
+            else:
+                diff = self._fadd(s_f32_loc[r], neg_max_l)
+            p = rocdl.exp2(ir.F32Type.get(), _raw(diff))
+            p_vals_l.append(p)
+            local_sum_l = self._fadd(local_sum_l, p)
+        tile_sum_l = self.row_sum_reduce(local_sum_l)
+        l_new_l = self._fadd(self._fmul(corr_l, l_in), tile_sum_l)
+        c0_i32_l = fx.Int32(0).ir_value()
+        p_words_l = []
+        for st in range_constexpr(self.N_SUBTILES):
+            sub = []
+            for w in range_constexpr(4):
+                s0 = _raw(p_vals_l[st * self.ELEMS_PER_TILE + w * 4 + 0])
+                s1 = _raw(p_vals_l[st * self.ELEMS_PER_TILE + w * 4 + 1])
+                s2 = _raw(p_vals_l[st * self.ELEMS_PER_TILE + w * 4 + 2])
+                s3 = _raw(p_vals_l[st * self.ELEMS_PER_TILE + w * 4 + 3])
+                packed = c0_i32_l
+                packed = rocdl.cvt_pk_fp8_f32(T.i32, s0, s1, packed, 0)
+                packed = rocdl.cvt_pk_fp8_f32(T.i32, s2, s3, packed, 1)
+                sub.append(packed)
+            p_words_l.append(sub)
+        return (m_new_l, l_new_l, corr_l, p_words_l)
+
+    def _run_pv_mfma(self, p_words, cur_v_off, o_accs):
+        for pks in range_constexpr(self.t.PV_K_STEPS):
+            p_i64 = self._gather_p_i64_from_pwords(p_words, pks)
+            for dc in range_constexpr(self.t.D_CHUNKS):
+                v_i64 = self.load_v_frag_fp8(pks, dc, cur_v_off)
+                o_accs[dc] = self.mfma_fp8_k16(self.v16f32_type, [v_i64, p_i64, o_accs[dc], 0, 0, 0])
+        return o_accs
+
+    def _lds_as3_base(self, lds_view):
+        base_idx = _memref.extract_aligned_pointer_as_index(_llvm_value(lds_view))
+        base_i64 = fx.Int64(base_idx).ir_value()
+        return buffer_ops.create_llvm_ptr(base_i64, address_space=3)
+
+    def setup(
+        self,
+        Q,
+        K,
+        V,
+        O,  # noqa: E741
+        Q_descale,
+        K_descale,
+        V_descale,
+        Bias,
+        batch_size,
+        seq_len_q,
+        seq_len_k,
+        num_q_blocks,
+    ):
+        """Emit kernel prologue: pointers, LDS, tile indices, Q packs, constants."""
+        self.fm_fast = arith.FastMathFlags.fast
+        self.q_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(Q), fx.make_layout(1, 1))
+        self.o_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(O), fx.make_layout(1, 1))
+        qds_ptr = _extract_aligned_pointer(Q_descale)
+        self.kds_ptr = _extract_aligned_pointer(K_descale)
+        self.vds_ptr = _extract_aligned_pointer(V_descale)
+        if const_expr(self.t.use_bias):
+            self.bias_ptr = _extract_aligned_pointer(Bias)
+        bs_v_for_rsrc = fx.Int64(batch_size)
+        slk_v_for_rsrc = fx.Int64(seq_len_k)
+        num_k_blocks_for_rsrc = (slk_v_for_rsrc + self.t.BLOCK_N - 1) // self.t.BLOCK_N
+        kv_total_bytes = bs_v_for_rsrc * slk_v_for_rsrc * (self.t.NUM_KV_HEADS * self.t.HEAD_DIM)
+        v_total_bytes = (
+            bs_v_for_rsrc * (self.t.NUM_KV_HEADS * self.t.HEAD_DIM) * num_k_blocks_for_rsrc * self.t.BLOCK_N
+            if self.t.V_TRANSPOSED
+            else kv_total_bytes
+        )
+        self.k_rsrc = buffer_ops.create_buffer_resource(K, max_size=False, num_records_bytes=kv_total_bytes)
+        self.v_rsrc = buffer_ops.create_buffer_resource(V, max_size=False, num_records_bytes=v_total_bytes)
+        self.k_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(K), fx.make_layout(1, 1))
+        self.load_atom_64_i8 = fx.make_copy_atom(fx.rocdl.BufferCopy64b(), fx.Int8)
+        self.load_atom_128 = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Int32)
+        self.store_atom_64 = fx.make_copy_atom(fx.rocdl.BufferCopy64b(), fx.Int32)
+        register_as = int(fx.AddressSpace.Register)
+        self.o_store_reg_ty = fx.MemRefType.get(T.i32, fx.LayoutType.get(2, 1), register_as)
+        self.o_store_reg_lay = fx.make_layout(2, 1)
+        self.o_store_reg = fx.memref_alloca(self.o_store_reg_ty, self.o_store_reg_lay)
+        self.v4i32_type = Vec.make_type(4, fx.Int32)
+        self.v16i32_type = Vec.make_type(16, fx.Int32)
+        self.v16f32_type = Vec.make_type(16, fx.Float32)
+        self.v4f32_type = Vec.make_type(4, fx.Float32)
+        self.v8i8_type = Vec.make_type(8, fx.Int8)
+        self.seq_len_q_v = fx.Int64(seq_len_q)
+        self.seq_len_k_v = fx.Int64(seq_len_k)
+        base_ptr = self.allocator.get_base()
+        self.lds = SmemPtr(base_ptr, self.t.lds_base_offset, T.i8, shape=(self.t.LDS_K_TOTAL_BYTES,)).get()
+        self.lds_v = SmemPtr(
+            base_ptr, self.t.lds_base_offset + self.t.LDS_K_TOTAL_BYTES, T.i8, shape=(self.t.LDS_V_TOTAL_BYTES,)
+        ).get()
+        block_id = fx.Int64(gpu.block_idx.x)
+        self.tid = fx.Int64(gpu.thread_idx.x)
+        self.wave_id = self.tid // self.t.WARP_SIZE
+        self.lane = self.tid % self.t.WARP_SIZE
+        self.lane32 = self.lane % self.t.MFMA_M
+        self.klane = self.lane // self.t.MFMA_M
+        wave_q_offset = self.wave_id * self.t.ROWS_PER_WAVE
+        self.head_q_idx = block_id % self.t.NUM_Q_HEADS
+        batch_q_tile_id = block_id // self.t.NUM_Q_HEADS
+        num_q_tiles = (self.seq_len_q_v + self.t.BLOCK_M - 1) // self.t.BLOCK_M
+        q_tile_raw = batch_q_tile_id % num_q_tiles
+        self.batch_idx = batch_q_tile_id // num_q_tiles
+        if const_expr(self.t._LPT_SCHED):
+            q_tile_idx = num_q_tiles - 1 - q_tile_raw
+        else:
+            q_tile_idx = q_tile_raw
+        q_start = q_tile_idx * self.t.BLOCK_M
+        self.head_kv_idx = self.head_q_idx // self.t.GROUPS
+        self.load_row_k_batch = self.tid // self.t.THREADS_PER_ROW_K
+        self.load_lane_k = self.tid % self.t.THREADS_PER_ROW_K
+        self.load_col_k_base = self.load_lane_k * self.t.VEC_WIDTH_K
+        self.load_row_v_batch = self.tid // self.t.THREADS_PER_ROW_V
+        load_lane_v = self.tid % self.t.THREADS_PER_ROW_V
+        self.load_col_v_base = load_lane_v * self.t.VEC_WIDTH_V
+        self.q_row = q_start + wave_q_offset + self.lane32
+        self.q_row_i32 = fx.Int32(self.q_row)
+        self.q_in_bounds = self.q_row < self.seq_len_q_v
+        q_row_safe = self.q_in_bounds.select(self.q_row, fx.Int64(0))
+        c_zero_i64 = fx.Int64(0)
+        self.q_packs = []
+        for ks in range_constexpr(self.t.K_STEPS_QK):
+            q_col = fx.Int64(ks * self.t.MFMA_K_INT8) + self.klane * 8
+            g_idx = self.q_global_idx(q_row_safe, q_col)
+            half = fx.Int64(self._load_gm_i64(self.q_div, g_idx))
+            self.q_packs.append(self.q_in_bounds.select(half, c_zero_i64))
+        self.num_k_blocks_per_head = (self.seq_len_k_v + self.t.BLOCK_N - 1) // self.t.BLOCK_N
+        self.q_scale_num_blocks = fx.Int64(num_q_blocks)
+        q_scale_tile_raw = (q_start + wave_q_offset) // self.t.Q_SCALE_BLOCK_M
+        self.q_scale_tile_idx = (q_scale_tile_raw < self.q_scale_num_blocks).select(
+            q_scale_tile_raw, self.q_scale_num_blocks - 1
+        )
+        q_descale_base = (
+            self.batch_idx * self.t.NUM_Q_HEADS * self.q_scale_num_blocks
+            + self.head_q_idx * self.q_scale_num_blocks
+            + self.q_scale_tile_idx
+        )
+        self.q_ds = fx.Float32(self._load_ptr_f32(qds_ptr, q_descale_base))
+        self.v_descale_base = (self.batch_idx * self.t.NUM_KV_HEADS + self.head_kv_idx) * self.t.HEAD_DIM
+        self.c_neg_inf = fx.Float32(float("-inf"))
+        self.c_zero_f = fx.Float32(0.0)
+        self.c_one_f = fx.Float32(1.0)
+        self.c_zero_v16f32 = Vec.filled(16, 0.0, fx.Float32)
+        self.c_zero_v16i32 = Vec.filled(16, 0, fx.Int32)
+        self.shuf32_i32 = fx.Int32(32)
+        self.width_i32 = fx.Int32(self.t.WARP_SIZE)
+        _q_end = q_start + self.t.BLOCK_M
+        if const_expr(self.t.CAUSAL):
+            self.kv_upper = (_q_end < self.seq_len_k_v).select(_q_end, self.seq_len_k_v)
+        else:
+            self.kv_upper = self.seq_len_k_v
+        self.K_BUF1_OFF = fx.Int64(self.t.LDS_K_BYTES)
+        self.V_BUF1_OFF = fx.Int64(self.t.LDS_V_BYTES)
+        self.ZERO_INDEX = fx.Int64(0)
+        self.N_SUBTILES = self.t.BLOCK_N // self.t.MFMA_N
+        self.ELEMS_PER_TILE = 16
+        self.NUM_S_VALS = self.N_SUBTILES * self.ELEMS_PER_TILE
+        self.klane_i32 = fx.Int32(self.klane)
+        self.klane_off_i32 = self.klane_i32 * fx.Int32(4)
+        self.seq_len_k_i32 = fx.Int32(self.seq_len_k_v)
+
+    def write_output(self, loop_results, _FINAL_OFF_L, _FINAL_OFF_O_ACCS):
+        """Normalize accumulators by 1/l and apply V descale; store guarded by caller."""
+        l_final = loop_results[_FINAL_OFF_L]
+        o_finals = [loop_results[_FINAL_OFF_O_ACCS + dc] for dc in range_constexpr(self.t.D_CHUNKS)]
+        inv_l = self._fdiv(self.c_one_f, l_final)
+        inv_l_fp8 = _raw(inv_l)
+        for dc in range_constexpr(self.t.D_CHUNKS):
+            for msub in range_constexpr(4):
+                d_col_base = fx.Int64(dc * self.t.MFMA_M + msub * 8) + self.klane * 4
+                v_ds_vec = Vec(
+                    self._load_ptr_f32_vec4(
+                        self.vds_ptr, self.v_descale_base + dc * self.t.MFMA_M + msub * 8 + self.klane * 4
+                    )
+                )
+                bf16_elems = []
+                for erem in range_constexpr(4):
+                    i_pos = msub * 4 + erem
+                    v_ds = v_ds_vec[erem]
+                    o_elem = fx.Vector(o_finals[dc])[i_pos].ir_value()
+                    scale = self._fmul(inv_l_fp8, v_ds)
+                    o_norm = self._fmul(o_elem, scale)
+                    bf16_elems.append(self.f32_to_bf16_trunc(o_norm))
+                o_vec = Vec.from_elements(bf16_elems, fx.BFloat16).ir_value()
+                o_global = self.q_global_idx(self.q_row, d_col_base)
+                self._store_gm_bf16x4(self.o_div, o_global, o_vec)
+
+
+def _detect_gpu_name():
+    """Return the GPU marketing name (e.g. 'AMD Instinct MI308X') or ''."""
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return torch.cuda.get_device_name(0) or ""
+    except Exception:
+        pass
+    try:
+        import subprocess
+
+        out = subprocess.run(["rocminfo"], capture_output=True, text=True, timeout=10).stdout
+        for line in out.splitlines():
+            if "Marketing Name" in line and "MI" in line:
+                return line.split(":", 1)[1].strip()
+    except Exception:
+        pass
+    return ""
+
+
+def _require_mi308x(gpu_arch):
+    """Raise unless running on an AMD MI308X (gfx942); this kernel targets MI308X only."""
+    gpu_name = _detect_gpu_name()
+    is_gfx942 = isinstance(gpu_arch, str) and gpu_arch.startswith("gfx942")
+    is_mi308x = "MI308" in gpu_name.upper()
+    if not (is_gfx942 and is_mi308x):
+        raise RuntimeError(
+            f"SageAttention CDNA kernel supports only AMD MI308X (gfx942); "
+            f"got arch={gpu_arch!r} name={gpu_name!r}. Other hardware is not supported."
+        )
+
+
+def _make_sage_launch_config(
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    causal=False,
+    block_m=None,
+    block_n=None,
+    flat_work_group_size=None,
+    use_bias=False,
+    v_transposed: bool = False,
+    bias_block_m: int | None = None,
+    path_tag: str = "auto",
+):
+    """Compute traits, allocator, tags, and launch dimensions for one kernel build."""
+    gpu_arch = get_hip_arch()
+    _require_mi308x(gpu_arch)
+    WARP_SIZE = get_warp_size(gpu_arch)
+    MFMA_M = 32
+    MFMA_N = 32
+    path_tag = f"{path_tag}_w256"
+    MFMA_K_INT8 = 16
+    MFMA_K_FP8 = 16
+    ROWS_PER_WAVE = MFMA_M
+    BLOCK_M = block_m if block_m is not None else 256
+    BLOCK_N = block_n if block_n is not None else 128
+    Q_SCALE_BLOCK_M = bias_block_m if bias_block_m is not None else BLOCK_M
+    V_TRANSPOSED = bool(v_transposed)
+    NUM_WAVES = BLOCK_M // ROWS_PER_WAVE
+    if flat_work_group_size is None:
+        flat_work_group_size = NUM_WAVES * WARP_SIZE
+    BLOCK_SIZE = flat_work_group_size
+    K_STEPS_QK = head_dim // MFMA_K_INT8
+    D_CHUNK = MFMA_N
+    D_CHUNKS = head_dim // D_CHUNK
+    PV_K_STEPS = BLOCK_N // MFMA_K_FP8
+    assert head_dim % MFMA_K_INT8 == 0, f"head_dim {head_dim} must be divisible by {MFMA_K_INT8}"
+    assert BLOCK_M % ROWS_PER_WAVE == 0
+    assert BLOCK_N % MFMA_K_FP8 == 0
+    NUM_Q_HEADS = num_q_heads
+    NUM_KV_HEADS = num_kv_heads
+    HEAD_DIM = head_dim
+    CAUSAL = causal
+    GROUPS = num_q_heads // num_kv_heads
+    STRIDE_TOKEN = NUM_Q_HEADS * HEAD_DIM
+    KV_STRIDE_TOKEN = NUM_KV_HEADS * HEAD_DIM
+    _dma_env = os.environ.get("SAGE_LDS_DMA", "auto")
+    if _dma_env == "auto":
+        _dma_env = "0"
+    _dma_k = _dma_env in ("1", "k", "kv")
+    _dma_any = _dma_k
+    _cpr_k_host = head_dim // 16
+    _cpr_k_is_p2 = _cpr_k_host > 0 and _cpr_k_host & _cpr_k_host - 1 == 0
+    _dma_xor = _dma_any and _cpr_k_is_p2 and (os.environ.get("SAGE_LDS_DMA_XOR", "1") not in ("0", ""))
+    if const_expr(_dma_any):
+        path_tag = f"{path_tag}_dma{_dma_env}" + ("x" if _dma_xor else "")
+    _defer_env = os.environ.get("SAGE_DEFER_SCALE", "auto")
+    if _defer_env in ("0", ""):
+        _DEFER_SCALE = False
+    elif _defer_env == "force":
+        _DEFER_SCALE = True
+    else:
+        _DEFER_SCALE = not CAUSAL or BLOCK_M <= 128
+    if use_bias:
+        _DEFER_SCALE = False
+    if const_expr(_DEFER_SCALE):
+        path_tag = f"{path_tag}_ds"
+    _lpt_env = os.environ.get("SAGE_LPT_SCHED", "auto")
+    _LPT_SCHED = _lpt_env not in ("0", "")
+    if const_expr(_LPT_SCHED):
+        path_tag = f"{path_tag}_lpt"
+    path_tag = f"{path_tag}_{'causal' if CAUSAL else 'nc'}"
+    _default_lds_pad = "8" if V_TRANSPOSED else "4"
+    _LDS_PAD = int(os.environ.get("SAGE_LDS_PAD", _default_lds_pad))
+    if _LDS_PAD < 0 or _LDS_PAD % 4 != 0:
+        raise ValueError("SAGE_LDS_PAD must be a non-negative multiple of 4")
+    path_tag = f"{path_tag}_pad{_LDS_PAD}"
+    if const_expr(_dma_k):
+        K_STRIDE = HEAD_DIM
+    else:
+        K_STRIDE = HEAD_DIM + _LDS_PAD
+    V_STRIDE = BLOCK_N + _LDS_PAD
+    VEC_WIDTH_K = 16
+    VEC_WIDTH_V = 16
+    THREADS_PER_ROW_K = HEAD_DIM // VEC_WIDTH_K
+    THREADS_PER_ROW_V = HEAD_DIM // VEC_WIDTH_V
+    ROWS_PER_BATCH_K = BLOCK_SIZE // THREADS_PER_ROW_K
+    ROWS_PER_BATCH_V = BLOCK_SIZE // THREADS_PER_ROW_V
+    if ROWS_PER_BATCH_K >= BLOCK_N:
+        NUM_BATCHES_K = 1
+        K_NEEDS_GUARD = ROWS_PER_BATCH_K > BLOCK_N
+    else:
+        NUM_BATCHES_K = BLOCK_N // ROWS_PER_BATCH_K
+        K_NEEDS_GUARD = False
+    if V_TRANSPOSED:
+        NUM_BATCHES_V = 1
+        V_NEEDS_GUARD = False
+    elif ROWS_PER_BATCH_V >= BLOCK_N:
+        NUM_BATCHES_V = 1
+        V_NEEDS_GUARD = ROWS_PER_BATCH_V > BLOCK_N
+    else:
+        NUM_BATCHES_V = BLOCK_N // ROWS_PER_BATCH_V
+        V_NEEDS_GUARD = False
+    LDS_K_BYTES = BLOCK_N * K_STRIDE * 1
+    LDS_V_BYTES = HEAD_DIM * V_STRIDE * 1
+    _pipe_env = os.environ.get("SAGE_PIPE_STAGES", "2")
+    NUM_PIPE_STAGES = 1 if _pipe_env in ("0", "1") else 2
+    LDS_K_TOTAL_BYTES = LDS_K_BYTES * NUM_PIPE_STAGES
+    LDS_V_TOTAL_BYTES = LDS_V_BYTES * NUM_PIPE_STAGES
+    LDS_TOTAL_BYTES = LDS_K_TOTAL_BYTES + LDS_V_TOTAL_BYTES
+    if NUM_PIPE_STAGES == 2 and LDS_TOTAL_BYTES > _LDS_CAP_BYTES:
+        NUM_PIPE_STAGES = 1
+        LDS_K_TOTAL_BYTES = LDS_K_BYTES
+        LDS_V_TOTAL_BYTES = LDS_V_BYTES
+        LDS_TOTAL_BYTES = LDS_K_TOTAL_BYTES + LDS_V_TOTAL_BYTES
+    if NUM_PIPE_STAGES == 2:
+        path_tag = f"{path_tag}_pipe2"
+    else:
+        path_tag = f"{path_tag}_pipe1"
+    LDS_TOTAL_I8_ELEMS = LDS_TOTAL_BYTES
+    allocator = SmemAllocator(
+        None, arch=gpu_arch, global_sym_name=f"sage_attn_cdna_smem_M{BLOCK_M}N{BLOCK_N}_{path_tag}"
+    )
+    lds_base_offset = allocator._align(allocator.ptr, 16)
+    allocator.ptr = lds_base_offset + LDS_TOTAL_I8_ELEMS
+
+    t = _SageTraits(
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_SIZE=BLOCK_SIZE,
+        CAUSAL=CAUSAL,
+        D_CHUNKS=D_CHUNKS,
+        GROUPS=GROUPS,
+        HEAD_DIM=HEAD_DIM,
+        KV_STRIDE_TOKEN=KV_STRIDE_TOKEN,
+        K_NEEDS_GUARD=K_NEEDS_GUARD,
+        K_STEPS_QK=K_STEPS_QK,
+        K_STRIDE=K_STRIDE,
+        LDS_K_BYTES=LDS_K_BYTES,
+        LDS_K_TOTAL_BYTES=LDS_K_TOTAL_BYTES,
+        LDS_V_BYTES=LDS_V_BYTES,
+        LDS_V_TOTAL_BYTES=LDS_V_TOTAL_BYTES,
+        MFMA_K_FP8=MFMA_K_FP8,
+        MFMA_K_INT8=MFMA_K_INT8,
+        MFMA_M=MFMA_M,
+        MFMA_N=MFMA_N,
+        NUM_BATCHES_K=NUM_BATCHES_K,
+        NUM_BATCHES_V=NUM_BATCHES_V,
+        NUM_KV_HEADS=NUM_KV_HEADS,
+        NUM_PIPE_STAGES=NUM_PIPE_STAGES,
+        NUM_Q_HEADS=NUM_Q_HEADS,
+        PV_K_STEPS=PV_K_STEPS,
+        Q_SCALE_BLOCK_M=Q_SCALE_BLOCK_M,
+        ROWS_PER_BATCH_K=ROWS_PER_BATCH_K,
+        ROWS_PER_BATCH_V=ROWS_PER_BATCH_V,
+        ROWS_PER_WAVE=ROWS_PER_WAVE,
+        STRIDE_TOKEN=STRIDE_TOKEN,
+        THREADS_PER_ROW_K=THREADS_PER_ROW_K,
+        THREADS_PER_ROW_V=THREADS_PER_ROW_V,
+        VEC_WIDTH_K=VEC_WIDTH_K,
+        VEC_WIDTH_V=VEC_WIDTH_V,
+        V_NEEDS_GUARD=V_NEEDS_GUARD,
+        V_STRIDE=V_STRIDE,
+        V_TRANSPOSED=V_TRANSPOSED,
+        WARP_SIZE=WARP_SIZE,
+        _DEFER_SCALE=_DEFER_SCALE,
+        _LPT_SCHED=_LPT_SCHED,
+        _dma_any=_dma_any,
+        _dma_k=_dma_k,
+        _dma_xor=_dma_xor,
+        lds_base_offset=lds_base_offset,
+        use_bias=use_bias,
+    )
+    _cache_tag = (
+        gpu_arch,
+        BLOCK_M,
+        BLOCK_N,
+        CAUSAL,
+        HEAD_DIM,
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        _DEFER_SCALE,
+        _LPT_SCHED,
+        _dma_k,
+        _dma_xor,
+        V_TRANSPOSED,
+        use_bias,
+        NUM_PIPE_STAGES,
+        path_tag,
+    )
+    return dict(
+        t=t,
+        allocator=allocator,
+        path_tag=path_tag,
+        cache_tag=_cache_tag,
+        gpu_arch=gpu_arch,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_SIZE=BLOCK_SIZE,
+        NUM_Q_HEADS=NUM_Q_HEADS,
+    )
+
+
+class SageKernelContext:
+    """Runtime kernel state container; helpers read/write through ``core``."""
+
+    def __init__(self, core: "_SageKernel"):
+        self.core = core
+        self.t = core.t
+
+
+class SageKLoader:
+    def __init__(self, ctx: SageKernelContext):
+        self.ctx = ctx
+
+    def coop_load_k(self, tile_start, buf_off):
+        return self.ctx.core.coop_load_k(tile_start, buf_off)
+
+
+class SageVLoader:
+    def __init__(self, ctx: SageKernelContext):
+        self.ctx = ctx
+
+    def coop_load_v(self, tile_start, buf_off):
+        return self.ctx.core.coop_load_v(tile_start, buf_off)
+
+
+class SageQKSoftmaxHelper:
+    def __init__(self, ctx: SageKernelContext):
+        self.ctx = ctx
+
+    def emit_qk_softmax_pquant(self, kv_block_start, k_buf_off, m_in, l_in):
+        return self.ctx.core._emit_qk_softmax_pquant(kv_block_start, k_buf_off, m_in, l_in)
+
+
+class SagePVGemmHelper:
+    def __init__(self, ctx: SageKernelContext):
+        self.ctx = ctx
+
+    def run_pv_mfma(self, p_words, cur_v_off, o_accs):
+        return self.ctx.core._run_pv_mfma(p_words, cur_v_off, o_accs)
+
+
+class SageStoreHelper:
+    def __init__(self, ctx: SageKernelContext):
+        self.ctx = ctx
+
+    def write_output(self, loop_results, final_off_l, final_off_o_accs):
+        return self.ctx.core.write_output(loop_results, final_off_l, final_off_o_accs)
+
+
+class SageKernelFacade:
+    """Facade wiring context, helpers, and the core emitter."""
+
+    def __init__(self, t, allocator):
+        self.core = _SageKernel(t, allocator)
+        self.t = t
+        self.ctx = SageKernelContext(self.core)
+        self.k_loader = SageKLoader(self.ctx)
+        self.v_loader = SageVLoader(self.ctx)
+        self.qk_softmax = SageQKSoftmaxHelper(self.ctx)
+        self.pv_gemm = SagePVGemmHelper(self.ctx)
+        self.store = SageStoreHelper(self.ctx)
+
+    def setup(self, *args, **kwargs):
+        return self.core.setup(*args, **kwargs)
+
+    @property
+    def q_in_bounds(self):
+        return self.core.q_in_bounds
+
+    def __getattr__(self, name):
+        return getattr(self.core, name)

--- a/kernels/attention/sage_attn_utils.py
+++ b/kernels/attention/sage_attn_utils.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Shared module-level helpers for the CDNA SageAttention kernel.
+
+State-free MLIR-facing free functions extracted from build_sage_attn_cdna_module.
+Moving them here changes nothing about the emitted IR/ISA.
+"""
+
+import math as host_math
+
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import fly as _fly
+from flydsl._mlir.dialects import llvm as _llvm
+from flydsl.expr import arith
+from flydsl.expr import math as _math
+from flydsl.expr.typing import T
+from flydsl.expr.utils.arith import _to_raw as _raw
+
+_LOG2E = host_math.log2(host_math.e)
+_LDS_CAP_BYTES = 65536
+
+
+def _llvm_value(value):
+    if hasattr(value, "ir_value") and not isinstance(value, ir.Value):
+        return value.ir_value()
+    return value
+
+
+def _llvm_ptr_ty():
+    return ir.Type.parse("!llvm.ptr")
+
+
+def _extract_aligned_pointer(tensor) -> ir.Value:
+    return _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), _llvm_value(tensor))
+
+
+def _pointer_load(result_type: ir.Type, ptr: ir.Value) -> ir.Value:
+    return _llvm.LoadOp(result_type, _llvm_value(ptr)).result
+
+
+def _pointer_store(value: ir.Value, ptr: ir.Value):
+    return _llvm.StoreOp(_llvm_value(value), _llvm_value(ptr))
+
+
+def _fadd(a, b, fm):
+    return arith.addf(_raw(a), _raw(b), fastmath=fm)
+
+
+def _fsub(a, b, fm):
+    return arith.subf(_raw(a), _raw(b), fastmath=fm)
+
+
+def _fmul(a, b, fm):
+    return arith.mulf(_raw(a), _raw(b), fastmath=fm)
+
+
+def _fmax(a, b, fm):
+    return arith.MaxNumFOp(_raw(a), _raw(b), fastmath=fm).result
+
+
+def _ffma(a, b, c, fm):
+    """Fused a*b + c (single rounding); folds the QK descale into the exp arg."""
+    return _math.fma(_raw(a), _raw(b), _raw(c), fastmath=fm)
+
+
+def _sitofp(v):
+    return arith.SIToFPOp(T.f32, _raw(v)).result

--- a/kernels/attention/sage_attn_utils.py
+++ b/kernels/attention/sage_attn_utils.py
@@ -3,18 +3,18 @@
 
 """Shared module-level helpers for the CDNA SageAttention kernel.
 
-State-free MLIR-facing free functions extracted from build_sage_attn_cdna_module.
-Moving them here changes nothing about the emitted IR/ISA.
+State-free fx-facing free functions extracted from build_sage_attn_cdna_module.
 """
 
 import math as host_math
 
+import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import fly as _fly
 from flydsl._mlir.dialects import llvm as _llvm
 from flydsl.expr import arith
-from flydsl.expr import math as _math
 from flydsl.expr.typing import T
+from flydsl.expr.typing import Vector as Vec
 from flydsl.expr.utils.arith import _to_raw as _raw
 
 _LOG2E = host_math.log2(host_math.e)
@@ -43,26 +43,25 @@ def _pointer_store(value: ir.Value, ptr: ir.Value):
     return _llvm.StoreOp(_llvm_value(value), _llvm_value(ptr))
 
 
-def _fadd(a, b, fm):
-    return arith.addf(_raw(a), _raw(b), fastmath=fm)
+def _f32_to_bf16_trunc(f32_raw):
+    """Bitwise f32 → bf16 truncation (upper 16 bits)."""
+    i32_val = arith.bitcast(T.i32, _raw(f32_raw))
+    upper = arith.ShRUIOp(i32_val, arith.constant(16, type=T.i32)).result
+    i16_val = arith.TruncIOp(T.i16, upper).result
+    return arith.bitcast(T.bf16, i16_val)
 
 
-def _fsub(a, b, fm):
-    return arith.subf(_raw(a), _raw(b), fastmath=fm)
+def _i32_pair_to_i64(lo, hi):
+    return ((fx.Uint64(hi) << 32) | fx.Uint64(lo)).ir_value()
 
 
-def _fmul(a, b, fm):
-    return arith.mulf(_raw(a), _raw(b), fastmath=fm)
+def _lds_vec_load(vec_type, lds_view, offset):
+    return Vec.load(vec_type, lds_view, [fx.Index(offset)])
 
 
-def _fmax(a, b, fm):
-    return arith.MaxNumFOp(_raw(a), _raw(b), fastmath=fm).result
+def _lds_vec_store(vec, lds_view, offset):
+    Vec(vec).store(lds_view, [fx.Index(offset)])
 
 
-def _ffma(a, b, c, fm):
-    """Fused a*b + c (single rounding); folds the QK descale into the exp arg."""
-    return _math.fma(_raw(a), _raw(b), _raw(c), fastmath=fm)
-
-
-def _sitofp(v):
-    return arith.SIToFPOp(T.f32, _raw(v)).result
+def _lds_vec_store_elem(elem, lds_view, offset, elem_ty):
+    Vec.from_elements([elem], elem_ty).store(lds_view, [fx.Index(offset)])

--- a/tests/arch_compat.py
+++ b/tests/arch_compat.py
@@ -18,6 +18,7 @@ CDNA_ONLY_TESTS = frozenset(
         "test_pa.py",
         "test_quant.py",
         "test_allreduce.py",  # custom_all_reduce requires CDNA (gfx9xx)
+        "test_sage_attn.py",  # MI308X gfx942 SageAttention; also module-skip if not MI308
     }
 )
 

--- a/tests/kernels/test_sage_attn.py
+++ b/tests/kernels/test_sage_attn.py
@@ -10,7 +10,6 @@ import torch
 import torch.nn.functional as F
 
 from flydsl.runtime.device import get_rocm_arch
-from kernels.attention.sage_attn_cdna import build_sage_attn_cdna_module
 
 pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
 
@@ -19,13 +18,13 @@ try:
     _GPU_NAME = torch.cuda.get_device_name(0) if torch.cuda.is_available() else ""
 except Exception:
     _GPU_NAME = ""
-_IS_MI308X = isinstance(_ARCH, str) and _ARCH.startswith("gfx942") and "MI308" in _GPU_NAME.upper()
-pytestmark.append(
-    pytest.mark.skipif(
-        not _IS_MI308X,
-        reason=f"SageAttention CDNA kernel supports only AMD MI308X (gfx942); got arch={_ARCH} name={_GPU_NAME}",
+if not (isinstance(_ARCH, str) and _ARCH.startswith("gfx942") and "MI308" in _GPU_NAME.upper()):
+    pytest.skip(
+        f"SageAttention CDNA kernel supports only AMD MI308X (gfx942); got arch={_ARCH} name={_GPU_NAME}",
+        allow_module_level=True,
     )
-)
+
+from kernels.attention.sage_attn_cdna import build_sage_attn_cdna_module  # noqa: E402
 
 
 def _fp8_dtype():
@@ -72,7 +71,7 @@ def test_sage_attn_bf16(causal):
     q_int8, q_scale, k_int8, k_scale, v_fp8, v_scale = _quantize(q, k, v, block_m, block_n, softmax_scale)
 
     out = torch.empty_like(q)
-    dummy = torch.empty(1, device="cuda", dtype=torch.float32)
+    bias = torch.empty(1, device="cuda", dtype=torch.float32)
     kernel = build_sage_attn_cdna_module(
         num_q_heads=heads,
         num_kv_heads=heads,
@@ -81,7 +80,6 @@ def test_sage_attn_bf16(causal):
         sm_scale=softmax_scale,
         block_m=block_m,
         block_n=block_n,
-        gfx942_w256=True,
         v_transposed=True,
     )
     kernel(
@@ -92,10 +90,7 @@ def test_sage_attn_bf16(causal):
         q_scale,
         k_scale,
         v_scale,
-        dummy,
-        dummy,
-        dummy,
-        dummy,
+        bias,
         batch,
         seq_len,
         seq_len,
@@ -112,7 +107,7 @@ def test_sage_attn_bf16(causal):
     ).transpose(1, 2)
     cosine = F.cosine_similarity(out.float().reshape(-1, head_dim), ref.reshape(-1, head_dim), dim=1)
     assert torch.isfinite(out).all()
-    assert cosine.min().item() > 0.97
+    assert cosine.min().item() > 0.99
     assert cosine.mean().item() > 0.99
 
 
@@ -127,7 +122,7 @@ def _bench_tflops(batch, seq_len, heads, head_dim, causal, block_m=256, block_n=
     sm = head_dim**-0.5
     q8, qs, k8, ks, vf8, vs = _quantize(q, k, v, block_m, block_n, sm)
     out = torch.empty_like(q)
-    dummy = torch.empty(1, device="cuda", dtype=torch.float32)
+    bias = torch.empty(1, device="cuda", dtype=torch.float32)
     kernel = build_sage_attn_cdna_module(
         num_q_heads=heads,
         num_kv_heads=heads,
@@ -136,7 +131,6 @@ def _bench_tflops(batch, seq_len, heads, head_dim, causal, block_m=256, block_n=
         sm_scale=sm,
         block_m=block_m,
         block_n=block_n,
-        gfx942_w256=True,
         v_transposed=True,
     )
     args = (
@@ -147,10 +141,7 @@ def _bench_tflops(batch, seq_len, heads, head_dim, causal, block_m=256, block_n=
         qs,
         ks,
         vs,
-        dummy,
-        dummy,
-        dummy,
-        dummy,
+        bias,
         batch,
         seq_len,
         seq_len,

--- a/tests/kernels/test_sage_attn.py
+++ b/tests/kernels/test_sage_attn.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Correctness tests for the CDNA SageAttention kernel."""
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flydsl.runtime.device import get_rocm_arch
+from kernels.attention.sage_attn_cdna import build_sage_attn_cdna_module
+
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
+_ARCH = get_rocm_arch()
+pytestmark.append(
+    pytest.mark.skipif(
+        not isinstance(_ARCH, str) or not (_ARCH.startswith("gfx942") or _ARCH.startswith("gfx950")),
+        reason=f"SageAttention requires gfx942 or gfx950, got {_ARCH}",
+    )
+)
+
+
+def _fp8_dtype():
+    return torch.float8_e4m3fn if _ARCH.startswith("gfx95") else torch.float8_e4m3fnuz
+
+
+def _quantize(q, k, v, block_m, block_n, softmax_scale):
+    batch, seq_len, heads, head_dim = q.shape
+    q_blocks = math.ceil(seq_len / block_m)
+    k_blocks = math.ceil(seq_len / block_n)
+
+    q_scaled = q.float() * (softmax_scale * math.log2(math.e))
+    q_view = q_scaled.view(batch, q_blocks, block_m, heads, head_dim)
+    q_amax = q_view.abs().amax(dim=(2, 4)).permute(0, 2, 1).contiguous()
+    q_scale = (q_amax / 127.0).clamp_min(torch.finfo(torch.float32).tiny)
+    q_scale_bsh = q_scale.permute(0, 2, 1)[:, :, None, :, None]
+    q_int8 = torch.round(q_view / q_scale_bsh).clamp(-127, 127).to(torch.int8).view_as(q)
+
+    k_view = k.float().view(batch, k_blocks, block_n, heads, head_dim)
+    k_amax = k_view.abs().amax(dim=(2, 4)).permute(0, 2, 1).contiguous()
+    k_scale = (k_amax / 127.0).clamp_min(torch.finfo(torch.float32).tiny)
+    k_scale_bsh = k_scale.permute(0, 2, 1)[:, :, None, :, None]
+    k_int8 = torch.round(k_view / k_scale_bsh).clamp(-127, 127).to(torch.int8).view_as(k)
+
+    fp8_dtype = _fp8_dtype()
+    fp8_max = torch.finfo(fp8_dtype).max
+    v_scale = (v.float().abs().amax(dim=1) / fp8_max).clamp_min(torch.finfo(torch.float32).tiny)
+    v_fp8 = (v.float() / v_scale[:, None]).clamp(-fp8_max, fp8_max).to(fp8_dtype)
+    v_blocked = (
+        v_fp8.permute(0, 2, 3, 1).reshape(batch, heads, head_dim, k_blocks, block_n).permute(0, 1, 3, 2, 4).contiguous()
+    )
+    return q_int8, q_scale, k_int8, k_scale, v_blocked, v_scale
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_sage_attn_bf16(causal):
+    torch.manual_seed(42)
+    batch, seq_len, heads, head_dim = 1, 256, 8, 128
+    block_m, block_n = 256, 64
+    q = torch.randn(batch, seq_len, heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    softmax_scale = head_dim**-0.5
+    q_int8, q_scale, k_int8, k_scale, v_fp8, v_scale = _quantize(q, k, v, block_m, block_n, softmax_scale)
+
+    out = torch.empty_like(q)
+    dummy = torch.empty(1, device="cuda", dtype=torch.float32)
+    kernel = build_sage_attn_cdna_module(
+        num_q_heads=heads,
+        num_kv_heads=heads,
+        head_dim=head_dim,
+        causal=causal,
+        sm_scale=softmax_scale,
+        block_m=block_m,
+        block_n=block_n,
+        gfx942_w256=True,
+        v_transposed=True,
+    )
+    kernel(
+        q_int8.reshape(-1),
+        k_int8.reshape(-1),
+        v_fp8.reshape(-1),
+        out.reshape(-1),
+        q_scale,
+        k_scale,
+        v_scale,
+        dummy,
+        dummy,
+        dummy,
+        dummy,
+        batch,
+        seq_len,
+        seq_len,
+        q_scale.shape[2],
+        stream=torch.cuda.current_stream(),
+    )
+
+    ref = F.scaled_dot_product_attention(
+        q.float().transpose(1, 2),
+        k.float().transpose(1, 2),
+        v.float().transpose(1, 2),
+        is_causal=causal,
+        scale=head_dim**-0.5,
+    ).transpose(1, 2)
+    cosine = F.cosine_similarity(out.float().reshape(-1, head_dim), ref.reshape(-1, head_dim), dim=1)
+    assert torch.isfinite(out).all()
+    assert cosine.min().item() > 0.97
+    assert cosine.mean().item() > 0.99

--- a/tests/kernels/test_sage_attn.py
+++ b/tests/kernels/test_sage_attn.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
-"""Correctness tests for the CDNA SageAttention kernel."""
+"""Correctness tests for the CDNA SageAttention kernel (AMD MI308X / gfx942)."""
 
 import math
 
@@ -15,10 +15,15 @@ from kernels.attention.sage_attn_cdna import build_sage_attn_cdna_module
 pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
 
 _ARCH = get_rocm_arch()
+try:
+    _GPU_NAME = torch.cuda.get_device_name(0) if torch.cuda.is_available() else ""
+except Exception:
+    _GPU_NAME = ""
+_IS_MI308X = isinstance(_ARCH, str) and _ARCH.startswith("gfx942") and "MI308" in _GPU_NAME.upper()
 pytestmark.append(
     pytest.mark.skipif(
-        not isinstance(_ARCH, str) or not (_ARCH.startswith("gfx942") or _ARCH.startswith("gfx950")),
-        reason=f"SageAttention requires gfx942 or gfx950, got {_ARCH}",
+        not _IS_MI308X,
+        reason=f"SageAttention CDNA kernel supports only AMD MI308X (gfx942); got arch={_ARCH} name={_GPU_NAME}",
     )
 )
 
@@ -109,3 +114,66 @@ def test_sage_attn_bf16(causal):
     assert torch.isfinite(out).all()
     assert cosine.min().item() > 0.97
     assert cosine.mean().item() > 0.99
+
+
+def _bench_tflops(batch, seq_len, heads, head_dim, causal, block_m=256, block_n=64, iters=20):
+    """Benchmark one shape; return kernel-only TFLOPS on MI308X."""
+    import time
+
+    torch.manual_seed(42)
+    q = torch.randn(batch, seq_len, heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    sm = head_dim**-0.5
+    q8, qs, k8, ks, vf8, vs = _quantize(q, k, v, block_m, block_n, sm)
+    out = torch.empty_like(q)
+    dummy = torch.empty(1, device="cuda", dtype=torch.float32)
+    kernel = build_sage_attn_cdna_module(
+        num_q_heads=heads,
+        num_kv_heads=heads,
+        head_dim=head_dim,
+        causal=causal,
+        sm_scale=sm,
+        block_m=block_m,
+        block_n=block_n,
+        gfx942_w256=True,
+        v_transposed=True,
+    )
+    args = (
+        q8.reshape(-1),
+        k8.reshape(-1),
+        vf8.reshape(-1),
+        out.reshape(-1),
+        qs,
+        ks,
+        vs,
+        dummy,
+        dummy,
+        dummy,
+        dummy,
+        batch,
+        seq_len,
+        seq_len,
+        qs.shape[2],
+    )
+    stream = torch.cuda.current_stream()
+    for _ in range(3):
+        kernel(*args, stream=stream)
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        kernel(*args, stream=stream)
+    torch.cuda.synchronize()
+    us = (time.perf_counter() - t0) / iters * 1e6
+    flops = 2 * (2 * batch * heads * seq_len * seq_len * head_dim) * (0.5 if causal else 1.0)
+    return us, flops / (us * 1e-6) / 1e12
+
+
+if __name__ == "__main__":
+    print(f"arch={_ARCH}  SageAttention CDNA (MI308X) kernel TFLOPS")
+    print(f"{'shape':>22} {'causal':>6} {'us':>10} {'TFLOPS':>9}")
+    for shape in [(1, 4608, 24, 128), (1, 8448, 24, 128)]:
+        for causal in (False, True):
+            us, tflops = _bench_tflops(*shape, causal=causal)
+            b, s, h, d = shape
+            print(f"{f'B{b}_S{s}_H{h}_D{d}':>22} {str(causal):>6} {us:>10.1f} {tflops:>9.2f}")


### PR DESCRIPTION
# Summary
Add a standalone FlyDSL SageAttention V1 kernel for AMD Instinct MI308X (gfx942).

# Motivation
SageAttention uses INT8 Q/K and FP8 V to reduce attention bandwidth and improve dense diffusion-model attention performance. This contribution makes the production attention kernel available directly in the FlyDSL kernel repository.

# SageAttention principle and this kernel's role
SageAttention is a mixed-precision attention recipe rather than only an INT8 matrix multiplication. The complete path has two layers:

| Layer | Operation | Purpose |
|---|---|---|
| Preprocessing / quantization | Optional Hadamard rotation of Q/K | Spreads channel outliers while preserving the floating-point QK product because the normalized Hadamard matrix is orthogonal. This is not implemented by this PR's low-level kernel. |
| Preprocessing / quantization | K smoothing | Centers K over the sequence dimension, reducing its dynamic range before INT8 quantization. |
| Preprocessing / quantization | Optional blockwise Q smoothing | Subtracts a Q-block mean before INT8 quantization, reducing Q outliers. |
| Preprocessing / quantization | Score correction (delta_s) | Restores the score term removed by Q smoothing: delta_s = softmax_scale * q_mean * K_smooth^T. |
| Preprocessing / quantization | Quantize Q/K to INT8 and V to FP8 | Produces per-block Q/K scales, per-channel V scales, and blocked FP8 V storage. |
| This PR's FlyDSL kernel | INT8 QK, online softmax, FP8 PV | Computes corrected attention with FP32 score/softmax/PV accumulation and writes BF16 output. |

For one Q block, the data flow is:

| Step | Value |
|---|---|
| K smoothing | K_smooth = K - mean_sequence(K) |
| Q smoothing | Q_smooth = Q - mean_block(Q) |
| Quantization | Q_int8 ~= Q_smooth / q_scale, K_int8 ~= K_smooth / k_scale, V_fp8 ~= V / v_scale |
| Approximate score | score ~= softmax_scale * (Q_int8 * K_int8^T) * q_scale * k_scale + delta_s |
| Output | O ~= softmax(score) * V_fp8 * v_scale |

The Q correction is exact before quantization:

```
softmax_scale * Q_smooth * K_smooth^T + delta_s
= softmax_scale * Q * K_smooth^T
```

Therefore Q smoothing lowers INT8 quantization error without changing the K-smoothed floating-point target. K smoothing deliberately changes every score row only by a key-independent constant when the mean is taken over keys; softmax is invariant to that common row shift. A normalized Hadamard rotation, when enabled by a higher-level wrapper, similarly preserves floating-point QK while making channel magnitudes more uniform before quantization.

This PR starts after preprocessing. Its inputs are already-quantized INT8 Q/K, blocked FP8 V, Q/K/V descale tensors, and an optional score-bias tensor carrying delta_s. The kernel then performs:

- INT8 QK MFMA with FP32 accumulation.
- Per-Q-block and per-K-block descale plus softmax scaling.
- Optional lane/column-exact delta_s addition before softmax.
- Online FP32 softmax.
- Native FP8 PV MFMA with FP32 accumulation.
- V descale and BF16 output conversion.

The production Qwen path uses Q-smoothing blocks of 128 query tokens (BLKQ=128) independently of this kernel's attention scheduling tile (BLOCK_M=256). A 256-row FlyDSL workgroup therefore consumes the correction data for two 128-row Q-smoothing blocks. BLOCK_M and Hadamard BLOCK_R are unrelated: the former tiles sequence rows; the latter, when used, tiles head-dimension rotation.

# Changes
- Add an MI308X/gfx942 SageAttention builder under kernels/attention/.
- Use the production BLOCK_M=256, BLOCK_N=64 FlyDSL configuration on gfx942.
- Implement INT8 QK MFMA and native FP8 PV MFMA with FP32 accumulation.
- Double-buffer K/V in LDS and consume blocked-V storage.
- Support the validated dense MHA path with causal/non-causal execution and optional score bias.
- Keep score-bias loads lane/column exact using cooperative scalar loads and ds_bpermute.
- Add direct BF16 correctness coverage for causal and non-causal execution.

# Performance
Measured on AMD Instinct MI308X (gfx942). Throughput is reported in TFLOPS using the dense attention FLOP count `4 * B * H * S^2 * D` (QK^T and PV, FP32-accumulated), with B=1 and D=128; higher TFLOPS is faster. `speedup = FlyDSL TFLOPS / Triton TFLOPS`, so values above 1 mean FlyDSL is faster.

## Production configurations: attention kernel only
Quantization is outside the timed region. Each implementation uses its independently tuned production tile: Triton A3 uses BLOCK_M=128, BLOCK_N=64, 4 warps; FlyDSL uses BLOCK_M=256, BLOCK_N=64.

| Shape | Triton A3 | FlyDSL | Speedup |
|---|---|---|---|
| S=1024, H=8 | 27.9 TFLOPS | 55.1 TFLOPS | 1.96x |
| S=4096, H=8 | 168.8 TFLOPS | 194.1 TFLOPS | 1.15x |
| S=4608, H=24 | 208.6 TFLOPS | 223.4 TFLOPS | 1.07x |
| S=8400, H=24 | 216.9 TFLOPS | 254.0 TFLOPS | 1.17x |
| S=8786, H=24 | 218.3 TFLOPS | 242.1 TFLOPS | 1.11x |
| S=8832, H=24 | 221.1 TFLOPS | 245.3 TFLOPS | 1.11x |

## Iso-tile integration benchmark: complete SmoothQ wrapper
This historical integration benchmark forces both Triton PR4033 and FlyDSL attention to BLOCK_M=256, BLOCK_N=64. The timed region includes SmoothQ preprocessing, quantization, attention, and output handling, so the values below are effective attention TFLOPS over the full wrapper time (`4 * B * H * S^2 * D / total_time`), not attention-kernel-only throughput. It isolates implementation efficiency at the same problem tile, but it is not the production comparison because production Triton A3 is faster at 128x64.

| Shape | Triton PR4033 256x64 | FlyDSL 256x64 | Speedup |
|---|---|---|---|
| S=4608, H=24 | 81.8 TFLOPS | 103.4 TFLOPS | 1.264x |
| S=8400, H=24 | 106.0 TFLOPS | 158.1 TFLOPS | 1.491x |
| S=8786, H=24 | 101.6 TFLOPS | 153.2 TFLOPS | 1.507x |
| S=8832, H=24 | 100.8 TFLOPS | 151.8 TFLOPS | 1.505x |

# Qwen-Image-Edit integration
This PR intentionally contributes the standalone low-level kernel builder. It accepts pre-quantized INT8 Q/K, blocked FP8 V, descale tensors, and an optional score-bias tensor. It does not add the AITER high-level flydsl_sage_attn_func, SmoothQ preprocessing/quantization wrapper, or Qwen-Image-Edit attention dispatcher to this repository.

The same kernel source was exercised in the external AITER/Qwen-Image-Edit integration with 1920 FlyDSL attention calls and 0 fallbacks. An 8-step, 1024x1024, seed-0 run completed and produced the validated FlyDSL PNG. However, checking out this FlyDSL PR alone is not sufficient to rerun that model: the AITER wrapper/quantization integration is also required.

# Testing
Validated on AMD Instinct MI308X (gfx942); the test module skips before importing the CDNA kernel on Navi and all other GPUs.

- Causal and non-causal BF16 correctness: 2 passed.
- Minimum cosine similarity requirement: >0.99; observed minimum: 0.998324 across the three validation shapes.
- Output remained bit-exact against the stored baseline for B1/S256/H8/D128, B1/S4608/H24/D128, and B1/S8448/H24/D128.
- Kernel-only non-causal performance after cleanup: 220.78 TFLOPS at S=4608/H=24 and 253.30 TFLOPS at S=8448/H=24; no regression against the 217.34 and 250.68 TFLOPS baselines.
- `ruff check kernels/attention/sage_attn_cdna.py kernels/attention/sage_attn_utils.py tests/kernels/test_sage_attn.py`
- `black --check --line-length 120 kernels/attention/sage_attn_cdna.py kernels/attention/sage_attn_utils.py tests/kernels/test_sage_attn.py`
- `python3 -m py_compile kernels/attention/sage_attn_cdna.py kernels/attention/sage_attn_utils.py tests/kernels/test_sage_attn.py`

GQA/MQA and arbitrary tail lengths are not claimed as validated capabilities by this PR.

# Dependencies
- No new third-party dependencies added.
