### PR TITLE
fix(kernels): correct stale kernels.mma import in mxfp4_preshuffle

### DIFF
--- a/kernels/gemm/mxfp4_preshuffle.py
+++ b/kernels/gemm/mxfp4_preshuffle.py
@@ -22,7 +22,7 @@ from flydsl.expr.typing import (
     T,
 )
 from flydsl.expr.typing import Vector as Vec
-from kernels.mma.mfma_preshuffle_pipeline import xcd_remap_bx_by
+from kernels.common.mma.mfma_preshuffle_pipeline import xcd_remap_bx_by
 
 _A_ELEM = {"fp4": Float4E2M1FN, "fp6": Float6E2M3FN, "fp8": Float8E4M3FN}
 


### PR DESCRIPTION
## Problem

CI test collection fails on `main` (and PR #866) with:

```
ERROR collecting kernels/test_preshuffle_gemm.py
...
kernels/gemm/mxfp4_preshuffle.py:25: in <module>
    from kernels.mma.mfma_preshuffle_pipeline import xcd_remap_bx_by
E   ModuleNotFoundError: No module named 'kernels.mma'
```

The MMA helper modules now live under `kernels/common/mma/`, but
`kernels/gemm/mxfp4_preshuffle.py` still imported `xcd_remap_bx_by` from
the old top-level `kernels.mma` path. Since this is a module-level
import, pytest aborts collection of the whole file, failing the entire
test run.

## Fix

Point the import at `kernels.common.mma.mfma_preshuffle_pipeline`,
matching every sibling in `kernels/gemm/` (e.g. `preshuffle_gemm.py:15`,
which imports the same symbol). One-line change; no behavior change.

Verified there are no other stale `kernels.mma` references in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)