### PR TITLE
Fix Vector list()-iteration hang 

### DIFF
--- a/python/flydsl/expr/typing.py
+++ b/python/flydsl/expr/typing.py
@@ -1843,6 +1843,10 @@ class Vector(ArithValue):
         if idx is None:
             return self
         if isinstance(idx, int):
+            if idx < 0:
+                idx += self.numel
+            if not 0 <= idx < self.numel:
+                raise IndexError(f"vector index {idx} out of range for numel {self.numel}")
             res = _vector.ExtractOp(self, static_position=[idx], dynamic_position=[]).result
             return self._dtype(res)
         if isinstance(idx, (Numeric, ArithValue, ir.Value)):
@@ -1879,6 +1883,16 @@ class Vector(ArithValue):
             res_shape = self._slice_shape(self._shape, coord)
             return self._build_result(res, res_shape, row_major=True)
         raise TypeError(f"unsupported index type: {type(idx)}")
+
+    def __len__(self) -> int:
+        return self.numel
+
+    def __iter__(self):
+        # Without this, list()/unpacking falls back to the legacy sequence
+        # protocol (self[0], self[1], ...), which spins forever because the
+        # int branch of __getitem__ used to never raise IndexError (see #793).
+        for i in range(self.numel):
+            yield self[i]
 
     def _build_result(self, value, shape, *, row_major=False) -> "Vector":
         shape = self._canonical_shape(shape)

--- a/python/flydsl/expr/typing.py
+++ b/python/flydsl/expr/typing.py
@@ -1843,10 +1843,11 @@ class Vector(ArithValue):
         if idx is None:
             return self
         if isinstance(idx, int):
+            orig_idx = idx
             if idx < 0:
                 idx += self.numel
             if not 0 <= idx < self.numel:
-                raise IndexError(f"vector index {idx} out of range for numel {self.numel}")
+                raise IndexError(f"vector index {orig_idx} out of range for numel {self.numel}")
             res = _vector.ExtractOp(self, static_position=[idx], dynamic_position=[]).result
             return self._dtype(res)
         if isinstance(idx, (Numeric, ArithValue, ir.Value)):

--- a/tests/unit/test_vector_iteration.py
+++ b/tests/unit/test_vector_iteration.py
@@ -66,6 +66,7 @@ def test_int_index_out_of_range_raises():
 @pytest.mark.l0_backend_agnostic
 def test_negative_index():
     """v[-1] resolves to the last lane; too-negative raises IndexError."""
+
     def body(v):
         assert v[-1] is not None
         with pytest.raises(IndexError):

--- a/tests/unit/test_vector_iteration.py
+++ b/tests/unit/test_vector_iteration.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Regression tests for Vector iteration / list() conversion (ROCm/FlyDSL#793).
+
+Previously ``list(Vec(buffer_load(vec_width>1)))`` hung during tracing: Vector
+defined ``__getitem__`` but neither ``__iter__`` nor ``__len__``, so CPython fell
+back to the legacy sequence protocol (``v[0], v[1], ...``) which only stops on
+``IndexError`` -- and the integer branch never raised one, emitting an unbounded
+stream of ``vector.extract`` ops.
+"""
+
+import pytest
+
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import func
+from flydsl.expr.typing import Vector
+
+
+def _in_vector_func(numel, body):
+    """Run ``body(v)`` on a Vector over a ``vector<numel x f32>`` func argument."""
+    with ir.Context() as ctx:
+        ctx.allow_unregistered_dialects = True
+        with ir.Location.unknown(ctx):
+            module = ir.Module.create()
+            with ir.InsertionPoint(module.body):
+                vec_ty = ir.VectorType.get([numel], ir.F32Type.get())
+                f = func.FuncOp("t", ir.FunctionType.get([vec_ty], []))
+                with ir.InsertionPoint(f.add_entry_block()):
+                    (arg,) = list(f.entry_block.arguments)
+                    result = body(Vector(arg))
+                    func.ReturnOp([])
+                    return result
+
+
+@pytest.mark.l0_backend_agnostic
+def test_list_of_vector_terminates():
+    """list(Vec) yields exactly numel scalar values instead of hanging (#793)."""
+    vals = _in_vector_func(4, list)
+    assert len(vals) == 4
+
+
+@pytest.mark.l0_backend_agnostic
+def test_len_of_vector():
+    assert _in_vector_func(4, len) == 4
+
+
+@pytest.mark.l0_backend_agnostic
+def test_vector_unpacking():
+    n = _in_vector_func(3, lambda v: len([x for x in v]))
+    assert n == 3
+
+
+@pytest.mark.l0_backend_agnostic
+def test_int_index_out_of_range_raises():
+    def body(v):
+        with pytest.raises(IndexError):
+            v[v.numel]
+        return True
+
+    assert _in_vector_func(4, body)
+
+
+@pytest.mark.l0_backend_agnostic
+def test_negative_index():
+    """v[-1] resolves to the last lane; too-negative raises IndexError."""
+    def body(v):
+        assert v[-1] is not None
+        with pytest.raises(IndexError):
+            v[-(v.numel + 1)]
+        return True
+
+    assert _in_vector_func(4, body)

--- a/tests/unit/test_vector_iteration.py
+++ b/tests/unit/test_vector_iteration.py
@@ -48,9 +48,18 @@ def test_len_of_vector():
 
 
 @pytest.mark.l0_backend_agnostic
-def test_vector_unpacking():
+def test_vector_iteration():
     n = _in_vector_func(3, lambda v: len([x for x in v]))
     assert n == 3
+
+
+@pytest.mark.l0_backend_agnostic
+def test_vector_unpacking():
+    def body(v):
+        a, b, c = v
+        return len((a, b, c))
+
+    assert _in_vector_func(3, body) == 3
 
 
 @pytest.mark.l0_backend_agnostic


### PR DESCRIPTION
## Summary
Fixes [#793](https://github.com/ROCm/FlyDSL/issues/793). 
`list(Vec(buffer_load(vec_width>1)))` hung indefinitely during tracing and never emitted IR.

(https://github.com/ROCm/FlyDSL/blob/main/python/flydsl/expr/typing.py) defines `__getitem__` but neither `__iter__` nor `__len__`. When an object has `__getitem__` and no `__iter__`, `list()` falls back to CPython's legacy sequence protocol — `v[0], v[1], v[2], …` - which stops only when `__getitem__` raises `IndexError`. 

The integer branch never bounds-checked and never raised, so tracing looped forever, emitting an
unbounded stream of `vector.extract` ops and finalizing no IR.

## Fix
- Add `__len__` (returns `numel`) and `__iter__` (yields the `numel` lanes) so
  `list()`, unpacking, and `for` iterate correctly and terminate.
- Bounds-check the integer branch of `__getitem__`: normalize negative indices
  and raise a clear `IndexError` when out of range, instead of silently emitting
  an out-of-range extract.

## Behavior

| Case | Before | After |
|---|---|---|
| `list(vec)` (numel=4) | hangs, unbounded `vector.extract` | `[v0, v1, v2, v3]` |
| `len(vec)` | `TypeError` | `4` |
| `for x in vec` / unpacking | infinite loop | iterates the lanes |
| `vec[4]` (OOB) | invalid extract, no error | `IndexError` |
| `vec[-1]` | invalid negative position | last lane |

## Tests
- New `tests/unit/test_vector_iteration.py` (5 cases, `l0_backend_agnostic`): list termination, `len`, unpacking, OOB `IndexError`, negative indexing.
- Verified the new termination test hangs on the unpatched tree (killed by timeout) and passes with this change.
- Full backend-agnostic unit sweep: 205 passed, 0 failed.
