### PR TITLE
Fix host dispatch benchmark timing window

### DIFF
--- a/tests/unit/test_launch_overhead.py
+++ b/tests/unit/test_launch_overhead.py
@@ -112,10 +112,27 @@ def bench_wallclock(fn, n_warmup=20, n_iters=1000):
     t0 = time.perf_counter()
     for _ in range(n_iters):
         fn()
-    torch.cuda.synchronize()
     t1 = time.perf_counter()
+    torch.cuda.synchronize()
 
     return (t1 - t0) / n_iters * 1e6  # µs
+
+
+def test_bench_wallclock_excludes_final_gpu_drain(monkeypatch):
+    """The final drain must not be part of the host-dispatch window."""
+    sync_count = 0
+
+    def fake_synchronize():
+        nonlocal sync_count
+        sync_count += 1
+
+    monkeypatch.setattr(torch.cuda, "synchronize", fake_synchronize)
+    monkeypatch.setattr(time, "perf_counter", lambda: float(sync_count))
+
+    measured_us = bench_wallclock(lambda: None, n_warmup=0, n_iters=1)
+
+    assert measured_us == 0.0
+    assert sync_count == 2
 
 
 def main():


### PR DESCRIPTION
## Summary
- move the final GPU drain outside `bench_wallclock`'s measured interval so it measures host dispatch as documented
- add a deterministic regression test that locks the synchronization/timestamp ordering
- keep the change intentionally narrow; the broader timing-contract and CI analysis is documented in the [supporting Gist](https://gist.github.com/jhinpan/bac693979c52690626fc8b895da4d2ff)

## Why
The previous implementation sampled the end timestamp after `torch.cuda.synchronize()`. For GPU-bound workloads that turns the metric into roughly `max(host submit, GPU throughput)` rather than CPU dispatch overhead, contradicting the function's docstring and making results workload-size dependent.

## Test plan
- [x] `python3 -m pytest tests/unit/test_launch_overhead.py -q`
- [x] `python3 -m ruff check tests/unit/test_launch_overhead.py`