### PR TITLE
Fix hierarchical reduced predicates in copy layout lowering

### DIFF
--- a/lib/Dialect/Fly/Transforms/LayoutLowering.cpp
+++ b/lib/Dialect/Fly/Transforms/LayoutLowering.cpp
@@ -29,6 +29,7 @@
 #include "flydsl/Dialect/Fly/Utils/TiledOpUtils.h"
 
 #include <functional>
+#include <optional>
 #include <string>
 
 using namespace mlir;
@@ -2154,6 +2155,29 @@ public:
   }
 };
 
+/// Return the predicate shape for one predicate per copy atom.
+///
+/// A tiled copy encodes its value mode as
+///   ((ATOM_V, ATOM_REST), REST...)
+/// while an atom predicate intentionally drops ATOM_V:
+///   (ATOM_REST, REST...)
+///
+/// Keep this structural: ATOM_REST may itself be hierarchical, so rank
+/// differences cannot reliably identify a reduced predicate.
+static std::optional<IntTupleAttr> getReducedCopyPredicateShape(IntTupleAttr srcShape) {
+  if (srcShape.isLeaf() || srcShape.rank() == 0)
+    return std::nullopt;
+  IntTupleAttr valueMode = srcShape.at(0);
+  if (valueMode.isLeaf() || valueMode.rank() != 2)
+    return std::nullopt;
+
+  SmallVector<Attribute> modes;
+  modes.push_back(valueMode.at(1));
+  for (int32_t i = 1; i < srcShape.rank(); ++i)
+    modes.push_back(srcShape.at(i));
+  return IntTupleAttr::get(ArrayAttr::get(srcShape.getContext(), modes));
+}
+
 class ExpandCopyOpLowering : public OpRewritePattern<CopyOp> {
 public:
   using OpRewritePattern<CopyOp>::OpRewritePattern;
@@ -2205,18 +2229,34 @@ public:
       }
     }
 
-    if (pred && predLayoutAttr.rank() == srcRank - 1) {
-      LayoutBuilder<LayoutValueAdaptor> builder(rewriter, loc);
-      LayoutAttr unitAttr = LayoutAttr::get(ctx, IntTupleAttr::getLeafStatic(ctx, 1),
-                                            IntTupleAttr::getLeafStatic(ctx, 0));
-      Value unitLayout = builder.materializeConstantLayout(unitAttr).getValue();
-      Value predLayoutVal = GetLayoutOp::create(rewriter, loc, pred);
-      Value newPredLayout =
-          PrependOp::create(rewriter, loc, predLayoutVal, unitLayout, IntegerAttr());
-      Value predIter = GetIterOp::create(rewriter, loc, pred);
-      pred = MakeViewOp::create(rewriter, loc, predIter, newPredLayout);
-      predMemRefTy = cast<fly::MemRefType>(pred.getType());
-      predLayoutAttr = getLayoutAttr(predMemRefTy.getLayout());
+    if (pred) {
+      IntTupleAttr srcShape = srcLayoutAttr.getShape();
+      IntTupleAttr predShape = predLayoutAttr.getShape();
+      std::optional<IntTupleAttr> reducedPredShape = getReducedCopyPredicateShape(srcShape);
+
+      if (reducedPredShape && predShape == *reducedPredShape) {
+        // Normalize the atom-predicate contract to the full source hierarchy by
+        // broadcasting over ATOM_V:
+        //
+        //   (ATOM_REST, REST...)
+        //       -> (1, ATOM_REST, REST...)
+        //       -> ((1, ATOM_REST), REST...)
+        //
+        // The zero stride on the inserted unit mode makes one predicate gate
+        // the whole copy atom, independent of ATOM_V.
+        LayoutBuilder<LayoutValueAdaptor> builder(rewriter, loc);
+        LayoutAttr unitAttr = LayoutAttr::get(ctx, IntTupleAttr::getLeafStatic(ctx, 1),
+                                              IntTupleAttr::getLeafStatic(ctx, 0));
+        Value unitLayout = builder.materializeConstantLayout(unitAttr).getValue();
+        Value predLayoutVal = GetLayoutOp::create(rewriter, loc, pred);
+        Value predWithUnit =
+            PrependOp::create(rewriter, loc, predLayoutVal, unitLayout, IntegerAttr());
+        Value normalizedPredLayout = GroupOp::create(rewriter, loc, predWithUnit, 0, 2);
+        Value predIter = GetIterOp::create(rewriter, loc, pred);
+        pred = MakeViewOp::create(rewriter, loc, predIter, normalizedPredLayout);
+        predMemRefTy = cast<fly::MemRefType>(pred.getType());
+        predLayoutAttr = getLayoutAttr(predMemRefTy.getLayout());
+      }
     }
 
     if (srcRank == 1) {

--- a/tests/mlir/Transforms/expand_copy_hierarchical_reduced_pred.mlir
+++ b/tests/mlir/Transforms/expand_copy_hierarchical_reduced_pred.mlir
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 FlyDSL Project Contributors
+// RUN: %fly-opt %s --fly-layout-lowering | FileCheck %s --check-prefix=LAYOUT
+// RUN: %fly-opt %s --fly-layout-lowering --fly-convert-atom-call-to-ssa-form --fly-promote-regmem-to-vectorssa | FileCheck %s --check-prefix=SSA
+
+// Regression test for a reduced predicate whose ATOM_REST is hierarchical.
+//
+// Source V-mode: (ATOM_V, ATOM_REST) = (1, (2, 2))
+// Predicate:     ATOM_REST           =     (2, 2)
+//
+// Rank-based reduced-predicate detection confused the two rank-2 shapes and
+// generated vector.extract_strided_slice offset=4,size=2 from vector<4xi1>.
+
+// LAYOUT-LABEL: gpu.func @hierarchical_reduced_pred_copy
+// LAYOUT-COUNT-4: fly.copy_atom_call
+// LAYOUT-NOT: fly.copy(
+// SSA-LABEL: gpu.func @hierarchical_reduced_pred_copy
+// SSA-COUNT-4: fly.copy_atom_call_ssa
+// SSA-NOT: vector.extract_strided_slice
+gpu.module @expand_copy_hierarchical_reduced_pred {
+  gpu.func @hierarchical_reduced_pred_copy(
+      %src_ptr: !fly.ptr<f32, global>,
+      %dst_ptr: !fly.ptr<f32, register>,
+      %pred_ptr: !fly.ptr<i1, register>) kernel {
+    %src_shape = fly.make_int_tuple()
+        : () -> !fly.int_tuple<((1,(2,2)),1,1)>
+    %src_stride = fly.make_int_tuple()
+        : () -> !fly.int_tuple<((0,(1,2)),0,0)>
+    %src_layout = fly.make_layout(%src_shape, %src_stride)
+        : (!fly.int_tuple<((1,(2,2)),1,1)>, !fly.int_tuple<((0,(1,2)),0,0)>)
+        -> !fly.layout<((1,(2,2)),1,1):((0,(1,2)),0,0)>
+    %src = fly.make_view(%src_ptr, %src_layout)
+        : (!fly.ptr<f32, global>, !fly.layout<((1,(2,2)),1,1):((0,(1,2)),0,0)>)
+        -> !fly.memref<f32, global, ((1,(2,2)),1,1):((0,(1,2)),0,0)>
+
+    %dst_layout = fly.make_layout(%src_shape, %src_stride)
+        : (!fly.int_tuple<((1,(2,2)),1,1)>, !fly.int_tuple<((0,(1,2)),0,0)>)
+        -> !fly.layout<((1,(2,2)),1,1):((0,(1,2)),0,0)>
+    %dst = fly.make_view(%dst_ptr, %dst_layout)
+        : (!fly.ptr<f32, register>, !fly.layout<((1,(2,2)),1,1):((0,(1,2)),0,0)>)
+        -> !fly.memref<f32, register, ((1,(2,2)),1,1):((0,(1,2)),0,0)>
+
+    %pred_shape = fly.make_int_tuple()
+        : () -> !fly.int_tuple<((2,2),1,1)>
+    %pred_stride = fly.make_int_tuple()
+        : () -> !fly.int_tuple<((1,2),0,0)>
+    %pred_layout = fly.make_layout(%pred_shape, %pred_stride)
+        : (!fly.int_tuple<((2,2),1,1)>, !fly.int_tuple<((1,2),0,0)>)
+        -> !fly.layout<((2,2),1,1):((1,2),0,0)>
+    %pred = fly.make_view(%pred_ptr, %pred_layout)
+        : (!fly.ptr<i1, register>, !fly.layout<((2,2),1,1):((1,2),0,0)>)
+        -> !fly.memref<i1, register, ((2,2),1,1):((1,2),0,0)>
+
+    %atom = fly.make_copy_atom {valBits = 32 : i32}
+        : !fly.copy_atom<!fly.universal_copy<32>, 32>
+    fly.copy(%atom, %src, %dst, %pred)
+        : (!fly.copy_atom<!fly.universal_copy<32>, 32>,
+           !fly.memref<f32, global, ((1,(2,2)),1,1):((0,(1,2)),0,0)>,
+           !fly.memref<f32, register, ((1,(2,2)),1,1):((0,(1,2)),0,0)>,
+           !fly.memref<i1, register, ((2,2),1,1):((1,2),0,0)>) -> ()
+    gpu.return
+  }
+}


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix copy layout lowering for reduced predicates when `ATOM_REST` has a hierarchical shape.
## Technical Details
A reduced copy predicate contains one boolean value per copy atom, so its shape intentionally omits `ATOM_V`. The source and predicate shapes follow this contract:
```text
source:    ((ATOM_V, ATOM_REST), REST...)
predicate: (ATOM_REST, REST...)
```
The previous lowering detected reduced predicates using:
```c++
if (pred && predLayoutAttr.rank() == srcRank - 1) {
  // Prepend a unit mode.
}
```
This assumes that removing `ATOM_V` always reduces the rank by one. That is not true when `ATOM_REST` is hierarchical.

For example:
- source V-mode:    (1, (2, 2))
- predicate V-mode:     (2, 2)

Both shapes have rank 2, so the old condition does not recognize the predicate as reduced.

The subsequent recursive copy expansion slices the predicate according to the source hierarchy and eventually generates an invalid operation:
```text
vector.extract_strided_slice offset=[4], size=[2] from vector<4xi1>
```

## Changes
  - derives the expected reduced predicate shape from the source shape structure;
  - normalizes `(ATOM_REST, REST...)` to `((1, ATOM_REST), REST...)`;
  - removes the rank-based reduced-predicate heuristic;
  - adds a regression test covering hierarchical `ATOM_REST=(2,2)`.

<!-- Explain the changes along with any relevant GitHub links. -->

## Minimal reproduction
Starting from examples/01-vectorAdd.py, make the following changes:
```text
-    copy_atom = fx.make_copy_atom(fx.UniversalCopy128b(), fx.Float32)
+    copy_atom = fx.make_copy_atom(fx.UniversalCopy32b(), fx.Float32)
```
Apply the same copy-atom change in the JIT function and change the value layout:
```text
-    copy_atom = fx.make_copy_atom(fx.UniversalCopy128b(), fx.Float32)
+    copy_atom = fx.make_copy_atom(fx.UniversalCopy32b(), fx.Float32)

     tiled_copy = fx.make_tiled_copy_tv(
         copy_atom,
         fx.make_ordered_layout((8, 16), order=(1, 0)),
-        fx.make_ordered_layout((1, 4), order=(0, 1)),
+        fx.make_ordered_layout((2, 2), order=(1, 0)),
     )
```
The existing predicate construction remains unchanged:
```text
thr_cC = thr_copy.partition_S(cC)[(0, None), None, None]
thr_pC = fx.make_fragment_like(thr_cC, dtype=fx.Boolean)

for i in fx.range_constexpr(fx.size(thr_pC.shape).unpack()):
    thr_pC[i] = fx.elem_less(thr_cC[i], (M, N))

fx.copy(copy_atom, thr_gA, thr_rA, pred=thr_pC)
```
This produces:
- source shape:    ((1,(2,2)),1,1)
- predicate shape: ((2,2),1,1)

Before this fix, compiling the example fails with the out-of-bounds `vector.extract_strided_slice` described above.

## Fix

The lowering now derives the expected reduced predicate shape structurally:

((ATOM_V, ATOM_REST), REST...)
                    ↓
(ATOM_REST, REST...)

When the actual predicate shape matches this structure, its layout is normalized before recursive copy expansion:

(ATOM_REST, REST...)
    -> (1, ATOM_REST, REST...)
    -> ((1, ATOM_REST), REST...)

The inserted unit mode uses zero stride:

1:0

This preserves one predicate per copy atom without allocating or copying predicate data. It only aligns the predicate layout hierarchy with the source hierarchy.

## Test Plan
  - Full FlyDSL C++ and Python build completed successfully.
  - New hierarchical reduced-predicate layout-lowering test passed.
  - New full SSA-lowering regression test passed.
  - Existing expand_copy_reduced_pred.mlir test passed.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
The reproducer ran successfully on gfx950/MI355X and reported: PASS
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
