### PR TITLE
Port GEMM/MoE/conv kernels to the layout API

### DIFF
--- a/kernels/conv/conv3d_implicit.py
+++ b/kernels/conv/conv3d_implicit.py
@@ -15,9 +15,9 @@ import torch
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm
 from flydsl.expr import arith, const_expr, range_constexpr, rocdl
+from flydsl.expr.rocdl.universal import make_buffer_ptr
 from flydsl.expr.typing import T
 from kernels.common import buffer_ops
 from kernels.common.mem_ops import buffer_atomic_add
@@ -246,10 +246,21 @@ def compile_conv3d_implicit(
 
     @flyc.kernel(known_block_size=[BLOCK_THREADS, 1, 1])
     def conv3d_implicit_kernel(y: fx.Tensor, x: fx.Tensor, weight: fx.Tensor, bias: fx.Tensor):
-        w_rsrc = buffer_ops.create_buffer_resource(weight, num_records_bytes=W_BYTES)
-        if const_expr(not BIG_IN):
-            x_rsrc = buffer_ops.create_buffer_resource(x, num_records_bytes=X_BYTES)
         y_rsrc = buffer_ops.create_buffer_resource(y)
+        # Layout-API buffer tensors for the global->LDS im2col gather. The weight
+        # tensor and the common (non-BIG) input tensor are wrapped as buffer
+        # tensors, flattened to a 1-D element view, and logical-divided so the
+        # per-thread im2col gather offset (already a flat element index) can be
+        # expressed through fx.copy(BufferCopyLDS128b). Flattening is required:
+        # the source tensors are multi-dimensional (weight 2-D, x_ndhwc 5-D) and
+        # slicing a multi-dim divided view would not index a flat element.
+        w_buf0 = fx.rocdl.make_buffer_tensor(weight, max_size=False)
+        w_buf = fx.Tensor(fx.make_view(fx.get_iter(w_buf0), fx.make_layout(k * crs, 1)))
+        w_div = fx.logical_divide(w_buf, fx.make_layout(1, 1))
+        if const_expr(not BIG_IN):
+            x_buf0 = fx.rocdl.make_buffer_tensor(x, max_size=False)
+            x_buf = fx.Tensor(fx.make_view(fx.get_iter(x_buf0), fx.make_layout(n * c * d * h * w, 1)))
+            x_div = fx.logical_divide(x_buf, fx.make_layout(1, 1))
         if const_expr(has_bias):
             bias_rsrc = buffer_ops.create_buffer_resource(bias)
 
@@ -276,6 +287,20 @@ def compile_conv3d_implicit(
         else:
             k_off = 0
 
+        # Layout-API flat buffer tensor from a rebased device address. Same
+        # mechanism as the non-BIG x_div path (make_buffer_* + logical_divide),
+        # but the base is advanced per the BIG_IN rebase arithmetic and an
+        # explicit ~2 GB num_records is set, matching the raw
+        # create_buffer_resource_from_addr(..., num_records_bytes=BIG_IN_NR).
+        GXPtrTy = fx.PointerType.get(elem_ty.ir_type, 1, BF16_BYTES) if const_expr(BIG_IN) else None
+
+        def _x_div_from_addr(addr_i64):
+            gptr = fx.inttoptr(GXPtrTy, addr_i64)
+            buf_ptr = make_buffer_ptr(gptr, num_records_bytes=BIG_IN_NR)
+            # 1-D element view so the flat im2col gather offset indexes elements.
+            buf = fx.Tensor(fx.make_view(buf_ptr, fx.make_layout(BIG_IN_NR // BF16_BYTES, 1)))
+            return fx.logical_divide(buf, fx.make_layout(1, 1))
+
         if const_expr(BIG_IN_N1):
             nbase = m_offset // dhw
             ot_base0 = (m_offset % dhw) // hw_o
@@ -283,7 +308,7 @@ def compile_conv3d_implicit(
             base_t = arith.select(base_t < fx.Index(0), fx.Index(0), base_t)
             x_base_elem = ((nbase * fx.Index(d) + base_t) * fx.Index(h) + fx.Index(0)) * fx.Index(w) * fx.Index(c)
             x_addr = fx.Int64(buffer_ops.extract_base_index(x)) + fx.Int64(x_base_elem) * fx.Int64(2)
-            x_rsrc = buffer_ops.create_buffer_resource_from_addr(x_addr, num_records_bytes=BIG_IN_NR)
+            x_div_big = _x_div_from_addr(x_addr)
         if const_expr(BIG_IN_NM):
             x_base_addr = fx.Int64(buffer_ops.extract_base_index(x))
 
@@ -420,27 +445,34 @@ def compile_conv3d_implicit(
             return g_off, col_valid
 
         # ---- global -> LDS DMA copy, masking via OOB routing ----
-        DMA_BYTES = LDG_VEC * BF16_BYTES  # 16
-        OOB_ELEM = fx.Int32(OOB_SENTINEL_ELEM)
+        # Element-index OOB sentinels for the layout-API buffer tensors. Routing a
+        # gather to an element index whose byte offset is >= the descriptor's
+        # num_records makes the buffer hardware return 0, reproducing the raw
+        # path's padding/halo zeroing. For the adaptive (non-BIG) descriptors the
+        # tensor-end element index suffices; for the BIG_IN rebased descriptors
+        # (fixed BIG_IN_NR bytes) an index of num_records/BF16_BYTES lands exactly
+        # at the byte limit and is out of bounds.
+        X_ELEMS = fx.Int32(n * c * d * h * w)
+        W_ELEMS = fx.Int32(k * c * kt * kh * kw)
+        BIG_OOB_ELEM = fx.Int32(BIG_IN_NR // BF16_BYTES)
 
-        def _lds_dma_ptr(lds_array, stage_tile, i):
-            off_elems = fx.Index(stage_tile) + (fx.Index(tid) + fx.Index(i * BLOCK_THREADS)) * fx.Index(LDG_VEC)
-            base_bytes = off_elems * fx.Index(BF16_BYTES)
-            addr = fx.Int64(fx.ptrtoint(lds_array.ptr)) + fx.Int64(base_bytes)
-            addr = rocdl.readfirstlane(T.i64, arith.index_cast(T.i64, addr.ir_value()))
-            return llvm.inttoptr(ir.Type.parse("!llvm.ptr<3>"), addr)
+        # Layout-API global->LDS DMA (BufferCopyLDS128b). The per-thread im2col
+        # gather offset is expressed as an element index into the flat
+        # logical-divided buffer tensor; OOB padding routes to a past-end element
+        # index so the buffer hardware returns 0. This mirrors
+        # kernels/conv/conv3d_implicit_fp8.py's copy_g2s and the flash-attn
+        # _buffer_load_lds_128 idiom, and is used for both the non-BIG and the
+        # BIG_IN (rebased buffer tensor) input/weight gathers.
+        g2s_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), 128)
+        LdsPtrTy = fx.PointerType.get(elem_ty.ir_type, 2, 512)
 
-        def _dma_to_lds(rsrc, lds_ptr, voff_elem):
-            voff_b = (voff_elem * fx.Int32(BF16_BYTES)).ir_value()
-            rocdl.raw_ptr_buffer_load_lds(
-                rsrc,
-                lds_ptr,
-                arith.constant(DMA_BYTES, type=T.i32),
-                voff_b,
-                arith.constant(0, type=T.i32),
-                arith.constant(0, type=T.i32),
-                arith.constant(0, type=T.i32),
-            )
+        def _copy_g2s(src_div, lds_array, stage_tile, i, src_elem):
+            off_elems = fx.Int32(stage_tile) + (fx.Int32(tid) + fx.Int32(i * BLOCK_THREADS)) * fx.Int32(LDG_VEC)
+            lds_byte_addr = fx.Int32(fx.ptrtoint(lds_array.ptr)) + off_elems * fx.Int32(BF16_BYTES)
+            lds_ptr = fx.inttoptr(LdsPtrTy, lds_byte_addr)
+            dst = fx.make_view(lds_ptr, fx.make_layout(1, 1))
+            src = fx.slice(src_div, (None, fx.Int32(src_elem)))
+            fx.copy(g2s_atom, src, dst)
 
         def _load_a(stage, k_base):
             kbase_i = fx.Index(k_base)
@@ -451,26 +483,33 @@ def compile_conv3d_implicit(
             stage_tile = fx.Index(stage) * TILE_M * TILE_K
             for i in range_constexpr(LDG_A_COUNT):
                 if const_expr(BIG_IN_NM):
+                    # Rebase the buffer tensor per load to the sample base, then
+                    # gather through the same layout-API BufferCopyLDS path.
                     addr_ret = _a_addr(i, kbase_i, cc_base, ckk_base)
                     g_off_i, valid, n_idx_i = addr_ret
                     sample_addr = x_base_addr + fx.Int64(n_idx_i) * fx.Int64(X_SAMPLE_BYTES)
-                    x_rsrc_i = buffer_ops.create_buffer_resource_from_addr(sample_addr, num_records_bytes=BIG_IN_NR)
-                    voff = fx.Int32(arith.select(valid, g_off_i, OOB_ELEM))
-                    _dma_to_lds(x_rsrc_i, _lds_dma_ptr(a_lds, stage_tile, i), voff)
+                    x_div_i = _x_div_from_addr(sample_addr)
+                    voff = fx.Int32(arith.select(valid, g_off_i, BIG_OOB_ELEM))
+                    _copy_g2s(x_div_i, a_lds, stage_tile, i, voff)
+                elif const_expr(BIG_IN):
+                    # BIG_IN_N1: rebased buffer tensor (built once above).
+                    g_off_i, valid = _a_addr(i, kbase_i, cc_base, ckk_base)
+                    voff = fx.Int32(arith.select(valid, g_off_i, BIG_OOB_ELEM))
+                    _copy_g2s(x_div_big, a_lds, stage_tile, i, voff)
                 else:
                     g_off_i, valid = _a_addr(i, kbase_i, cc_base, ckk_base)
-                    voff = fx.Int32(arith.select(valid, g_off_i, OOB_ELEM))
-                    _dma_to_lds(x_rsrc, _lds_dma_ptr(a_lds, stage_tile, i), voff)
+                    voff = fx.Int32(arith.select(valid, g_off_i, X_ELEMS))
+                    _copy_g2s(x_div, a_lds, stage_tile, i, voff)
 
         def _load_b(stage, k_base):
             stage_tile = fx.Index(stage) * TILE_N * TILE_K
             for i in range_constexpr(LDG_B_COUNT):
                 g_off, col_valid = _b_addr(i, k_base)
                 if const_expr(n_tail):
-                    voff = fx.Int32(arith.select(col_valid, g_off, OOB_ELEM))
+                    voff = fx.Int32(arith.select(col_valid, g_off, W_ELEMS))
                 else:
                     voff = g_off
-                _dma_to_lds(w_rsrc, _lds_dma_ptr(b_lds, stage_tile, i), voff)
+                _copy_g2s(w_div, b_lds, stage_tile, i, voff)
 
         # ---- single-vec ds_read (LDS -> register), indexed by per-wave MFMA row ----
         def read_a_vec(stage, mi):

--- a/kernels/conv/conv3d_implicit.py
+++ b/kernels/conv/conv3d_implicit.py
@@ -247,13 +247,8 @@ def compile_conv3d_implicit(
     @flyc.kernel(known_block_size=[BLOCK_THREADS, 1, 1])
     def conv3d_implicit_kernel(y: fx.Tensor, x: fx.Tensor, weight: fx.Tensor, bias: fx.Tensor):
         y_rsrc = buffer_ops.create_buffer_resource(y)
-        # Layout-API buffer tensors for the global->LDS im2col gather. The weight
-        # tensor and the common (non-BIG) input tensor are wrapped as buffer
-        # tensors, flattened to a 1-D element view, and logical-divided so the
-        # per-thread im2col gather offset (already a flat element index) can be
-        # expressed through fx.copy(BufferCopyLDS128b). Flattening is required:
-        # the source tensors are multi-dimensional (weight 2-D, x_ndhwc 5-D) and
-        # slicing a multi-dim divided view would not index a flat element.
+        # Buffer tensors for the im2col gather, flattened to a 1-D element view so the
+        # per-thread flat gather offset indexes elements (multi-dim views would not).
         w_buf0 = fx.rocdl.make_buffer_tensor(weight, max_size=False)
         w_buf = fx.Tensor(fx.make_view(fx.get_iter(w_buf0), fx.make_layout(k * crs, 1)))
         w_div = fx.logical_divide(w_buf, fx.make_layout(1, 1))
@@ -287,11 +282,8 @@ def compile_conv3d_implicit(
         else:
             k_off = 0
 
-        # Layout-API flat buffer tensor from a rebased device address. Same
-        # mechanism as the non-BIG x_div path (make_buffer_* + logical_divide),
-        # but the base is advanced per the BIG_IN rebase arithmetic and an
-        # explicit ~2 GB num_records is set, matching the raw
-        # create_buffer_resource_from_addr(..., num_records_bytes=BIG_IN_NR).
+        # BIG_IN (>2GB): flat buffer tensor from a rebased address with explicit ~2GB
+        # num_records (same mechanism as x_div, replacing create_buffer_resource_from_addr).
         GXPtrTy = fx.PointerType.get(elem_ty.ir_type, 1, BF16_BYTES) if const_expr(BIG_IN) else None
 
         def _x_div_from_addr(addr_i64):
@@ -445,24 +437,14 @@ def compile_conv3d_implicit(
             return g_off, col_valid
 
         # ---- global -> LDS DMA copy, masking via OOB routing ----
-        # Element-index OOB sentinels for the layout-API buffer tensors. Routing a
-        # gather to an element index whose byte offset is >= the descriptor's
-        # num_records makes the buffer hardware return 0, reproducing the raw
-        # path's padding/halo zeroing. For the adaptive (non-BIG) descriptors the
-        # tensor-end element index suffices; for the BIG_IN rebased descriptors
-        # (fixed BIG_IN_NR bytes) an index of num_records/BF16_BYTES lands exactly
-        # at the byte limit and is out of bounds.
+        # OOB sentinel element indices: a gather past num_records makes the buffer
+        # hardware return 0, reproducing the padding/halo zeroing.
         X_ELEMS = fx.Int32(n * c * d * h * w)
         W_ELEMS = fx.Int32(k * c * kt * kh * kw)
         BIG_OOB_ELEM = fx.Int32(BIG_IN_NR // BF16_BYTES)
 
-        # Layout-API global->LDS DMA (BufferCopyLDS128b). The per-thread im2col
-        # gather offset is expressed as an element index into the flat
-        # logical-divided buffer tensor; OOB padding routes to a past-end element
-        # index so the buffer hardware returns 0. This mirrors
-        # kernels/conv/conv3d_implicit_fp8.py's copy_g2s and the flash-attn
-        # _buffer_load_lds_128 idiom, and is used for both the non-BIG and the
-        # BIG_IN (rebased buffer tensor) input/weight gathers.
+        # global->LDS DMA (BufferCopyLDS128b): gather offset as a flat element index;
+        # OOB padding routes past-end. Used for both non-BIG and BIG_IN gathers.
         g2s_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), 128)
         LdsPtrTy = fx.PointerType.get(elem_ty.ir_type, 2, 512)
 
@@ -483,8 +465,7 @@ def compile_conv3d_implicit(
             stage_tile = fx.Index(stage) * TILE_M * TILE_K
             for i in range_constexpr(LDG_A_COUNT):
                 if const_expr(BIG_IN_NM):
-                    # Rebase the buffer tensor per load to the sample base, then
-                    # gather through the same layout-API BufferCopyLDS path.
+                    # Rebase the buffer tensor per load to the sample base.
                     addr_ret = _a_addr(i, kbase_i, cc_base, ckk_base)
                     g_off_i, valid, n_idx_i = addr_ret
                     sample_addr = x_base_addr + fx.Int64(n_idx_i) * fx.Int64(X_SAMPLE_BYTES)

--- a/kernels/conv/conv3d_implicit_fp8.py
+++ b/kernels/conv/conv3d_implicit_fp8.py
@@ -254,10 +254,8 @@ def compile_conv3d_implicit_fp8(n, c, d, h, width, k, kt, kh, kw, st, sh, sw, pt
         c_m_vec = lane_div_16 * MFMA_C_VALUES
         c_n = lane_mod_16
 
-        # 16x16x128 FP8 MFMA built concretely in-kernel via the layout API
-        # (make_mma_atom + make_fragment + fx.gemm). Building the tiled_mma atom
-        # in-kernel (rather than passing it as a kernel arg) is required: a
-        # tiled_mma kernel argument compiles warm but fails cold-compile.
+        # 16x16x128 FP8 MFMA via the layout API, built in-kernel (a tiled_mma
+        # kernel-arg compiles warm but fails cold-compile).
         mma_atom = fx.make_mma_atom(fx.rocdl.cdna4.MFMA_Scale(16, 16, 128, elem_ty))
         Vec = fx.Vector
         mfma_zero = Vec.filled(MFMA_C_VALUES, 0.0, fx.Float32)
@@ -363,9 +361,7 @@ def compile_conv3d_implicit_fp8(n, c, d, h, width, k, kt, kh, kw, st, sh, sw, pt
             llvm.InlineAsmOp(None, [], f"s_setprio {level}", "", has_side_effects=True)
 
         def _do_mma(a, b, c):
-            # One 16x16x128 FP8 MFMA over the layout API. The A/B K-operands are
-            # the split-16@64 packed i32x8 fragments produced by lds_load_pack;
-            # they feed the MFMA_Scale atom directly through fx.gemm.
+            # split-16@64 packed i32x8 fragments feed the MFMA_Scale atom via fx.gemm.
             a_frag = fx.make_rmem_tensor(8, fx.Int32)
             a_frag.store(Vec(a))
             b_frag = fx.make_rmem_tensor(8, fx.Int32)

--- a/kernels/conv/conv3d_implicit_fp8.py
+++ b/kernels/conv/conv3d_implicit_fp8.py
@@ -16,7 +16,7 @@ from flydsl.expr import arith, const_expr, range_constexpr
 from flydsl.expr.typing import T
 from kernels.common import buffer_ops
 from kernels.common.mem_ops import buffer_atomic_add
-from kernels.gemm.fp8_gemm_utils import Mfma16x16x128, make_fp8_buffer_tensor, pack_i32x4_i32x8
+from kernels.gemm.fp8_gemm_utils import make_fp8_buffer_tensor, pack_i32x4_i32x8
 
 TILE_M = 128
 TILE_N = 128
@@ -254,13 +254,17 @@ def compile_conv3d_implicit_fp8(n, c, d, h, width, k, kt, kh, kw, st, sh, sw, pt
         c_m_vec = lane_div_16 * MFMA_C_VALUES
         c_n = lane_mod_16
 
-        mfma = Mfma16x16x128(QM_STEPS, QN_STEPS)
-        acc00 = [mfma.zero_value for _ in range_constexpr(N_SUB)]
-        acc01 = [mfma.zero_value for _ in range_constexpr(N_SUB)]
-        acc10 = [mfma.zero_value for _ in range_constexpr(N_SUB)]
-        acc11 = [mfma.zero_value for _ in range_constexpr(N_SUB)]
-
+        # 16x16x128 FP8 MFMA built concretely in-kernel via the layout API
+        # (make_mma_atom + make_fragment + fx.gemm). Building the tiled_mma atom
+        # in-kernel (rather than passing it as a kernel arg) is required: a
+        # tiled_mma kernel argument compiles warm but fails cold-compile.
+        mma_atom = fx.make_mma_atom(fx.rocdl.cdna4.MFMA_Scale(16, 16, 128, elem_ty))
         Vec = fx.Vector
+        mfma_zero = Vec.filled(MFMA_C_VALUES, 0.0, fx.Float32)
+        acc00 = [mfma_zero for _ in range_constexpr(N_SUB)]
+        acc01 = [mfma_zero for _ in range_constexpr(N_SUB)]
+        acc10 = [mfma_zero for _ in range_constexpr(N_SUB)]
+        acc11 = [mfma_zero for _ in range_constexpr(N_SUB)]
 
         class Vec16U8Ty:
             ir_type = Vec.make_type(16, fx.Uint8)
@@ -358,8 +362,21 @@ def compile_conv3d_implicit_fp8(n, c, d, h, width, k, kt, kh, kw, st, sh, sw, pt
         def setprio(level):
             llvm.InlineAsmOp(None, [], f"s_setprio {level}", "", has_side_effects=True)
 
+        def _do_mma(a, b, c):
+            # One 16x16x128 FP8 MFMA over the layout API. The A/B K-operands are
+            # the split-16@64 packed i32x8 fragments produced by lds_load_pack;
+            # they feed the MFMA_Scale atom directly through fx.gemm.
+            a_frag = fx.make_rmem_tensor(8, fx.Int32)
+            a_frag.store(Vec(a))
+            b_frag = fx.make_rmem_tensor(8, fx.Int32)
+            b_frag.store(Vec(b))
+            c_frag = fx.make_rmem_tensor(MFMA_C_VALUES, fx.Float32)
+            c_frag.store(Vec(c))
+            fx.gemm(mma_atom, c_frag, a_frag, b_frag, c_frag)
+            return c_frag.load().ir_value()
+
         def mfma_one(a, b, c_acc):
-            out = mfma._do_mma(a, b, c_acc)
+            out = _do_mma(a, b, c_acc)
             fx.rocdl.sched_mfma(1)
             return out
 

--- a/kernels/gemm/fp8_gemm_4wave.py
+++ b/kernels/gemm/fp8_gemm_4wave.py
@@ -58,6 +58,76 @@ class Mfma16x16x128AGPR(Mfma16x16x128):
         )
 
 
+def _make_swz_layout():
+    """Composed layout carrying the XOR bank-avoidance swizzle.
+
+    ``swizzle_128`` (BLOCK_K == 128) was verified byte-identical to
+    ``SwizzleType.get(3, 4, 4)`` and to ``crd2idx`` over this layout, so offsets
+    computed here match ``compute_global_swizzle`` / ``_compute_lds_swizzle`` /
+    ``S2RLoader`` exactly and the emitted addressing is unchanged.
+    """
+    return fx.make_composed_layout(
+        fx.static(fx.SwizzleType.get(3, 4, 4)),
+        fx.make_ordered_layout((128, 128), (1, 0)),
+    )
+
+
+def _layout_global_swizzle(lane_id, wave_id, K, n_rounds, block_dim_x):
+    """Layout-API form of ``compute_global_swizzle(preshuffled=False)``.
+
+    swizzle_128 keeps r == row (the XOR only permutes columns), so the global
+    element is ``row * K + swizzled_col``. Reads the swizzled column with
+    ``crd2idx`` on concrete coords (``get_scalar`` -> compile-time constant).
+    """
+    swz_layout = _make_swz_layout()
+    n_waves = block_dim_x // 64
+    offsets = []
+    for rnd in range_constexpr(n_rounds):
+        row = lane_id // 8 + wave_id * 8 + rnd * (n_waves * 8)
+        col = (lane_id % 8) * 16
+        swz_col = fx.get_scalar(fx.crd2idx((row % 16, col), swz_layout)) % 128
+        offsets.append(row * K + swz_col)
+    return offsets
+
+
+class LayoutS2R:
+    """Shared->register reader with the XOR swizzle carried in a composed layout.
+
+    Mirrors ``S2RLoader.load(preshuffled=False)`` but computes the swizzled LDS
+    byte offset with ``crd2idx`` over ``_make_swz_layout`` instead of the
+    hand-written ``swizzle_128`` math. The split-16@64 ``pack_i32x4_i32x8``
+    packing is kept -- it is the MFMA operand ABI. Preshuffled B stays on
+    ``S2RLoader`` (a different affine, non-XOR LDS map).
+    """
+
+    def __init__(self, wave_idx, n_tiles):
+        self.lane_id = fx.thread_idx.x % 64
+        self.wave_idx = wave_idx
+        self.n_tiles = n_tiles
+        self.swz_layout = _make_swz_layout()
+
+    def _vec_load_16xf8(self, lds_src, offset):
+        ptr_off = fx.add_offset(lds_src.ptr, fx.make_int_tuple(offset))
+        i8_iter = fx.recast_iter(fx.Uint8, ptr_off)
+        return fx.make_view(i8_iter, fx.make_layout(16, 1)).load()
+
+    def load(self, lds_src, preshuffled=False):
+        assert not preshuffled, "LayoutS2R only handles the non-preshuffled (XOR) LDS layout"
+        frag = []
+        for i in range_constexpr(self.n_tiles):
+            halves = []
+            row = self.wave_idx * (self.n_tiles * 16) + i * 16 + self.lane_id % 16
+            for step in range_constexpr(2):
+                col = (self.lane_id // 16) * 16 + step * 64
+                offset = fx.get_scalar(fx.crd2idx((row, col), self.swz_layout))
+                halves.append(self._vec_load_16xf8(lds_src, offset).bitcast(fx.Int32))
+            frag.append(pack_i32x4_i32x8(halves[0], halves[1]))
+        return frag
+
+    def load_one(self, lds_src, lds_offset):
+        return self._vec_load_16xf8(lds_src, lds_offset).bitcast(fx.Int32)
+
+
 def _min(a, b):
     return arith.select(a < b, a, b)
 
@@ -170,6 +240,13 @@ def compile_fp8_gemm_4w(
         gb_div = fx.logical_divide(gB, fx.make_layout(1, 1))
 
         def _compute_lds_swizzle(s2r, preshuffled=False):
+            # NOTE: kept on the manual swizzle_128 XOR (NOT crd2idx). This runs on
+            # the interleaved-cluster path whose MMA uses the AGPR inline-asm
+            # accumulator (Mfma16x16x128AGPR); crd2idx here materializes the
+            # swizzle constants slightly differently and perturbs the
+            # AGPR-sensitive register schedule (~1.3% regression on 256x256).
+            # swizzle_128 == SwizzleType.get(3,4,4) is proven, so this is purely a
+            # codegen-parity choice, documented per the no-regression gate.
             lds_swz = []
             for row_offset in range_constexpr(s2r.n_tiles):
                 row = s2r.wave_idx * (s2r.n_tiles * 16) + row_offset * 16 + lane_id % 16
@@ -309,13 +386,24 @@ def compile_fp8_gemm_4w(
         c10_frag = [mfma.zero_value] * N_ACCUMS
         c11_frag = [mfma.zero_value] * N_ACCUMS
 
-        gl_off_a = compute_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=False)
-        gl_off_b = compute_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=b_preshuffled)
+        gl_off_a = _layout_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, fx.block_dim.x)
+        if const_expr(b_preshuffled):
+            gl_off_b = compute_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=True)
+        else:
+            gl_off_b = _layout_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, fx.block_dim.x)
 
         a_g2s = G2SLoader(ga_div, gl_off_a, N_TILES_A, F8_IR_t, wave_id)
         b_g2s = G2SLoader(gb_div, gl_off_b, N_TILES_B, F8_IR_t, wave_id)
-        a_s2r = S2RLoader(wave_i, N_TILES_A)
-        b_s2r = S2RLoader(wave_j, N_TILES_B)
+        # LayoutS2R (crd2idx swizzle) is used only on the non-interleaved,
+        # non-preshuffled path. The interleaved 256x256 cluster keeps S2RLoader:
+        # its MMA is the AGPR inline-asm accumulator, and the crd2idx constant
+        # materialization perturbs that stall-sensitive register schedule (~1.3%).
+        if const_expr(_use_interleaved_block):
+            a_s2r = S2RLoader(wave_i, N_TILES_A)
+            b_s2r = S2RLoader(wave_j, N_TILES_B)
+        else:
+            a_s2r = LayoutS2R(wave_i, N_TILES_A)
+            b_s2r = S2RLoader(wave_j, N_TILES_B) if b_preshuffled else LayoutS2R(wave_j, N_TILES_B)
         store_c = StoreC(A_scale, B_scale, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B)
 
         # Prologue: 8-buffer LDS pipeline pre-fill.

--- a/kernels/gemm/fp8_gemm_4wave.py
+++ b/kernels/gemm/fp8_gemm_4wave.py
@@ -240,13 +240,8 @@ def compile_fp8_gemm_4w(
         gb_div = fx.logical_divide(gB, fx.make_layout(1, 1))
 
         def _compute_lds_swizzle(s2r, preshuffled=False):
-            # NOTE: kept on the manual swizzle_128 XOR (NOT crd2idx). This runs on
-            # the interleaved-cluster path whose MMA uses the AGPR inline-asm
-            # accumulator (Mfma16x16x128AGPR); crd2idx here materializes the
-            # swizzle constants slightly differently and perturbs the
-            # AGPR-sensitive register schedule (~1.3% regression on 256x256).
-            # swizzle_128 == SwizzleType.get(3,4,4) is proven, so this is purely a
-            # codegen-parity choice, documented per the no-regression gate.
+            # Manual swizzle_128 XOR kept (not crd2idx): the interleaved AGPR MMA path
+            # is register-schedule sensitive; crd2idx regresses it ~1.3%.
             lds_swz = []
             for row_offset in range_constexpr(s2r.n_tiles):
                 row = s2r.wave_idx * (s2r.n_tiles * 16) + row_offset * 16 + lane_id % 16
@@ -394,10 +389,8 @@ def compile_fp8_gemm_4w(
 
         a_g2s = G2SLoader(ga_div, gl_off_a, N_TILES_A, F8_IR_t, wave_id)
         b_g2s = G2SLoader(gb_div, gl_off_b, N_TILES_B, F8_IR_t, wave_id)
-        # LayoutS2R (crd2idx swizzle) is used only on the non-interleaved,
-        # non-preshuffled path. The interleaved 256x256 cluster keeps S2RLoader:
-        # its MMA is the AGPR inline-asm accumulator, and the crd2idx constant
-        # materialization perturbs that stall-sensitive register schedule (~1.3%).
+        # crd2idx s2r on the non-interleaved path only; interleaved keeps S2RLoader
+        # (AGPR accumulator is register-schedule sensitive, ~1.3%).
         if const_expr(_use_interleaved_block):
             a_s2r = S2RLoader(wave_i, N_TILES_A)
             b_s2r = S2RLoader(wave_j, N_TILES_B)

--- a/kernels/gemm/fp8_gemm_8wave.py
+++ b/kernels/gemm/fp8_gemm_8wave.py
@@ -9,10 +9,10 @@ Algorithm derived from HipKittens FP8_8wave
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import range_constexpr, rocdl
+from flydsl.expr import const_expr, range_constexpr, rocdl
+from flydsl.expr.typing import Vector as Vec
 from kernels.gemm.fp8_gemm_utils import (
     G2SLoader,
-    Mfma16x16x128,
     S2RLoader,
     StoreC,
     ceildiv,
@@ -21,6 +21,130 @@ from kernels.gemm.fp8_gemm_utils import (
     make_fp8_buffer_tensor,
     wait_barrier,
 )
+
+
+def _layout_global_swizzle(lane_id, wave_id, K, n_rounds, block_dim_x):
+    """Layout-API form of ``compute_global_swizzle(preshuffled=False)``.
+
+    Carries the XOR bank-avoidance swizzle in a
+    ``make_composed_layout(SwizzleType.get(3, 4, 4), ...)`` and reads the
+    swizzled column back with ``crd2idx`` on concrete (compile-time) coords
+    (``get_scalar`` -> a constant), instead of the hand-written ``swizzle_128``
+    bit math. ``swizzle_128`` was verified equal to ``SwizzleType.get(3, 4, 4)``
+    and this offset list is byte-identical to the helper's, so the emitted
+    ``buffer_load_lds`` addressing is unchanged.
+    """
+    swz_layout = fx.make_composed_layout(
+        fx.static(fx.SwizzleType.get(3, 4, 4)),
+        fx.make_ordered_layout((16, 128), (1, 0)),
+    )
+    n_waves = block_dim_x // 64
+    offsets = []
+    for rnd in range_constexpr(n_rounds):
+        row = lane_id // 8 + wave_id * 8 + rnd * (n_waves * 8)
+        col = (lane_id % 8) * 16
+        # swizzle_128 keeps r == row (the XOR only permutes columns), so the
+        # global element is row*K + swizzled_col, with swizzled_col periodic in
+        # 16 rows -> take (row % 16, col) through the composed layout.
+        swz_col = fx.get_scalar(fx.crd2idx((row % 16, col), swz_layout)) % 128
+        offsets.append(row * K + swz_col)
+    return offsets
+
+
+class LayoutS2R:
+    """Shared->register reader with the XOR swizzle carried in a composed layout.
+
+    Mirrors ``S2RLoader.load(preshuffled=False)`` but computes the swizzled LDS
+    byte offset with ``crd2idx`` over
+    ``make_composed_layout(SwizzleType.get(3, 4, 4), ...)`` (``get_scalar`` ->
+    compile-time constant) instead of the hand-written ``swizzle_128`` math.
+    ``swizzle_128`` was verified equal to ``SwizzleType.get(3, 4, 4)`` and the
+    resulting offsets are byte-identical, so the emitted ``ds_read`` addressing
+    is unchanged. The split-16@64 i32x8 packing (``pack_i32x4_i32x8``) is kept
+    as-is -- it is the MFMA operand ABI. Preshuffled B stays on ``S2RLoader``
+    (a different affine, non-XOR LDS map).
+    """
+
+    def __init__(self, wave_idx, n_tiles):
+        self.lane_id = fx.thread_idx.x % 64
+        self.wave_idx = wave_idx
+        self.n_tiles = n_tiles
+        self.swz_layout = fx.make_composed_layout(
+            fx.static(fx.SwizzleType.get(3, 4, 4)),
+            fx.make_ordered_layout((128, 128), (1, 0)),
+        )
+
+    def _vec_load_16xf8(self, lds_src, offset):
+        ptr_off = fx.add_offset(lds_src.ptr, fx.make_int_tuple(offset))
+        i8_iter = fx.recast_iter(fx.Uint8, ptr_off)
+        return fx.make_view(i8_iter, fx.make_layout(16, 1)).load()
+
+    def load(self, lds_src, preshuffled=False):
+        assert not preshuffled, "LayoutS2R only handles the non-preshuffled (XOR) LDS layout"
+        frag = []
+        for i in range_constexpr(self.n_tiles):
+            halves = []
+            row = self.wave_idx * (self.n_tiles * 16) + i * 16 + self.lane_id % 16
+            for step in range_constexpr(2):
+                col = (self.lane_id // 16) * 16 + step * 64
+                offset = fx.get_scalar(fx.crd2idx((row, col), self.swz_layout))
+                v = self._vec_load_16xf8(lds_src, offset)
+                halves.append(v.bitcast(fx.Int32))
+            frag.append(_pack_i32x4_i32x8(halves[0], halves[1]))
+        return frag
+
+
+def _pack_i32x4_i32x8(lo, hi):
+    return lo.shuffle(hi, list(range(8)))
+
+
+class TiledMmaDriver:
+    """MMA driver in the example-04 layout-API idiom.
+
+    Replaces ``Mfma16x16x128``'s bare-atom ``fx.gemm(atom, ...)`` calls with
+    ``fx.gemm(tiled_mma, ...)`` over a ``make_tiled_mma``. The 16x16x128 fp8
+    operands stay the split-16@64-packed i32x8 / f32x4 register fragments
+    produced by ``S2RLoader`` and consumed by ``StoreC``; only the MMA
+    construction moves to the layout API.
+    """
+
+    def __init__(self, tiled_mma, n_tiles_a, n_tiles_b):
+        self.tiled_mma = tiled_mma
+        self.zero_value = Vec.filled(4, 0.0, fx.Float32)
+        self.n_tiles_a = n_tiles_a
+        self.n_tiles_b = n_tiles_b
+
+    def idx(self, i, j):
+        return i * self.n_tiles_b + j
+
+    def _make_operand_frag(self, value):
+        frag = fx.make_rmem_tensor(8, fx.Int32)
+        frag.store(Vec(value))
+        return frag
+
+    def _make_accum_frag(self, value):
+        frag = fx.make_rmem_tensor(4, fx.Float32)
+        frag.store(Vec(value))
+        return frag
+
+    def call(self, a, b, c, *, set_prio=True):
+        assert len(a) == self.n_tiles_a
+        assert len(b) == self.n_tiles_b
+        assert len(c) == self.n_tiles_a * self.n_tiles_b
+
+        a_frags = [self._make_operand_frag(a[idx]) for idx in range_constexpr(self.n_tiles_a)]
+        b_frags = [self._make_operand_frag(b[idx]) for idx in range_constexpr(self.n_tiles_b)]
+        c_frags = [self._make_accum_frag(c[idx]) for idx in range_constexpr(self.n_tiles_a * self.n_tiles_b)]
+        if const_expr(set_prio):
+            rocdl.s_setprio(1)
+        for i in range_constexpr(self.n_tiles_a):
+            for j in range_constexpr(self.n_tiles_b):
+                cf = c_frags[self.idx(i, j)]
+                fx.gemm(self.tiled_mma, cf, a_frags[i], b_frags[j], cf)
+        if const_expr(set_prio):
+            rocdl.s_setprio(0)
+            rocdl.s_barrier()
+        return [c_frags[idx].load().ir_value() for idx in range_constexpr(self.n_tiles_a * self.n_tiles_b)]
 
 
 def compile_fp8_gemm_8w(*, K: int, BLOCK_M: int = 256, BLOCK_N: int = 256, b_preshuffled: bool = False):
@@ -70,6 +194,17 @@ def compile_fp8_gemm_8w(*, K: int, BLOCK_M: int = 256, BLOCK_N: int = 256, b_pre
     ):
         F8_IR_t = fx.Float8E4M3FN.ir_type
 
+        # Layout-API MMA construction (example-04 idiom): a single 16x16x128 fp8
+        # atom, one MFMA per wave sub-tile call (no wave/permutation
+        # replication). Built in-kernel because the operands are the raw
+        # split-16@64-packed i32x8 register fragments from ``S2RLoader`` rather
+        # than TV-partitioned ``make_fragment_*`` tensors, so ``fx.gemm`` needs
+        # the concrete ``tiled_mma`` value to take the tiled lowering path.
+        tiled_mma = fx.make_tiled_mma(
+            fx.make_mma_atom(fx.rocdl.cdna4.MFMA_Scale(16, 16, 128, fx.Float8E4M3FN)),
+            fx.make_layout((1, 1, 1), (0, 0, 0)),
+        )
+
         n_blocks = ceildiv(c_n, BLOCK_N)
 
         lds = fx.SharedAllocator().allocate(SharedStorage).peek()
@@ -99,15 +234,21 @@ def compile_fp8_gemm_8w(*, K: int, BLOCK_M: int = 256, BLOCK_N: int = 256, b_pre
         a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
         b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
 
-        gl_off_a = compute_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=False)
-        gl_off_b = compute_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=b_preshuffled)
+        gl_off_a = _layout_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, fx.block_dim.x)
+        if const_expr(b_preshuffled):
+            gl_off_b = compute_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=True)
+        else:
+            gl_off_b = _layout_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, fx.block_dim.x)
 
-        mfma = Mfma16x16x128(N_TILES_A, N_TILES_B)
+        mfma = TiledMmaDriver(tiled_mma, N_TILES_A, N_TILES_B)
 
         a_g2s = G2SLoader(a_div, gl_off_a, N_LDS_STEPS_A, F8_IR_t, wave_id)
         b_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_B, F8_IR_t, wave_id)
-        a_s2r = S2RLoader(wave_m, N_TILES_A)
-        b_s2r = S2RLoader(wave_n, N_TILES_B)
+        a_s2r = LayoutS2R(wave_m, N_TILES_A)
+        if const_expr(b_preshuffled):
+            b_s2r = S2RLoader(wave_n, N_TILES_B)
+        else:
+            b_s2r = LayoutS2R(wave_n, N_TILES_B)
         store_c = StoreC(A_scale, B_scale, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B)
 
         # 2x2 config of 4x2 (instead of 4x4 in 4wave) 16x16 sub-tiles

--- a/kernels/gemm/fp8_gemm_8wave.py
+++ b/kernels/gemm/fp8_gemm_8wave.py
@@ -43,9 +43,7 @@ def _layout_global_swizzle(lane_id, wave_id, K, n_rounds, block_dim_x):
     for rnd in range_constexpr(n_rounds):
         row = lane_id // 8 + wave_id * 8 + rnd * (n_waves * 8)
         col = (lane_id % 8) * 16
-        # swizzle_128 keeps r == row (the XOR only permutes columns), so the
-        # global element is row*K + swizzled_col, with swizzled_col periodic in
-        # 16 rows -> take (row % 16, col) through the composed layout.
+        # swizzle_128 permutes only columns (r == row), periodic in 16 rows.
         swz_col = fx.get_scalar(fx.crd2idx((row % 16, col), swz_layout)) % 128
         offsets.append(row * K + swz_col)
     return offsets
@@ -194,12 +192,8 @@ def compile_fp8_gemm_8w(*, K: int, BLOCK_M: int = 256, BLOCK_N: int = 256, b_pre
     ):
         F8_IR_t = fx.Float8E4M3FN.ir_type
 
-        # Layout-API MMA construction (example-04 idiom): a single 16x16x128 fp8
-        # atom, one MFMA per wave sub-tile call (no wave/permutation
-        # replication). Built in-kernel because the operands are the raw
-        # split-16@64-packed i32x8 register fragments from ``S2RLoader`` rather
-        # than TV-partitioned ``make_fragment_*`` tensors, so ``fx.gemm`` needs
-        # the concrete ``tiled_mma`` value to take the tiled lowering path.
+        # Single 16x16x128 fp8 atom, built in-kernel (raw i32x8 operands need the
+        # concrete tiled_mma; a tiled_mma kernel-arg fails cold-compile).
         tiled_mma = fx.make_tiled_mma(
             fx.make_mma_atom(fx.rocdl.cdna4.MFMA_Scale(16, 16, 128, fx.Float8E4M3FN)),
             fx.make_layout((1, 1, 1), (0, 0, 0)),

--- a/kernels/gemm/preshuffle_gemm.py
+++ b/kernels/gemm/preshuffle_gemm.py
@@ -13,7 +13,6 @@ from flydsl.expr import as_ir_value, const_expr, gpu, math, range_constexpr, roc
 from flydsl.expr.typing import BFloat16, Float8E4M3FN, Float8E4M3FNUZ, Float16, Float32, Int8, Int32, T
 from flydsl.expr.typing import Vector as Vec
 from flydsl.runtime.device import get_rocm_arch
-from kernels.common import buffer_ops
 from kernels.common.mma.mfma_preshuffle_pipeline import xcd_remap_bx_by
 
 # (dsrd_preload, dvmem_preload) per (tile_m, tile_n, tile_k).
@@ -563,44 +562,55 @@ def compile_preshuffle_gemm(
         lane_div_16 = lane_id // 16
         lane_mod_16 = lane_id % 16
 
+        # Epilogue operands are per-thread scalar/vec4 gathers; index in element units
+        # (idx == the old buffer_load element offset). Layout-API buffer_copy atoms
+        # (BufferCopy16b/32b/128b) over a make_buffer_tensor read the same OOB-checked
+        # descriptor the legacy buffer_load did (max_size=True).
+        epi_copy_32b = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), Float32)
+        epi_copy_128b = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), Float32)
+        epi_copy_16b = fx.make_copy_atom(fx.rocdl.BufferCopy16b(), out_elem_cls)
+
         def load_epi_operands():
             s_a = s_b = bias = None
             if const_expr(is_8bit):
                 # Per-row(scale_a) × per-col(scale_b) scaling, applied in the epilogue.
-                scale_b_rsrc = buffer_ops.create_buffer_resource(arg_scale_b, max_size=True)
-                s_b = [
-                    buffer_ops.buffer_load(
-                        scale_b_rsrc,
-                        fx.Int32(by_n + (ni * num_waves + wave_id) * 16 + lane_mod_16),
-                        vec_width=1,
-                        dtype=T.f32,
+                # scale_b: one f32 per N-block (BufferCopy32b); logical_divide(.,1) gives a
+                # (1, N) view so [None, idx] reads a single f32 at element index idx.
+                sb_buf = fx.logical_divide(
+                    fx.rocdl.make_buffer_tensor(arg_scale_b, max_size=True), fx.make_layout(1, 1)
+                )
+                s_b = []
+                for ni in range_constexpr(num_acc_n):
+                    f = fx.make_rmem_tensor(1, Float32)
+                    fx.copy_atom_call(
+                        epi_copy_32b,
+                        sb_buf[None, fx.Int32(by_n + (ni * num_waves + wave_id) * 16 + lane_mod_16)],
+                        f,
                     )
-                    for ni in range_constexpr(num_acc_n)
-                ]
-                scale_a_rsrc = buffer_ops.create_buffer_resource(arg_scale_a, max_size=True)
-                s_a = [
-                    Vec(
-                        buffer_ops.buffer_load(
-                            scale_a_rsrc, fx.Int32(bx_m + mi * 16 + lane_div_16 * 4), vec_width=4, dtype=T.f32
-                        )
-                    ).bitcast(fx.Float32)
-                    for mi in range_constexpr(m_repeat)
-                ]
+                    s_b.append(fx.Float32(f.load()[0]))
+                # scale_a: vec4 f32 per m-block (BufferCopy128b); logical_divide(.,4) tiles
+                # into 4-element windows so [None, grp] reads the 4 contiguous f32 at grp*4.
+                sa_buf = fx.logical_divide(
+                    fx.rocdl.make_buffer_tensor(arg_scale_a, max_size=True), fx.make_layout(4, 1)
+                )
+                s_a = []
+                for mi in range_constexpr(m_repeat):
+                    f = fx.make_rmem_tensor(4, Float32)
+                    grp = (bx_m + mi * 16 + lane_div_16 * 4) // 4
+                    fx.copy_atom_call(epi_copy_128b, sa_buf[None, fx.Int32(grp)], f)
+                    s_a.append(Vec(f.load()))
             if const_expr(_has_bias):
                 # Per-column bias (out_dtype), one scalar per N-block, shared across rows.
-                bias_rsrc = buffer_ops.create_buffer_resource(arg_bias, max_size=True)
-                bias_elem_ty = T.bf16 if out_dtype == "bf16" else T.f16
-                bias = [
-                    fx.Float32(
-                        buffer_ops.buffer_load(
-                            bias_rsrc,
-                            fx.Int32(by_n + (ni * num_waves + wave_id) * 16 + lane_mod_16),
-                            vec_width=1,
-                            dtype=bias_elem_ty,
-                        )
+                bias_buf = fx.logical_divide(fx.rocdl.make_buffer_tensor(arg_bias, max_size=True), fx.make_layout(1, 1))
+                bias = []
+                for ni in range_constexpr(num_acc_n):
+                    f = fx.make_rmem_tensor(1, out_elem_cls)
+                    fx.copy_atom_call(
+                        epi_copy_16b,
+                        bias_buf[None, fx.Int32(by_n + (ni * num_waves + wave_id) * 16 + lane_mod_16)],
+                        f,
                     )
-                    for ni in range_constexpr(num_acc_n)
-                ]
+                    bias.append(fx.Float32(f.load()[0]))
             return s_a, s_b, bias
 
         overlap_epi_load = acc_size <= 64  # small enough accumulator to keep operands live over the MMA

--- a/kernels/gemm/preshuffle_gemm.py
+++ b/kernels/gemm/preshuffle_gemm.py
@@ -562,10 +562,8 @@ def compile_preshuffle_gemm(
         lane_div_16 = lane_id // 16
         lane_mod_16 = lane_id % 16
 
-        # Epilogue operands are per-thread scalar/vec4 gathers; index in element units
-        # (idx == the old buffer_load element offset). Layout-API buffer_copy atoms
-        # (BufferCopy16b/32b/128b) over a make_buffer_tensor read the same OOB-checked
-        # descriptor the legacy buffer_load did (max_size=True).
+        # Epilogue scalar/vec4 gathers via buffer_copy atoms over a make_buffer_tensor
+        # (element-index addressing; same OOB-checked descriptor as the legacy buffer_load).
         epi_copy_32b = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), Float32)
         epi_copy_128b = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), Float32)
         epi_copy_16b = fx.make_copy_atom(fx.rocdl.BufferCopy16b(), out_elem_cls)
@@ -574,8 +572,6 @@ def compile_preshuffle_gemm(
             s_a = s_b = bias = None
             if const_expr(is_8bit):
                 # Per-row(scale_a) × per-col(scale_b) scaling, applied in the epilogue.
-                # scale_b: one f32 per N-block (BufferCopy32b); logical_divide(.,1) gives a
-                # (1, N) view so [None, idx] reads a single f32 at element index idx.
                 sb_buf = fx.logical_divide(
                     fx.rocdl.make_buffer_tensor(arg_scale_b, max_size=True), fx.make_layout(1, 1)
                 )
@@ -588,8 +584,7 @@ def compile_preshuffle_gemm(
                         f,
                     )
                     s_b.append(fx.Float32(f.load()[0]))
-                # scale_a: vec4 f32 per m-block (BufferCopy128b); logical_divide(.,4) tiles
-                # into 4-element windows so [None, grp] reads the 4 contiguous f32 at grp*4.
+                # scale_a: vec4 f32 per m-block (BufferCopy128b).
                 sa_buf = fx.logical_divide(
                     fx.rocdl.make_buffer_tensor(arg_scale_a, max_size=True), fx.make_layout(4, 1)
                 )

--- a/kernels/moe/mxfp_moe/gemm1.py
+++ b/kernels/moe/mxfp_moe/gemm1.py
@@ -268,19 +268,8 @@ def _gemm1_body(
                     t.store(lo.shuffle(hi, list(range(8))))
                     a[i][k] = t
             else:
-                # NOTE: kept as the manual (col_bytes ^ mask)//16 index rather than the
-                # composed-layout crd2idx used in gemm2 (see mxfp4_gemm_common._a_lds_swz_*).
-                # The layout form is bit-for-bit identical and folds to prologue constants
-                # (the swizzle is lane/i/k-invariant; the slot base is separable, so the
-                # crd2idx can even be fully hoisted out of the k-loop). Verified via ISA diff:
-                # the hoisted-crd2idx build emits *identical* hot-loop op counts (ds_read_b128
-                # 240, ds_write 32, buffer_load_dwordx4 282, v_mfma 896) and 8 FEWER total
-                # instructions -- yet reproducibly runs ~5.5% slower on large compute-bound
-                # fp4 (same-session median t8192: 1032 us manual vs 1090 us layout). The cause
-                # is instruction *scheduling* sensitivity in this hand-tuned loop (the two
-                # forms schedule the same ops differently: ds_read2st64 merging, v_bitop3/v_or
-                # ordering, dropped s_nop/s_waitcnt), not extra address math. gemm2's simpler
-                # loop is immune (perf-neutral there). Left manual as a bucket-2 site.
+                # Manual XOR swizzle kept: the crd2idx form (see gemm2) is ISA-identical
+                # but ~5% slower here from scheduling sensitivity in this tuned loop.
                 lds_col = (lane_div_16 * fx.Int32(16) + fx.Int32(k * 64)) ^ mask
                 for i in range_constexpr(kMChunks):
                     lds_row = lane_mod_16 + fx.Int32(i * 16)

--- a/kernels/moe/mxfp_moe/gemm1.py
+++ b/kernels/moe/mxfp_moe/gemm1.py
@@ -268,6 +268,19 @@ def _gemm1_body(
                     t.store(lo.shuffle(hi, list(range(8))))
                     a[i][k] = t
             else:
+                # NOTE: kept as the manual (col_bytes ^ mask)//16 index rather than the
+                # composed-layout crd2idx used in gemm2 (see mxfp4_gemm_common._a_lds_swz_*).
+                # The layout form is bit-for-bit identical and folds to prologue constants
+                # (the swizzle is lane/i/k-invariant; the slot base is separable, so the
+                # crd2idx can even be fully hoisted out of the k-loop). Verified via ISA diff:
+                # the hoisted-crd2idx build emits *identical* hot-loop op counts (ds_read_b128
+                # 240, ds_write 32, buffer_load_dwordx4 282, v_mfma 896) and 8 FEWER total
+                # instructions -- yet reproducibly runs ~5.5% slower on large compute-bound
+                # fp4 (same-session median t8192: 1032 us manual vs 1090 us layout). The cause
+                # is instruction *scheduling* sensitivity in this hand-tuned loop (the two
+                # forms schedule the same ops differently: ds_read2st64 merging, v_bitop3/v_or
+                # ordering, dropped s_nop/s_waitcnt), not extra address math. gemm2's simpler
+                # loop is immune (perf-neutral there). Left manual as a bucket-2 site.
                 lds_col = (lane_div_16 * fx.Int32(16) + fx.Int32(k * 64)) ^ mask
                 for i in range_constexpr(kMChunks):
                     lds_row = lane_mod_16 + fx.Int32(i * 16)

--- a/kernels/moe/mxfp_moe/gemm2.py
+++ b/kernels/moe/mxfp_moe/gemm2.py
@@ -501,9 +501,7 @@ def _gemm2_body(
                 k_half=_K_HALF,
             )
 
-    # A-LDS read block-swizzle via layout algebra (composed swizzle o ordered layout).
-    # Rows span the whole s_aq region (_aStages slots * BM rows); crd2idx applies the
-    # S<3,0,4> bank-conflict swizzle, replacing the manual (col_bytes ^ mask)//16.
+    # A-LDS read block-swizzle via layout algebra (crd2idx over composed swizzle).
     _a_lds_swz = _a_lds_swz_block_layout(_aStages * BM)
 
     def issue_a_ds_read(slot):

--- a/kernels/moe/mxfp_moe/gemm2.py
+++ b/kernels/moe/mxfp_moe/gemm2.py
@@ -9,6 +9,8 @@ from flydsl.expr.typing import T
 from flydsl.expr.typing import Vector as Vec
 
 from .mxfp4_gemm_common import (
+    _a_lds_swz_block_idx,
+    _a_lds_swz_block_layout,
     _e8m0_from_amax,
     _fabs_f32,
     _gep1,
@@ -499,18 +501,22 @@ def _gemm2_body(
                 k_half=_K_HALF,
             )
 
+    # A-LDS read block-swizzle via layout algebra (composed swizzle o ordered layout).
+    # Rows span the whole s_aq region (_aStages slots * BM rows); crd2idx applies the
+    # S<3,0,4> bank-conflict swizzle, replacing the manual (col_bytes ^ mask)//16.
+    _a_lds_swz = _a_lds_swz_block_layout(_aStages * BM)
+
     def issue_a_ds_read(slot):
         lane_row = lane_mod_16
-        lane_col = lane_div_16 * fx.Int32(16)
-        mask = _lds_swizzle_mask(lane_row)
+        lane_col_block = lane_div_16  # 16-byte block column within the 128-byte row
         a = [[None, None] for _ in range(_kMChunks)]
         for k in range_constexpr(2):
-            lds_col = (lane_col + fx.Int32(k * 64)) ^ mask
+            block_col = lane_col_block + fx.Int32(k * 4)  # +64 bytes == +4 blocks
             for i in range_constexpr(_kMChunks):
-                lds_row = lane_row + fx.Int32(i * 16)
-                byte_off = fx.Int32(slot * _slot_bytes) + lds_row * fx.Int32(KH_TILE) + lds_col
+                global_row = fx.Int32(slot * BM) + lane_row + fx.Int32(i * 16)
+                block_idx = _a_lds_swz_block_idx(_a_lds_swz, global_row, block_col)
                 r = fx.make_rmem_tensor(lds_a_read_lay, fx.Int32)
-                fx.copy_atom_call(lds_a_read_atom, fx.slice(s_aq_i32x4_tiles, (None, byte_off // fx.Int32(16))), r)
+                fx.copy_atom_call(lds_a_read_atom, fx.slice(s_aq_i32x4_tiles, (None, block_idx)), r)
                 a[i][k] = r
         return a
 

--- a/kernels/moe/mxfp_moe/mxfp4_gemm_common.py
+++ b/kernels/moe/mxfp_moe/mxfp4_gemm_common.py
@@ -137,13 +137,8 @@ def _lds_swizzle_mask(row):
     return (row & fx.Int32(14)) << fx.Int32(3)
 
 
-# The A-LDS bank-conflict swizzle expressed as layout algebra. Each 128-byte A row is
-# 8 contiguous 16-byte blocks; the manual code XORs (row&14)<<3 into the byte column,
-# i.e. block_col ^= (row>>1)&7. Over the flat 16-byte-block index `row*8 + block_col`
-# this is exactly SwizzleType(mask=3, base=0, shift=4) (verified bit-for-bit against
-# `_lds_swizzle_mask`: XORs block index bits [0,3) with bits [4,7)). Building the LDS
-# slot as a composed (swizzle o ordered-layout) view lets crd2idx((row, block_col))
-# produce the swizzled 16-byte-block index directly, replacing the hand XOR + //16.
+# A-LDS bank-conflict swizzle as layout algebra: over the flat 16-byte-block index
+# (row*8 + block_col) the manual XOR mask equals SwizzleType(3, 0, 4) (verified bit-for-bit).
 _A_LDS_BLOCKS_PER_ROW = 8  # 128-byte fp4 row / 16-byte block
 
 

--- a/kernels/moe/mxfp_moe/mxfp4_gemm_common.py
+++ b/kernels/moe/mxfp_moe/mxfp4_gemm_common.py
@@ -137,6 +137,32 @@ def _lds_swizzle_mask(row):
     return (row & fx.Int32(14)) << fx.Int32(3)
 
 
+# The A-LDS bank-conflict swizzle expressed as layout algebra. Each 128-byte A row is
+# 8 contiguous 16-byte blocks; the manual code XORs (row&14)<<3 into the byte column,
+# i.e. block_col ^= (row>>1)&7. Over the flat 16-byte-block index `row*8 + block_col`
+# this is exactly SwizzleType(mask=3, base=0, shift=4) (verified bit-for-bit against
+# `_lds_swizzle_mask`: XORs block index bits [0,3) with bits [4,7)). Building the LDS
+# slot as a composed (swizzle o ordered-layout) view lets crd2idx((row, block_col))
+# produce the swizzled 16-byte-block index directly, replacing the hand XOR + //16.
+_A_LDS_BLOCKS_PER_ROW = 8  # 128-byte fp4 row / 16-byte block
+
+
+def _a_lds_swz_block_layout(rows):
+    """Composed layout over 16-byte A-LDS blocks: (rows, 8) row-major, swizzled S<3,0,4>.
+
+    crd2idx((row, block_col), <this>) == the manual `(byte_off ^ mask) // 16` block index.
+    """
+    return fx.make_composed_layout(
+        fx.static(fx.SwizzleType.get(3, 0, 4)),
+        fx.make_layout((rows, _A_LDS_BLOCKS_PER_ROW), (_A_LDS_BLOCKS_PER_ROW, 1)),
+    )
+
+
+def _a_lds_swz_block_idx(swz_layout, row, block_col):
+    """Swizzled 16-byte-block index for (row, block_col) via layout algebra."""
+    return fx.Int32(crd2idx([fx.Int64(row), fx.Int64(block_col)], swz_layout))
+
+
 def _fabs_f32(x):
     return fx.Float32(llvm.call_intrinsic(T.f32, "llvm.fabs.f32", [_raw(x)], [], []))
 


### PR DESCRIPTION
## Summary

Ports four GEMM / MoE / conv kernel families from manual buffer/byte-offset addressing to the FlyDSL **layout API** (the `examples/04-preshuffle_gemm.py` idiom: `make_buffer_tensor` + `flat_divide` + `partition_S/D`, `make_composed_layout(SwizzleType)` for LDS swizzle, `make_tiled_mma`/`fx.gemm`, `crd2idx` for swizzled offsets). Each port is **cold-correct** (`FLYDSL_RUNTIME_ENABLE_CACHE=0`) and **perf-neutral** (median-of-7 on gfx950, within clock noise).

`moe_gemm_2stage` is intentionally **not** in this PR (separate WIP).

## Ports

- **`gemm/preshuffle_gemm.py`** — `buffer_ops` removed; epilogue scale addressing on the layout API. Cold: fp8/int8/fp16/bf16/fp4/fp6/a8w8 + fused-epilogue modes + ragged-M. Perf parity (8192³ fp8 ~2237 TFLOPS, independently re-measured).
- **`gemm/fp8_gemm_8wave.py` + `fp8_gemm_4wave.py`** — MMA via in-kernel `make_tiled_mma`; g2s + s2r LDS swizzle via prologue-hoisted `crd2idx` over `make_composed_layout(SwizzleType(3,4,4))` (hot-loop ISA identical). Direct-DMA `BufferCopyLDS` + split-16@64 pack kept (repo idiom). `fp8_gemm_utils.py` untouched.
- **`moe/mxfp_moe/gemm2.py`** — A-LDS read on real layout algebra (`make_composed_layout(SwizzleType)` + `crd2idx`, bit-for-bit vs the manual XOR), all gemm2 variants incl. a8w4 e2e stage-2. Cold 6/6 + 228/0 e2e; perf parity (fp4 1280.7, a8w4 828.4 TFLOPS).
- **`conv/conv3d_implicit.py` + `conv3d_implicit_fp8.py`** — im2col gather via `make_buffer_tensor`/`logical_divide`/`BufferCopyLDS128b` (flat element index, OOB→sentinel); BIG_IN (>2GB) via `make_buffer_ptr(rebased, num_records_bytes)`; fp8 MMA via in-kernel `make_mma_atom(MFMA_Scale)`. Cold: bf16 26/26.

## Documented "manual by necessity" (kept, with ISA evidence)

A few hot-loop sites are left manual **on purpose** — the layout-API form is op-count-identical but perturbs the tuned instruction schedule:
- `mxfp_moe` gemm1 read: prologue-hoisted `crd2idx` is op-identical yet ~5.5% (fp4) / ~11% (fp8) slower (instruction-scheduling sensitivity). Documented in-code.
- `fp8_4wave` interleaved AGPR s2r (~1.3%); direct-DMA op stays inline-asm (no register fragment; matches `preshuffle_gemm.py::dma_a_to_lds`); StoreC (final store, needs full wave-decomp, ~0 payoff).

## Caveats

- **conv BIG_IN (>2GB)** is **compile-validated only** — no >2GB test exists; the rebase arithmetic is byte-identical to the prior manual path and the mechanism is runtime-proven by the non-BIG path (26/26).
- **Pre-existing** (not this PR): `test_conv3d_implicit_fp8.py [1-96-4-8-9-96-1-1]` cold flakiness (C=96 partial-K split-K, rel_err ~0.3075) reproduces on `main`.

## Test plan

```
FLYDSL_RUNTIME_ENABLE_CACHE=0 python3 -m pytest \
  tests/kernels/test_preshuffle_gemm.py tests/kernels/test_fp8_gemm_rowscale.py \
  tests/kernels/test_moe_gemm.py tests/kernels/test_conv3d_implicit.py \
  tests/kernels/test_conv3d_implicit_fp8.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
