### PR TITLE
[CI] Make MLIR cache fallback reliable

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -118,9 +118,9 @@ jobs:
           echo "Docs-only change: GPU tests skipped (check-signal=${CHECK_SIGNAL_RESULT}); reporting 'test (${{ matrix.runners }})' as passed."
 
   # ---------------------------------------------------------------------------
-  # Prepare one shared MLIR install before GPU jobs. On a cache miss, build LLVM
-  # once and either persist it from main or publish a short-lived artifact for
-  # the current PR run. GPU jobs never compile LLVM independently.
+  # Prepare one shared MLIR install before GPU jobs. Restore or build LLVM once,
+  # then publish a short-lived artifact for every GPU job in the current run.
+  # Only main persists rebuilt installs in the cross-run cache.
   # ---------------------------------------------------------------------------
   prepare-mlir:
     needs: [check-signal, detect-changes]
@@ -142,12 +142,11 @@ jobs:
           ref: ${{ env.GITHUB_COMMIT_SHA }}
           path: flydsl-test
 
-      - name: Look up shared MLIR cache
+      - name: Restore shared MLIR cache
         id: mlir-cache
         uses: actions/cache/restore@v4
         with:
           path: mlir_install.tgz
-          lookup-only: true
           key: mlir-install-${{ runner.os }}-${{ runner.arch }}-${{ env.MLIR_CACHE_VERSION }}-${{ hashFiles('flydsl-test/thirdparty/llvm-hash.txt', 'flydsl-test/scripts/build_llvm.sh') }}
 
       - name: Start MLIR build container
@@ -197,8 +196,7 @@ jobs:
           path: mlir_install.tgz
           key: ${{ steps.mlir-cache.outputs.cache-primary-key }}
 
-      - name: Upload MLIR fallback for this run
-        if: steps.mlir-cache.outputs.cache-hit != 'true'
+      - name: Upload prepared MLIR tarball for this run
         uses: actions/upload-artifact@v4
         with:
           name: mlir-install-${{ github.run_id }}
@@ -295,30 +293,12 @@ jobs:
           docker exec flydsl_test bash -c "python3 -m pip install -U 'hypothesis>=6.82.0'"
           docker exec flydsl_test bash -c "git config --global --add safe.directory /flydsl-test && cd /flydsl-test && git log"
     
-      # Cache MLIR install tarball across workflow runs.
-      - name: Restore cached MLIR install tarball (if available)
-        id: mlir-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: mlir_install.tgz
-          key: mlir-install-${{ runner.os }}-${{ runner.arch }}-${{ env.MLIR_CACHE_VERSION }}-${{ hashFiles('flydsl-test/thirdparty/llvm-hash.txt', 'flydsl-test/scripts/build_llvm.sh') }}
-
-      - name: Use cached MLIR install tarball (skip LLVM build)
-        if: steps.mlir-cache.outputs.cache-hit == 'true'
-        run: |
-          ls -lh mlir_install.tgz
-          docker cp mlir_install.tgz flydsl_test:/tmp/mlir_install.tgz
-          docker exec flydsl_test bash -c "rm -rf /llvm-project/mlir_install && mkdir -p /llvm-project && tar -xzf /tmp/mlir_install.tgz -C /llvm-project"
-          docker exec flydsl_test bash -c "ls -la /llvm-project/mlir_install/lib/cmake/mlir"
-
       - name: Download prepared MLIR tarball
-        if: steps.mlir-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: mlir-install-${{ github.run_id }}
 
       - name: Use prepared MLIR install tarball
-        if: steps.mlir-cache.outputs.cache-hit != 'true'
         run: |
           ls -lh mlir_install.tgz
           docker cp mlir_install.tgz flydsl_test:/tmp/mlir_install.tgz
@@ -585,29 +565,12 @@ jobs:
           docker exec flydsl_test bash -c "python3 -m pip install -U 'hypothesis>=6.82.0'"
           docker exec flydsl_test bash -c "git config --global --add safe.directory /flydsl-test && cd /flydsl-test && git log"
 
-      - name: Restore cached MLIR install tarball (if available)
-        id: mlir-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: mlir_install.tgz
-          key: mlir-install-${{ runner.os }}-${{ runner.arch }}-${{ env.MLIR_CACHE_VERSION }}-${{ hashFiles('flydsl-test/thirdparty/llvm-hash.txt', 'flydsl-test/scripts/build_llvm.sh') }}
-
-      - name: Use cached MLIR install tarball (skip LLVM build)
-        if: steps.mlir-cache.outputs.cache-hit == 'true'
-        run: |
-          ls -lh mlir_install.tgz
-          docker cp mlir_install.tgz flydsl_test:/tmp/mlir_install.tgz
-          docker exec flydsl_test bash -c "rm -rf /llvm-project/mlir_install && mkdir -p /llvm-project && tar -xzf /tmp/mlir_install.tgz -C /llvm-project"
-          docker exec flydsl_test bash -c "ls -la /llvm-project/mlir_install/lib/cmake/mlir"
-
       - name: Download prepared MLIR tarball
-        if: steps.mlir-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: mlir-install-${{ github.run_id }}
 
       - name: Use prepared MLIR install tarball
-        if: steps.mlir-cache.outputs.cache-hit != 'true'
         run: |
           ls -lh mlir_install.tgz
           docker cp mlir_install.tgz flydsl_test:/tmp/mlir_install.tgz


### PR DESCRIPTION
## Summary
- restore the shared MLIR cache only in `prepare-mlir`
- always upload the prepared tarball as a short-lived run artifact
- make single- and multi-GPU jobs consume that artifact instead of independently restoring the 2.1 GB cache
- preserve the existing behavior of rebuilding once on a restore failure and saving rebuilt caches only from `main`

## Root cause
The `lookup-only` probe could succeed while a later GPU-job restore failed. In run 30076185312, the signed cache download URL expired at 48.1%; in run 30076858081, the Navi runner reported a cache miss. Because the probe had succeeded, `prepare-mlir` had skipped artifact upload, so both jobs then failed with `Artifact not found`.

## Test plan
- [x] Run `actionlint` on `.github/workflows/flydsl.yaml`
- [ ] Confirm `prepare-mlir` always uploads `mlir-install-${{ github.run_id }}`
- [ ] Confirm all GPU jobs download the prepared artifact without running `actions/cache/restore`
- [ ] Confirm a cache restore failure falls back to one LLVM build in `prepare-mlir`


Made with [Cursor](https://cursor.com)