### PR TITLE
[Refactor] Align RMSNorm with current FlyDSL kernel style

### DIFF
--- a/kernels/norm/rmsnorm_bwd_kernel.py
+++ b/kernels/norm/rmsnorm_bwd_kernel.py
@@ -166,7 +166,7 @@ def build_rmsnorm_bwd_module(N: int, dtype_str: str, weight_dtype_str: str | Non
                 wdy = dy * g
                 dx = (wdy - x_hat * c1) * rstd
                 dx_e = dx if dtype_str == "f32" else dx.to(elem_dtype)
-                store_scalar(copy_atom_s, elem_dtype, elem_dtype, dx_div, idx, dx_e)
+                store_scalar(copy_atom_s, elem_dtype, dx_div, idx, dx_e)
 
                 dw = dy * x_hat
                 atomic_add(DWeight, idx, dw, dtype_bytes=4)
@@ -333,7 +333,7 @@ def build_fused_add_rmsnorm_bwd_module(N: int, dtype_str: str, weight_dtype_str:
                 d_added = (wdy - a_hat * c1) * rstd
                 total = d_added + dres_out
                 total_e = total if dtype_str == "f32" else total.to(elem_dtype)
-                store_scalar(copy_atom_s, elem_dtype, elem_dtype, dx_div, idx, total_e)
+                store_scalar(copy_atom_s, elem_dtype, dx_div, idx, total_e)
 
                 dw = dy * a_hat
                 atomic_add(DWeight, idx, dw, dtype_bytes=4)
@@ -494,7 +494,7 @@ def _build_rmsnorm_bwd_two_stage_module(
                 )
 
         dweight_partial = fx.Vector.filled(PARTIAL_ACC_SIZE, 0.0, fx.Float32)
-        for row in range(fx.Int32(bid), MIn, num_programs):
+        for row in range(bid, MIn, num_programs):
             row_source = fx.slice(Source_buf, (row, None))
             row_dy = fx.slice(DY_buf, (row, None))
             row_dx = fx.slice(DX_buf, (row, None))
@@ -574,7 +574,7 @@ def _build_rmsnorm_bwd_two_stage_module(
                         store_vec(copy_atom_io, IO_WIDTH, elem_dtype, dx_e, dx_div, io_idx)
                     else:
                         dx_e = dx if dtype_str == "f32" else dx.to(elem_dtype)
-                        store_scalar(copy_atom_io, elem_dtype, elem_dtype, dx_div, io_idx, dx_e)
+                        store_scalar(copy_atom_io, elem_dtype, dx_div, io_idx, dx_e)
 
                 dw = dy * source_hat
                 if const_expr(USE_VEC):
@@ -595,7 +595,6 @@ def _build_rmsnorm_bwd_two_stage_module(
                     partial_value = dweight_partial[tile_i * IO_WIDTH + lane]
                     store_scalar(
                         copy_atom_f32,
-                        fx.Float32,
                         fx.Float32,
                         partial_div,
                         partial_idx,
@@ -629,26 +628,26 @@ def _build_rmsnorm_bwd_two_stage_module(
         lds = fx.SharedAllocator().allocate(DWeightReduceStorage).peek()
         s_partial = lds.s_red.view(fx.make_layout(DWEIGHT_REDUCE_THREADS, 1))
 
-        acc = fx.Float32(0.0)
+        c_zero_f = fx.Float32(0.0)
+        acc = c_zero_f
         for partial_base in range(0, num_programs, DWEIGHT_REDUCE_ROW_LANES):
             partial_row = partial_base + partial_lane
             partial_valid = partial_row < num_programs
             partial_row_safe = partial_valid.select(partial_row, 0)
             partial_idx = partial_row_safe * N + col_safe
             value = load_scalar(copy_atom_f32, fx.Float32, partial_div, partial_idx)
-            acc = acc + partial_valid.select(value, fx.Float32(0.0))
+            acc = acc + partial_valid.select(value, c_zero_f)
         fx.memref_store(acc, s_partial, tid)
         gpu.barrier()
 
         if partial_lane == 0:
             if col < N:
-                total = fx.Float32(0.0)
+                total = c_zero_f
                 for lane in range_constexpr(DWEIGHT_REDUCE_ROW_LANES):
                     total = total + fx.memref_load(s_partial, lane * DWEIGHT_REDUCE_COLS + col_lane)
                 out = total if weight_dtype_str == "f32" else total.to(weight_elem_dtype)
                 store_scalar(
                     weight_copy_atom_s,
-                    weight_elem_dtype,
                     weight_elem_dtype,
                     dweight_div,
                     col,

--- a/kernels/norm/rmsnorm_bwd_kernel.py
+++ b/kernels/norm/rmsnorm_bwd_kernel.py
@@ -1,13 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
-"""RMSNorm backward kernel builders (plain + fused-add / prenorm).
-
-Split out of ``rmsnorm_kernel.py`` so the training-only backward path lives in
-its own module (per review on #800). Device-side helpers and constants are
-shared via ``rmsnorm_common.py``; the forward builders and the autograd glue
-that ties forward+backward together stay in ``rmsnorm_kernel.py``.
-"""
+"""RMSNorm backward kernel builders for plain and fused-add variants."""
 
 import math
 
@@ -48,17 +42,12 @@ def is_rmsnorm_bwd_two_stage_vec_config(N: int, dtype_str: str) -> bool:
 
 
 def build_rmsnorm_bwd_module(N: int, dtype_str: str, weight_dtype_str: str | None = None):
-    """Fused RMSNorm backward: grid=(M,), one block per row.
+    """RMSNorm backward atomic fallback: one block per row.
 
     Pass 1: c1 = mean_N(x_hat * wdy), x_hat = x*rstd, wdy = dy*gamma.
     Pass 2: dx = (wdy - x_hat*c1) * rstd  -> DX (elem dtype);
             dw_elem = dy * x_hat (fp32)   -> atomicAdd into DWeight[idx] (fp32).
     eps is baked into Rstd by the forward, so it is not needed here.
-
-    Perf follow-ups (deferred; correctness-complete as-is): this is the generic
-    scalar path only — a vectorized fast path (mirroring the forward) and caching
-    x/dy/gamma between pass 1 and pass 2 (the forward caches `in_local`) would cut
-    global traffic. Left out of PR 1 to keep the first backward reviewable.
     """
     weight_dtype_str = resolve_rmsnorm_weight_dtype(dtype_str, weight_dtype_str)
     RED_SLOTS = max(1, (BLOCK_THREADS + WARP_SIZE - 1) // WARP_SIZE)
@@ -214,12 +203,9 @@ def build_fused_add_rmsnorm_bwd_module(N: int, dtype_str: str, weight_dtype_str:
 
     eps is baked into Rstd by the forward, so it is not needed here.
 
-    DResidualOut is ALWAYS a real tensor: the python wrapper passes a zero
+    DResidualOut is always a real tensor: the Python wrapper passes a zero
     tensor when the caller has no downstream residual grad (pure-norm case).
     This keeps the kernel branch-free wrt None.
-
-    Perf follow-ups (deferred; correctness-complete): generic scalar path only —
-    a vectorized fast path + caching between passes would cut global traffic.
     """
     weight_dtype_str = resolve_rmsnorm_weight_dtype(dtype_str, weight_dtype_str)
     RED_SLOTS = max(1, (BLOCK_THREADS + WARP_SIZE - 1) // WARP_SIZE)

--- a/kernels/norm/rmsnorm_common.py
+++ b/kernels/norm/rmsnorm_common.py
@@ -12,7 +12,6 @@ have to import from each other. Keeping these here follows the topical
 
 import flydsl.expr as fx
 from flydsl.expr import const_expr
-from flydsl.expr.typing import full
 from kernels.common.kernels_common import get_warp_size
 
 KERNEL_NAME = "rmsnorm"
@@ -60,9 +59,9 @@ def load_scalar(copy_atom, elem_dtype, divided_tensor, index):
     return fx.memref_load_vec(r)[0]
 
 
-def store_scalar(copy_atom, elem_dtype, store_dtype, divided_tensor, index, val):
+def store_scalar(copy_atom, elem_dtype, divided_tensor, index, val):
     r = fx.make_rmem_tensor(1, elem_dtype)
-    ts = full(1, store_dtype(val), store_dtype)
+    ts = fx.Vector.filled(1, val, elem_dtype)
     fx.memref_store_vec(ts, r)
     view = fx.slice(divided_tensor, (None, index))
     fx.copy_atom_call(copy_atom, r, view)

--- a/kernels/norm/rmsnorm_kernel.py
+++ b/kernels/norm/rmsnorm_kernel.py
@@ -170,12 +170,9 @@ def build_rmsnorm_module(
 
             return fx.memref_load(s_red, 0), fx.memref_load(s_red2, 0)
 
-        # ==================================================================
-        # Fast path: N is a multiple of tile_cols
-        # ==================================================================
+        # Fast path for complete 128-bit tiles.
         if const_expr(N >= tile_cols and N % tile_cols == 0 and elem_bits <= 16):
             num_tiles = N // tile_cols
-            # ── Layout API: buffer-backed tensors + tiled access ─────
             Input_buf = fx.rocdl.make_buffer_tensor(Input)
             Output_buf = fx.rocdl.make_buffer_tensor(Output)
             Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
@@ -229,9 +226,7 @@ def build_rmsnorm_module(
                 _store_vec(copy_atom, VEC_WIDTH, elem_dtype, out_e, out_div, out_idx)
 
         else:
-            # ==============================================================
-            # Generic path: scalar 2-pass for arbitrary N
-            # ==============================================================
+            # Scalar fallback for arbitrary N.
             Input_buf = fx.rocdl.make_buffer_tensor(Input)
             Output_buf = fx.rocdl.make_buffer_tensor(Output)
             Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
@@ -580,12 +575,9 @@ def build_fused_add_rmsnorm_module(
 
             return fx.memref_load(s_red, 0), fx.memref_load(s_red2, 0)
 
-        # ==================================================================
-        # Fast path: N is a multiple of tile_cols
-        # ==================================================================
+        # Fast path for complete 128-bit tiles.
         if const_expr(N >= tile_cols and N % tile_cols == 0 and elem_bits <= 16):
             num_tiles = N // tile_cols
-            # ── Layout API: buffer-backed tensors + tiled access ─────
             Input_buf = fx.rocdl.make_buffer_tensor(Input)
             ResidualIn_buf = fx.rocdl.make_buffer_tensor(ResidualIn)
             Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
@@ -645,9 +637,7 @@ def build_fused_add_rmsnorm_module(
                 _store_vec(copy_atom, VEC_WIDTH, elem_dtype, y_e, out_div, idx)
 
         else:
-            # ==============================================================
-            # Generic path: scalar 2-pass for arbitrary N
-            # ==============================================================
+            # Scalar fallback for arbitrary N.
             Input_buf = fx.rocdl.make_buffer_tensor(Input)
             ResidualIn_buf = fx.rocdl.make_buffer_tensor(ResidualIn)
             Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
@@ -875,14 +865,11 @@ def _build_rmsnorm_quant_module(
 
             return fx.memref_load(s_red, 0)
 
-        # ==================================================================
-        # Fast path: N is a multiple of tile_cols
-        # ==================================================================
+        # Fast path for complete 128-bit tiles.
         if const_expr(N >= tile_cols and N % tile_cols == 0 and elem_bits <= 16):
             num_tiles = N // tile_cols
             quant_half_width = VEC_WIDTH // 2
             abs_mask = full(VEC_WIDTH, fx.Uint32(0x7FFFFFFF), fx.Uint32)
-            # ── Layout API: buffer-backed tensors + tiled access ─────
             Input_buf = fx.rocdl.make_buffer_tensor(Input)
             Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
             Output_buf = fx.rocdl.make_buffer_tensor(Output)
@@ -961,9 +948,7 @@ def _build_rmsnorm_quant_module(
                 _store_vec(copy_atom_q, quant_half_width, quant_dtype, q_hi, out_div_q, out_idx + 1)
 
         else:
-            # ==============================================================
-            # Generic path: scalar 3-pass for arbitrary N
-            # ==============================================================
+            # Scalar fallback for arbitrary N.
             Input_buf = fx.rocdl.make_buffer_tensor(Input)
             Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
             Output_buf = fx.rocdl.make_buffer_tensor(Output)
@@ -1249,14 +1234,11 @@ def _build_fused_add_rmsnorm_quant_module(
 
             return fx.memref_load(s_red, 0)
 
-        # ==================================================================
-        # Fast path: N is a multiple of tile_cols
-        # ==================================================================
+        # Fast path for complete 128-bit tiles.
         if const_expr(N >= tile_cols and N % tile_cols == 0 and elem_bits <= 16):
             num_tiles = N // tile_cols
             quant_half_width = VEC_WIDTH // 2
             abs_mask = full(VEC_WIDTH, fx.Uint32(0x7FFFFFFF), fx.Uint32)
-            # ── Layout API: buffer-backed tensors + tiled access ─────
             Input_buf = fx.rocdl.make_buffer_tensor(Input)
             ResidualIn_buf = fx.rocdl.make_buffer_tensor(ResidualIn)
             Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
@@ -1343,9 +1325,7 @@ def _build_fused_add_rmsnorm_quant_module(
                 _store_vec(copy_atom_q, quant_half_width, quant_dtype, q_hi, out_div_q, out_idx + 1)
 
         else:
-            # ==============================================================
-            # Generic path: scalar 3-pass for arbitrary N
-            # ==============================================================
+            # Scalar fallback for arbitrary N.
             Input_buf = fx.rocdl.make_buffer_tensor(Input)
             ResidualIn_buf = fx.rocdl.make_buffer_tensor(ResidualIn)
             Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
@@ -1522,9 +1502,7 @@ def build_fused_add_rmsnorm_smoothquant_module(
     )
 
 
-# =====================================================================
-# Python wrappers + autograd (quack-aligned). PR 1: plain rmsnorm.
-# =====================================================================
+# Python wrappers and autograd.
 if torch is not None:
     from kernels.common.tensor_shim import _run_compiled
     from kernels.norm.rmsnorm_common import torch_dtype_to_str as _torch_dtype_to_str
@@ -1725,9 +1703,7 @@ if torch is not None:
         out_flat = RMSNormFunction.apply(x_flat, weight, eps)
         return out_flat.reshape(x.shape)
 
-    # -----------------------------------------------------------------
-    # Fused-add / prenorm RMSNorm wrappers + autograd (PR 2).
-    # -----------------------------------------------------------------
+    # Fused-add / prenorm wrappers and autograd.
     _FUSED_ADD_FWD_CACHE: dict = {}
     _FUSED_ADD_BWD_CACHE: dict = {}
 

--- a/kernels/norm/rmsnorm_kernel.py
+++ b/kernels/norm/rmsnorm_kernel.py
@@ -6,8 +6,8 @@
 RMSNorm(x) = x / sqrt(mean(x^2) + eps) * gamma
 
 Two paths:
-  - Fast path (N % tile_cols == 0): buffer_load/store vectorised access.
-  - Generic path (arbitrary N): scalar copy_atom_call.
+  - Fast path (N % tile_cols == 0): 128-bit buffer copies.
+  - Generic path (arbitrary N): scalar guarded copies.
 """
 
 import math
@@ -1529,10 +1529,9 @@ if torch is not None:
     from kernels.common.tensor_shim import _run_compiled
     from kernels.norm.rmsnorm_common import torch_dtype_to_str as _torch_dtype_to_str
 
-    # Forward caches retain CompiledFunctions; eps is a compile-time kernel
-    # constant, so it is part of the key.  Backward caches instead retain one
-    # persistent JitFunction launcher per structural specialization and device;
-    # _run_compiled owns the launcher's single CompiledFunction in ``._cf``.
+    # Each cache retains one JitFunction launcher per specialization and device;
+    # _run_compiled owns the launcher's CompiledFunction in ``._cf``. eps is a
+    # compile-time forward constant, so it remains part of those cache keys.
     _FWD_CACHE: dict = {}
     _BWD_CACHE: dict = {}
 
@@ -1579,68 +1578,49 @@ if torch is not None:
             return ("two_stage", min(M, num_programs))
         return ("atomic", None)
 
-    def _get_fwd_compiled(
-        x,
-        weight,
-        out,
-        rstd,
-        M,
+    def _get_fwd_launcher(
         N,
         dtype_str,
         weight_dtype_str,
         store_rstd,
         eps,
-        stream,
+        device,
     ):
-        key = (N, dtype_str, weight_dtype_str, store_rstd, float(eps), x.device)
-        entry = _FWD_CACHE.get(key)
-        if entry is None:
-            launch_fn = build_rmsnorm_module(
-                N,
-                dtype_str,
-                store_rstd=store_rstd,
-                eps=eps,
-                weight_dtype_str=weight_dtype_str,
-            )
-            if store_rstd:
-                compiled = flyc.compile(launch_fn, x, weight, out, rstd, M, stream)
-            else:
-                compiled = flyc.compile(launch_fn, x, weight, out, M, stream)
-            _FWD_CACHE[key] = compiled
-            entry = compiled
-        return entry
+        key = (N, dtype_str, weight_dtype_str, store_rstd, float(eps), device)
+        launcher = _FWD_CACHE.get(key)
+        if launcher is None:
+            with torch.cuda.device(device):
+                launcher = build_rmsnorm_module(
+                    N,
+                    dtype_str,
+                    store_rstd=store_rstd,
+                    eps=eps,
+                    weight_dtype_str=weight_dtype_str,
+                )
+            _FWD_CACHE[key] = launcher
+        return launcher
 
     def rmsnorm_fwd(x, weight, eps=EPS, store_rstd=False):
         """Forward RMSNorm. Returns (out, rstd). eps is baked into the kernel."""
         assert x.dim() == 2, "rmsnorm_fwd expects a 2D (M, N) input"
         assert x.is_contiguous() and weight.is_contiguous(), "rmsnorm_fwd expects contiguous inputs"
         assert weight.device == x.device, "rmsnorm_fwd: weight and x must be on the same device"
+        device = x.device
         M, N = x.shape
         out = torch.empty_like(x)
-        rstd = torch.empty((M,), device=x.device, dtype=torch.float32) if store_rstd else None
+        rstd = torch.empty((M,), device=device, dtype=torch.float32) if store_rstd else None
         dtype_str = _torch_dtype_to_str(x.dtype)
         weight_dtype_str = _resolve_rmsnorm_weight_dtype(dtype_str, _torch_dtype_to_str(weight.dtype))
-        # Bind compile + launch to the tensors' device so the compiled kernel and
-        # the stream belong to the right GPU/context (multi-GPU correctness).
-        with torch.cuda.device(x.device):
-            stream = torch.cuda.current_stream()
-            compiled = _get_fwd_compiled(
-                x,
-                weight,
-                out,
-                rstd,
-                M,
-                N,
-                dtype_str,
-                weight_dtype_str,
-                store_rstd,
-                eps,
-                stream,
-            )
-            if store_rstd:
-                compiled(x, weight, out, rstd, M, stream)
-            else:
-                compiled(x, weight, out, M, stream)
+        launcher = _get_fwd_launcher(
+            N,
+            dtype_str,
+            weight_dtype_str,
+            store_rstd,
+            eps,
+            device,
+        )
+        args = (x, weight, out, rstd, M) if store_rstd else (x, weight, out, M)
+        _run_compiled_on_device(launcher, device, args)
         return out, rstd
 
     def rmsnorm_bwd(x, weight, dout, rstd, eps=EPS):
@@ -1751,38 +1731,27 @@ if torch is not None:
     _FUSED_ADD_FWD_CACHE: dict = {}
     _FUSED_ADD_BWD_CACHE: dict = {}
 
-    def _get_fused_add_fwd_compiled(
-        x,
-        residual,
-        weight,
-        out,
-        residual_out,
-        rstd,
-        M,
+    def _get_fused_add_fwd_launcher(
         N,
         dtype_str,
         weight_dtype_str,
         store_rstd,
         eps,
-        stream,
+        device,
     ):
-        key = (N, dtype_str, weight_dtype_str, store_rstd, float(eps), x.device)
-        entry = _FUSED_ADD_FWD_CACHE.get(key)
-        if entry is None:
-            launch_fn = build_fused_add_rmsnorm_module(
-                N,
-                dtype_str,
-                store_rstd=store_rstd,
-                eps=eps,
-                weight_dtype_str=weight_dtype_str,
-            )
-            if store_rstd:
-                compiled = flyc.compile(launch_fn, x, residual, weight, out, residual_out, rstd, M, stream)
-            else:
-                compiled = flyc.compile(launch_fn, x, residual, weight, out, residual_out, M, stream)
-            _FUSED_ADD_FWD_CACHE[key] = compiled
-            entry = compiled
-        return entry
+        key = (N, dtype_str, weight_dtype_str, store_rstd, float(eps), device)
+        launcher = _FUSED_ADD_FWD_CACHE.get(key)
+        if launcher is None:
+            with torch.cuda.device(device):
+                launcher = build_fused_add_rmsnorm_module(
+                    N,
+                    dtype_str,
+                    store_rstd=store_rstd,
+                    eps=eps,
+                    weight_dtype_str=weight_dtype_str,
+                )
+            _FUSED_ADD_FWD_CACHE[key] = launcher
+        return launcher
 
     def fused_add_rmsnorm_fwd(x, residual, weight, eps=EPS, store_rstd=False):
         """Forward fused-add RMSNorm. Returns (out, residual_out, rstd).
@@ -1803,30 +1772,24 @@ if torch is not None:
         M, N = x.shape
         out = torch.empty_like(x)
         residual_out = torch.empty_like(x)
-        rstd = torch.empty((M,), device=x.device, dtype=torch.float32) if store_rstd else None
+        device = x.device
+        rstd = torch.empty((M,), device=device, dtype=torch.float32) if store_rstd else None
         dtype_str = _torch_dtype_to_str(x.dtype)
         weight_dtype_str = _resolve_rmsnorm_weight_dtype(dtype_str, _torch_dtype_to_str(weight.dtype))
-        with torch.cuda.device(x.device):
-            stream = torch.cuda.current_stream()
-            compiled = _get_fused_add_fwd_compiled(
-                x,
-                residual,
-                weight,
-                out,
-                residual_out,
-                rstd,
-                M,
-                N,
-                dtype_str,
-                weight_dtype_str,
-                store_rstd,
-                eps,
-                stream,
-            )
-            if store_rstd:
-                compiled(x, residual, weight, out, residual_out, rstd, M, stream)
-            else:
-                compiled(x, residual, weight, out, residual_out, M, stream)
+        launcher = _get_fused_add_fwd_launcher(
+            N,
+            dtype_str,
+            weight_dtype_str,
+            store_rstd,
+            eps,
+            device,
+        )
+        args = (
+            (x, residual, weight, out, residual_out, rstd, M)
+            if store_rstd
+            else (x, residual, weight, out, residual_out, M)
+        )
+        _run_compiled_on_device(launcher, device, args)
         return out, residual_out, rstd
 
     def fused_add_rmsnorm_bwd(added, weight, dout, rstd, dresidual_out=None, eps=EPS):

--- a/kernels/norm/rmsnorm_kernel.py
+++ b/kernels/norm/rmsnorm_kernel.py
@@ -16,7 +16,7 @@ import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl.expr import arith, const_expr, gpu, range_constexpr
 from flydsl.expr import math as fmath
-from flydsl.expr.typing import ReductionOp, full
+from flydsl.expr.typing import ReductionOp
 from flydsl.runtime.device import get_rocm_arch
 from kernels.common.kernels_common import dtype_to_elem_type
 
@@ -59,7 +59,7 @@ SMALL_N_THRESHOLD = 2048
 
 def _store_yscale(scale_copy_atom, yscale_div, index, val):
     r = fx.make_rmem_tensor(1, fx.Float32)
-    ts = full(1, fx.Float32(val), fx.Float32)
+    ts = fx.Vector.filled(1, val, fx.Float32)
     fx.memref_store_vec(ts, r)
     fx.copy_atom_call(scale_copy_atom, r, fx.slice(yscale_div, (None, index)))
 
@@ -210,7 +210,7 @@ def build_rmsnorm_module(
 
             if const_expr(store_rstd):
                 if tid == 0:
-                    _store_scalar(rstd_copy_atom, fx.Float32, fx.Float32, rstd_div, bid, rrms)
+                    _store_scalar(rstd_copy_atom, fx.Float32, rstd_div, bid, rrms)
 
             # Pass 2: normalize + gamma + store (reuse cached input)
             for tile_i in range_constexpr(num_tiles):
@@ -267,7 +267,7 @@ def build_rmsnorm_module(
 
             if const_expr(store_rstd):
                 if tid == 0:
-                    _store_scalar(rstd_copy_atom, fx.Float32, fx.Float32, rstd_div, bid, rrms)
+                    _store_scalar(rstd_copy_atom, fx.Float32, rstd_div, bid, rrms)
 
             for base_idx_int in range_constexpr(0, N, BLOCK_THREADS):
                 idx = tid + base_idx_int
@@ -279,7 +279,7 @@ def build_rmsnorm_module(
                     norm = x * rrms
                     y = norm * g
                     y_e = _to_elem_scalar(dtype_str, elem_dtype, y)
-                    _store_scalar(copy_atom_s, elem_dtype, elem_dtype, out_div, idx, y_e)
+                    _store_scalar(copy_atom_s, elem_dtype, out_div, idx, y_e)
 
     if store_rstd:
 
@@ -372,7 +372,7 @@ def _build_rmsnorm_large_m_small_n_module(
 
         lane = tid % THREADS_PER_ROW
         row_local = tid // THREADS_PER_ROW
-        row = bid * fx.Int32(BLOCK_M) + row_local
+        row = bid * BLOCK_M + row_local
 
         if row < MIn:
             elem_dtype = dtype_to_elem_type(dtype_str)
@@ -409,7 +409,7 @@ def _build_rmsnorm_large_m_small_n_module(
                 w = x
                 for _sh_exp in range_constexpr(int(math.log2(THREADS_PER_ROW))):
                     off = THREADS_PER_ROW // (2 << _sh_exp)
-                    peer = w.shuffle_xor(off, fx.Int32(THREADS_PER_ROW))
+                    peer = w.shuffle_xor(off, THREADS_PER_ROW)
                     w = w.addf(peer, fastmath=fm_fast)
                 return w
 
@@ -432,7 +432,7 @@ def _build_rmsnorm_large_m_small_n_module(
 
             if const_expr(store_rstd):
                 if lane == 0:
-                    _store_scalar(rstd_copy_atom, fx.Float32, fx.Float32, rstd_div, row, rrms)
+                    _store_scalar(rstd_copy_atom, fx.Float32, rstd_div, row, rrms)
 
             for base_idx_int in range_constexpr(0, BLOCK_N, THREADS_PER_ROW):
                 idx = lane + base_idx_int
@@ -443,7 +443,7 @@ def _build_rmsnorm_large_m_small_n_module(
                     g = g_e if weight_dtype_str == "f32" else g_e.to(fx.Float32)
                     y = (x * rrms) * g
                     y_e = _to_elem_scalar(dtype_str, elem_dtype, y)
-                    _store_scalar(copy_atom_s, elem_dtype, elem_dtype, out_div, idx, y_e)
+                    _store_scalar(copy_atom_s, elem_dtype, out_div, idx, y_e)
 
     if store_rstd:
 
@@ -458,7 +458,7 @@ def _build_rmsnorm_large_m_small_n_module(
         ):
             launcher = rmsnorm_large_m_small_n_kernel(Input, Gamma, Rstd, Output, m_in)
             launcher.launch(
-                grid=((m_in + fx.Int32(BLOCK_M - 1)) // fx.Int32(BLOCK_M), 1, 1),
+                grid=((m_in + BLOCK_M - 1) // BLOCK_M, 1, 1),
                 block=(BLOCK_THREADS_SPECIAL, 1, 1),
                 stream=stream,
             )
@@ -477,7 +477,7 @@ def _build_rmsnorm_large_m_small_n_module(
         # we pass Gamma to fill the argument (it is never dereferenced in-kernel).
         launcher = rmsnorm_large_m_small_n_kernel(Input, Gamma, Gamma, Output, m_in)
         launcher.launch(
-            grid=((m_in + fx.Int32(BLOCK_M - 1)) // fx.Int32(BLOCK_M), 1, 1),
+            grid=((m_in + BLOCK_M - 1) // BLOCK_M, 1, 1),
             block=(BLOCK_THREADS_SPECIAL, 1, 1),
             stream=stream,
         )
@@ -625,7 +625,7 @@ def build_fused_add_rmsnorm_module(
 
             if const_expr(store_rstd):
                 if tid == 0:
-                    _store_scalar(rstd_copy_atom, fx.Float32, fx.Float32, rstd_div, bid, rrms)
+                    _store_scalar(rstd_copy_atom, fx.Float32, rstd_div, bid, rrms)
 
             # Pass 2: normalize + gamma + store (reuse cached added values)
             for tile_i in range_constexpr(num_tiles):
@@ -677,7 +677,7 @@ def build_fused_add_rmsnorm_module(
                 residual = residual_e if dtype_str == "f32" else residual_e.to(fx.Float32)
                 added_e = _to_elem_scalar(dtype_str, elem_dtype, x + residual)
                 if idx < N:
-                    _store_scalar(copy_atom_s, elem_dtype, elem_dtype, residual_out_div, idx, added_e)
+                    _store_scalar(copy_atom_s, elem_dtype, residual_out_div, idx, added_e)
                 added = added_e if dtype_str == "f32" else added_e.to(fx.Float32)
                 added2 = added * added
                 thread_sumsq = thread_sumsq + is_valid.select(added2, c_zero_f)
@@ -689,7 +689,7 @@ def build_fused_add_rmsnorm_module(
 
             if const_expr(store_rstd):
                 if tid == 0:
-                    _store_scalar(rstd_copy_atom, fx.Float32, fx.Float32, rstd_div, bid, rrms)
+                    _store_scalar(rstd_copy_atom, fx.Float32, rstd_div, bid, rrms)
 
             for base_idx_int in range_constexpr(0, N, BLOCK_THREADS):
                 idx = tid + base_idx_int
@@ -700,7 +700,7 @@ def build_fused_add_rmsnorm_module(
                     added = added_e if dtype_str == "f32" else added_e.to(fx.Float32)
                     y = (added * rrms) * g
                     y_e = _to_elem_scalar(dtype_str, elem_dtype, y)
-                    _store_scalar(copy_atom_s, elem_dtype, elem_dtype, out_div, idx, y_e)
+                    _store_scalar(copy_atom_s, elem_dtype, out_div, idx, y_e)
 
     if store_rstd:
 
@@ -869,7 +869,7 @@ def _build_rmsnorm_quant_module(
         if const_expr(N >= tile_cols and N % tile_cols == 0 and elem_bits <= 16):
             num_tiles = N // tile_cols
             quant_half_width = VEC_WIDTH // 2
-            abs_mask = full(VEC_WIDTH, fx.Uint32(0x7FFFFFFF), fx.Uint32)
+            abs_mask = fx.Vector.filled(VEC_WIDTH, 0x7FFFFFFF, fx.Uint32)
             Input_buf = fx.rocdl.make_buffer_tensor(Input)
             Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
             Output_buf = fx.rocdl.make_buffer_tensor(Output)
@@ -1038,7 +1038,7 @@ def _build_rmsnorm_quant_module(
                         y = y * s
                     q = y * inv_scale
                     q_i8 = q.to(quant_dtype)
-                    _store_scalar(copy_atom_qs, quant_dtype, quant_dtype, out_div, idx, q_i8)
+                    _store_scalar(copy_atom_qs, quant_dtype, out_div, idx, q_i8)
 
     if is_smooth:
 
@@ -1238,7 +1238,7 @@ def _build_fused_add_rmsnorm_quant_module(
         if const_expr(N >= tile_cols and N % tile_cols == 0 and elem_bits <= 16):
             num_tiles = N // tile_cols
             quant_half_width = VEC_WIDTH // 2
-            abs_mask = full(VEC_WIDTH, fx.Uint32(0x7FFFFFFF), fx.Uint32)
+            abs_mask = fx.Vector.filled(VEC_WIDTH, 0x7FFFFFFF, fx.Uint32)
             Input_buf = fx.rocdl.make_buffer_tensor(Input)
             ResidualIn_buf = fx.rocdl.make_buffer_tensor(ResidualIn)
             Gamma_buf = fx.rocdl.make_buffer_tensor(Gamma)
@@ -1376,7 +1376,7 @@ def _build_fused_add_rmsnorm_quant_module(
                 residual = residual_e if dtype_str == "f32" else residual_e.to(fx.Float32)
                 added_e = _to_elem_scalar(dtype_str, elem_dtype, x + residual)
                 if idx < N:
-                    _store_scalar(copy_atom_s, elem_dtype, elem_dtype, residual_out_div, idx, added_e)
+                    _store_scalar(copy_atom_s, elem_dtype, residual_out_div, idx, added_e)
                 added = added_e if dtype_str == "f32" else added_e.to(fx.Float32)
                 added2 = added * added
                 thread_sumsq = thread_sumsq + is_valid.select(added2, c_zero_f)
@@ -1428,7 +1428,7 @@ def _build_fused_add_rmsnorm_quant_module(
                         y = y * s
                     q = y * inv_scale
                     q_i8 = q.to(quant_dtype)
-                    _store_scalar(copy_atom_qs, quant_dtype, quant_dtype, out_div, idx, q_i8)
+                    _store_scalar(copy_atom_qs, quant_dtype, out_div, idx, q_i8)
 
     if is_smooth:
 

--- a/kernels/norm/rmsnorm_kernel.py
+++ b/kernels/norm/rmsnorm_kernel.py
@@ -57,13 +57,6 @@ KERNEL_NAME = "rmsnorm"
 SMALL_N_THRESHOLD = 2048
 
 
-def _store_yscale(scale_copy_atom, yscale_div, index, val):
-    r = fx.make_rmem_tensor(1, fx.Float32)
-    ts = fx.Vector.filled(1, val, fx.Float32)
-    fx.memref_store_vec(ts, r)
-    fx.copy_atom_call(scale_copy_atom, r, fx.slice(yscale_div, (None, index)))
-
-
 def _quant_dtype_to_elem_type(dtype_str: str):
     if dtype_str in ("i8", "int8"):
         return fx.Int8
@@ -933,7 +926,7 @@ def _build_rmsnorm_quant_module(
             final_scale = (scale == c_zero_f).select(c_one_f, scale)
 
             if tid == 0:
-                _store_yscale(scale_copy_atom, yscale_div, bid, final_scale)
+                _store_scalar(scale_copy_atom, fx.Float32, yscale_div, bid, final_scale)
 
             inv_scale = c_one_f / final_scale
 
@@ -1019,7 +1012,7 @@ def _build_rmsnorm_quant_module(
             final_scale = (scale == c_zero_f).select(c_one_f, scale)
 
             if tid == 0:
-                _store_yscale(scale_copy_atom, yscale_div, bid, final_scale)
+                _store_scalar(scale_copy_atom, fx.Float32, yscale_div, bid, final_scale)
 
             inv_scale = c_one_f / final_scale
 
@@ -1310,7 +1303,7 @@ def _build_fused_add_rmsnorm_quant_module(
             final_scale = (scale == c_zero_f).select(c_one_f, scale)
 
             if tid == 0:
-                _store_yscale(scale_copy_atom, yscale_div, bid, final_scale)
+                _store_scalar(scale_copy_atom, fx.Float32, yscale_div, bid, final_scale)
 
             inv_scale = c_one_f / final_scale
 
@@ -1409,7 +1402,7 @@ def _build_fused_add_rmsnorm_quant_module(
             final_scale = (scale == c_zero_f).select(c_one_f, scale)
 
             if tid == 0:
-                _store_yscale(scale_copy_atom, yscale_div, bid, final_scale)
+                _store_scalar(scale_copy_atom, fx.Float32, yscale_div, bid, final_scale)
 
             inv_scale = c_one_f / final_scale
 

--- a/tests/kernels/test_rmsnorm.py
+++ b/tests/kernels/test_rmsnorm.py
@@ -1605,6 +1605,53 @@ def test_rmsnorm_bwd_mixed_weight_keeps_vector_io(fused_add):
 
 
 @pytest.mark.parametrize("fused_add", (False, True), ids=("plain", "fused_add"))
+def test_rmsnorm_fwd_cache_reuses_compiled_launcher(monkeypatch, fused_add):
+    """Forward hot calls use the shared _run_compiled fast path."""
+    device = torch.device("cuda", torch.cuda.current_device())
+    M, N = 8, 512
+    x = torch.randn((M, N), device=device, dtype=DTYPE_BF16)
+    weight = torch.rand((N,), device=device, dtype=DTYPE_BF16)
+    residual = torch.randn_like(x) if fused_add else None
+    builder_name = "build_fused_add_rmsnorm_module" if fused_add else "build_rmsnorm_module"
+    cache = rmsnorm_kernel_impl._FUSED_ADD_FWD_CACHE if fused_add else rmsnorm_kernel_impl._FWD_CACHE
+    original_builder = getattr(rmsnorm_kernel_impl, builder_name)
+    build_count = 0
+    run_compiled_count = 0
+
+    def counted_builder(*args, **kwargs):
+        nonlocal build_count
+        build_count += 1
+        return original_builder(*args, **kwargs)
+
+    def counted_run_compiled(*args, **kwargs):
+        nonlocal run_compiled_count
+        run_compiled_count += 1
+        return _run_compiled(*args, **kwargs)
+
+    monkeypatch.setattr(rmsnorm_kernel_impl, builder_name, counted_builder)
+    monkeypatch.setattr(rmsnorm_kernel_impl, "_run_compiled", counted_run_compiled)
+    saved_cache = cache.copy()
+    cache.clear()
+
+    try:
+        if fused_add:
+            rmsnorm_kernel_impl.fused_add_rmsnorm_fwd(x, residual, weight, store_rstd=True)
+            rmsnorm_kernel_impl.fused_add_rmsnorm_fwd(x, residual, weight, store_rstd=True)
+        else:
+            rmsnorm_kernel_impl.rmsnorm_fwd(x, weight, store_rstd=True)
+            rmsnorm_kernel_impl.rmsnorm_fwd(x, weight, store_rstd=True)
+        torch.cuda.synchronize(device)
+
+        launcher = cache[(N, "bf16", "bf16", True, float(EPS), device)]
+        assert build_count == 1
+        assert run_compiled_count == 2
+        assert launcher._cf is not None
+    finally:
+        cache.clear()
+        cache.update(saved_cache)
+
+
+@pytest.mark.parametrize("fused_add", (False, True), ids=("plain", "fused_add"))
 def test_rmsnorm_bwd_two_stage_cache_reuse_across_m(monkeypatch, fused_add):
     """One staged compiled callable must serve multiple runtime row counts."""
     device = torch.device("cuda", torch.cuda.current_device())


### PR DESCRIPTION
## Summary

This is a behavior-preserving cleanup of the RMSNorm forward/backward implementation using the repository's `kernel-code-cleanup` guidance.

- align plain and fused forward launch caching with the shared `_run_compiled` / raw-stream pattern already used by maintained FlyDSL kernels
- remove redundant `fx.Int32` / `fx.Float32` wrapping and use Python literals where the typed operand already determines the runtime type
- replace legacy `full(...)` calls with the canonical `fx.Vector.filled(...)` surface and remove duplicate store-dtype plumbing from the RMSNorm scalar-store helper
- route quantization-scale writes through that shared scalar-store helper instead of maintaining an equivalent local implementation
- replace stale legacy terminology and verbose section banners with concise comments that preserve only path choices and invariants
- retain the tuned backward atomic/two-stage split and genuine single-atom copy helpers; those are intentional lower-level primitives, not legacy migration targets

The goal is coding consistency and maintainability rather than a shape-specific speedup. Kernel math, memory layouts, and backward dispatch policy are unchanged.

## Test plan

- [x] `bash scripts/check_python_style.sh --base upstream/main`
- [x] `HIP_VISIBLE_DEVICES=7 FLYDSL_RUNTIME_ENABLE_CACHE=0 python3 -m pytest tests/kernels/test_rmsnorm.py -q -m 'not benchmark and not large_shape and not multi_gpu'` (30 passed, 6 deselected)
- [x] `HIP_VISIBLE_DEVICES=6,7 FLYDSL_RUNTIME_ENABLE_CACHE=0 python3 -m pytest tests/kernels/test_rmsnorm.py::test_rmsnorm_multi_gpu tests/kernels/test_rmsnorm.py::test_fused_add_rmsnorm_device_mismatch -q` (2 passed)
- [x] plain and fused forward launcher-reuse regression tests (2 passed)