### PR TITLE
[fix] Autotuner: propagate the tuned function's return value

### DIFF
--- a/python/flydsl/autotune.py
+++ b/python/flydsl/autotune.py
@@ -405,9 +405,9 @@ class Autotuner:
             from .compiler.kernel_function import CompilationContext
 
             with CompilationContext.compile_hints(compiler_opts):
-                self.fn(*args, **kwargs)
+                return self.fn(*args, **kwargs)
         else:
-            self.fn(*args, **kwargs)
+            return self.fn(*args, **kwargs)
 
     def _run_config(self, config, args, kwargs):
         """Run the chosen config as a real (non-benchmark) call. Re-applies

--- a/tests/unit/test_autotune.py
+++ b/tests/unit/test_autotune.py
@@ -711,5 +711,47 @@ def test_artifact_key_must_name_a_kernel_parameter():
         _make_artifact_tuner(key=["mni"])
 
 
+# ── return-value propagation ─────────────────────────────────────────────
+def test_call_returns_tuned_fn_value(monkeypatch):
+    """The tuned function's return value must propagate through __call__ on both
+    the search path and the cache-hit path."""
+    monkeypatch.setenv("FLYDSL_AUTOTUNE", "1")  # force the search path first
+
+    def fn(a, out, BLOCK):
+        return ("result", BLOCK)
+
+    tuner = _make_tuner(
+        fn=fn,
+        configs=[Config(BLOCK=64), Config(BLOCK=128)],
+        do_bench_fn=lambda call, warmup, rep: (call(), 1.0)[1],
+    )
+    args = (FakeTensor((8,)), FakeTensor((1,)))
+
+    searched = tuner(*args)  # search path -> runs the winning config
+    assert searched == ("result", 64)
+
+    monkeypatch.setenv("FLYDSL_AUTOTUNE", "0")
+    hit = tuner(*args)  # cache-hit path
+    assert hit == ("result", 64)
+
+
+def test_call_returns_none_when_fn_returns_none(monkeypatch):
+    """In-place kernels (write into `out`, return nothing) still return None --
+    the fix only forwards whatever the tuned fn returns, it doesn't fabricate."""
+    monkeypatch.setenv("FLYDSL_AUTOTUNE", "1")
+
+    def fn(a, out, BLOCK):
+        out._data[0] = float(BLOCK)  # writes in place, returns None
+
+    tuner = _make_tuner(
+        fn=fn,
+        configs=[Config(BLOCK=64)],
+        do_bench_fn=lambda call, warmup, rep: (call(), 1.0)[1],
+    )
+    args = (FakeTensor((8,)), FakeTensor((1,)))
+    assert tuner(*args) is None
+    assert args[1]._data[0] == 64.0
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

`Autotuner._run_with_hints` calls `self.fn(*args, **kwargs)` on both branches (with and without compiler hints) but does not return it. As a result `Autotuner.__call__` always yields `None`, even though `_run_config` does `return self._run_with_hints(...)` and `__call__` returns `_run_config(...)` — the value is threaded all the way up to this one method, which drops it.

Any autotuned function that produces its result as a **return value** (rather than writing into a caller-owned output buffer) therefore silently gets `None`. Callers currently work around this by allocating an output tensor themselves, passing it in, and returning that buffer instead of trusting the autotuner's return.

## Fix

Add the missing `return` on both branches of `_run_with_hints`.

Backward compatible:
- Callers that ignore the return value (in-place kernels writing into `out`) are unaffected — the fn still returns `None`, so the tuner still returns `None`.
- Callers whose fn returns its result now receive it.

## Test

Adds two cases to `tests/unit/test_autotune.py` (GPU-free):

- `test_call_returns_tuned_fn_value` — the tuned fn's return value propagates through `__call__` on both the search path and the cache-hit path. **Fails without the fix** (`assert None == ('result', 64)`).
- `test_call_returns_none_when_fn_returns_none` — an in-place fn that returns nothing still yields `None`, confirming the fix only forwards the value and doesn't fabricate one.

Run:

```
pytest tests/unit/test_autotune.py -k return -v
```
