### PR TITLE
fix(mega_moe): correct GEMM2 A-scale indexing for BM=16

### DIFF
--- a/kernels/mega_moe/gemm2.py
+++ b/kernels/mega_moe/gemm2.py
@@ -177,7 +177,7 @@ def gemm2_compute_v2(
     tilesPerScaleChunk = 256 // BK  # K-tiles sharing one 256-K E8M0 word
     numAccN = (BN // 4) // 16  # 16-column MFMA subblocks per wave
     nPairs = max(1, numAccN // 2)  # one B-scale per two 16-column subblocks
-    # BM16: single 16-row block owning a 32-row scale chunk (chunk==m_block_idx, rg0-only).
+    # BM16: a single 16-row block is one row-group of a shared 32-row scale chunk.
     is_bm16 = BM < 32
     rg_off = 0
     kScaleSubBlocks = max(1, kMChunks // 2)
@@ -290,9 +290,13 @@ def gemm2_compute_v2(
     # The shared e8m0 scale layout bounds each A-scale view to its remaining bytes.
     sc_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), 32)
 
-    asc_per_mb = fx.Int32(kScaleSubBlocks) * kAS_per_chunk_dw * fx.Int32(4)
+    # BM16 blocks consume half a 32-row chunk each, so scale bytes per block halve too.
+    asc_per_mb = fx.Int32(kScaleSubBlocks) * kAS_per_chunk_dw * fx.Int32(2 if is_bm16 else 4)
     asc_num = fx.Int64(i32_max_m_blocks) * fx.Int64(asc_per_mb)
-    scale_chunk0 = m_block_idx if const_expr(is_bm16) else m_row // 32
+    scale_chunk0 = m_row // fx.Int32(32)
+    # Byte order inside one e8m0 word is [k0/rg0, k0/rg1, k1/rg0, k1/rg1]; opsel_a only reaches
+    # rg0, so odd BM16 blocks shift the word down one byte to land on their rg1 scales.
+    a_rg_shift = ((m_row // fx.Int32(16)) & fx.Int32(1)) * fx.Int32(8) if const_expr(is_bm16) else None
 
     def make_ascale_view(sub):
         base_dw = (scale_chunk0 + fx.Int32(sub)) * kAS_per_chunk_dw
@@ -396,6 +400,8 @@ def gemm2_compute_v2(
     def mfma_cluster(bqf, bsf, sa, kt_rt):
         # opsel (no gate/up split): mni=J//2, in_b=J%2; sa is a per-32-row-chunk list.
         sa = [shift_scale_word(sa[sub], kt_rt) for sub in range_constexpr(kScaleSubBlocks)]
+        if const_expr(is_bm16):
+            sa = [_raw(fx.Int32(word).shrui(a_rg_shift)) for word in sa]
         sb_words = [shift_scale_word(_raw(Vec(bsf[mni].load())[0]), kt_rt) for mni in range_constexpr(nPairs)]
         for J in range_constexpr(numAccN):
             mni, in_b = J // 2, J % 2


### PR DESCRIPTION
# fix(mega_moe): correct GEMM2 A-scale indexing for BM=16

**Base branch: `mega_moe_v1`** (not `main`) — this is a fix on top of #876, rebased onto its current
head `e092035d`.

## Summary

`gemm2_compute_v2` mis-indexes the e8m0 activation scales whenever `BM < 32`, so **every `BM=16`
config computes wrong results**: relL2 `9.33e-1` against the oracle, with a large fraction of output
rows exactly zero. This is a 9-insertion / 3-deletion fix to `kernels/mega_moe/gemm2.py`.

`BM >= 32` codegen is unchanged — every edit is either guarded by `is_bm16` or reduces to the
previous `else` branch when `is_bm16` is false.

## Root cause

The incorrect assumption is stated in the original comment:

> `BM16: single 16-row block owning a 32-row scale chunk (chunk==m_block_idx, rg0-only).`

A 16-row block is **one row-group of a shared 32-row scale chunk**, not the owner of a whole chunk.
Three consequences:

1. `scale_chunk0 = m_block_idx` indexes *chunks* with a *block* counter. Once `m_block_idx` reaches
   the padded upper half it addresses past the region stage 1 actually wrote, reads back zeros, and
   zeroes those output rows. It must be `m_row // 32` for every `BM`.
2. Bytes within one e8m0 word are ordered `[k0/rg0, k0/rg1, k1/rg0, k1/rg1]`, and `opsel_a` can only
   select `rg0`. Odd 16-row blocks must therefore shift the word down one byte (`shrui` by 8) to
   reach their `rg1` scales.
3. `asc_per_mb` assumes a full 32-row chunk per block. A `BM=16` block covers half of one, so its
   per-block scale byte count halves.

## The change

- `scale_chunk0 = m_row // 32` unconditionally, replacing the `m_block_idx` special case.
- New `a_rg_shift = ((m_row // 16) & 1) * 8`, applied to the A-scale words via `shrui` in
  `mfma_cluster` so odd 16-row blocks land on their `rg1` scales.
- `asc_per_mb` multiplier becomes `2 if is_bm16 else 4`.
- Corrected the misleading comment that encoded the wrong ownership model.

## Why this is not a corner case

The autotuner legitimately selects `BM=16` for stage 2 in production. A DeepSeek-R1 decode profile on
8×MI355X (gfx950, EP8 + DP8, a8w4) selected exactly `megamoe_stage2_t16x256x256_sbm32_fp8_...` — the
`BM=16, SBM=32` variant this patch repairs — and kept selecting it across decode batch sizes from 61
to 966 tokens/rank. Any consumer that lets the autotuner choose freely will hit this.

## Validation

`tests/kernels/test_mega_moe_v2.py` on gfx950:

| Configuration | Before | After |
|---|---|---|
| `BM=16` (r1_v3, v4_flash; topk=1 and topk=8) | `9.33e-1` FAIL | `4.68e-2` PASS |
| `BM=32 / 64 / 128` | pass | unchanged |
| stage1-only path | `2.66e-2` | `2.66e-2` unchanged |

The unchanged stage1-only number confirms the change is isolated to stage 2.

## Reproducing — please read before re-testing

**Clear the FlyDSL kernel cache or set `FLYDSL_RUNTIME_ENABLE_CACHE=0`.**

```bash
export FLYDSL_RUNTIME_ENABLE_CACHE=0   # or: rm -rf ~/.flydsl/cache
python -m pytest tests/kernels/test_mega_moe_v2.py