### PR TITLE
[CI] Smoke test shared MLIR cache workflow

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -22,6 +22,7 @@ concurrency:
 env:
   DOCKER_IMAGE: "rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.9.1"
   # Bump when the container or LLVM build environment changes incompatibly.
+  # Workflow-only changes do not invalidate the shared MLIR cache.
   MLIR_CACHE_VERSION: "rocm7.2-ubuntu24.04-py3.12-v1"
   GITHUB_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}


### PR DESCRIPTION
## Summary
- add one non-functional workflow comment
- trigger the full CI workflow after the shared MLIR cache fixes merged

## Validation goals
- [ ] `prepare-mlir` restores the existing shared cache without rebuilding LLVM
- [ ] the prepared MLIR artifact uploads successfully
- [ ] MI325, MI355, and Navi consume the artifact successfully
- [ ] all tests and benchmarks pass


Made with [Cursor](https://cursor.com)