### PR TITLE
[Runtime] Resolve JIT target from invocation device

### DIFF
--- a/docs/architecture_guide.md
+++ b/docs/architecture_guide.md
@@ -382,8 +382,8 @@ Transforms Python control flow to MLIR ops at the AST level:
 | Variable | Default | Description |
 |---|---|---|
 | `FLYDSL_COMPILE_OPT_LEVEL` | `2` | Optimization level (0–3) |
-| `COMPILE_ONLY` | `0` | If `1`, compile without creating an executor. Returns `None`. |
-| `ARCH` | auto-detect | Override target GPU architecture (e.g., `gfx942`, `gfx950`). |
+| `COMPILE_ONLY` | `0` | If `1`, compile without creating an executor. A device-less workflow must set an explicit target. |
+| `ARCH` | invocation device | Highest-priority target GPU architecture override (e.g., `gfx942`, `gfx950`). |
 
 ### 5.2 Debug Options (`FLYDSL_DEBUG_*`)
 
@@ -408,11 +408,21 @@ Transforms Python control flow to MLIR ops at the AST level:
 
 ### 5.4 Architecture Detection Priority
 
-`get_rocm_arch()` in `runtime/device.py` checks in order:
-1. `FLYDSL_GPU_ARCH` env var
-2. `HSA_OVERRIDE_GFX_VERSION` env var (supports `9.4.2` → `gfx942` format)
-3. `rocm_agent_enumerator` system tool
-4. Default: `gfx942`
+ROCm compilation resolves the target in this order:
+
+1. `ARCH`
+2. `FLYDSL_GPU_ARCH`
+3. `HSA_OVERRIDE_GFX_VERSION` (supports `9.4.2` → `gfx942`)
+4. The logical device carried by the invocation's tensor arguments
+5. The HIP current device when no argument carries device metadata
+
+There is no fallback ISA. If HIP cannot resolve an execution device, FlyDSL
+raises instead of assuming `gfx942`. Device-less compile-only workflows must
+set one of the three explicit overrides.
+
+The architecture participates in the compiled-artifact cache key. Same-ISA
+devices may reuse that artifact, while loaded executable state remains isolated
+per logical device.
 
 ---
 

--- a/docs/kernel_authoring_guide.md
+++ b/docs/kernel_authoring_guide.md
@@ -572,8 +572,12 @@ FLYDSL_RUNTIME_ENABLE_CACHE=0 python my_script.py  # or: rm -rf ~/.flydsl/cache
 ### 9.4 Compile-Only Mode
 
 ```bash
-COMPILE_ONLY=1 python my_script.py
+ARCH=gfx942 COMPILE_ONLY=1 python my_script.py
 ```
+
+When the invocation has no GPU tensor, compile-only mode requires an explicit
+`ARCH`, `FLYDSL_GPU_ARCH`, or `HSA_OVERRIDE_GFX_VERSION`; FlyDSL does not guess
+an ISA.
 
 ---
 

--- a/lib/Bindings/Python/DLTensorAdaptor.h
+++ b/lib/Bindings/Python/DLTensorAdaptor.h
@@ -95,6 +95,10 @@ public:
     return reinterpret_cast<int64_t>(static_cast<char *>(tensor_->data) + tensor_->byte_offset);
   }
 
+  int getDeviceType() const { return static_cast<int>(tensor_->device.device_type); }
+
+  int getDeviceId() const { return tensor_->device.device_id; }
+
   int64_t getSizeInBytes() const {
     int64_t numElements = 1;
     for (int64_t s : shape_) {

--- a/lib/Bindings/Python/FlyExtension.cpp
+++ b/lib/Bindings/Python/FlyExtension.cpp
@@ -1002,10 +1002,8 @@ NB_MODULE(_mlirDialectsFly, m) {
       .def_prop_ro("shape", &DLTensorAdaptor::getShape, "Get tensor shape as tuple")
       .def_prop_ro("stride", &DLTensorAdaptor::getStride, "Get tensor stride as tuple")
       .def_prop_ro("data_ptr", &DLTensorAdaptor::getDataPtr, "Get data pointer as int64")
-      .def_prop_ro("device_type", &DLTensorAdaptor::getDeviceType,
-                   "Get the DLPack device type")
-      .def_prop_ro("device_id", &DLTensorAdaptor::getDeviceId,
-                   "Get the logical device id")
+      .def_prop_ro("device_type", &DLTensorAdaptor::getDeviceType, "Get the DLPack device type")
+      .def_prop_ro("device_id", &DLTensorAdaptor::getDeviceId, "Get the logical device id")
       .def_prop_ro("address_space", &DLTensorAdaptor::getAddressSpace,
                    "Get address space (0=host, 1=device)")
       .def_prop_ro(

--- a/lib/Bindings/Python/FlyExtension.cpp
+++ b/lib/Bindings/Python/FlyExtension.cpp
@@ -1002,6 +1002,10 @@ NB_MODULE(_mlirDialectsFly, m) {
       .def_prop_ro("shape", &DLTensorAdaptor::getShape, "Get tensor shape as tuple")
       .def_prop_ro("stride", &DLTensorAdaptor::getStride, "Get tensor stride as tuple")
       .def_prop_ro("data_ptr", &DLTensorAdaptor::getDataPtr, "Get data pointer as int64")
+      .def_prop_ro("device_type", &DLTensorAdaptor::getDeviceType,
+                   "Get the DLPack device type")
+      .def_prop_ro("device_id", &DLTensorAdaptor::getDeviceId,
+                   "Get the logical device id")
       .def_prop_ro("address_space", &DLTensorAdaptor::getAddressSpace,
                    "Get address space (0=host, 1=device)")
       .def_prop_ro(

--- a/lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp
+++ b/lib/Runtime/ROCm/FlyRocmRuntimeWrappers.cpp
@@ -14,6 +14,7 @@
 
 #include <cassert>
 #include <cstdio>
+#include <cstring>
 #include <dlfcn.h>
 #include <vector>
 
@@ -235,4 +236,20 @@ extern "C" StridedMemRefType<int32_t, 1> mgpuMemGetDeviceMemRef1dInt32(int32_t *
 extern "C" void mgpuSetDefaultDevice(int32_t device) {
   defaultDevice = device;
   HIP_REPORT_IF_ERROR(hipSetDevice(device));
+}
+
+extern "C" int32_t mgpuGetDeviceArch(int32_t device, char *arch, size_t capacity) {
+  if (!arch || capacity == 0)
+    return static_cast<int32_t>(hipErrorInvalidValue);
+
+  hipDeviceProp_t properties{};
+  hipError_t result = hipGetDeviceProperties(&properties, device);
+  if (result != hipSuccess)
+    return static_cast<int32_t>(result);
+
+  const size_t length = std::strlen(properties.gcnArchName);
+  if (length + 1 > capacity)
+    return static_cast<int32_t>(hipErrorInvalidValue);
+  std::memcpy(arch, properties.gcnArchName, length + 1);
+  return static_cast<int32_t>(hipSuccess);
 }

--- a/python/flydsl/autotune.py
+++ b/python/flydsl/autotune.py
@@ -31,13 +31,15 @@ def _env_fingerprint() -> tuple:
         return ()
 
 
-def _toolchain_fingerprint() -> str:
+def _toolchain_fingerprint(arch: str = "") -> str:
     """Hash of the compiler toolchain, so a codegen change invalidates old
     configs. Reuses jit_function._flydsl_key(); falls back to the version."""
     try:
+        from .compiler.backends import get_backend
         from .compiler.jit_function import _flydsl_key
 
-        return _flydsl_key()
+        target = get_backend(arch=arch).target if arch else None
+        return _flydsl_key(target)
     except Exception:
         try:
             import flydsl
@@ -47,14 +49,38 @@ def _toolchain_fingerprint() -> str:
             return ""
 
 
-def _device_fingerprint() -> str:
+def _device_fingerprint(device_id=None) -> str:
     """GPU arch string (e.g. 'gfx950'), or '' if unavailable."""
     try:
         from .runtime.device import get_rocm_arch
 
-        return str(get_rocm_arch())
+        return str(get_rocm_arch(device_id))
     except Exception:
         return ""
+
+
+def _invocation_device_id(sig_args) -> int | None:
+    """Resolve one logical GPU device from tensor/stream arguments."""
+    devices = set()
+    for value in sig_args.values():
+        device_id = None
+        dlpack_device = getattr(value, "__dlpack_device__", None)
+        if callable(dlpack_device):
+            try:
+                device_type, candidate = dlpack_device()
+                if int(device_type) in (2, 10):
+                    device_id = int(candidate)
+            except Exception:
+                pass
+        if device_id is None and torch is not None and isinstance(value, torch.cuda.Stream):
+            stream_device = value.device
+            device_id = stream_device.index
+        if device_id is not None:
+            devices.add(device_id)
+
+    if len(devices) > 1:
+        raise ValueError(f"FlyDSL autotune arguments must reside on the same device, got {sorted(devices)}")
+    return next(iter(devices), None)
 
 
 def _normalize_strides(t) -> tuple:
@@ -236,9 +262,11 @@ class Autotuner:
         # tuned under different conditions. _flydsl_key is lru_cached, so this is
         # cheap. (_toolchain/_device fingerprints are functions, not frozen at
         # construction — otherwise the device axis would go stale.)
+        device_id = _invocation_device_id(sig_args)
+        device_fingerprint = _device_fingerprint(device_id)
         key_vals.append(("_env_", _env_fingerprint()))
-        key_vals.append(("_toolchain_", _toolchain_fingerprint()))
-        key_vals.append(("_device_", _device_fingerprint()))
+        key_vals.append(("_toolchain_", _toolchain_fingerprint(device_fingerprint)))
+        key_vals.append(("_device_", device_fingerprint))
         effective_hints = getattr(self.fn, "_effective_compile_hints", None)
         if callable(effective_hints):
             hint_key = tuple(

--- a/python/flydsl/autotune.py
+++ b/python/flydsl/autotune.py
@@ -63,16 +63,14 @@ def _device_fingerprint(device=None) -> str:
 
 def _invocation_device(sig_args):
     """Resolve one canonical logical GPU device from call arguments."""
-    from .runtime.device_runtime import Device, device_from_argument
+    from .runtime.device_runtime import device_from_argument, device_from_stream_argument
 
     devices = set()
     for value in sig_args.values():
         device = device_from_argument(value)
-        if device is None and torch is not None and isinstance(value, torch.cuda.Stream):
-            stream_device = value.device
-            if stream_device.index is not None:
-                kind = "rocm" if getattr(torch.version, "hip", None) else "cuda"
-                device = Device(kind=kind, index=int(stream_device.index))
+        if device is None:
+            kind = "rocm" if torch is not None and getattr(torch.version, "hip", None) else "cuda"
+            device = device_from_stream_argument(value, cuda_kind=kind)
         if device is not None:
             devices.add(device)
 
@@ -327,6 +325,8 @@ class Autotuner:
         sig_args.update(kwargs)
         device = _invocation_device(sig_args)
         stream = sig_args.get("stream")
+        if getattr(stream, "_is_stream_param", False):
+            stream = stream.value
         if isinstance(stream, torch.cuda.Stream):
             return torch.cuda.stream(stream)
         if isinstance(stream, int):

--- a/python/flydsl/autotune.py
+++ b/python/flydsl/autotune.py
@@ -49,37 +49,36 @@ def _toolchain_fingerprint(arch: str = "") -> str:
             return ""
 
 
-def _device_fingerprint(device_id=None) -> str:
+def _device_fingerprint(device=None) -> str:
     """GPU arch string (e.g. 'gfx950'), or '' if unavailable."""
     try:
         from .runtime.device import get_rocm_arch
 
-        return str(get_rocm_arch(device_id))
+        if device is not None and device.kind != "rocm":
+            return f"{device.kind}:{device.index}"
+        return str(get_rocm_arch(None if device is None else device.index))
     except Exception:
         return ""
 
 
-def _invocation_device_id(sig_args) -> int | None:
-    """Resolve one logical GPU device from tensor/stream arguments."""
+def _invocation_device(sig_args):
+    """Resolve one canonical logical GPU device from call arguments."""
+    from .runtime.device_runtime import Device, device_from_argument
+
     devices = set()
     for value in sig_args.values():
-        device_id = None
-        dlpack_device = getattr(value, "__dlpack_device__", None)
-        if callable(dlpack_device):
-            try:
-                device_type, candidate = dlpack_device()
-                if int(device_type) in (2, 10):
-                    device_id = int(candidate)
-            except Exception:
-                pass
-        if device_id is None and torch is not None and isinstance(value, torch.cuda.Stream):
+        device = device_from_argument(value)
+        if device is None and torch is not None and isinstance(value, torch.cuda.Stream):
             stream_device = value.device
-            device_id = stream_device.index
-        if device_id is not None:
-            devices.add(device_id)
+            if stream_device.index is not None:
+                kind = "rocm" if getattr(torch.version, "hip", None) else "cuda"
+                device = Device(kind=kind, index=int(stream_device.index))
+        if device is not None:
+            devices.add(device)
 
     if len(devices) > 1:
-        raise ValueError(f"FlyDSL autotune arguments must reside on the same device, got {sorted(devices)}")
+        rendered = ", ".join(f"{device.kind}:{device.index}" for device in sorted(devices, key=repr))
+        raise ValueError(f"FlyDSL autotune arguments must reside on the same device, got {rendered}")
     return next(iter(devices), None)
 
 
@@ -262,8 +261,8 @@ class Autotuner:
         # tuned under different conditions. _flydsl_key is lru_cached, so this is
         # cheap. (_toolchain/_device fingerprints are functions, not frozen at
         # construction — otherwise the device axis would go stale.)
-        device_id = _invocation_device_id(sig_args)
-        device_fingerprint = _device_fingerprint(device_id)
+        device = _invocation_device(sig_args)
+        device_fingerprint = _device_fingerprint(device)
         key_vals.append(("_env_", _env_fingerprint()))
         key_vals.append(("_toolchain_", _toolchain_fingerprint(device_fingerprint)))
         key_vals.append(("_device_", device_fingerprint))
@@ -326,18 +325,20 @@ class Autotuner:
             return nullcontext()
         sig_args = dict(zip(self.arg_names, args))
         sig_args.update(kwargs)
+        device = _invocation_device(sig_args)
         stream = sig_args.get("stream")
         if isinstance(stream, torch.cuda.Stream):
             return torch.cuda.stream(stream)
         if isinstance(stream, int):
-            device = next(
-                (value.device for value in sig_args.values() if isinstance(value, torch.Tensor) and value.is_cuda),
-                None,
-            )
+            torch_device = None if device is None else torch.device("cuda", device.index)
             stream = (
-                torch.cuda.default_stream(device) if stream == 0 else torch.cuda.ExternalStream(stream, device=device)
+                torch.cuda.default_stream(torch_device)
+                if stream == 0
+                else torch.cuda.ExternalStream(stream, device=torch_device)
             )
             return torch.cuda.stream(stream)
+        if device is not None:
+            return torch.cuda.device(device.index)
         return nullcontext()
 
     def _bench_one(self, config, args, kwargs):

--- a/python/flydsl/compiler/backends/__init__.py
+++ b/python/flydsl/compiler/backends/__init__.py
@@ -63,11 +63,14 @@ def _make_backend(name: str, arch: str) -> BaseBackend:
     return backend_cls(target)
 
 
-def get_backend(name: Optional[str] = None, *, arch: str = "") -> BaseBackend:
+def get_backend(name: Optional[str] = None, *, arch: str = "", device=None) -> BaseBackend:
     """Resolve a backend instance.
 
     *name* defaults to ``FLYDSL_COMPILE_BACKEND`` env var (or ``'rocm'``).
     *arch* overrides the auto-detected architecture when non-empty.
+    *device* supplies invocation-device metadata when no explicit *arch* is
+    given. Explicit environment overrides remain backend-owned and take
+    precedence over the device architecture.
 
     Compile/runtime pairing (``FLYDSL_COMPILE_BACKEND`` vs ``FLYDSL_RUNTIME_KIND``)
     is validated on each :class:`~flydsl.compiler.jit_function.JitFunction` call
@@ -85,7 +88,8 @@ def get_backend(name: Optional[str] = None, *, arch: str = "") -> BaseBackend:
                 raise ImportError(f"Compile backend '{name}' failed to import") from _import_errors[name]
             available = ", ".join(sorted(_registry)) or "(none)"
             raise ValueError(f"Unknown compile backend '{name}'. Registered backends: {available}")
-        arch = backend_cls.detect_target().arch
+        target = backend_cls.detect_target_for_device(device) if device is not None else backend_cls.detect_target()
+        arch = target.arch
     return _make_backend(name, arch)
 
 

--- a/python/flydsl/compiler/backends/base.py
+++ b/python/flydsl/compiler/backends/base.py
@@ -49,6 +49,18 @@ class BaseBackend(metaclass=ABCMeta):
         ...
 
     @classmethod
+    def detect_target_for_device(cls, device) -> GPUTarget:
+        """Resolve a target from invocation-device metadata.
+
+        Backends must opt in explicitly so a device-bearing invocation never
+        silently falls back to process-wide detection.
+        """
+        raise RuntimeError(
+            f"{cls.__name__} cannot resolve a target from invocation device {device}; "
+            "pass an explicit target architecture"
+        )
+
+    @classmethod
     def make_target(cls, arch: str) -> GPUTarget:
         """Build a GPUTarget for an explicit *arch* string.
 

--- a/python/flydsl/compiler/backends/rocm.py
+++ b/python/flydsl/compiler/backends/rocm.py
@@ -3,7 +3,7 @@
 
 from typing import List, Tuple
 
-from ...runtime.device import get_rocm_arch, is_rdna_arch
+from ...runtime.device import get_rocm_arch, get_rocm_arch_override, is_rdna_arch, normalize_rocm_arch
 from ...utils import env
 from .base import BaseBackend, GPUTarget
 
@@ -12,19 +12,40 @@ class RocmBackend(BaseBackend):
     """ROCm / AMDGPU compile backend (HIP runtime, ROCDL lowering)."""
 
     @staticmethod
+    def _explicit_arch() -> str:
+        return get_rocm_arch_override() or ""
+
+    @classmethod
+    def _target(cls, arch: str) -> GPUTarget:
+        warp_size = 32 if is_rdna_arch(arch) else 64
+        return GPUTarget(backend="rocm", arch=arch, warp_size=warp_size)
+
+    @staticmethod
     def supports_target(target: GPUTarget) -> bool:
         return target.backend == "rocm"
 
     @staticmethod
     def detect_target() -> GPUTarget:
-        arch = env.compile.arch or get_rocm_arch()
-        warp_size = 32 if is_rdna_arch(arch) else 64
-        return GPUTarget(backend="rocm", arch=arch, warp_size=warp_size)
+        arch = RocmBackend._explicit_arch()
+        if not arch:
+            if env.compile.compile_only:
+                raise RuntimeError(
+                    "ROCm compile-only target is unresolved; set ARCH, FLYDSL_GPU_ARCH, "
+                    "or HSA_OVERRIDE_GFX_VERSION to an explicit target"
+                )
+            arch = get_rocm_arch()
+        return RocmBackend._target(arch)
+
+    @classmethod
+    def detect_target_for_device(cls, device) -> GPUTarget:
+        if device.kind != "rocm":
+            raise ValueError(f"ROCm backend requires a ROCm device, got {device}")
+        arch = cls._explicit_arch() or get_rocm_arch(device.index)
+        return cls._target(arch)
 
     @classmethod
     def make_target(cls, arch: str) -> GPUTarget:
-        warp_size = 32 if is_rdna_arch(arch) else 64
-        return GPUTarget(backend="rocm", arch=arch, warp_size=warp_size)
+        return cls._target(normalize_rocm_arch(arch, source="target architecture"))
 
     # -- compile pipeline ------------------------------------------------
 

--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -27,9 +27,27 @@ from ..expr.typing import (
     Tensor,
     address_space_from_attr,
 )
+from ..runtime.device_runtime import Device
 from .protocol import DslType, JitArgument
 
 _RESOLVE_SIG_WARNED = set()
+
+
+def _dlpack_device(device_type: int, device_id: int) -> Optional[Device]:
+    # DLPack: kDLCUDA=2, kDLROCM=10. PyTorch uses its "cuda" namespace
+    # for ROCm but exports kDLROCM from __dlpack__.
+    if device_type == 10:
+        return Device(kind="rocm", index=int(device_id))
+    if device_type == 2:
+        kind = "rocm" if getattr(torch.version, "hip", None) else "cuda"
+        return Device(kind=kind, index=int(device_id))
+    return None
+
+
+def jit_argument_device(value) -> Optional[Device]:
+    """Return optional framework-adapter device metadata from a JIT argument."""
+    provider = getattr(value, "__flydsl_device__", None)
+    return provider() if provider is not None else None
 
 
 def resolve_signature(func):
@@ -451,6 +469,11 @@ class DLTensorJitArg(MemRefJitArg):
         dladaptor = DLTensorAdaptor(dl)
         self.dladaptor = dladaptor
         self.with_stream_dlpack = with_stream
+        try:
+            device_type, device_id = dladaptor.device_type, dladaptor.device_id
+        except AttributeError:
+            device_type, device_id = dltensor.__dlpack_device__()
+        self.device = _dlpack_device(device_type, device_id)
         super().__init__(
             element_bits=dladaptor.element_bits,
             shape=dladaptor.shape,
@@ -465,6 +488,9 @@ class DLTensorJitArg(MemRefJitArg):
     def element_type(self):
         # The dtype as an ir Type, built in the active (compile) context.
         return self.dladaptor.dtype
+
+    def __flydsl_device__(self):
+        return self.device
 
     def __c_abi_spec__(self):
         with_stream = self.with_stream_dlpack
@@ -551,6 +577,10 @@ class TorchTensorJitArg(MemRefJitArg):
         dynamic_layout: bool = True,
     ):
         self.torch_tensor = tensor
+        self.device = None
+        if tensor.device.type == "cuda":
+            kind = "rocm" if getattr(torch.version, "hip", None) else "cuda"
+            self.device = Device(kind=kind, index=tensor.get_device())
         super().__init__(
             element_bits=tensor.element_size() * 8,
             shape=tensor.shape,
@@ -564,6 +594,9 @@ class TorchTensorJitArg(MemRefJitArg):
     @property
     def element_type(self):
         return torch_dtype_to_mlir_type(self.dtype)
+
+    def __flydsl_device__(self):
+        return self.device
 
     def __c_abi_spec__(self):
         def ptr_fill(a, s):

--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -34,20 +34,33 @@ _RESOLVE_SIG_WARNED = set()
 
 
 def _dlpack_device(device_type: int, device_id: int) -> Optional[Device]:
-    # DLPack: kDLCUDA=2, kDLROCM=10. PyTorch uses its "cuda" namespace
-    # for ROCm but exports kDLROCM from __dlpack__.
+    # DLPack: kDLCUDA=2 and kDLROCM=10 are unambiguous producer APIs.
     if device_type == 10:
         return Device(kind="rocm", index=int(device_id))
     if device_type == 2:
-        kind = "rocm" if getattr(torch.version, "hip", None) else "cuda"
-        return Device(kind=kind, index=int(device_id))
+        return Device(kind="cuda", index=int(device_id))
     return None
 
 
 def jit_argument_device(value) -> Optional[Device]:
     """Return optional framework-adapter device metadata from a JIT argument."""
     provider = getattr(value, "__flydsl_device__", None)
-    return provider() if provider is not None else None
+    if provider is not None:
+        device = provider()
+        if device is not None:
+            return device
+
+    if isinstance(value, Stream):
+        raw = value.value
+        stream_device = getattr(raw, "device", None)
+        if getattr(stream_device, "type", None) == "cuda":
+            index = stream_device.index
+            if index is None:
+                index = getattr(raw, "device_index", None)
+            if index is not None:
+                kind = "rocm" if getattr(torch.version, "hip", None) else "cuda"
+                return Device(kind=kind, index=int(index))
+    return None
 
 
 def resolve_signature(func):

--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -27,7 +27,7 @@ from ..expr.typing import (
     Tensor,
     address_space_from_attr,
 )
-from ..runtime.device_runtime import Device, device_from_argument, device_from_dlpack
+from ..runtime.device_runtime import Device, device_from_argument, device_from_dlpack, device_from_stream_argument
 from .protocol import DslType, JitArgument
 
 _RESOLVE_SIG_WARNED = set()
@@ -43,17 +43,8 @@ def jit_argument_device(value) -> Optional[Device]:
     if device is not None:
         return device
 
-    if isinstance(value, Stream):
-        raw = value.value
-        stream_device = getattr(raw, "device", None)
-        if getattr(stream_device, "type", None) == "cuda":
-            index = stream_device.index
-            if index is None:
-                index = getattr(raw, "device_index", None)
-            if index is not None:
-                kind = "rocm" if getattr(torch.version, "hip", None) else "cuda"
-                return Device(kind=kind, index=int(index))
-    return None
+    kind = "rocm" if getattr(torch.version, "hip", None) else "cuda"
+    return device_from_stream_argument(value, cuda_kind=kind)
 
 
 def resolve_signature(func):

--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -27,28 +27,21 @@ from ..expr.typing import (
     Tensor,
     address_space_from_attr,
 )
-from ..runtime.device_runtime import Device
+from ..runtime.device_runtime import Device, device_from_argument, device_from_dlpack
 from .protocol import DslType, JitArgument
 
 _RESOLVE_SIG_WARNED = set()
 
 
 def _dlpack_device(device_type: int, device_id: int) -> Optional[Device]:
-    # DLPack: kDLCUDA=2 and kDLROCM=10 are unambiguous producer APIs.
-    if device_type == 10:
-        return Device(kind="rocm", index=int(device_id))
-    if device_type == 2:
-        return Device(kind="cuda", index=int(device_id))
-    return None
+    return device_from_dlpack(device_type, device_id)
 
 
 def jit_argument_device(value) -> Optional[Device]:
     """Return optional framework-adapter device metadata from a JIT argument."""
-    provider = getattr(value, "__flydsl_device__", None)
-    if provider is not None:
-        device = provider()
-        if device is not None:
-            return device
+    device = device_from_argument(value)
+    if device is not None:
+        return device
 
     if isinstance(value, Stream):
         raw = value.value

--- a/python/flydsl/compiler/jit_executor.py
+++ b/python/flydsl/compiler/jit_executor.py
@@ -5,6 +5,8 @@ import ctypes
 import importlib
 import pickle
 import threading
+from contextlib import nullcontext
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Callable, List, Optional
@@ -60,10 +62,11 @@ def _resolve_qualname(ref: str) -> Optional[Callable]:
 
 @lru_cache(maxsize=1)
 def _resolve_runtime_libs() -> List[str]:
+    from .._mlir import _mlir_libs
     from .backends import get_backend
 
     backend = get_backend()
-    mlir_libs_dir = Path(__file__).resolve().parent.parent / "_mlir" / "_mlir_libs"
+    mlir_libs_dir = Path(_mlir_libs.__file__).resolve().parent
     libs = [mlir_libs_dir / name for name in backend.jit_runtime_lib_basenames()]
     for lib in libs:
         if not lib.exists():
@@ -85,9 +88,10 @@ def _pack_ciface_args(*args) -> ctypes.c_void_p:
 class GpuJitModule:
     """Owns GPU modules loaded for one ExecutionEngine."""
 
-    def __init__(self, engine: ExecutionEngine, modules: List[int]):
+    def __init__(self, engine: ExecutionEngine, modules: List[int], device=None):
         self.engine = engine
         self.modules = list(modules)
+        self.device = device
         self._runtime_lib = ctypes.CDLL(str(_resolve_runtime_libs()[0]))
         self._runtime_lib.mgpuModuleUnload.argtypes = [ctypes.c_void_p]
         self._runtime_lib.mgpuModuleUnload.restype = None
@@ -97,10 +101,15 @@ class GpuJitModule:
         if self._unloaded:
             return
         try:
-            for module in self.modules:
-                if module:
-                    self._runtime_lib.mgpuModuleUnload(ctypes.c_void_p(module))
-            self.modules.clear()
+            from ..runtime.device_runtime import get_device_runtime
+
+            runtime = get_device_runtime()
+            guard = runtime.device_guard(self.device.index) if self.device is not None else nullcontext()
+            with guard:
+                for module in self.modules:
+                    if module:
+                        self._runtime_lib.mgpuModuleUnload(ctypes.c_void_p(module))
+                self.modules.clear()
         finally:
             self._unloaded = True
 
@@ -214,6 +223,15 @@ class CallState:
         return dispatch(args_tuple)
 
 
+@dataclass
+class _DeviceExecutable:
+    module: object
+    engine: object
+    jit_module: object
+    context: object
+    func_exe: object
+
+
 class CompiledArtifact:
     def __init__(
         self,
@@ -230,10 +248,7 @@ class CompiledArtifact:
         self._post_load_processors = post_load_processors or []
         self._link_libs = link_libs or []
         self._uses_explicit_module = uses_explicit_module
-        self._module = None
-        self._engine = None
-        self._jit_module = None
-        self._func_exe = None
+        self._executables = {}
         self._lock = threading.Lock()
 
     def __getstate__(self):
@@ -298,22 +313,22 @@ class CompiledArtifact:
             raise pickle.UnpicklingError(
                 "CompiledArtifact could not resolve required post-load " f"processors: {missing}"
             )
-        self._module = None
-        self._engine = None
-        self._jit_module = None
-        self._func_exe = None
+        self._executables = {}
         self._lock = threading.Lock()
 
-    def _ensure_engine(self):
-        with self._lock:
-            if self._engine is not None:
-                return
+    def _load_executable(self, device):
+        from ..runtime.device_runtime import get_device_runtime
+        from .jit_function import _create_mlir_context
 
-            # Keep the Context alive on self._ctx: destroying it
-            # while ExecutionEngine still holds HSA code objects
-            # causes GPU memory access faults.
-            from .jit_function import _create_mlir_context
-
+        runtime = get_device_runtime()
+        if device is not None and runtime.kind != device.kind:
+            raise RuntimeError(
+                f"Compiled artifact device runtime {device.kind!r} does not match " f"active runtime {runtime.kind!r}"
+            )
+        guard = runtime.device_guard(device.index) if device is not None else nullcontext()
+        with guard:
+            # Keep the Context alive with the ExecutionEngine: destroying it
+            # while HSA code objects are loaded causes GPU memory access faults.
             ctx = _create_mlir_context()
             with ctx:
                 module = ir.Module.parse(self._ir_text)
@@ -343,25 +358,24 @@ class CompiledArtifact:
                         "loader symbol used by MLIR."
                     )
 
-                jit_module = GpuJitModule(engine, loaded_modules)
+                jit_module = GpuJitModule(engine, loaded_modules, device)
                 for proc in self._post_load_processors:
                     for mod_handle in loaded_modules:
                         proc(mod_handle)
             else:
                 jit_module = None
 
-            self._module = module
-            self._engine = engine
-            self._jit_module = jit_module
-            self._ctx = ctx
+            func_ptr = engine.raw_lookup(self._entry)
+            func_exe = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(func_ptr)
+            return _DeviceExecutable(module, engine, jit_module, ctx, func_exe)
 
-    def _get_func_exe(self):
-        if self._func_exe is None:
-            if self._engine is None:
-                self._ensure_engine()
-            func_ptr = self._engine.raw_lookup(self._entry)
-            self._func_exe = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(func_ptr)
-        return self._func_exe
+    def _get_func_exe(self, device):
+        with self._lock:
+            executable = self._executables.get(device)
+            if executable is None:
+                executable = self._load_executable(device)
+                self._executables[device] = executable
+            return executable.func_exe
 
     def dump(self, compiled: bool = True):
         if compiled:

--- a/python/flydsl/compiler/jit_executor.py
+++ b/python/flydsl/compiler/jit_executor.py
@@ -199,13 +199,17 @@ class CallState:
     -- no per-slot loop, no ctypes allocation. Thread-local for thread safety.
     """
 
-    __slots__ = ("_func_exe", "_spec", "_tls", "_factory")
+    __slots__ = ("_func_exe", "_spec", "_tls", "_factory", "_keepalive")
 
-    def __init__(self, slot_specs, func_exe):
+    def __init__(self, slot_specs, func_exe, *, keepalive=None):
         self._func_exe = func_exe
         self._spec = slot_specs  # list of (arg_idx, ctype, fill)
         self._tls = threading.local()
         self._factory = _build_dispatch_factory(slot_specs)
+        # A ctypes function created from a raw ExecutionEngine address does not
+        # retain that engine. Keep its owning CompiledArtifact alive for exactly
+        # as long as this cached dispatch state can call the pointer.
+        self._keepalive = keepalive
 
     def _make_dispatch(self):
         # Allocate one typed storage per slot + the packed pointer array; the null

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -25,6 +25,7 @@ from .._mlir.passmanager import PassManager
 from ..expr.meta import tracing_context
 from ..expr.typing import Constexpr, Stream
 from ..expr.utils.arith import fastmath as fastmath_ctx
+from ..runtime.device_runtime import Device, get_device_runtime
 from ..utils import env, log
 from .ast_rewriter import ASTRewriter
 from .backends import compile_backend_name, get_backend
@@ -36,7 +37,12 @@ from .diagnostics import (
     warn_annotation_value_mismatch,
     warn_invalid_annotations,
 )
-from .jit_argument import convert_to_jit_arguments, is_type_param_annotation, resolve_signature
+from .jit_argument import (
+    convert_to_jit_arguments,
+    is_type_param_annotation,
+    jit_argument_device,
+    resolve_signature,
+)
 from .jit_executor import CallState, CompiledArtifact
 from .kernel_function import (
     CompilationContext,
@@ -59,6 +65,21 @@ from .protocol import (
 EXTRA_SOURCE_DIRS: List[str] = []
 
 CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "currsize", "disk_size"])
+
+
+@dataclass(frozen=True)
+class _Invocation:
+    target: Any
+    device: Optional[Device]
+
+
+def _device_guard(device: Optional[Device]):
+    if device is None:
+        return nullcontext()
+    runtime = get_device_runtime()
+    if runtime.kind != device.kind:
+        raise RuntimeError(f"Invocation device runtime {device.kind!r} does not match active runtime {runtime.kind!r}")
+    return runtime.device_guard(device.index)
 
 
 class FileLock:
@@ -292,16 +313,29 @@ def _snapshot_refs(refs: List[Tuple[str, str, dict]], *, stable: bool) -> Dict[T
     return out
 
 
-def _flydsl_key() -> str:
+def _flydsl_key(target=None) -> str:
     extra = list(EXTRA_SOURCE_DIRS)
     env_extra = os.environ.get("FLYDSL_EXTRA_SOURCE_DIRS", "")
     if env_extra:
         extra.extend(d.strip() for d in env_extra.split(":") if d.strip())
-    return _flydsl_key_cached(_use_external_binary_codegen(), env.compile.llvm_dir, tuple(extra))
+    backend = get_backend(target.backend, arch=target.arch) if target is not None else get_backend()
+    return _flydsl_key_cached(
+        _use_external_binary_codegen(),
+        env.compile.llvm_dir,
+        backend.target.backend,
+        backend.target.arch,
+        tuple(extra),
+    )
 
 
 @lru_cache(maxsize=4)
-def _flydsl_key_cached(use_external_binary: bool, llvm_dir: str, extra_source_dirs: tuple = ()) -> str:
+def _flydsl_key_cached(
+    use_external_binary: bool,
+    llvm_dir: str,
+    backend_name: str,
+    backend_arch: str,
+    extra_source_dirs: tuple = (),
+) -> str:
     """Compute a hash fingerprint of the entire FlyDSL compiler toolchain.
 
     Covers:
@@ -345,7 +379,7 @@ def _flydsl_key_cached(use_external_binary: bool, llvm_dir: str, extra_source_di
             contents.append(hashlib.sha256(f.read()).hexdigest())
 
     # 2) Hash native shared libraries (C++ passes, runtime wrappers, bindings).
-    backend = get_backend()
+    backend = get_backend(backend_name, arch=backend_arch)
     mlir_libs_dir = flydsl_root / "_mlir" / "_mlir_libs"
     if mlir_libs_dir.is_dir():
         for pattern in backend.native_lib_patterns():
@@ -570,14 +604,14 @@ def _collect_dependency_sources(
     return sources
 
 
-def _jit_function_cache_key(func: Callable, owner_cls=None) -> str:
+def _jit_function_cache_key(func: Callable, owner_cls=None, target=None) -> str:
     in_progress = _keys_in_progress()
     added = id(func) not in in_progress
     if added:
         in_progress.add(id(func))
     try:
         parts = []
-        parts.append(_flydsl_key())
+        parts.append(_flydsl_key(target))
         parts.append(_get_func_source(func))
         try:
             rootFile = inspect.getfile(func)
@@ -1172,11 +1206,11 @@ class JitFunction:
         self.compile_hints = dict(compile_hints) if compile_hints is not None else {}
         self.manager_key = None
         self._manager_owner_cls = None
+        self._manager_target = None
         self.cache_manager = None
-        self._call_state_cache = {}  # cache_key -> CallState
+        self._call_state_cache = {}  # (artifact cache key, device) -> CallState
         self._sig = None  # lazy: set on first call
         self._has_self_param = False  # lazy: set in _ensure_sig
-        self._backend_target = None  # lazy: GPUTarget resolved once in _ensure_sig
         self._mem_cache = {}
         self._last_compiled = None  # (cache_key, CompiledArtifact) for compile()
         self._extern_linkage_keys = set()
@@ -1250,16 +1284,16 @@ class JitFunction:
             self._sig = full_sig.replace(parameters=params[1:])
         else:
             self._sig = full_sig
-        self._backend_target = get_backend().target  # frozen dataclass, stable
 
         # Definition-time annotation validity check (once per function, signature-only).
         warn_invalid_annotations(self._sig, context="@jit")
 
-    def _ensure_cache_manager(self, owner_cls=None):
-        if self.manager_key is not None and self._manager_owner_cls is owner_cls:
+    def _ensure_cache_manager(self, owner_cls=None, target=None):
+        if self.manager_key is not None and self._manager_owner_cls is owner_cls and self._manager_target == target:
             return
         self._manager_owner_cls = owner_cls
-        self.manager_key = _jit_function_cache_key(self.func, owner_cls=owner_cls)
+        self._manager_target = target
+        self.manager_key = _jit_function_cache_key(self.func, owner_cls=owner_cls, target=target)
 
         run_only = env.runtime.run_only
         if run_only and env.debug.dump_ir:
@@ -1284,9 +1318,9 @@ class JitFunction:
         self.cache_manager = JitCacheManager(cache_dir)
         self.cache_manager.load_all()
 
-    def _resolve_and_make_cache_key(self, bound_args, *, effective_hints=None):
+    def _resolve_and_make_cache_key(self, bound_args, *, effective_hints=None, return_invocation=False):
         """Resolve raw call values into JitArgument instances *in place* and
-        build the tuple cache key from them.
+        build the tuple cache key and invocation target from them.
 
         Side effect: entries in ``bound_args`` whose annotation is neither
         ``Constexpr[T]`` nor ``Type[T]`` are replaced with their resolved
@@ -1300,29 +1334,18 @@ class JitFunction:
         from .jit_argument import JitArgumentRegistry
 
         sig = self._sig
-        # Re-read env vars on every call.
-        key_parts = [("_env_", _cache_invalidating_env_values()), ("_target_", self._backend_target)]
-        if effective_hints is None:
-            effective_hints = self._effective_compile_hints()
-        if effective_hints:
-            hint_key = tuple(
-                sorted(
-                    (key, type(value).__module__, type(value).__qualname__, repr(value))
-                    for key, value in effective_hints.items()
-                )
-            )
-            key_parts.append(("_hints_", hint_key))
-
+        argument_key_parts = []
+        devices = set()
         for name, arg in bound_args.items():
             param = sig.parameters.get(name)
             ann = param.annotation if param else inspect.Parameter.empty
 
             if ann is not inspect.Parameter.empty:
                 if Constexpr.is_constexpr_annotation(ann):
-                    key_parts.append((name, Constexpr.value_signature(arg)))
+                    argument_key_parts.append((name, Constexpr.value_signature(arg)))
                     continue
                 if is_type_param_annotation(ann):
-                    key_parts.append((name, arg))
+                    argument_key_parts.append((name, arg))
                     continue
 
             if isinstance(arg, JitArgument):
@@ -1339,9 +1362,34 @@ class JitFunction:
                 jit_arg = ctor(arg)
 
             bound_args[name] = jit_arg
-            key_parts.append((name, cache_signature(jit_arg)))
+            argument_key_parts.append((name, cache_signature(jit_arg)))
+            device = jit_argument_device(jit_arg)
+            if device is not None:
+                devices.add(device)
 
-        return tuple(key_parts)
+        if len(devices) > 1:
+            rendered = ", ".join(f"{device.kind}:{device.index}" for device in sorted(devices, key=repr))
+            raise ValueError(f"FlyDSL JIT arguments must reside on the same device, got {rendered}")
+        device = next(iter(devices), None)
+        backend = get_backend(device=device)
+        invocation = _Invocation(target=backend.target, device=device)
+
+        # Re-read env vars on every call.
+        key_parts = [("_env_", _cache_invalidating_env_values()), ("_target_", invocation.target)]
+        if effective_hints is None:
+            effective_hints = self._effective_compile_hints()
+        if effective_hints:
+            hint_key = tuple(
+                sorted(
+                    (key, type(value).__module__, type(value).__qualname__, repr(value))
+                    for key, value in effective_hints.items()
+                )
+            )
+            key_parts.append(("_hints_", hint_key))
+        key_parts.extend(argument_key_parts)
+
+        cache_key = tuple(key_parts)
+        return (cache_key, invocation) if return_invocation else cache_key
 
     def _globals_key_prefix(self, owner_cls=None) -> tuple:
         """Memoized ``("_globals_", ...)`` cache-key segment for ``owner_cls``.
@@ -1361,14 +1409,23 @@ class JitFunction:
             cache[owner_cls] = (("_globals_", tuple(sorted(stable.items()))),) if stable else ()
         return cache[owner_cls]
 
-    def _build_full_cache_key(self, bound_arguments, *, owner_cls=None, bound_self=None, effective_hints=None):
+    def _build_full_cache_key(
+        self,
+        bound_arguments,
+        *,
+        owner_cls=None,
+        bound_self=None,
+        effective_hints=None,
+        return_invocation=False,
+    ):
         """Build the complete cache key: arg signatures + stable globals snapshot + self type."""
-        cache_key = self._globals_key_prefix(owner_cls) + self._resolve_and_make_cache_key(
-            bound_arguments, effective_hints=effective_hints
+        resolved_key, invocation = self._resolve_and_make_cache_key(
+            bound_arguments, effective_hints=effective_hints, return_invocation=True
         )
+        cache_key = self._globals_key_prefix(owner_cls) + resolved_key
         if bound_self is not None:
             cache_key = (("_self_type_", type(bound_self)),) + cache_key
-        return cache_key
+        return (cache_key, invocation) if return_invocation else cache_key
 
     @staticmethod
     def _cache_key_to_str(cache_key) -> str:
@@ -1387,7 +1444,6 @@ class JitFunction:
                 raise TypeError(f"{self.func.__name__}() missing 'self' argument")
             bound_self, args = args[0], args[1:]
         owner_cls = type(bound_self) if bound_self is not None else None
-        self._ensure_cache_manager(owner_cls)
 
         # snapshot the used globals on first compile (per owner_cls) and RAISE on
         # any later change.
@@ -1400,28 +1456,39 @@ class JitFunction:
         bound = sig.bind(*args, **kwargs)
         bound.apply_defaults()
 
-        # Resolve once so cache identity and compilation use the same options.
-        effective_hints = self._effective_compile_hints()
-        cache_key = self._build_full_cache_key(
-            bound.arguments,
-            owner_cls=owner_cls,
-            bound_self=bound_self,
-            effective_hints=effective_hints,
-        )
-
-        args_tuple = tuple(bound.arguments.values())
-
-        # Compile/runtime pairing at JIT entry (not in CompiledArtifact / ExecutionEngine init).
+        # Validate the process-wide compile/runtime pairing before target
+        # resolution consults invocation-device metadata.
         from ..runtime.device_runtime import ensure_compile_runtime_pairing_from_env
 
         ensure_compile_runtime_pairing_from_env(compile_backend_name())
 
+        # Resolve once so cache identity and compilation use the same options.
+        effective_hints = self._effective_compile_hints()
+        cache_key, invocation = self._build_full_cache_key(
+            bound.arguments,
+            owner_cls=owner_cls,
+            bound_self=bound_self,
+            effective_hints=effective_hints,
+            return_invocation=True,
+        )
+
+        args_tuple = tuple(bound.arguments.values())
+        if invocation.device is None and not env.compile.compile_only:
+            runtime = get_device_runtime()
+            invocation = _Invocation(
+                target=invocation.target,
+                device=Device(kind=runtime.kind, index=runtime.current_device_id()),
+            )
+        dispatch_key = (cache_key, invocation.device)
+        self._ensure_cache_manager(owner_cls, invocation.target)
+
         # Fast path: reuse pre-built CallState (no ctypes alloc, no DLPack)
-        call_state = self._call_state_cache.get(cache_key)
+        call_state = self._call_state_cache.get(dispatch_key)
         if call_state is not None:
             if env.compile.compile_only:
                 return None
-            return call_state(args_tuple)
+            with _device_guard(invocation.device):
+                return call_state(args_tuple)
 
         # Normal path: check in-process cache first, then optional disk cache.
         # In run_only mode the disk cache is read regardless of enable_cache, since
@@ -1447,10 +1514,11 @@ class JitFunction:
             state = _build_call_state(
                 sig,
                 args_tuple,
-                cached_func._get_func_exe(),
+                cached_func._get_func_exe(invocation.device),
             )
-            self._call_state_cache[cache_key] = state
-            return state(args_tuple)
+            self._call_state_cache[dispatch_key] = state
+            with _device_guard(invocation.device):
+                return state(args_tuple)
 
         if run_only:
             cdir = getattr(self.cache_manager, "cache_dir", None)
@@ -1490,7 +1558,9 @@ class JitFunction:
                 self._mem_cache[cache_key] = compiled_func
                 self._last_compiled = (cache_key, compiled_func)
             else:
-                with _create_mlir_context() as ctx, _hints_ctx:
+                # Tracing helpers that query the current architecture must see
+                # the same device that selected the backend target.
+                with _device_guard(invocation.device), _create_mlir_context() as ctx, _hints_ctx:
                     param_names, jit_args, dsl_types, constexpr_values = convert_to_jit_arguments(sig, bound)
                     # Per-call value/annotation consistency check.
                     for pname, dsl_type in zip(param_names, dsl_types):
@@ -1512,7 +1582,10 @@ class JitFunction:
                     module.operation.attributes["gpu.container_module"] = ir.UnitAttr.get()
 
                     with ir.InsertionPoint(module.body), loc:
-                        backend = get_backend()
+                        backend = get_backend(
+                            invocation.target.backend,
+                            arch=invocation.target.arch,
+                        )
                         gpu_module = create_gpu_module("kernels", targets=backend.gpu_module_targets())
 
                         func_op = func.FuncOp(self.func.__name__, (ir_types, []))
@@ -1601,7 +1674,7 @@ class JitFunction:
 
         # OUTSIDE lock: engine init + kernel launch
         if env.compile.compile_only:
-            print(f"[flydsl] COMPILE_ONLY=1, compilation succeeded (arch={get_backend().target.arch})")
+            print(f"[flydsl] COMPILE_ONLY=1, compilation succeeded (arch={invocation.target.arch})")
             return None
 
         # The in-process CompiledArtifact cache above owns the ExecutionEngine/
@@ -1610,10 +1683,11 @@ class JitFunction:
         state = _build_call_state(
             sig,
             args_tuple,
-            compiled_func._get_func_exe(),
+            compiled_func._get_func_exe(invocation.device),
         )
-        self._call_state_cache[cache_key] = state
-        return state(args_tuple)
+        self._call_state_cache[dispatch_key] = state
+        with _device_guard(invocation.device):
+            return state(args_tuple)
 
 
 def _ensure_stream_arg(jit_args: list) -> bool:
@@ -1639,22 +1713,26 @@ class CompiledFunction:
     All MLIR compilation, signature analysis, and argument metadata resolution
     happen once at ``compile()`` time.  The ``__call__`` hot path does only:
 
-    1. Update pre-allocated ctypes storage (data_ptr / scalar extraction)
-    2. Invoke the JIT'd C function pointer
+    1. Enter the compiled invocation device when needed
+    2. Update pre-allocated ctypes storage (data_ptr / scalar extraction)
+    3. Invoke the JIT'd C function pointer
 
     No ``inspect.Signature.bind``, no ``_resolve_and_make_cache_key``, no cache lookup.
     Accepts **positional arguments only** (same count and order as the
-    original ``@flyc.jit`` function).
+    original ``@flyc.jit`` function). The callable is pinned to its compile
+    invocation device; replacement tensor arguments must remain on that device.
     """
 
-    __slots__ = ("_call_state", "_keepalive")
+    __slots__ = ("_call_state", "_keepalive", "_device")
 
-    def __init__(self, call_state, keepalive):
+    def __init__(self, call_state, keepalive, device):
         self._call_state = call_state
         self._keepalive = keepalive  # prevent GC of CompiledArtifact / ExecutionEngine
+        self._device = device
 
     def __call__(self, *args):
-        return self._call_state(args)
+        with _device_guard(self._device):
+            return self._call_state(args)
 
 
 def _compile_impl(func, *args) -> CompiledFunction:
@@ -1685,7 +1763,13 @@ def _compile_impl(func, *args) -> CompiledFunction:
     sig = jf._sig  # guaranteed initialized after __call__
     bound = sig.bind(*args)
     bound.apply_defaults()
-    cache_key = jf._build_full_cache_key(bound.arguments)
+    cache_key, invocation = jf._build_full_cache_key(bound.arguments, return_invocation=True)
+    if invocation.device is None and not env.compile.compile_only:
+        runtime = get_device_runtime()
+        invocation = _Invocation(
+            target=invocation.target,
+            device=Device(kind=runtime.kind, index=runtime.current_device_id()),
+        )
     args_tuple = tuple(bound.arguments.values())
 
     # Look up the CompiledArtifact.  We must hold a direct reference to it
@@ -1701,11 +1785,16 @@ def _compile_impl(func, *args) -> CompiledFunction:
     if artifact is None:
         raise RuntimeError("flyc.compile(): compilation succeeded but no cached artifact found.")
 
-    call_state = jf._call_state_cache.get(cache_key)
+    dispatch_key = (cache_key, invocation.device)
+    call_state = jf._call_state_cache.get(dispatch_key)
     if call_state is None:
-        call_state = _build_call_state(sig, args_tuple, artifact._get_func_exe())
+        call_state = _build_call_state(
+            sig,
+            args_tuple,
+            artifact._get_func_exe(invocation.device),
+        )
 
-    return CompiledFunction(call_state, artifact)
+    return CompiledFunction(call_state, artifact, invocation.device)
 
 
 class CompileCallable:

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -447,6 +447,16 @@ def _is_user_function(func, rootFile):
     return os.path.dirname(os.path.abspath(funcFile)) == os.path.dirname(os.path.abspath(rootFile))
 
 
+def _dependency_root_file(value, underlying, fallback):
+    """Use a nested DSL callable's own directory when walking its helpers."""
+    if isinstance(value, (JitFunction, KernelFunction)):
+        try:
+            return inspect.getfile(underlying)
+        except (TypeError, OSError):
+            pass
+    return fallback
+
+
 def _owner_class_from_func(func):
     qualname = getattr(func, "__qualname__", "")
     parts = qualname.split(".")[:-1]
@@ -566,7 +576,13 @@ def _collect_dependency_sources(
         visited.add(id(underlying))
         should_recurse = _emit("", name, obj, underlying)
         if should_recurse:
-            sources.extend(_collect_dependency_sources(underlying, rootFile, visited))
+            sources.extend(
+                _collect_dependency_sources(
+                    underlying,
+                    _dependency_root_file(obj, underlying, rootFile),
+                    visited,
+                )
+            )
 
     # 2) Scan closure variables (co_freevars → __closure__) for callable
     #    dependencies.  This catches @flyc.kernel functions defined in an
@@ -583,7 +599,13 @@ def _collect_dependency_sources(
             visited.add(id(underlying))
             should_recurse = _emit("closure:", name, val, underlying)
             if should_recurse:
-                sources.extend(_collect_dependency_sources(underlying, rootFile, visited))
+                sources.extend(
+                    _collect_dependency_sources(
+                        underlying,
+                        _dependency_root_file(val, underlying, rootFile),
+                        visited,
+                    )
+                )
 
     owner_cls = owner_cls or _owner_class_from_func(func)
     if owner_cls is not None:
@@ -1130,7 +1152,7 @@ def _resolve_jit_arg_type(arg, annotation):
     return constructor
 
 
-def _build_call_state(sig, args_tuple, func_exe):
+def _build_call_state(sig, args_tuple, func_exe, *, keepalive=None):
     """Build a CallState for fast repeated dispatch.
 
     Resolves each parameter's JitArgument type using the same registry as
@@ -1170,7 +1192,7 @@ def _build_call_state(sig, args_tuple, func_exe):
     if not has_user_stream:
         slot_specs.append((-1, ctypes.c_void_p, None))
 
-    return CallState(slot_specs, func_exe)
+    return CallState(slot_specs, func_exe, keepalive=keepalive)
 
 
 class JitFunction:
@@ -1206,6 +1228,7 @@ class JitFunction:
         self._sig = None  # lazy: set on first call
         self._has_self_param = False  # lazy: set in _ensure_sig
         self._mem_cache = {}
+        self._artifact_cache_lock = threading.Lock()
         self._last_compiled = None  # (cache_key, CompiledArtifact) for compile()
         self._extern_linkage_keys = set()
 
@@ -1265,6 +1288,18 @@ class JitFunction:
         if self.cache_manager is None:
             return None
         return self.cache_manager.cache_info()
+
+    def _publish_artifact(self, cache_key, artifact):
+        """Publish and return the one in-process artifact for *cache_key*.
+
+        Cold concurrent callers may independently compile or unpickle the same
+        key. They must rebind to the retained artifact before creating function
+        pointers or CallState objects.
+        """
+        with self._artifact_cache_lock:
+            canonical = self._mem_cache.setdefault(cache_key, artifact)
+            self._last_compiled = (cache_key, canonical)
+            return canonical
 
     def _ensure_sig(self):
         """Initialize signature + param metadata on first call (not at decoration time)."""
@@ -1506,7 +1541,7 @@ class JitFunction:
                 _rejected_link_libs = True
                 cached_func = None
             if cached_func is not None:
-                self._mem_cache[cache_key] = cached_func
+                cached_func = self._publish_artifact(cache_key, cached_func)
 
         if cached_func is not None:
             if env.compile.compile_only:
@@ -1516,6 +1551,7 @@ class JitFunction:
                 sig,
                 args_tuple,
                 cached_func._get_func_exe(invocation.device),
+                keepalive=cached_func,
             )
             self._call_state_cache[dispatch_key] = state
             with _device_guard(invocation.device):
@@ -1555,9 +1591,7 @@ class JitFunction:
 
             if _lock_result is not None and not getattr(_lock_result, "_link_libs", None):
                 # Cache hit after waiting for another process to compile.
-                compiled_func = _lock_result
-                self._mem_cache[cache_key] = compiled_func
-                self._last_compiled = (cache_key, compiled_func)
+                compiled_func = self._publish_artifact(cache_key, _lock_result)
             else:
                 # Tracing helpers that query the current architecture must see
                 # the same device that selected the backend target.
@@ -1659,14 +1693,9 @@ class JitFunction:
                         uses_explicit_module=extern_linked,
                     )
 
-                    # Always keep a reference to the latest compilation result so
-                    # flyc.compile() can retrieve it even when caching is disabled.
-                    self._last_compiled = (cache_key, compiled_func)
-
-                    # Keep compiled artifacts alive within the process even when disk
-                    # cache is disabled. This preserves code object lifetime for
-                    # profiler/roctracer teardown and enables fast same-process reuse.
-                    self._mem_cache[cache_key] = compiled_func
+                    # Keep one canonical artifact alive even when disk caching is
+                    # disabled, and discard any duplicate produced by a cold race.
+                    compiled_func = self._publish_artifact(cache_key, compiled_func)
                     if _cache_writer and not extern_linked:
                         try:
                             _cache_writer(compiled_func)
@@ -1678,13 +1707,13 @@ class JitFunction:
             print(f"[flydsl] COMPILE_ONLY=1, compilation succeeded (arch={invocation.target.arch})")
             return None
 
-        # The in-process CompiledArtifact cache above owns the ExecutionEngine/
-        # code object, so the function pointer remains valid even when disk
-        # cache is off.
+        # CallState explicitly retains the CompiledArtifact that owns this raw
+        # function pointer.
         state = _build_call_state(
             sig,
             args_tuple,
             compiled_func._get_func_exe(invocation.device),
+            keepalive=compiled_func,
         )
         self._call_state_cache[dispatch_key] = state
         with _device_guard(invocation.device):
@@ -1795,6 +1824,7 @@ def _compile_impl(func, *args) -> Optional[CompiledFunction]:
             sig,
             args_tuple,
             artifact._get_func_exe(invocation.device),
+            keepalive=artifact,
         )
 
     return CompiledFunction(call_state, artifact, invocation.device)

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -1152,12 +1152,13 @@ def _resolve_jit_arg_type(arg, annotation):
     return constructor
 
 
-def _build_call_state(sig, args_tuple, func_exe, *, keepalive=None):
+def _build_call_state(sig, args_tuple, artifact, device):
     """Build a CallState for fast repeated dispatch.
 
     Resolves each parameter's JitArgument type using the same registry as
     convert_to_jit_arguments, then asks it for a reusable slot specification.
-    This ensures a single source of truth for argument packing.
+    The artifact supplies both the function pointer and its lifetime owner, so
+    callers cannot publish a pointer with a missing or mismatched keepalive.
     """
 
     slot_specs = []
@@ -1192,7 +1193,11 @@ def _build_call_state(sig, args_tuple, func_exe, *, keepalive=None):
     if not has_user_stream:
         slot_specs.append((-1, ctypes.c_void_p, None))
 
-    return CallState(slot_specs, func_exe, keepalive=keepalive)
+    return CallState(
+        slot_specs,
+        artifact._get_func_exe(device),
+        keepalive=artifact,
+    )
 
 
 class JitFunction:
@@ -1550,8 +1555,8 @@ class JitFunction:
             state = _build_call_state(
                 sig,
                 args_tuple,
-                cached_func._get_func_exe(invocation.device),
-                keepalive=cached_func,
+                cached_func,
+                invocation.device,
             )
             self._call_state_cache[dispatch_key] = state
             with _device_guard(invocation.device):
@@ -1712,8 +1717,8 @@ class JitFunction:
         state = _build_call_state(
             sig,
             args_tuple,
-            compiled_func._get_func_exe(invocation.device),
-            keepalive=compiled_func,
+            compiled_func,
+            invocation.device,
         )
         self._call_state_cache[dispatch_key] = state
         with _device_guard(invocation.device):
@@ -1823,8 +1828,8 @@ def _compile_impl(func, *args) -> Optional[CompiledFunction]:
         call_state = _build_call_state(
             sig,
             args_tuple,
-            artifact._get_func_exe(invocation.device),
-            keepalive=artifact,
+            artifact,
+            invocation.device,
         )
 
     return CompiledFunction(call_state, artifact, invocation.device)

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -466,7 +466,6 @@ def _collect_class_member_dependency_sources(
     rootFile,
     owner_cls,
     visited: Set[int],
-    target=None,
 ) -> List[str]:
     sources = []
 
@@ -490,7 +489,6 @@ def _collect_class_member_dependency_sources(
                 rootFile,
                 visited,
                 owner_cls=owner_cls,
-                target=target,
             )
         )
 
@@ -532,25 +530,11 @@ def _collect_closure_scalar_vals(func, visited_ids: Optional[Set[int]] = None) -
     return vals
 
 
-# Per-thread ``id(func)`` set of keys being computed, to break cache-key
-# dependency cycles. Thread-local so concurrent compilations don't collide.
-_key_computation = threading.local()
-
-
-def _keys_in_progress() -> Set[int]:
-    stack = getattr(_key_computation, "stack", None)
-    if stack is None:
-        stack = set()
-        _key_computation.stack = stack
-    return stack
-
-
 def _collect_dependency_sources(
     func,
     rootFile,
     visited: Optional[Set[int]] = None,
     owner_cls=None,
-    target=None,
 ) -> List[str]:
     from .kernel_function import KernelFunction
 
@@ -559,19 +543,13 @@ def _collect_dependency_sources(
     sources = []
 
     def _emit(prefix: str, name: str, val, underlying):
-        # JitFunction has its own manager_key — use it as a stable identity
-        # so cross-directory deps are tracked without dragging in the full
-        # source file (which would force ad-hoc same-dir filtering).
+        closure_vals = sorted(_collect_closure_scalar_vals(underlying))
+        closure_suffix = f":closure_vals={','.join(closure_vals)}" if closure_vals else ""
         if isinstance(val, JitFunction):
-            # Cycle: this jit is already being keyed — emit a placeholder.
-            if id(val.func) in _keys_in_progress():
-                label = getattr(val.func, "__qualname__", getattr(val.func, "__name__", name))
-                sources.append(f"{prefix}jit-recursive:{name}:{label}")
-                return False
-            manager_key, _manager = val._ensure_cache_manager(target=target)
-            sources.append(f"{prefix}jit:{name}:{manager_key}")
-            return False  # do not recurse: manager_key already covers transitive deps
-        sources.append(f"{prefix}{name}:{_get_func_source(underlying)}")
+            label = f"{val.func.__module__}:{val.func.__qualname__}"
+            sources.append(f"{prefix}jit:{name}:{label}:{_get_func_source(underlying)}{closure_suffix}")
+            return True
+        sources.append(f"{prefix}{name}:{_get_func_source(underlying)}{closure_suffix}")
         return True  # recurse to pick up nested helpers
 
     # 1) Scan global name references (co_names → __globals__)
@@ -588,7 +566,7 @@ def _collect_dependency_sources(
         visited.add(id(underlying))
         should_recurse = _emit("", name, obj, underlying)
         if should_recurse:
-            sources.extend(_collect_dependency_sources(underlying, rootFile, visited, target=target))
+            sources.extend(_collect_dependency_sources(underlying, rootFile, visited))
 
     # 2) Scan closure variables (co_freevars → __closure__) for callable
     #    dependencies.  This catches @flyc.kernel functions defined in an
@@ -605,7 +583,7 @@ def _collect_dependency_sources(
             visited.add(id(underlying))
             should_recurse = _emit("closure:", name, val, underlying)
             if should_recurse:
-                sources.extend(_collect_dependency_sources(underlying, rootFile, visited, target=target))
+                sources.extend(_collect_dependency_sources(underlying, rootFile, visited))
 
     owner_cls = owner_cls or _owner_class_from_func(func)
     if owner_cls is not None:
@@ -615,7 +593,6 @@ def _collect_dependency_sources(
                 rootFile,
                 owner_cls,
                 visited,
-                target=target,
             )
         )
 
@@ -623,35 +600,32 @@ def _collect_dependency_sources(
 
 
 def _jit_function_cache_key(func: Callable, owner_cls=None, target=None) -> str:
-    in_progress = _keys_in_progress()
-    added = id(func) not in in_progress
-    if added:
-        in_progress.add(id(func))
+    parts = []
+    parts.append(_flydsl_key(target))
+    parts.append(_get_func_source(func))
     try:
-        parts = []
-        parts.append(_flydsl_key(target))
-        parts.append(_get_func_source(func))
-        try:
-            rootFile = inspect.getfile(func)
-        except (TypeError, OSError):
-            rootFile = ""
-        depSources = _collect_dependency_sources(func, rootFile, owner_cls=owner_cls, target=target)
-        depSources.sort()
-        parts.extend(depSources)
+        rootFile = inspect.getfile(func)
+    except (TypeError, OSError):
+        rootFile = ""
+    depSources = _collect_dependency_sources(
+        func,
+        rootFile,
+        visited={id(func)},
+        owner_cls=owner_cls,
+    )
+    depSources.sort()
+    parts.extend(depSources)
 
-        # Collect scalar closure values recursively — this covers compile-time parameters
-        # (tile_m, tile_n, waves_per_eu, etc.) captured directly by the @jit launcher OR
-        # indirectly via nested @kernel / helper functions, without requiring an explicit
-        # _cache_tag tuple in every kernel factory function.
-        all_closure_vals = sorted(_collect_closure_scalar_vals(func))
-        if all_closure_vals:
-            parts.append("closure_vals:" + ",".join(all_closure_vals))
+    # Collect scalar closure values recursively — this covers compile-time parameters
+    # (tile_m, tile_n, waves_per_eu, etc.) captured directly by the @jit launcher OR
+    # indirectly via nested @kernel / helper functions, without requiring an explicit
+    # _cache_tag tuple in every kernel factory function.
+    all_closure_vals = sorted(_collect_closure_scalar_vals(func))
+    if all_closure_vals:
+        parts.append("closure_vals:" + ",".join(all_closure_vals))
 
-        combined = "\n".join(parts)
-        return hashlib.sha256(combined.encode()).hexdigest()[:32]
-    finally:
-        if added:
-            in_progress.discard(id(func))
+    combined = "\n".join(parts)
+    return hashlib.sha256(combined.encode()).hexdigest()[:32]
 
 
 def _stage_label_from_fragment(fragment: str) -> str:

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -466,6 +466,7 @@ def _collect_class_member_dependency_sources(
     rootFile,
     owner_cls,
     visited: Set[int],
+    target=None,
 ) -> List[str]:
     sources = []
 
@@ -483,7 +484,15 @@ def _collect_class_member_dependency_sources(
 
         visited.add(id(underlying))
         sources.append(f"class:{owner_cls.__qualname__}.{name}:{_get_func_source(underlying)}")
-        sources.extend(_collect_dependency_sources(underlying, rootFile, visited, owner_cls=owner_cls))
+        sources.extend(
+            _collect_dependency_sources(
+                underlying,
+                rootFile,
+                visited,
+                owner_cls=owner_cls,
+                target=target,
+            )
+        )
 
     return sources
 
@@ -541,6 +550,7 @@ def _collect_dependency_sources(
     rootFile,
     visited: Optional[Set[int]] = None,
     owner_cls=None,
+    target=None,
 ) -> List[str]:
     from .kernel_function import KernelFunction
 
@@ -558,8 +568,8 @@ def _collect_dependency_sources(
                 label = getattr(val.func, "__qualname__", getattr(val.func, "__name__", name))
                 sources.append(f"{prefix}jit-recursive:{name}:{label}")
                 return False
-            val._ensure_cache_manager()
-            sources.append(f"{prefix}jit:{name}:{val.manager_key}")
+            manager_key, _manager = val._ensure_cache_manager(target=target)
+            sources.append(f"{prefix}jit:{name}:{manager_key}")
             return False  # do not recurse: manager_key already covers transitive deps
         sources.append(f"{prefix}{name}:{_get_func_source(underlying)}")
         return True  # recurse to pick up nested helpers
@@ -578,7 +588,7 @@ def _collect_dependency_sources(
         visited.add(id(underlying))
         should_recurse = _emit("", name, obj, underlying)
         if should_recurse:
-            sources.extend(_collect_dependency_sources(underlying, rootFile, visited))
+            sources.extend(_collect_dependency_sources(underlying, rootFile, visited, target=target))
 
     # 2) Scan closure variables (co_freevars → __closure__) for callable
     #    dependencies.  This catches @flyc.kernel functions defined in an
@@ -595,11 +605,19 @@ def _collect_dependency_sources(
             visited.add(id(underlying))
             should_recurse = _emit("closure:", name, val, underlying)
             if should_recurse:
-                sources.extend(_collect_dependency_sources(underlying, rootFile, visited))
+                sources.extend(_collect_dependency_sources(underlying, rootFile, visited, target=target))
 
     owner_cls = owner_cls or _owner_class_from_func(func)
     if owner_cls is not None:
-        sources.extend(_collect_class_member_dependency_sources(func, rootFile, owner_cls, visited))
+        sources.extend(
+            _collect_class_member_dependency_sources(
+                func,
+                rootFile,
+                owner_cls,
+                visited,
+                target=target,
+            )
+        )
 
     return sources
 
@@ -617,7 +635,7 @@ def _jit_function_cache_key(func: Callable, owner_cls=None, target=None) -> str:
             rootFile = inspect.getfile(func)
         except (TypeError, OSError):
             rootFile = ""
-        depSources = _collect_dependency_sources(func, rootFile, owner_cls=owner_cls)
+        depSources = _collect_dependency_sources(func, rootFile, owner_cls=owner_cls, target=target)
         depSources.sort()
         parts.extend(depSources)
 
@@ -1208,6 +1226,8 @@ class JitFunction:
         self._manager_owner_cls = None
         self._manager_target = None
         self.cache_manager = None
+        self._cache_managers = {}
+        self._cache_managers_lock = threading.Lock()
         self._call_state_cache = {}  # (artifact cache key, device) -> CallState
         self._sig = None  # lazy: set on first call
         self._has_self_param = False  # lazy: set in _ensure_sig
@@ -1289,12 +1309,6 @@ class JitFunction:
         warn_invalid_annotations(self._sig, context="@jit")
 
     def _ensure_cache_manager(self, owner_cls=None, target=None):
-        if self.manager_key is not None and self._manager_owner_cls is owner_cls and self._manager_target == target:
-            return
-        self._manager_owner_cls = owner_cls
-        self._manager_target = target
-        self.manager_key = _jit_function_cache_key(self.func, owner_cls=owner_cls, target=target)
-
         run_only = env.runtime.run_only
         if run_only and env.debug.dump_ir:
             raise ValueError(
@@ -1303,20 +1317,33 @@ class JitFunction:
             )
 
         need_cache = env.runtime.enable_cache or run_only
-        if not need_cache:
-            self.cache_manager = None
-            return
-
         cache_root = env.runtime.cache_dir
-        if not cache_root:
-            if run_only:
-                raise RuntimeError("FLYDSL_RUNTIME_RUN_ONLY=1 but FLYDSL_RUNTIME_CACHE_DIR is empty.")
-            self.cache_manager = None
-            return
+        manager_slot = (owner_cls, target, need_cache, cache_root)
+        with self._cache_managers_lock:
+            entry = self._cache_managers.get(manager_slot)
 
-        cache_dir = Path(cache_root) / f"{self.func.__name__}_{self.manager_key}"
-        self.cache_manager = JitCacheManager(cache_dir)
-        self.cache_manager.load_all()
+        if entry is None:
+            manager_key = _jit_function_cache_key(self.func, owner_cls=owner_cls, target=target)
+            manager = None
+            if need_cache:
+                if not cache_root:
+                    if run_only:
+                        raise RuntimeError("FLYDSL_RUNTIME_RUN_ONLY=1 but FLYDSL_RUNTIME_CACHE_DIR is empty.")
+                else:
+                    cache_dir = Path(cache_root) / f"{self.func.__name__}_{manager_key}"
+                    manager = JitCacheManager(cache_dir)
+                    manager.load_all()
+            candidate = (manager_key, manager)
+            with self._cache_managers_lock:
+                entry = self._cache_managers.setdefault(manager_slot, candidate)
+
+        with self._cache_managers_lock:
+            # Preserve the single-manager introspection attributes for existing
+            # callers, but execution uses the returned target-local pair.
+            self._manager_owner_cls = owner_cls
+            self._manager_target = target
+            self.manager_key, self.cache_manager = entry
+            return entry
 
     def _resolve_and_make_cache_key(self, bound_args, *, effective_hints=None, return_invocation=False):
         """Resolve raw call values into JitArgument instances *in place* and
@@ -1480,7 +1507,7 @@ class JitFunction:
                 device=Device(kind=runtime.kind, index=runtime.current_device_id()),
             )
         dispatch_key = (cache_key, invocation.device)
-        self._ensure_cache_manager(owner_cls, invocation.target)
+        manager_key, cache_manager = self._ensure_cache_manager(owner_cls, invocation.target)
 
         # Fast path: reuse pre-built CallState (no ctypes alloc, no DLPack)
         call_state = self._call_state_cache.get(dispatch_key)
@@ -1500,7 +1527,7 @@ class JitFunction:
         cached_func = self._mem_cache.get(cache_key)
         if cached_func is None and allow_disk_cache and not env.debug.dump_ir:
             str_key = self._cache_key_to_str(cache_key)
-            cached_func = self.cache_manager.get(str_key) if self.cache_manager else None
+            cached_func = cache_manager.get(str_key) if cache_manager else None
             if cached_func is not None and getattr(cached_func, "_link_libs", None):
                 _rejected_link_libs = True
                 cached_func = None
@@ -1521,12 +1548,12 @@ class JitFunction:
                 return state(args_tuple)
 
         if run_only:
-            cdir = getattr(self.cache_manager, "cache_dir", None)
+            cdir = getattr(cache_manager, "cache_dir", None)
             cdir_exists = cdir.exists() if cdir is not None else False
             msg = (
                 f"FLYDSL_RUNTIME_RUN_ONLY=1 but no usable AOT cache for "
                 f"{self.func.__name__}: "
-                f"manager_key={self.manager_key}, "
+                f"manager_key={manager_key}, "
                 f"cache_key={self._cache_key_to_str(cache_key)[:96]}..., "
                 f"cache_dir={cdir} (exists={cdir_exists})"
             )
@@ -1543,10 +1570,10 @@ class JitFunction:
         compiled_func = None  # will be set inside lock or compile path
 
         # Determine whether to use compile_lock for cross-process safety.
-        _use_compile_lock = use_disk_cache and self.cache_manager and not env.debug.dump_ir
+        _use_compile_lock = use_disk_cache and cache_manager and not env.debug.dump_ir
         if _use_compile_lock:
             str_key = self._cache_key_to_str(cache_key)
-            _compile_lock_ctx = self.cache_manager.compile_lock(str_key)
+            _compile_lock_ctx = cache_manager.compile_lock(str_key)
         else:
             _compile_lock_ctx = nullcontext((None, None))
 
@@ -1735,7 +1762,7 @@ class CompiledFunction:
             return self._call_state(args)
 
 
-def _compile_impl(func, *args) -> CompiledFunction:
+def _compile_impl(func, *args) -> Optional[CompiledFunction]:
     """Pre-compile a ``@flyc.jit`` function, returning a fast callable.
 
     Usage::
@@ -1758,6 +1785,8 @@ def _compile_impl(func, *args) -> CompiledFunction:
     jf = func
 
     jf(*args)
+    if env.compile.compile_only:
+        return None
 
     # Retrieve the CallState (already built by __call__ above).
     sig = jf._sig  # guaranteed initialized after __call__

--- a/python/flydsl/expr/buffer_ops.py
+++ b/python/flydsl/expr/buffer_ops.py
@@ -55,15 +55,11 @@ def _get_buffer_flags(arch=None):
       bits [29:28] - OOB_SELECT (RDNA only): 0=structured, 2=none, 3=check offset
       bits [31:30] - Type (must be 0)
 
-    CDNA (gfx9xx):    (7 << 12) | (4 << 15)                         = 0x20070
-    RDNA (gfx10+):    (7 << 12) | (4 << 15) | (1 << 24) | (2 << 28) = 0x21020070
+    CDNA (gfx9xx):    (7 << 12) | (4 << 15)                         = 0x27000
+    RDNA (gfx10+):    (7 << 12) | (4 << 15) | (1 << 24) | (2 << 28) = 0x21027000
       - bit 24 set to 1 (required on RDNA)
       - OOB_SELECT=2 (no bounds checking, matching LLVM boundsCheck=false)
     """
-    import os
-
-    if arch is None:
-        arch = os.environ.get("FLYDSL_GPU_ARCH")
     flags = (7 << 12) | (4 << 15)
     if is_rdna_arch(arch):
         flags |= 1 << 24  # reserved bit, must be 1 on RDNA

--- a/python/flydsl/runtime/__init__.py
+++ b/python/flydsl/runtime/__init__.py
@@ -5,6 +5,7 @@
 
 from .device_runtime import (
     COMPILE_BACKEND_TO_RUNTIME_KIND,
+    Device,
     DeviceRuntime,
     RocmDeviceRuntime,
     ensure_compile_runtime_compatible,
@@ -16,6 +17,7 @@ from .device_runtime import (
 
 __all__ = [
     "COMPILE_BACKEND_TO_RUNTIME_KIND",
+    "Device",
     "DeviceRuntime",
     "RocmDeviceRuntime",
     "ensure_compile_runtime_compatible",

--- a/python/flydsl/runtime/device.py
+++ b/python/flydsl/runtime/device.py
@@ -6,55 +6,47 @@ import os
 import subprocess
 from typing import Optional
 
-_ROCM_AGENT_TIMEOUT_S = int(os.environ.get("FLYDSL_ROCM_AGENT_TIMEOUT", "300"))
+
+def normalize_rocm_arch(value: str, *, source: str = "ROCm architecture") -> str:
+    """Normalize ``gfxNNN`` or ``major.minor.step`` into a base gfx name."""
+    value = value.strip().lower().split(":", 1)[0]
+    if value.startswith("gfx") and len(value) > 3 and all(ch.isalnum() or ch == "-" for ch in value[3:]):
+        return value
+    parts = value.split(".")
+    if len(parts) == 3 and all(part.isdigit() for part in parts):
+        return f"gfx{''.join(parts)}"
+    raise ValueError(f"Invalid {source} {value!r}; expected gfxNNN or major.minor.step")
 
 
-def _arch_from_rocm_agent_enumerator() -> Optional[str]:
-    """Query rocm_agent_enumerator (standard ROCm tool) for the first GPU arch."""
-    try:
-        out = subprocess.check_output(
-            ["rocm_agent_enumerator", "-name"],
-            text=True,
-            timeout=_ROCM_AGENT_TIMEOUT_S,
-            stderr=subprocess.DEVNULL,
-        )
-        for line in out.splitlines():
-            name = line.strip()
-            if name.startswith("gfx") and name != "gfx000":
-                return name
-    except Exception:
-        pass
+def get_rocm_arch_override() -> Optional[str]:
+    """Return the explicit ROCm target using the canonical precedence."""
+    for name in ("ARCH", "FLYDSL_GPU_ARCH", "HSA_OVERRIDE_GFX_VERSION"):
+        value = os.environ.get(name)
+        if value:
+            return normalize_rocm_arch(value, source=name)
     return None
 
 
-@functools.lru_cache(maxsize=None)
-def _arch_from_hardware() -> str:
-    """Cached hardware detection (rocm_agent_enumerator is slow)."""
-    arch = _arch_from_rocm_agent_enumerator()
-    if arch:
-        return arch.split(":", 1)[0]
-    return "gfx942"
+def get_rocm_arch(device_id: Optional[int] = None) -> str:
+    """Resolve one logical HIP device's architecture without a fallback ISA."""
+    override = get_rocm_arch_override()
+    if override:
+        return override
 
+    from .device_runtime import get_device_runtime
 
-def get_rocm_arch() -> str:
-    """Best-effort ROCm GPU arch string (e.g. 'gfx942')."""
-    env = os.environ.get("FLYDSL_GPU_ARCH") or os.environ.get("HSA_OVERRIDE_GFX_VERSION")
-    if env:
-        if env.startswith("gfx"):
-            return env
-        if env.count(".") == 2:
-            parts = env.split(".")
-            return f"gfx{parts[0]}{parts[1]}{parts[2]}"
-
-    return _arch_from_hardware()
+    runtime = get_device_runtime()
+    if device_id is None:
+        device_id = runtime.current_device_id()
+    return runtime.device_arch(device_id)
 
 
 @functools.lru_cache(maxsize=None)
 def get_rocm_device_count() -> int:
     """Best-effort ROCm visible GPU count via ``rocm_agent_enumerator`` (standard ROCm tool).
 
-    Uses the same invocation as :func:`_arch_from_rocm_agent_enumerator`. Returns 0
-    when the tool is unavailable or no discrete GPU agents are reported.
+    Returns 0 when the tool is unavailable or no discrete GPU agents are
+    reported. Runtime target resolution uses HIP instead of this helper.
     """
     try:
         out = subprocess.check_output(

--- a/python/flydsl/runtime/device_runtime/__init__.py
+++ b/python/flydsl/runtime/device_runtime/__init__.py
@@ -19,7 +19,15 @@ from __future__ import annotations
 from typing import Dict, Optional, Type
 
 from ...utils import env
-from .base import Device, DeviceRuntime, device_from_argument, device_from_dlpack
+from .base import (
+    Device,
+    DeviceRuntime,
+    device_from_argument,
+    device_from_dlpack,
+)
+from .base import (
+    device_from_stream_argument as device_from_stream_argument,
+)
 from .rocm import RocmDeviceRuntime
 
 # Compile-backend id -> device-runtime kind (single string namespace).

--- a/python/flydsl/runtime/device_runtime/__init__.py
+++ b/python/flydsl/runtime/device_runtime/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Dict, Optional, Type
 
 from ...utils import env
-from .base import Device, DeviceRuntime
+from .base import Device, DeviceRuntime, device_from_argument, device_from_dlpack
 from .rocm import RocmDeviceRuntime
 
 # Compile-backend id -> device-runtime kind (single string namespace).
@@ -165,6 +165,8 @@ __all__ = [
     "COMPILE_BACKEND_TO_RUNTIME_KIND",
     "Device",
     "DeviceRuntime",
+    "device_from_argument",
+    "device_from_dlpack",
     "RocmDeviceRuntime",
     "ensure_compile_runtime_compatible",
     "ensure_compile_runtime_pairing_from_env",

--- a/python/flydsl/runtime/device_runtime/__init__.py
+++ b/python/flydsl/runtime/device_runtime/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Dict, Optional, Type
 
 from ...utils import env
-from .base import DeviceRuntime
+from .base import Device, DeviceRuntime
 from .rocm import RocmDeviceRuntime
 
 # Compile-backend id -> device-runtime kind (single string namespace).
@@ -163,6 +163,7 @@ def get_device_runtime() -> DeviceRuntime:
 
 __all__ = [
     "COMPILE_BACKEND_TO_RUNTIME_KIND",
+    "Device",
     "DeviceRuntime",
     "RocmDeviceRuntime",
     "ensure_compile_runtime_compatible",

--- a/python/flydsl/runtime/device_runtime/base.py
+++ b/python/flydsl/runtime/device_runtime/base.py
@@ -6,7 +6,17 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import ClassVar
+
+
+@dataclass(frozen=True)
+class Device:
+    """Logical device identity within one process-wide runtime stack."""
+
+    kind: str
+    index: int
 
 
 class DeviceRuntime(metaclass=ABCMeta):
@@ -26,3 +36,23 @@ class DeviceRuntime(metaclass=ABCMeta):
     @abstractmethod
     def current_device_id(self) -> int:
         """Current device id for this runtime."""
+
+    def set_device_id(self, device_id: int) -> None:
+        """Make *device_id* current for the calling thread."""
+        raise NotImplementedError(f"{type(self).__name__} does not implement set_device_id()")
+
+    def device_arch(self, device_id: int) -> str:
+        """Return the compile architecture for one logical device."""
+        raise NotImplementedError(f"{type(self).__name__} does not implement device_arch()")
+
+    @contextmanager
+    def device_guard(self, device_id: int):
+        """Run with *device_id* current, restoring the caller's device."""
+        previous = self.current_device_id()
+        if previous != device_id:
+            self.set_device_id(device_id)
+        try:
+            yield
+        finally:
+            if previous != device_id:
+                self.set_device_id(previous)

--- a/python/flydsl/runtime/device_runtime/base.py
+++ b/python/flydsl/runtime/device_runtime/base.py
@@ -19,6 +19,35 @@ class Device:
     index: int
 
 
+def device_from_dlpack(device_type: int, device_id: int) -> Device | None:
+    """Map canonical DLPack GPU device types to a FlyDSL device."""
+    if int(device_type) == 10:  # kDLROCM
+        return Device(kind="rocm", index=int(device_id))
+    if int(device_type) == 2:  # kDLCUDA
+        return Device(kind="cuda", index=int(device_id))
+    return None
+
+
+def device_from_argument(value) -> Device | None:
+    """Read framework-neutral device metadata from a call argument."""
+    provider = getattr(value, "__flydsl_device__", None)
+    if provider is not None:
+        device = provider()
+        if device is not None:
+            if not isinstance(device, Device):
+                raise TypeError(f"__flydsl_device__ must return Device or None, got {device!r}")
+            return device
+
+    dlpack_device = getattr(value, "__dlpack_device__", None)
+    if callable(dlpack_device):
+        try:
+            device_type, device_id = dlpack_device()
+        except Exception:
+            return None
+        return device_from_dlpack(device_type, device_id)
+    return None
+
+
 class DeviceRuntime(metaclass=ABCMeta):
     """Vendor-neutral runtime: one implementation per process (HIP, CUDA, …).
 

--- a/python/flydsl/runtime/device_runtime/base.py
+++ b/python/flydsl/runtime/device_runtime/base.py
@@ -48,6 +48,20 @@ def device_from_argument(value) -> Device | None:
     return None
 
 
+def device_from_stream_argument(value, *, cuda_kind: str = "cuda") -> Device | None:
+    """Read a CUDA/HIP-style stream's logical device without importing a framework."""
+    raw = value.value if getattr(value, "_is_stream_param", False) else value
+    stream_device = getattr(raw, "device", None)
+    if getattr(stream_device, "type", None) != "cuda":
+        return None
+    index = getattr(stream_device, "index", None)
+    if index is None:
+        index = getattr(raw, "device_index", None)
+    if index is None:
+        return None
+    return Device(kind=cuda_kind, index=int(index))
+
+
 class DeviceRuntime(metaclass=ABCMeta):
     """Vendor-neutral runtime: one implementation per process (HIP, CUDA, …).
 

--- a/python/flydsl/runtime/device_runtime/rocm.py
+++ b/python/flydsl/runtime/device_runtime/rocm.py
@@ -6,18 +6,20 @@
 from __future__ import annotations
 
 import ctypes
+import functools
+from pathlib import Path
 from typing import ClassVar
 
-from ..device import get_rocm_device_count
 from .base import DeviceRuntime
 
 # Cached HIP runtime handle (``libamdhip64``); cached once.
 _HIP_LIB = None
 _HIP_LIB_TRIED = False
+_FLY_RUNTIME_LIB = None
+_FLY_RUNTIME_LIB_TRIED = False
 
 
-def _hip_get_device() -> int:
-    """Active HIP device index via ``hipGetDevice``."""
+def _get_hip_lib():
     global _HIP_LIB, _HIP_LIB_TRIED
     if not _HIP_LIB_TRIED:
         _HIP_LIB_TRIED = True
@@ -26,32 +28,91 @@ def _hip_get_device() -> int:
                 lib = ctypes.CDLL(soname)
                 lib.hipGetDevice.argtypes = [ctypes.POINTER(ctypes.c_int)]
                 lib.hipGetDevice.restype = ctypes.c_int
+                lib.hipSetDevice.argtypes = [ctypes.c_int]
+                lib.hipSetDevice.restype = ctypes.c_int
+                lib.hipGetDeviceCount.argtypes = [ctypes.POINTER(ctypes.c_int)]
+                lib.hipGetDeviceCount.restype = ctypes.c_int
                 _HIP_LIB = lib
                 break
             except OSError:
                 continue
     if _HIP_LIB is None:
-        return 0
+        raise RuntimeError("Unable to load libamdhip64; cannot resolve the active ROCm device")
+    return _HIP_LIB
+
+
+def _get_fly_runtime_lib():
+    global _FLY_RUNTIME_LIB, _FLY_RUNTIME_LIB_TRIED
+    if not _FLY_RUNTIME_LIB_TRIED:
+        _FLY_RUNTIME_LIB_TRIED = True
+        from ..._mlir import _mlir_libs
+
+        path = Path(_mlir_libs.__file__).resolve().parent / "libfly_jit_runtime.so"
+        try:
+            lib = ctypes.CDLL(str(path))
+            lib.mgpuGetDeviceArch.argtypes = [ctypes.c_int32, ctypes.c_char_p, ctypes.c_size_t]
+            lib.mgpuGetDeviceArch.restype = ctypes.c_int32
+            _FLY_RUNTIME_LIB = lib
+        except (AttributeError, OSError):
+            _FLY_RUNTIME_LIB = None
+    if _FLY_RUNTIME_LIB is None:
+        raise RuntimeError("Unable to load libfly_jit_runtime.so; rebuild FlyDSL before resolving a ROCm device target")
+    return _FLY_RUNTIME_LIB
+
+
+def _hip_get_device() -> int:
+    """Active HIP device index via ``hipGetDevice``."""
+    lib = _get_hip_lib()
     dev = ctypes.c_int(0)
-    try:
-        if _HIP_LIB.hipGetDevice(ctypes.byref(dev)) == 0:
-            return int(dev.value)
-    except Exception:
-        pass
-    return 0
+    result = lib.hipGetDevice(ctypes.byref(dev))
+    if result != 0:
+        raise RuntimeError(f"hipGetDevice failed with error code {result}")
+    return int(dev.value)
+
+
+def _hip_set_device(device_id: int) -> None:
+    result = _get_hip_lib().hipSetDevice(int(device_id))
+    if result != 0:
+        raise RuntimeError(f"hipSetDevice({device_id}) failed with error code {result}")
+
+
+def _hip_get_device_count() -> int:
+    count = ctypes.c_int(0)
+    result = _get_hip_lib().hipGetDeviceCount(ctypes.byref(count))
+    if result != 0:
+        raise RuntimeError(f"hipGetDeviceCount failed with error code {result}")
+    return int(count.value)
+
+
+@functools.lru_cache(maxsize=None)
+def _hip_device_arch(device_id: int) -> str:
+    arch = ctypes.create_string_buffer(256)
+    result = _get_fly_runtime_lib().mgpuGetDeviceArch(device_id, arch, len(arch))
+    if result != 0:
+        raise RuntimeError(f"hipGetDeviceProperties({device_id}) failed with error code {result}")
+    value = arch.value.decode("ascii").split(":", 1)[0]
+    if not value.startswith("gfx"):
+        raise RuntimeError(f"HIP returned an invalid architecture for device {device_id}: {value!r}")
+    return value
 
 
 class RocmDeviceRuntime(DeviceRuntime):
     """HIP-based runtime; matches compile backend ``rocm``.
 
-    ``device_count()`` delegates to ``rocm_agent_enumerator`` in ``device.py``;
-    ``current_device_id()`` queries HIP ``hipGetDevice`` directly.
+    Device identity and architecture come from HIP so logical device indices
+    respect the runtime's visibility/remapping rules.
     """
 
     kind: ClassVar[str] = "rocm"
 
     def device_count(self) -> int:
-        return get_rocm_device_count()
+        return _hip_get_device_count()
 
     def current_device_id(self) -> int:
         return _hip_get_device()
+
+    def set_device_id(self, device_id: int) -> None:
+        _hip_set_device(device_id)
+
+    def device_arch(self, device_id: int) -> str:
+        return _hip_device_arch(device_id)

--- a/python/flydsl/runtime/device_runtime/rocm.py
+++ b/python/flydsl/runtime/device_runtime/rocm.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import ctypes
 import functools
+import threading
 from pathlib import Path
 from typing import ClassVar
 
@@ -14,15 +15,21 @@ from .base import DeviceRuntime
 
 # Cached HIP runtime handle (``libamdhip64``); cached once.
 _HIP_LIB = None
-_HIP_LIB_TRIED = False
+_HIP_LIB_LOCK = threading.Lock()
 _FLY_RUNTIME_LIB = None
-_FLY_RUNTIME_LIB_TRIED = False
+_FLY_RUNTIME_LIB_LOCK = threading.Lock()
 
 
 def _get_hip_lib():
-    global _HIP_LIB, _HIP_LIB_TRIED
-    if not _HIP_LIB_TRIED:
-        _HIP_LIB_TRIED = True
+    global _HIP_LIB
+    if _HIP_LIB is not None:
+        return _HIP_LIB
+
+    with _HIP_LIB_LOCK:
+        if _HIP_LIB is not None:
+            return _HIP_LIB
+
+        last_error = None
         for soname in ("libamdhip64.so", "libamdhip64.so.6", "libamdhip64.so.5"):
             try:
                 lib = ctypes.CDLL(soname)
@@ -33,31 +40,39 @@ def _get_hip_lib():
                 lib.hipGetDeviceCount.argtypes = [ctypes.POINTER(ctypes.c_int)]
                 lib.hipGetDeviceCount.restype = ctypes.c_int
                 _HIP_LIB = lib
-                break
-            except OSError:
-                continue
-    if _HIP_LIB is None:
-        raise RuntimeError("Unable to load libamdhip64; cannot resolve the active ROCm device")
-    return _HIP_LIB
+                return lib
+            except OSError as exc:
+                last_error = exc
+
+        raise RuntimeError("Unable to load libamdhip64; cannot resolve the active ROCm device") from last_error
 
 
 def _get_fly_runtime_lib():
-    global _FLY_RUNTIME_LIB, _FLY_RUNTIME_LIB_TRIED
-    if not _FLY_RUNTIME_LIB_TRIED:
-        _FLY_RUNTIME_LIB_TRIED = True
-        from ..._mlir import _mlir_libs
+    global _FLY_RUNTIME_LIB
+    if _FLY_RUNTIME_LIB is not None:
+        return _FLY_RUNTIME_LIB
 
-        path = Path(_mlir_libs.__file__).resolve().parent / "libfly_jit_runtime.so"
+    with _FLY_RUNTIME_LIB_LOCK:
+        if _FLY_RUNTIME_LIB is not None:
+            return _FLY_RUNTIME_LIB
+
+        # Resolve against this concrete FlyDSL package, not the importable
+        # _mlir_libs module: editable/CI environments can also contain an older
+        # installed FlyDSL namespace whose runtime lacks the new symbol.
+        path = Path(__file__).resolve().parents[2] / "_mlir" / "_mlir_libs" / "libfly_jit_runtime.so"
         try:
             lib = ctypes.CDLL(str(path))
+        except OSError as exc:
+            raise RuntimeError(f"Unable to load FlyDSL ROCm runtime at {path}: {exc}") from exc
+        try:
             lib.mgpuGetDeviceArch.argtypes = [ctypes.c_int32, ctypes.c_char_p, ctypes.c_size_t]
             lib.mgpuGetDeviceArch.restype = ctypes.c_int32
-            _FLY_RUNTIME_LIB = lib
-        except (AttributeError, OSError):
-            _FLY_RUNTIME_LIB = None
-    if _FLY_RUNTIME_LIB is None:
-        raise RuntimeError("Unable to load libfly_jit_runtime.so; rebuild FlyDSL before resolving a ROCm device target")
-    return _FLY_RUNTIME_LIB
+        except AttributeError as exc:
+            raise RuntimeError(
+                f"FlyDSL ROCm runtime at {path} does not export mgpuGetDeviceArch; rebuild FlyDSL"
+            ) from exc
+        _FLY_RUNTIME_LIB = lib
+        return lib
 
 
 def _hip_get_device() -> int:

--- a/tests/language/conftest.py
+++ b/tests/language/conftest.py
@@ -25,7 +25,7 @@ def frontend_only_jit(monkeypatch):
     monkeypatch.setenv("ARCH", "gfx942")
     monkeypatch.setenv("COMPILE_ONLY", "1")
     monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
-    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda *_args: "test-flydsl-key")
 
     def compile_noop(cls, module, **_kwargs):
         return module

--- a/tests/python/examples/aot_example.py
+++ b/tests/python/examples/aot_example.py
@@ -9,11 +9,11 @@ Pre-compiles preshuffle GEMM kernels for specified configurations and stores
 the compiled binaries in a cache directory.
 
 Usage:
-    # Pre-compile with default configurations (auto-detect GPU arch)
-    python tests/python/examples/aot_example.py
+    # Device-less pre-compilation requires an explicit target
+    ARCH=gfx942 python tests/python/examples/aot_example.py
 
     # Custom cache directory
-    FLYDSL_RUNTIME_CACHE_DIR=/my/cache python tests/python/examples/aot_example.py
+    ARCH=gfx942 FLYDSL_RUNTIME_CACHE_DIR=/my/cache python tests/python/examples/aot_example.py
 
     # Pre-compile and verify by running kernels on GPU
     python tests/python/examples/aot_example.py --run_kernel
@@ -281,7 +281,10 @@ def main():
     args = parser.parse_args()
 
     cache_dir = os.environ.get("FLYDSL_RUNTIME_CACHE_DIR", "~/.flydsl/cache")
-    arch = os.environ.get("ARCH", "(auto-detect)")
+    arch = os.environ.get("ARCH") or os.environ.get("FLYDSL_GPU_ARCH") or os.environ.get("HSA_OVERRIDE_GFX_VERSION")
+    if not args.run_kernel and not arch:
+        parser.error("device-less pre-compilation requires ARCH, FLYDSL_GPU_ARCH, " "or HSA_OVERRIDE_GFX_VERSION")
+    arch = arch or "(invocation device)"
 
     configs = CONFIG_PRESETS[args.preset]
     dtypes = DTYPE_PRESETS.get(args.in_dtype, [args.in_dtype])

--- a/tests/unit/test_autotune.py
+++ b/tests/unit/test_autotune.py
@@ -238,7 +238,14 @@ def test_autotune_uses_canonical_provider_and_guards_benchmark_device(monkeypatc
         selected.append(index)
         return nullcontext()
 
-    monkeypatch.setattr(at.torch.cuda, "device", device_context)
+    class FakeCuda:
+        Stream = type("FakeStream", (), {})
+        device = staticmethod(device_context)
+
+    class FakeTorch:
+        cuda = FakeCuda()
+
+    monkeypatch.setattr(at, "torch", FakeTorch())
     tuner = _make_tuner()
     tensor = FakeWrappedTensor((8, 8), device_id=1)
 
@@ -248,6 +255,61 @@ def test_autotune_uses_canonical_provider_and_guards_benchmark_device(monkeypatc
 
     assert "gfx_device_1" in "".join(key)
     assert selected == [1]
+
+
+def test_autotune_resolves_and_benchmarks_wrapped_stream(monkeypatch):
+    import importlib
+
+    import flydsl.expr as fx
+
+    at = importlib.import_module("flydsl.autotune")
+    selected_streams = []
+
+    class FakeDevice:
+        type = "cuda"
+        index = 1
+
+    class FakeStream:
+        device = FakeDevice()
+        device_index = 1
+        cuda_stream = 1234
+
+    class FakeCuda:
+        Stream = FakeStream
+
+        @staticmethod
+        def stream(stream):
+            selected_streams.append(stream)
+            return nullcontext()
+
+    class FakeVersion:
+        hip = "test"
+
+    class FakeTorch:
+        cuda = FakeCuda()
+        version = FakeVersion()
+
+    monkeypatch.setattr(at, "torch", FakeTorch())
+    raw_stream = FakeStream()
+    wrapped_stream = fx.Stream(raw_stream)
+
+    device = at._invocation_device({"stream": wrapped_stream})
+    assert device.index == 1
+
+    def launch(stream):
+        pass
+
+    tuner = Autotuner(
+        fn=launch,
+        configs=[Config(BLOCK=128)],
+        key=[],
+        warmup=1,
+        rep=1,
+    )
+    with tuner._stream_context((wrapped_stream,), {}):
+        pass
+
+    assert selected_streams == [raw_stream]
 
 
 def test_key_varies_with_env_fingerprint(monkeypatch):

--- a/tests/unit/test_autotune.py
+++ b/tests/unit/test_autotune.py
@@ -16,10 +16,12 @@ with no GPU, no torch, and no compiled bindings.
 """
 
 import json
+from contextlib import nullcontext
 
 import pytest
 
 from flydsl.autotune import Autotuner, Config, _normalize_strides, autotune
+from flydsl.runtime.device_runtime import Device
 
 
 @pytest.fixture(autouse=True)
@@ -69,6 +71,15 @@ class FakeTensor:
 
     def copy_(self, other):
         self._data = list(other._data)
+
+
+class FakeWrappedTensor(FakeTensor):
+    def __init__(self, shape, device_id):
+        super().__init__(shape)
+        self._device = Device(kind="rocm", index=device_id)
+
+    def __flydsl_device__(self):
+        return self._device
 
 
 def _make_tuner(fn=None, **kw):
@@ -186,7 +197,11 @@ def test_key_uses_invocation_device_and_rejects_mixed_devices(monkeypatch):
     import importlib
 
     at = importlib.import_module("flydsl.autotune")
-    monkeypatch.setattr(at, "_device_fingerprint", lambda device_id=None: f"gfx_device_{device_id}")
+    monkeypatch.setattr(
+        at,
+        "_device_fingerprint",
+        lambda device=None: f"gfx_device_{None if device is None else device.index}",
+    )
     monkeypatch.setattr(at, "_toolchain_fingerprint", lambda arch="": f"toolchain_{arch}")
     tuner = _make_tuner()
 
@@ -205,6 +220,34 @@ def test_key_uses_invocation_device_and_rejects_mixed_devices(monkeypatch):
             (FakeTensor((8, 8), device_id=0), FakeTensor((8, 8), device_id=1)),
             {},
         )
+
+
+def test_autotune_uses_canonical_provider_and_guards_benchmark_device(monkeypatch):
+    import importlib
+
+    at = importlib.import_module("flydsl.autotune")
+    monkeypatch.setattr(
+        at,
+        "_device_fingerprint",
+        lambda device=None: f"gfx_device_{None if device is None else device.index}",
+    )
+    monkeypatch.setattr(at, "_toolchain_fingerprint", lambda arch="": f"toolchain_{arch}")
+    selected = []
+
+    def device_context(index):
+        selected.append(index)
+        return nullcontext()
+
+    monkeypatch.setattr(at.torch.cuda, "device", device_context)
+    tuner = _make_tuner()
+    tensor = FakeWrappedTensor((8, 8), device_id=1)
+
+    key = tuner._make_key((tensor, tensor), {})
+    with tuner._stream_context((tensor, tensor), {}):
+        pass
+
+    assert "gfx_device_1" in "".join(key)
+    assert selected == [1]
 
 
 def test_key_varies_with_env_fingerprint(monkeypatch):

--- a/tests/unit/test_autotune.py
+++ b/tests/unit/test_autotune.py
@@ -33,9 +33,10 @@ def _isolate_disk_cache(tmp_path, monkeypatch):
 class FakeTensor:
     """Minimal tensor stand-in with the attributes _make_key / restore_value use."""
 
-    def __init__(self, shape, dtype="float32", strides=None, fill=0.0):
+    def __init__(self, shape, dtype="float32", strides=None, fill=0.0, device_id=None):
         self.shape = tuple(shape)
         self.dtype = dtype
+        self.device_id = device_id
         if strides is None:
             # row-major contiguous strides
             strides = []
@@ -52,6 +53,11 @@ class FakeTensor:
 
     def stride(self):
         return self._strides
+
+    def __dlpack_device__(self):
+        if self.device_id is None:
+            raise RuntimeError("fake tensor has no device")
+        return (10, self.device_id)
 
     def zero_(self):
         self._data = [0.0] * len(self._data)
@@ -159,7 +165,7 @@ def test_key_varies_with_toolchain_fingerprint(monkeypatch):
     a = FakeTensor((8, 8))
     k1 = t._make_key((a, a), {})
     # read live per key, so a toolchain change mid-process invalidates the key
-    monkeypatch.setattr(at, "_toolchain_fingerprint", lambda: "a-different-fingerprint")
+    monkeypatch.setattr(at, "_toolchain_fingerprint", lambda *_args: "a-different-fingerprint")
     k2 = t._make_key((a, a), {})
     assert k1 != k2
 
@@ -171,9 +177,34 @@ def test_key_varies_with_device_fingerprint(monkeypatch):
     t = _make_tuner()
     a = FakeTensor((8, 8))
     k1 = t._make_key((a, a), {})
-    monkeypatch.setattr(at, "_device_fingerprint", lambda: "gfx_other")
+    monkeypatch.setattr(at, "_device_fingerprint", lambda *_args: "gfx_other")
     k2 = t._make_key((a, a), {})
     assert k1 != k2  # arch is a real key axis, read live (not frozen at construction)
+
+
+def test_key_uses_invocation_device_and_rejects_mixed_devices(monkeypatch):
+    import importlib
+
+    at = importlib.import_module("flydsl.autotune")
+    monkeypatch.setattr(at, "_device_fingerprint", lambda device_id=None: f"gfx_device_{device_id}")
+    monkeypatch.setattr(at, "_toolchain_fingerprint", lambda arch="": f"toolchain_{arch}")
+    tuner = _make_tuner()
+
+    key0 = tuner._make_key(
+        (FakeTensor((8, 8), device_id=0), FakeTensor((8, 8), device_id=0)),
+        {},
+    )
+    key1 = tuner._make_key(
+        (FakeTensor((8, 8), device_id=1), FakeTensor((8, 8), device_id=1)),
+        {},
+    )
+    assert key0 != key1
+
+    with pytest.raises(ValueError, match="same device"):
+        tuner._make_key(
+            (FakeTensor((8, 8), device_id=0), FakeTensor((8, 8), device_id=1)),
+            {},
+        )
 
 
 def test_key_varies_with_env_fingerprint(monkeypatch):

--- a/tests/unit/test_callstate_dispatch.py
+++ b/tests/unit/test_callstate_dispatch.py
@@ -13,6 +13,7 @@ implementation, so they hold regardless of loop-vs-codegen internals.
 
 import ctypes
 import gc
+import inspect
 import struct
 import weakref
 
@@ -21,7 +22,7 @@ import pytest
 torch = pytest.importorskip("torch")
 
 from flydsl.compiler import jit_argument as ja  # noqa: E402
-from flydsl.compiler.jit_function import CallState  # noqa: E402
+from flydsl.compiler.jit_function import CallState, _build_call_state  # noqa: E402
 from flydsl.expr.numeric import Int32  # noqa: E402
 
 
@@ -106,17 +107,25 @@ def test_callstate_dispatch_packs_changing_args_and_auto_stream():
 def test_callstate_keeps_function_owner_alive():
     """A cached raw function pointer must not outlive its owning engine/artifact."""
 
-    class Owner:
-        pass
+    calls = []
+    device = object()
 
-    owner = Owner()
-    owner_ref = weakref.ref(owner)
-    state = CallState([], lambda _packed: None, keepalive=owner)
+    class Artifact:
+        def _get_func_exe(self, actual_device):
+            assert actual_device is device
+            return lambda _packed: calls.append(True)
 
-    del owner
+    artifact = Artifact()
+    artifact_ref = weakref.ref(artifact)
+    state = _build_call_state(inspect.Signature(), (), artifact, device)
+
+    del artifact
     gc.collect()
-    assert owner_ref() is not None
+    assert artifact_ref() is not None
+
+    state(())
+    assert calls == [True]
 
     del state
     gc.collect()
-    assert owner_ref() is None
+    assert artifact_ref() is None

--- a/tests/unit/test_callstate_dispatch.py
+++ b/tests/unit/test_callstate_dispatch.py
@@ -12,7 +12,9 @@ implementation, so they hold regardless of loop-vs-codegen internals.
 """
 
 import ctypes
+import gc
 import struct
+import weakref
 
 import pytest
 
@@ -99,3 +101,22 @@ def test_callstate_dispatch_packs_changing_args_and_auto_stream():
         assert layout == _expected_layout_bytes(t)
         assert scalar == ival
         assert auto_stream in (None, 0)  # auto-stream slot stays NULL (default stream)
+
+
+def test_callstate_keeps_function_owner_alive():
+    """A cached raw function pointer must not outlive its owning engine/artifact."""
+
+    class Owner:
+        pass
+
+    owner = Owner()
+    owner_ref = weakref.ref(owner)
+    state = CallState([], lambda _packed: None, keepalive=owner)
+
+    del owner
+    gc.collect()
+    assert owner_ref() is not None
+
+    del state
+    gc.collect()
+    assert owner_ref() is None

--- a/tests/unit/test_class_bound_jit_kernel.py
+++ b/tests/unit/test_class_bound_jit_kernel.py
@@ -52,6 +52,7 @@ def reset_jit(jit_fn):
     jit_fn._last_compiled = None
     jit_fn.manager_key = None
     jit_fn._manager_owner_cls = None
+    jit_fn._manager_target = None
     jit_fn.cache_manager = None
     jit_fn._target = None
 
@@ -66,7 +67,7 @@ def frontend_only_compile(monkeypatch):
     monkeypatch.setenv("ARCH", "gfx942")
     monkeypatch.setenv("COMPILE_ONLY", "1")
     monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
-    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda *_args: "test-flydsl-key")
 
     def compile_noop(cls, module, *, arch: str = "", func_name: str = "", link_libs=None):
         return module

--- a/tests/unit/test_class_bound_jit_kernel.py
+++ b/tests/unit/test_class_bound_jit_kernel.py
@@ -54,6 +54,7 @@ def reset_jit(jit_fn):
     jit_fn._manager_owner_cls = None
     jit_fn._manager_target = None
     jit_fn.cache_manager = None
+    jit_fn._cache_managers.clear()
     jit_fn._target = None
 
     jit_fn._sig = None

--- a/tests/unit/test_compile_hints.py
+++ b/tests/unit/test_compile_hints.py
@@ -46,6 +46,7 @@ def _reset_jit_caches(jit_fn):
     jit_fn._mem_cache.clear()
     jit_fn._last_compiled = None
     jit_fn.manager_key = None
+    jit_fn._manager_target = None
     jit_fn.cache_manager = None
 
 
@@ -236,11 +237,7 @@ class TestCacheKeyIncludesTarget:
         assert target_entry == get_backend().target
 
     def test_different_arch_gives_different_key(self, monkeypatch):
-        """Monkeypatch ARCH env var → different GPUTarget → different cache key.
-
-        _backend_target is resolved once in _ensure_sig(); we reset _sig to
-        force re-resolution after changing ARCH.
-        """
+        """Changing ARCH is resolved per invocation and changes the cache key."""
         from flydsl.compiler.backends import _make_backend, get_backend
 
         jf = _noop_launch
@@ -251,7 +248,6 @@ class TestCacheKeyIncludesTarget:
         bound.apply_defaults()
 
         key1 = jf._resolve_and_make_cache_key(bound.arguments)
-        saved_target = jf._backend_target
 
         real_arch = get_backend().target.arch
         fake_arch = "gfx950" if real_arch != "gfx950" else "gfx942"
@@ -260,10 +256,6 @@ class TestCacheKeyIncludesTarget:
         _make_backend.cache_clear()
 
         try:
-            jf._sig = None
-            jf._backend_target = None
-            jf._ensure_sig()
-
             key2 = jf._resolve_and_make_cache_key(bound.arguments)
             assert key1 != key2
             t1 = next(v for k, v in key1 if k == "_target_")
@@ -272,8 +264,6 @@ class TestCacheKeyIncludesTarget:
         finally:
             monkeypatch.delenv("ARCH", raising=False)
             _make_backend.cache_clear()
-            jf._sig = sig
-            jf._backend_target = saved_target
 
 
 class TestCacheDisabledRegression:

--- a/tests/unit/test_compile_hints.py
+++ b/tests/unit/test_compile_hints.py
@@ -48,6 +48,7 @@ def _reset_jit_caches(jit_fn):
     jit_fn.manager_key = None
     jit_fn._manager_target = None
     jit_fn.cache_manager = None
+    jit_fn._cache_managers.clear()
 
 
 # ──────────────────────────────────────────────────────────────
@@ -317,3 +318,19 @@ class TestCacheDisabledRegression:
         assert avg_us >= 0
         assert len(_noop_launch._mem_cache) == 1
         assert len(_noop_launch._call_state_cache) == 1
+
+
+def test_compile_callable_compile_only_does_not_initialize_engine(monkeypatch):
+    from flydsl.compiler.jit_executor import CompiledArtifact
+    from flydsl.runtime.device import get_rocm_arch
+
+    _reset_jit_caches(_noop_launch)
+    monkeypatch.setenv("ARCH", get_rocm_arch())
+    monkeypatch.setenv("COMPILE_ONLY", "1")
+
+    def unexpected_engine_init(*_args, **_kwargs):
+        raise AssertionError("compile-only flyc.compile() initialized an executor")
+
+    monkeypatch.setattr(CompiledArtifact, "_get_func_exe", unexpected_engine_init)
+
+    assert flyc.compile(_noop_launch, torch.cuda.current_stream()) is None

--- a/tests/unit/test_constexpr.py
+++ b/tests/unit/test_constexpr.py
@@ -19,7 +19,7 @@ def frontend_only_jit(monkeypatch):
     monkeypatch.setenv("ARCH", "gfx942")
     monkeypatch.setenv("COMPILE_ONLY", "1")
     monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
-    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda *_args: "test-flydsl-key")
 
     def compile_noop(cls, module, **_kwargs):
         return module

--- a/tests/unit/test_device_target_resolution.py
+++ b/tests/unit/test_device_target_resolution.py
@@ -5,12 +5,19 @@
 
 from __future__ import annotations
 
+import threading
+
 import pytest
+import torch
 
 import flydsl.compiler as flyc
+import flydsl.expr as fx
 import flydsl.runtime.device_runtime as dr
+from flydsl.compiler import jit_function
 from flydsl.compiler.backends import _make_backend, get_backend
+from flydsl.compiler.jit_argument import _dlpack_device
 from flydsl.compiler.jit_executor import CompiledArtifact
+from flydsl.expr.buffer_ops import _get_buffer_flags
 from flydsl.runtime.device import get_rocm_arch
 from flydsl.runtime.device_runtime import Device, DeviceRuntime
 
@@ -56,6 +63,13 @@ class _DeviceArg:
         return self.device
 
 
+class _DeviceStream:
+    cuda_stream = 1234
+
+    def __init__(self, device_id):
+        self.device = torch.device("cuda", device_id)
+
+
 @flyc.jit
 def _device_launch(x):
     pass
@@ -66,12 +80,31 @@ def _device_less_launch():
     pass
 
 
+@flyc.jit
+def _stream_launch(x, stream: fx.Stream):
+    pass
+
+
+@flyc.jit
+def _nested_launch():
+    pass
+
+
+@flyc.jit
+def _parent_launch():
+    _nested_launch()
+
+
 @pytest.fixture(autouse=True)
 def _target_env(monkeypatch):
     old_runtime = dr._instance
     for name in ("ARCH", "FLYDSL_GPU_ARCH", "HSA_OVERRIDE_GFX_VERSION", "COMPILE_ONLY"):
         monkeypatch.delenv(name, raising=False)
     _make_backend.cache_clear()
+    if hasattr(_device_less_launch, "_cache_managers"):
+        _device_less_launch._cache_managers.clear()
+    _nested_launch._cache_managers.clear()
+    _parent_launch._cache_managers.clear()
     yield
     dr._instance = old_runtime
     _make_backend.cache_clear()
@@ -126,6 +159,71 @@ def test_mixed_device_arguments_fail_before_compilation():
 
     with pytest.raises(ValueError, match="same device"):
         _key_and_invocation(launch, _DeviceArg(0), _DeviceArg(1))
+
+
+def test_stream_device_participates_in_target_and_mismatch_validation():
+    dr._instance = _FakeRuntime(("gfx942", "gfx950"))
+
+    with pytest.raises(ValueError, match="same device"):
+        _key_and_invocation(_stream_launch, _DeviceArg(0), _DeviceStream(1))
+
+    _, invocation = _key_and_invocation(_stream_launch, _DeviceArg(1), _DeviceStream(1))
+    assert invocation.device == Device(kind="rocm", index=1)
+    assert invocation.target.arch == "gfx950"
+
+
+def test_buffer_flags_follow_canonical_override_precedence(monkeypatch):
+    monkeypatch.setenv("FLYDSL_GPU_ARCH", "gfx942")
+    monkeypatch.setenv("ARCH", "gfx1201")
+
+    assert _get_buffer_flags() == 0x21027000
+
+    monkeypatch.delenv("ARCH")
+    assert _get_buffer_flags() == 0x00027000
+
+
+def test_generic_dlpack_cuda_is_not_reclassified_as_rocm():
+    assert _dlpack_device(2, 1) == Device(kind="cuda", index=1)
+    assert _dlpack_device(10, 1) == Device(kind="rocm", index=1)
+
+
+def test_cache_managers_are_isolated_by_target_under_concurrency(tmp_path, monkeypatch):
+    monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "1")
+    monkeypatch.setenv("FLYDSL_RUNTIME_CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        jit_function,
+        "_jit_function_cache_key",
+        lambda _func, owner_cls=None, target=None: target.arch,
+    )
+    targets = [get_backend(arch=arch).target for arch in ("gfx942", "gfx950")]
+    barrier = threading.Barrier(len(targets))
+    results = {}
+
+    def resolve(target):
+        barrier.wait()
+        results[target.arch] = _device_less_launch._ensure_cache_manager(target=target)
+
+    threads = [threading.Thread(target=resolve, args=(target,)) for target in targets]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert results["gfx942"][0] == "gfx942"
+    assert results["gfx950"][0] == "gfx950"
+    assert results["gfx942"][1] is not results["gfx950"][1]
+    assert results["gfx942"][1].cache_dir.name.endswith("_gfx942")
+    assert results["gfx950"][1].cache_dir.name.endswith("_gfx950")
+
+
+def test_nested_jit_cache_manager_inherits_invocation_target(monkeypatch):
+    monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
+    target = get_backend(arch="gfx950").target
+
+    _parent_launch._ensure_cache_manager(target=target)
+
+    nested_targets = {slot[1] for slot in _nested_launch._cache_managers}
+    assert nested_targets == {target}
 
 
 def test_compile_only_without_device_requires_explicit_target(monkeypatch):

--- a/tests/unit/test_device_target_resolution.py
+++ b/tests/unit/test_device_target_resolution.py
@@ -204,6 +204,31 @@ def test_cache_managers_are_isolated_by_target_under_concurrency(tmp_path, monke
     assert results["gfx950"][1].cache_dir.name.endswith("_gfx950")
 
 
+def test_compiled_artifact_publication_is_canonical_under_concurrency():
+    @flyc.jit
+    def launch(x):
+        pass
+
+    cache_key = (("shared", True),)
+    candidates = [object(), object()]
+    barrier = threading.Barrier(len(candidates))
+    published = []
+
+    def publish(candidate):
+        barrier.wait()
+        published.append(launch._publish_artifact(cache_key, candidate))
+
+    threads = [threading.Thread(target=publish, args=(candidate,)) for candidate in candidates]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(published) == 2
+    assert published[0] is published[1]
+    assert launch._mem_cache[cache_key] is published[0]
+
+
 def test_compile_only_without_device_requires_explicit_target(monkeypatch):
     dr._instance = _FakeRuntime(("gfx942",))
     monkeypatch.setenv("COMPILE_ONLY", "1")
@@ -236,6 +261,78 @@ def test_device_guard_restores_the_callers_device():
 
     assert runtime.current_device_id() == 0
     assert runtime.set_calls == [1, 0]
+
+
+@pytest.mark.parametrize(
+    ("getter_name", "cache_name"),
+    [
+        ("_get_hip_lib", "_HIP_LIB"),
+        ("_get_fly_runtime_lib", "_FLY_RUNTIME_LIB"),
+    ],
+)
+def test_rocm_runtime_library_initialization_is_atomic(monkeypatch, getter_name, cache_name):
+    from flydsl.runtime.device_runtime import rocm
+
+    class _FakeFunction:
+        argtypes = None
+        restype = None
+
+        def __call__(self, *_args):
+            return 0
+
+    class _FakeRuntimeLibrary:
+        hipGetDevice = _FakeFunction()
+        hipSetDevice = _FakeFunction()
+        hipGetDeviceCount = _FakeFunction()
+        mgpuGetDeviceArch = _FakeFunction()
+
+    entered_loader = threading.Event()
+    release_loader = threading.Event()
+    second_started = threading.Event()
+    second_finished = threading.Event()
+    load_calls = []
+    results = []
+    errors = []
+
+    def load_library(_soname):
+        load_calls.append(_soname)
+        entered_loader.set()
+        assert release_loader.wait(timeout=5)
+        return _FakeRuntimeLibrary()
+
+    monkeypatch.setattr(rocm, cache_name, None)
+    monkeypatch.setattr(rocm.ctypes, "CDLL", load_library)
+    getter = getattr(rocm, getter_name)
+
+    def resolve(*, second=False):
+        if second:
+            second_started.set()
+        try:
+            results.append(getter())
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            if second:
+                second_finished.set()
+
+    first = threading.Thread(target=resolve)
+    second = threading.Thread(target=resolve, kwargs={"second": True})
+    first.start()
+    assert entered_loader.wait(timeout=5)
+    second.start()
+    assert second_started.wait(timeout=5)
+    second_finished.wait(timeout=0.1)
+    release_loader.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not errors
+    assert len(results) == 2
+    assert results[0] is results[1]
+    assert len(load_calls) == 1
+    if getter_name == "_get_fly_runtime_lib":
+        expected = rocm.Path(rocm.__file__).resolve().parents[2] / "_mlir" / "_mlir_libs" / "libfly_jit_runtime.so"
+        assert load_calls == [str(expected)]
 
 
 def test_compiled_artifact_loads_device_bound_state_once_per_device(monkeypatch):

--- a/tests/unit/test_device_target_resolution.py
+++ b/tests/unit/test_device_target_resolution.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Invocation-device target resolution and device-bound JIT state."""
+
+from __future__ import annotations
+
+import pytest
+
+import flydsl.compiler as flyc
+import flydsl.runtime.device_runtime as dr
+from flydsl.compiler.backends import _make_backend, get_backend
+from flydsl.compiler.jit_executor import CompiledArtifact
+from flydsl.runtime.device import get_rocm_arch
+from flydsl.runtime.device_runtime import Device, DeviceRuntime
+
+pytestmark = [pytest.mark.l0_backend_agnostic]
+
+
+class _FakeRuntime(DeviceRuntime):
+    kind = "rocm"
+
+    def __init__(self, archs=("gfx942",), current=0):
+        self.archs = tuple(archs)
+        self.current = current
+        self.set_calls = []
+
+    def device_count(self) -> int:
+        return len(self.archs)
+
+    def current_device_id(self) -> int:
+        return self.current
+
+    def set_device_id(self, device_id: int) -> None:
+        self.set_calls.append(device_id)
+        self.current = device_id
+
+    def device_arch(self, device_id: int) -> str:
+        return self.archs[device_id]
+
+
+class _DeviceArg:
+    def __init__(self, device_id):
+        self.device = Device(kind="rocm", index=device_id)
+
+    def __get_ir_types__(self):
+        return []
+
+    def __cache_signature__(self):
+        return (type(self),)
+
+    def __c_abi_spec__(self):
+        return []
+
+    def __flydsl_device__(self):
+        return self.device
+
+
+@flyc.jit
+def _device_launch(x):
+    pass
+
+
+@flyc.jit
+def _device_less_launch():
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _target_env(monkeypatch):
+    old_runtime = dr._instance
+    for name in ("ARCH", "FLYDSL_GPU_ARCH", "HSA_OVERRIDE_GFX_VERSION", "COMPILE_ONLY"):
+        monkeypatch.delenv(name, raising=False)
+    _make_backend.cache_clear()
+    yield
+    dr._instance = old_runtime
+    _make_backend.cache_clear()
+
+
+def _key_and_invocation(jit_fn, *args):
+    jit_fn._ensure_sig()
+    bound = jit_fn._sig.bind(*args)
+    bound.apply_defaults()
+    return jit_fn._build_full_cache_key(bound.arguments, return_invocation=True)
+
+
+def test_target_override_precedence(monkeypatch):
+    dr._instance = _FakeRuntime(("gfx1100",))
+    device = Device(kind="rocm", index=0)
+    monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "9.4.2")
+    monkeypatch.setenv("FLYDSL_GPU_ARCH", "gfx950")
+    monkeypatch.setenv("ARCH", "gfx1201")
+
+    assert get_backend(device=device).target.arch == "gfx1201"
+    assert get_rocm_arch() == "gfx1201"
+
+    monkeypatch.delenv("ARCH")
+    assert get_backend(device=device).target.arch == "gfx950"
+    assert get_rocm_arch() == "gfx950"
+
+    monkeypatch.delenv("FLYDSL_GPU_ARCH")
+    assert get_backend(device=device).target.arch == "gfx942"
+    assert get_rocm_arch() == "gfx942"
+
+
+def test_tensor_device_selects_target_and_cache_partition():
+    dr._instance = _FakeRuntime(("gfx942", "gfx942", "gfx950"))
+
+    key0, invocation0 = _key_and_invocation(_device_launch, _DeviceArg(0))
+    key1, invocation1 = _key_and_invocation(_device_launch, _DeviceArg(1))
+    key2, invocation2 = _key_and_invocation(_device_launch, _DeviceArg(2))
+
+    assert invocation0.target.arch == invocation1.target.arch == "gfx942"
+    assert invocation2.target.arch == "gfx950"
+    assert key0 == key1
+    assert key0 != key2
+    assert invocation0.device != invocation1.device
+
+
+def test_mixed_device_arguments_fail_before_compilation():
+    @flyc.jit
+    def launch(x, y):
+        pass
+
+    dr._instance = _FakeRuntime(("gfx942", "gfx950"))
+
+    with pytest.raises(ValueError, match="same device"):
+        _key_and_invocation(launch, _DeviceArg(0), _DeviceArg(1))
+
+
+def test_compile_only_without_device_requires_explicit_target(monkeypatch):
+    dr._instance = _FakeRuntime(("gfx942",))
+    monkeypatch.setenv("COMPILE_ONLY", "1")
+
+    with pytest.raises(RuntimeError, match="explicit target"):
+        _key_and_invocation(_device_less_launch)
+
+    monkeypatch.setenv("ARCH", "gfx950")
+    _, invocation = _key_and_invocation(_device_less_launch)
+    assert invocation.target.arch == "gfx950"
+    assert invocation.device is None
+
+
+def test_detection_failure_does_not_fall_back_to_gfx942():
+    class _BrokenRuntime(_FakeRuntime):
+        def device_arch(self, device_id):
+            raise RuntimeError("HIP target query failed")
+
+    dr._instance = _BrokenRuntime()
+
+    with pytest.raises(RuntimeError, match="HIP target query failed"):
+        get_rocm_arch()
+
+
+def test_device_guard_restores_the_callers_device():
+    runtime = _FakeRuntime(("gfx942", "gfx950"), current=0)
+
+    with runtime.device_guard(1):
+        assert runtime.current_device_id() == 1
+
+    assert runtime.current_device_id() == 0
+    assert runtime.set_calls == [1, 0]
+
+
+def test_compiled_artifact_loads_device_bound_state_once_per_device(monkeypatch):
+    artifact = CompiledArtifact(compiled_module="module", func_name="launch")
+    loads = []
+
+    def load(device):
+        loads.append(device)
+        return type("_Executable", (), {"func_exe": object()})()
+
+    monkeypatch.setattr(artifact, "_load_executable", load)
+    device0 = Device(kind="rocm", index=0)
+    device1 = Device(kind="rocm", index=1)
+
+    func0 = artifact._get_func_exe(device0)
+    assert artifact._get_func_exe(device0) is func0
+    assert artifact._get_func_exe(device1) is not func0
+    assert loads == [device0, device1]

--- a/tests/unit/test_device_target_resolution.py
+++ b/tests/unit/test_device_target_resolution.py
@@ -85,16 +85,6 @@ def _stream_launch(x, stream: fx.Stream):
     pass
 
 
-@flyc.jit
-def _nested_launch():
-    pass
-
-
-@flyc.jit
-def _parent_launch():
-    _nested_launch()
-
-
 @pytest.fixture(autouse=True)
 def _target_env(monkeypatch):
     old_runtime = dr._instance
@@ -103,8 +93,6 @@ def _target_env(monkeypatch):
     _make_backend.cache_clear()
     if hasattr(_device_less_launch, "_cache_managers"):
         _device_less_launch._cache_managers.clear()
-    _nested_launch._cache_managers.clear()
-    _parent_launch._cache_managers.clear()
     yield
     dr._instance = old_runtime
     _make_backend.cache_clear()
@@ -214,16 +202,6 @@ def test_cache_managers_are_isolated_by_target_under_concurrency(tmp_path, monke
     assert results["gfx942"][1] is not results["gfx950"][1]
     assert results["gfx942"][1].cache_dir.name.endswith("_gfx942")
     assert results["gfx950"][1].cache_dir.name.endswith("_gfx950")
-
-
-def test_nested_jit_cache_manager_inherits_invocation_target(monkeypatch):
-    monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
-    target = get_backend(arch="gfx950").target
-
-    _parent_launch._ensure_cache_manager(target=target)
-
-    nested_targets = {slot[1] for slot in _nested_launch._cache_managers}
-    assert nested_targets == {target}
 
 
 def test_compile_only_without_device_requires_explicit_target(monkeypatch):

--- a/tests/unit/test_jit_cache_key.py
+++ b/tests/unit/test_jit_cache_key.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl.compiler.jit_argument import JitArgumentRegistry
@@ -14,6 +16,12 @@ class _FakeCudaStream:
 
 
 JitArgumentRegistry.register(_FakeCudaStream)(fx.Stream)
+
+
+@pytest.fixture(autouse=True)
+def _explicit_gpu_free_target(monkeypatch):
+    """These cache-key tests do not own a GPU invocation."""
+    monkeypatch.setenv("ARCH", "gfx942")
 
 
 @flyc.jit

--- a/tests/unit/test_jit_cache_key_completeness.py
+++ b/tests/unit/test_jit_cache_key_completeness.py
@@ -341,6 +341,8 @@ def test_jit_self_reference_does_not_recurse_forever(tmp_path, monkeypatch):
 
 
 def test_mutually_referential_jits_do_not_recurse_forever(tmp_path, monkeypatch):
+    import threading
+
     monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
     monkeypatch.setattr(jit_function, "_flydsl_key", lambda *_args: "test-flydsl-key")
     mod = _load_mod(
@@ -362,51 +364,59 @@ def test_mutually_referential_jits_do_not_recurse_forever(tmp_path, monkeypatch)
         """,
     )
 
-    _reset_manager_key(mod.first)
-    _reset_manager_key(mod.second)
-    first_key = _manager_key(mod.first)
-    second_key = _manager_key(mod.second)
+    observed = set()
+    for _ in range(20):
+        _reset_manager_key(mod.first)
+        _reset_manager_key(mod.second)
+        barrier = threading.Barrier(2)
+        result = {}
 
-    assert first_key == _manager_key(mod.first)
-    assert second_key == _manager_key(mod.second)
+        def resolve(name, fn):
+            barrier.wait()
+            result[name] = _manager_key(fn)
 
+        threads = [
+            threading.Thread(target=resolve, args=("first", mod.first)),
+            threading.Thread(target=resolve, args=("second", mod.second)),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+            assert not thread.is_alive()
+        observed.add((result["first"], result["second"]))
 
-def test_in_progress_stack_is_thread_local():
-    """Each thread must get its own in-progress set."""
-    import threading
-
-    main_stack = jit_function._keys_in_progress()
-    assert jit_function._keys_in_progress() is main_stack
-
-    other = {}
-
-    def worker():
-        other["stack"] = jit_function._keys_in_progress()
-
-    t = threading.Thread(target=worker)
-    t.start()
-    t.join()
-
-    assert other["stack"] is not main_stack
+    assert len(observed) == 1
 
 
-def test_key_computation_leaves_no_in_progress_leak(tmp_path, monkeypatch):
-    """The in-progress stack must be empty again after keying."""
+def test_parent_key_includes_nested_jit_closure_values(tmp_path, monkeypatch):
     monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
     monkeypatch.setattr(jit_function, "_flydsl_key", lambda *_args: "test-flydsl-key")
-    mod = _load_mod(
-        tmp_path,
-        "jit_no_leak",
-        """
-        import flydsl.compiler as flyc
-        import flydsl.expr as fx
 
-        @flyc.jit
-        def solo(A: fx.Tensor):
-            _ = solo
-            return A
-        """,
-    )
+    def load(name, tile):
+        return _load_mod(
+            tmp_path,
+            name,
+            f"""
+            import flydsl.compiler as flyc
+            import flydsl.expr as fx
 
-    _manager_key(mod.solo, reset=True)
-    assert jit_function._keys_in_progress() == set()
+            def make_child(tile):
+                @flyc.jit
+                def child(A: fx.Tensor):
+                    _ = tile
+                    return A
+                return child
+
+            child = make_child({tile})
+
+            @flyc.jit
+            def parent(A: fx.Tensor):
+                return child(A)
+            """,
+        )
+
+    first = load("nested_closure_64", 64)
+    second = load("nested_closure_128", 128)
+
+    assert _manager_key(first.parent, reset=True) != _manager_key(second.parent, reset=True)

--- a/tests/unit/test_jit_cache_key_completeness.py
+++ b/tests/unit/test_jit_cache_key_completeness.py
@@ -17,6 +17,12 @@ from flydsl.compiler import jit_function
 from flydsl.compiler.protocol import cache_signature
 
 
+@pytest.fixture(autouse=True)
+def _explicit_gpu_free_target(monkeypatch):
+    """These cache-key tests do not own a GPU invocation."""
+    monkeypatch.setenv("ARCH", "gfx942")
+
+
 def _key(jit_fn, *args):
     jit_fn._ensure_sig()
     bound = jit_fn._sig.bind(*args)
@@ -57,6 +63,7 @@ def test_globals_drift_default_raises(tmp_path, monkeypatch):
     spec = importlib.util.spec_from_file_location("drift_default", src)
     mod = importlib.util.module_from_spec(spec)
     monkeypatch.setenv("COMPILE_ONLY", "1")  # auto-restored, no leak across tests
+    monkeypatch.setenv("ARCH", "gfx942")
     spec.loader.exec_module(mod)
     A = torch.zeros(8, dtype=torch.float32)
     mod.k(A)
@@ -91,8 +98,8 @@ def test_cache_key_is_device_independent():
     """The cache key's target is arch-only, with no device id component.
 
     The compiled kernel binary is device-independent, so a single in-process
-    artifact / func_exe is shared across same-arch GPUs (as on main). Folding a
-    device id into the key would needlessly split the cache per device.
+    artifact is shared across same-arch GPUs. Loaded executables remain
+    device-specific outside this artifact key.
     """
     from flydsl.compiler.backends import GPUTarget, get_backend
 
@@ -187,6 +194,7 @@ def _load_mod(tmp_path, name, body):
 def _reset_manager_key(jit_fn):
     jit_fn.manager_key = None
     jit_fn._manager_owner_cls = None
+    jit_fn._manager_target = None
     jit_fn.cache_manager = None
 
 
@@ -237,6 +245,7 @@ def test_dict_global_inplace_mutation_raises(tmp_path, monkeypatch):
         "    return A\n",
     )
     monkeypatch.setenv("COMPILE_ONLY", "1")
+    monkeypatch.setenv("ARCH", "gfx942")
     A = torch.zeros(8, dtype=torch.float32)
     mod.k(A)
     mod.CFG["tile"] = 128  # in-place mutation (same object id)
@@ -281,7 +290,7 @@ def test_top_level_launch_named_jit_does_not_recurse_forever(tmp_path, monkeypat
     ``kernel(...).launch(...)`` must not blow the stack while building its key.
     """
     monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
-    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda *_args: "test-flydsl-key")
     mod = _load_mod(
         tmp_path,
         "launch_attr_collision",
@@ -309,7 +318,7 @@ def test_top_level_launch_named_jit_does_not_recurse_forever(tmp_path, monkeypat
 
 def test_jit_self_reference_does_not_recurse_forever(tmp_path, monkeypatch):
     monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
-    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda *_args: "test-flydsl-key")
     mod = _load_mod(
         tmp_path,
         "jit_self_ref",
@@ -332,7 +341,7 @@ def test_jit_self_reference_does_not_recurse_forever(tmp_path, monkeypatch):
 
 def test_mutually_referential_jits_do_not_recurse_forever(tmp_path, monkeypatch):
     monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
-    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda *_args: "test-flydsl-key")
     mod = _load_mod(
         tmp_path,
         "jit_mutual_ref",
@@ -383,7 +392,7 @@ def test_in_progress_stack_is_thread_local():
 def test_key_computation_leaves_no_in_progress_leak(tmp_path, monkeypatch):
     """The in-progress stack must be empty again after keying."""
     monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
-    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda *_args: "test-flydsl-key")
     mod = _load_mod(
         tmp_path,
         "jit_no_leak",

--- a/tests/unit/test_jit_cache_key_completeness.py
+++ b/tests/unit/test_jit_cache_key_completeness.py
@@ -196,6 +196,7 @@ def _reset_manager_key(jit_fn):
     jit_fn._manager_owner_cls = None
     jit_fn._manager_target = None
     jit_fn.cache_manager = None
+    jit_fn._cache_managers.clear()
 
 
 def _manager_key(jit_fn, *, reset=False):

--- a/tests/unit/test_jit_cache_key_completeness.py
+++ b/tests/unit/test_jit_cache_key_completeness.py
@@ -420,3 +420,53 @@ def test_parent_key_includes_nested_jit_closure_values(tmp_path, monkeypatch):
     second = load("nested_closure_128", 128)
 
     assert _manager_key(first.parent, reset=True) != _manager_key(second.parent, reset=True)
+
+
+def test_parent_key_includes_cross_directory_child_helpers(tmp_path, monkeypatch):
+    import importlib.util
+
+    monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda *_args: "test-flydsl-key")
+
+    def load_version(version, helper_return):
+        root = tmp_path / version
+        child_dir = root / "child"
+        parent_dir = root / "parent"
+        child_dir.mkdir(parents=True)
+        parent_dir.mkdir(parents=True)
+
+        child_path = child_dir / "child_module.py"
+        child_path.write_text(textwrap.dedent(f"""
+                import flydsl.compiler as flyc
+                import flydsl.expr as fx
+
+                def helper(A):
+                    return {helper_return}
+
+                @flyc.jit
+                def child(A: fx.Tensor):
+                    return helper(A)
+                """))
+        child_spec = importlib.util.spec_from_file_location("cross_dir_child", child_path)
+        child_mod = importlib.util.module_from_spec(child_spec)
+        child_spec.loader.exec_module(child_mod)
+
+        parent_path = parent_dir / "parent_module.py"
+        parent_path.write_text(textwrap.dedent("""
+                import flydsl.compiler as flyc
+                import flydsl.expr as fx
+
+                @flyc.jit
+                def parent(A: fx.Tensor):
+                    return child(A)
+                """))
+        parent_spec = importlib.util.spec_from_file_location("cross_dir_parent", parent_path)
+        parent_mod = importlib.util.module_from_spec(parent_spec)
+        parent_mod.child = child_mod.child
+        parent_spec.loader.exec_module(parent_mod)
+        return parent_mod
+
+    first = load_version("first", "A")
+    second = load_version("second", "(A, A)")
+
+    assert _manager_key(first.parent, reset=True) != _manager_key(second.parent, reset=True)

--- a/tests/unit/test_layout_algebra.py
+++ b/tests/unit/test_layout_algebra.py
@@ -34,7 +34,7 @@ def frontend_only_jit(monkeypatch):
     monkeypatch.setenv("ARCH", "gfx942")
     monkeypatch.setenv("COMPILE_ONLY", "1")
     monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
-    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda *_args: "test-flydsl-key")
 
     def compile_layout_pipeline(cls, module, **_kwargs):
         pm = PassManager.parse(FLY_PIPELINE)

--- a/tests/unit/test_struct.py
+++ b/tests/unit/test_struct.py
@@ -35,7 +35,7 @@ def frontend_only_jit(monkeypatch):
     monkeypatch.setenv("ARCH", "gfx942")
     monkeypatch.setenv("COMPILE_ONLY", "1")
     monkeypatch.setenv("FLYDSL_RUNTIME_ENABLE_CACHE", "0")
-    monkeypatch.setattr(jit_function, "_flydsl_key", lambda: "test-flydsl-key")
+    monkeypatch.setattr(jit_function, "_flydsl_key", lambda *_args: "test-flydsl-key")
 
     def compile_noop(cls, module, **_kwargs):
         return module


### PR DESCRIPTION
## Summary

Resolve ROCm JIT targets from the device carried by each invocation instead of freezing the first process-wide architecture.

- Preserve one explicit override order: `ARCH` → `FLYDSL_GPU_ARCH` → `HSA_OVERRIDE_GFX_VERSION` → invocation device.
- Read each logical HIP device's `gcnArchName` through the FlyDSL ROCm runtime and remove the silent `gfx942` fallback.
- Propagate device identity from Torch, generic DLPack, and stream JIT arguments, rejecting mixed-device argument sets before compilation.
- Keep compiled artifacts architecture-keyed while isolating `ExecutionEngine`, loaded module, function pointer, and `CallState` per logical device.
- Keep disk cache managers target-local under concurrent heterogeneous-device calls, including nested JIT dependencies.
- Guard tracing, module load/unload, and launch with the invocation device so architecture-sensitive helpers and device-bound state stay consistent.
- Make buffer descriptor flags and autotune cache/toolchain fingerprints use the same canonical invocation target.
- Require an explicit target for device-less compile-only workflows; `flyc.compile()` no longer initializes an executor in compile-only mode.

## Invariants

- Same-architecture devices reuse the compiled artifact without sharing loaded executable state.
- Different architectures produce different target/cache keys.
- Tensor and stream arguments must agree on one logical device.
- A target-detection failure is explicit; it never silently compiles for `gfx942`.
- Explicit target overrides retain priority over invocation-device detection throughout code generation.

## Verification

- Full unit suite: `527 passed, 13 skipped`.
- Two-device MI355X RMSNorm forward/backward test: passed on `cuda:0` and `cuda:1` for atomic and staged paths.
- Standalone HIP runtime probe: `hipGetDeviceProperties` returned `gfx950:sramecc+:xnack-` for both tested logical devices through the new C ABI.
- Python/C++ style, Ruff, `py_compile`, and `git diff --check`: passed.
- Sphinx HTML build: passed with the three existing unrelated warnings.

Closes #878.

