### PR TITLE
Fix/moe gemm1 4gb offset overflow for kimi k2.6 pp4/pp4

### DIFF
--- a/kernels/moe/mixed_moe_gemm_2stage/gemm1.py
+++ b/kernels/moe/mixed_moe_gemm_2stage/gemm1.py
@@ -526,8 +526,6 @@ def compile_mixed_moe_gemm1(
             x_nbytes_i32 = arith.index_cast(T.i32, x_nbytes_idx)
             x_rsrc = buffer_ops.create_buffer_resource(arg_x, max_size=False, num_records_bytes=x_nbytes_i32)
 
-            w_rsrc = buffer_ops.create_buffer_resource(arg_w, max_size=False)
-
             # Out: [tokens*topk, inter_dim]
             numids_rsrc = buffer_ops.create_buffer_resource(
                 arg_num_valid_ids,
@@ -605,6 +603,24 @@ def compile_mixed_moe_gemm1(
             def _moe_gemm1_body():
                 # Gate expert offset: first inter_dim rows of each expert's 2*inter_dim block
                 expert_off_idx = expert_idx * arith.constant(2 * inter_dim, index=True)
+
+                # --- >4GB weight-offset overflow fix ---
+                # The weight (w1) is loaded via buffer_load, whose hardware voffset is 32-bit.
+                # A single buffer resource spanning the whole w1 tensor overflows that offset
+                # once w1 exceeds 2^32 bytes (e.g. K2.6 tp1: 385 experts x 2*2048 x 7168 fp4
+                # = 5.6GB), so high-index experts load wrong weights -> garbage output.
+                # Re-base the resource at this block's expert using a 64-bit byte offset so the
+                # per-load 32-bit offset only ever spans one expert (< 2^32). Weight row indices
+                # below are made expert-relative to match. Scale/bias resources are left absolute
+                # (they never exceed 4GB for supported shapes).
+                per_expert_w_bytes = (2 * inter_dim * model_dim * b_elem_bytes) // pack_K
+                expert_byte_off = expert_idx * arith.constant(per_expert_w_bytes, index=True)
+                w_rsrc_e = buffer_ops.create_buffer_resource(
+                    arg_w,
+                    max_size=False,
+                    num_records_bytes=per_expert_w_bytes,
+                    base_byte_offset=expert_byte_off,
+                )
 
                 # X loading -- KEY DIFFERENCE from stage2: X row = token_id only
                 x_load_bytes = 16
@@ -708,8 +724,10 @@ def compile_mixed_moe_gemm1(
                         col_g_list.append(col_g)
 
                     global_n = by_n + n_tile_base + c_offset + lane_mod_16
-                    # Gate/interleave: rows [expert_off, expert_off + 2*inter_dim)
-                    gate_row_w = expert_off_idx + global_n
+                    # Expert-relative row: the weight resource (w_rsrc_e) is re-based to this
+                    # expert's start, so rows are within [0, 2*inter_dim) -> the 32-bit buffer
+                    # offset never crosses 4GB. (Was: expert_off_idx + global_n.)
+                    gate_row_w = global_n
                     gate_coord = idx2crd(fx.Int32(gate_row_w), layout_n_blk_intra)
                     gate_n_blk_list.append(layout_get(gate_coord, 0))
                     gate_n_intra_list.append(layout_get(gate_coord, 1))
@@ -751,7 +769,7 @@ def compile_mixed_moe_gemm1(
                     b16 = _buffer_load_vec(
                         buffer_ops,
                         vector,
-                        w_rsrc,
+                        w_rsrc_e,
                         idx_pack,
                         elem_type=_w_elem_type(),
                         vec_elems=vec_elems,

--- a/tests/kernels/test_moe_gemm.py
+++ b/tests/kernels/test_moe_gemm.py
@@ -2141,6 +2141,38 @@ def test_moe_gemm_2stage_bf16_out(use_reduce):
     )
 
 
+@pytest.mark.large_shape
+@pytest.mark.skipif("gfx95" not in ARCH, reason="a4w4 MXFP4 requires gfx950+")
+def test_moe_gemm1_a4w4_weight_offset_over_4gb():
+    """Regression: a4w4 gemm1 weight offset must not overflow 32-bit when w1 > 4GB.
+
+    With experts=320, inter_dim=2048, model_dim=7168 the gate/up weight tensor is
+    320 * (2*2048) * 7168 * 0.5B = 4.38 GB > 2**32. Stage1 loads w1 via buffer_load
+    whose hardware voffset is 32-bit; a single resource spanning the whole tensor
+    wraps for high-index experts and loads wrong weights (observed rel_err ~0.5 at
+    w1=4.4GB vs 0.0 at 3.5GB). Real models hit this at tp1 (e.g. Kimi-K2.6:
+    385 experts x inter=2048 = 5.25 GB). The per-expert i64 re-based buffer
+    resource keeps each load's offset within one expert. Fails on the unfixed
+    kernel, passes with the fix.
+    """
+    run_moe_stage1(
+        tokens=64,
+        model_dim=7168,
+        inter_dim=2048,
+        experts=320,
+        topk=8,
+        tile_m=32,
+        tile_n=128,
+        tile_k=256,
+        doweight_stage1=False,
+        in_dtype="fp4",
+        out_dtype="bf16",
+        skip_ref=False,
+        num_iters=1,
+        num_warmup=0,
+    )
+
+
 @pytest.mark.parametrize("scale_dtype", ["f32", "bf16"], ids=["scale_f32", "scale_bf16"])
 def test_moe_gemm_w4a16_groupwise_scale(scale_dtype):
     """Test W4A16 groupwise scale with f32 and bf16 (packed) scale dtypes."""


### PR DESCRIPTION
# moe gemm1 (a4w4): fix >4 GB weight buffer-offset overflow

## Summary

The a4w4 MoE **stage-1** (gate+up) kernel loads the expert weight tensor `w1`
through a **single AMD buffer resource** spanning the whole tensor and indexes it
with the buffer instruction's **32-bit** byte offset (`buffer_load` voffset). When
`w1` exceeds **2³² bytes (4 GiB)**, the offset for high-index experts wraps around,
so those experts read the *wrong* weights and the kernel produces garbage output.

This is hit by real models at low tensor-parallel degree. Example — **Kimi-K2.6
MXFP4**, tp1 (all experts + full intermediate on one GPU):

```
w1 = experts × (2·inter) × model × 0.5 B (fp4)
   = 385 × (2·2048) × 7168 × 0.5 = 5.25 GB  > 4 GB  → overflow → garbage
```

At tp≥2 the intermediate is sharded (`inter ≤ 1024` → `w1 ≤ 2.8 GB < 4 GB`), which
is exactly why the bug only shows up at tp1.

### Is the 4 GB a hardcoded limit?

No. It is the **hardware limit of the AMD buffer descriptor's 32-bit byte offset**
(2³² reach from the resource base) — not an arbitrary software constant. The code
already reflects it: `flydsl/expr/buffer_ops.py` clamps `num_records` to
`0xFFFFFFFF`. Anything addressed through one buffer resource must stay within 4 GB
of its base.

## Fix

Re-base the weight buffer resource **per expert** using a **64-bit** base offset,
and make the weight row indices **expert-relative**. Each `buffer_load` then only
ever addresses within a single expert (`per_expert_w_bytes = 2·inter·model / pack`,
~14.7 MB for the shape above), so the 32-bit offset never crosses 4 GB.

```python
per_expert_w_bytes = (2 * inter_dim * model_dim * b_elem_bytes) // pack_K
expert_byte_off    = expert_idx * per_expert_w_bytes            # 64-bit
w_rsrc_e = create_buffer_resource(arg_w, num_records_bytes=per_expert_w_bytes,
                                  base_byte_offset=expert_byte_off)
...
gate_row_w = global_n            # expert-relative (was: expert_off_idx + global_n)
```

Scale/bias resources are left absolute — they stay < 4 GB for supported shapes
(w1-scale is `w1/32`, bias is tiny). `gemm2` (`w2`) uses the same single-resource
pattern but is not triggered here (`w2` at tp1 = 2.8 GB); it needs the same
treatment only if `w2` can exceed 4 GB.

## Precision + performance

Regression test: `tests/kernels/test_moe_gemm.py::test_moe_gemm1_a4w4_weight_offset_over_4gb`
(fails on the unfixed kernel, passes with the fix).

Single sweep on MI355X (gfx950), stage-1, `E=320, inter=2048, model=7168`
(**w1 = 4.38 GB, i.e. the >4 GB regime**, so "before" is the overflowing kernel),
token 1 → 128k. Precision = L2 rel_err of stage-1 output vs the torch reference;
perf = latency (30 iters):

| token | rel_err before | rel_err after | before (us) | after (us) | Δ |
|------:|:--------------:|:-------------:|:-----------:|:----------:|:--:|
| 1      | 0.5420 ✗ | 0.0000 ✓ | 192.5 | 188.9 | −1.9% |
| 2      | 0.0000 ✗† | 0.0000 ✓ | 189.7 | 187.0 | −1.4% |
| 4      | 0.4807 ✗ | 0.0000 ✓ | 187.6 | 185.8 | −1.0% |
| 8      | 0.5195 ✗ | 0.0000 ✓ | 188.8 | 188.3 | −0.3% |
| 16     | 0.4547 ✗ | 0.0000 ✓ | 273.7 | 279.1 | +2.0% |
| 32     | 0.4018 ✗ | 0.0000 ✓ | 452.2 | 454.3 | +0.5% |
| 64     | 0.4282 ✗ | 0.0000 ✓ | 682.0 | 681.5 | −0.1% |
| 128    | 0.4541 ✗ | 0.0000 ✓ | 802.0 | 811.8 | +1.2% |
| 256    | 0.4492 ✗ | 0.0000 ✓ | 828.1 | 847.4 | +2.3% |
| 512    | 0.4507 ✗ | 0.0000 ✓ | 843.8 | 852.2 | +1.0% |
| 1024   | 0.4575 ✗ | 0.0000 ✓ | 880.8 | 888.6 | +0.9% |
| 2048   | 0.4610 ✗ | 0.0000 ✓ | 1074.4 | 1076.1 | +0.2% |
| 4096   | 0.4597 ✗ | 0.0000 ✓ | 1418.7 | 1430.8 | +0.9% |
| 8192   | 0.4596 ✗ | 0.0000 ✓ | 2099.4 | 2104.0 | +0.2% |
| 16384  | 0.4601 ✗ | 0.0000 ✓ | 3527.1 | 3529.8 | +0.1% |
| 32768  | 0.4598 ✗ | 0.0000 ✓ | 6503.8 | 6504.0 | +0.0% |
| 65536  | (n/m) | (n/m) | 12569.3 | 12599.1 | +0.2% |
| 131072 | (n/m) | (n/m) | 25025.6 | 24997.0 | −0.1% |

- **Precision:** before ≈ 0.40–0.54 (garbage) → after 0.0000 (matches torch ref),
  consistently across token 16→32768 (confirming it's token-independent).
- **Perf:** before ≈ after within ±2.3% across the whole range (small-token jitter);
  the per-expert re-base is a per-M-block scalar cost outside the K loop, so no
  throughput impact.

† token=2 "before" is 0.0000 only because with so few tokens the random routing
happened to miss the high-index (overflowing) experts (≥292); token≥4 reproduces
it consistently. **(n/m)** = precision not measured — the fp32 torch reference is
too large for token≥65536; rel_err is expert-index-driven (token-independent), so
the values through 32768 are representative. Real deployments use E=385 (w1=5.25 GB).

## Test command

```bash
pytest tests/kernels/test_moe_gemm.py -k weight_offset_over_4gb
```
