### PR TITLE
[Bugfix] Resolve reg offset on dynamic add_offset chains

### DIFF
--- a/lib/Dialect/Fly/Transforms/PromoteRegMemToVectorSSA.cpp
+++ b/lib/Dialect/Fly/Transforms/PromoteRegMemToVectorSSA.cpp
@@ -86,17 +86,27 @@ bool isRegOperandOrResult(Operation *op) {
   return false;
 }
 
-std::optional<std::pair<MakePtrOp, int32_t>> resolveRegOffset(Value ptr) {
+/// Resolves the root alloca of an add_offset chain and its accumulated offset.
+///
+/// Nullopt result: the chain does not bottom out in a MakePtrOp.
+/// Nullopt `second`: the root is known but some link carries a dynamic offset,
+/// so there is no concrete displacement.  The root is still reported, so
+/// callers that only need its identity stay conservative; callers that need the
+/// displacement must bail.
+std::optional<std::pair<MakePtrOp, std::optional<int32_t>>> resolveRegOffset(Value ptr) {
   assert(isa<RegPtrValue>(ptr) && "expected register pointer");
 
   if (auto makePtrOp = ptr.getDefiningOp<MakePtrOp>()) {
-    return std::pair<MakePtrOp, int32_t>{makePtrOp, 0};
+    return std::pair<MakePtrOp, std::optional<int32_t>>{makePtrOp, 0};
   } else if (auto addOffsetOp = ptr.getDefiningOp<AddOffsetOp>()) {
     auto base = resolveRegOffset(addOffsetOp.getPtr());
     if (!base)
       return std::nullopt;
     IntAttr intAttr = addOffsetOp.getOffset().getType().getAttr().getLeafAsInt();
-    return std::pair<MakePtrOp, int32_t>{base->first, base->second + intAttr.getValue()};
+    if (!base->second || !intAttr.isStatic())
+      return std::pair<MakePtrOp, std::optional<int32_t>>{base->first, std::nullopt};
+    return std::pair<MakePtrOp, std::optional<int32_t>>{base->first,
+                                                        *base->second + intAttr.getValue()};
   } else {
     return std::nullopt;
   }
@@ -154,11 +164,25 @@ private:
       for (Value v : {recastOp.getSrc(), recastOp.getResult()}) {
         if (!isRegValue(v))
           continue;
+        // Only the root identity matters here: a dynamic offset must not stop
+        // the recast-reachable alloca from being excluded.
         auto root = resolveRegOffset(v);
         if (root)
           regAllocaInfos.erase(root->first);
       }
     });
+
+    // A dynamic link in the add_offset chain gives no concrete slot index, so
+    // the alloca it reaches cannot be promoted to a vector SSA value.
+    funcOp.walk([&](AddOffsetOp addOffsetOp) {
+      Value result = addOffsetOp.getResult();
+      if (!isRegValue(result))
+        return;
+      auto root = resolveRegOffset(result);
+      if (root && !root->second)
+        regAllocaInfos.erase(root->first);
+    });
+
     bool hasExcludedRoots = allocaOrder.size() != regAllocaInfos.size();
     llvm::erase_if(allocaOrder, [&](MakePtrOp r) { return !regAllocaInfos.count(r); });
 
@@ -220,7 +244,8 @@ private:
 
   std::optional<RegAccessInfo> getRegAccessInfo(Value ptr, Type valueType) {
     auto rootAndOffset = resolveRegOffset(ptr);
-    if (!rootAndOffset)
+    // A concrete displacement is required to index the vector SSA value.
+    if (!rootAndOffset || !rootAndOffset->second)
       return std::nullopt;
 
     int32_t width = 0;
@@ -235,7 +260,7 @@ private:
     if (!info)
       return std::nullopt;
 
-    return RegAccessInfo{rootAndOffset->first, rootAndOffset->second, width, info->elemTy};
+    return RegAccessInfo{rootAndOffset->first, *rootAndOffset->second, width, info->elemTy};
   }
 
   LogicalResult collectTouchedRegAllocaInRegion(Region &region, Operation *boundaryOp,
@@ -243,6 +268,8 @@ private:
     auto tryRecord = [&](Value ptr) {
       if (!isa<RegPtrValue>(ptr))
         return;
+      // Only the root identity matters here: a dynamic offset must not stop the
+      // alloca from being recorded as touched.
       auto root = resolveRegOffset(ptr);
       if (root && getAllocaInfo(root->first) && !boundaryOp->isProperAncestor(root->first))
         touchedRoots.insert(root->first);

--- a/tests/mlir/Transforms/promote_regmem_to_ssa_invalid.mlir
+++ b/tests/mlir/Transforms/promote_regmem_to_ssa_invalid.mlir
@@ -40,4 +40,21 @@ gpu.module @promote_regmem_to_ssa_recast_skip {
     fly.ptr.store(%sum, %out) : (i32, !fly.ptr<i32, global>) -> ()
     gpu.return
   }
+
+// A dynamic offset yields no concrete slot index, so the access must stay in
+// memory form.  Promoting it would silently read slot 0, because a dynamic
+// IntAttr carries value == 0.
+// CHECK-LABEL: gpu.func @skip_register_dynamic_offset
+// CHECK: fly.make_ptr() {dictAttrs = {allocSize = 4 : i64}}
+// CHECK: fly.add_offset
+// CHECK: fly.ptr.load
+// CHECK-NOT: vector.extract
+  gpu.func @skip_register_dynamic_offset(%out: !fly.ptr<f32, global>, %idx: i32) kernel {
+    %reg = fly.make_ptr() {dictAttrs = {allocSize = 4 : i64}} : () -> !fly.ptr<f32, register>
+    %dyn = fly.make_int_tuple(%idx) : (i32) -> !fly.int_tuple<?>
+    %slot = fly.add_offset(%reg, %dyn) : (!fly.ptr<f32, register>, !fly.int_tuple<?>) -> !fly.ptr<f32, register>
+    %val = fly.ptr.load(%slot) : (!fly.ptr<f32, register>) -> f32
+    fly.ptr.store(%val, %out) : (f32, !fly.ptr<f32, global>) -> ()
+    gpu.return
+  }
 }


### PR DESCRIPTION
## Summary

`resolveRegOffset` accumulated `add_offset` displacements without checking whether each link was static, so a register access through a dynamic offset was promoted to a hardcoded read of slot 0.

## Motivation

A dynamic `IntAttr` carries `value == 0` (`FlyAttrDefs.cpp`), so `IntAttr::getValue()` on a dynamic offset silently returns 0 instead of failing. Before this change, `add_offset(reg_ptr, dynamic)` lowered to:

```mlir
%0 = ub.poison : vector<4xf32>
%1 = vector.extract %0[0] : f32 from vector<4xf32>
```

The dynamic index is dropped entirely and the access is hardcoded to slot 0 — a deterministic read of the wrong element, not merely an undefined value.

## Changes

- `resolveRegOffset` now returns the root alloca plus an **optional** offset. The root is always reported, so the recast-exclusion walk and `collectTouchedRegAllocaInRegion` keep their conservative behaviour; only `getRegAccessInfo`, which needs a concrete slot index, bails out.
- Allocas reached through a dynamic chain are excluded from promotion up front, the same way the pass already excludes recast-reachable ones. Guarding the offset alone was not sufficient: the alloca would still be promoted while the unresolvable access stayed in memory form, tripping the pass's own post-condition check (`register operand/result remain after rmem SSA promotion`).

No kernel in the tree currently hits this path — a scan of 15 compiled kernels found no register-space `add_offset` with a dynamic offset — so this is a latent-correctness fix rather than a behaviour change for existing code.

## Performance (if applicable)

Not applicable. Per-kernel ISA resource comparison against the base commit shows no change: gfx942 33 kernels and gfx950 31 kernels, all identical in VGPR/SGPR/spill/scratch/ds_read.

## Testing

- [x] Unit tests added/updated — `tests/mlir/Transforms/promote_regmem_to_ssa_invalid.mlir` gains `@skip_register_dynamic_offset`, verified to **fail** without the source change and pass with it
- [ ] Performance benchmarks run — not applicable, see above
- [x] Tested on MI300X — full MLIR FileCheck suite (36/36) on gfx942; `clang-format` clean

## Dependencies

- [x] No new third-party dependencies added

## Breaking Changes

None.
