### PR TITLE
Feat: Add flydsl-lsp-server for FlyDSL .mlir editor support.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -69,6 +69,7 @@ Build the Fly C++ dialect, compiler passes, and embedded Python bindings:
 After a successful build you will have:
 
 - ``build-fly/bin/fly-opt`` -- the Fly optimization tool
+- ``build-fly/bin/flydsl-lsp-server`` -- MLIR Language Server for FlyDSL ``.mlir``
 - ``build-fly/python_packages/flydsl/`` -- Python package root containing:
 
   - ``flydsl/`` -- Python DSL API (sources from ``python/flydsl/``)

--- a/docs/testing_benchmarking_guide.md
+++ b/docs/testing_benchmarking_guide.md
@@ -46,6 +46,16 @@ cmake --build build-fly --target fly-opt -j$(nproc)
 build-fly/bin/fly-opt --fly-canonicalize tests/mlir/LayoutAlgebra/construction.mlir
 ```
 
+**Editor support (MLIR LSP):** `build-fly/bin/flydsl-lsp-server` is a thin
+`MlirLspServerMain` wrapper with Fly (+ backend) dialects registered. Point the
+editor's MLIR LSP client / `mlir-lsp-server` path at that binary for `.mlir`
+diagnostics, hover, go-to-definition, and completion. It is not a Python DSL /
+kernel language server.
+
+```bash
+cmake --build build-fly --target flydsl-lsp-server -j$(nproc)
+```
+
 ### 1.2 Python Tests (`tests/python/`)
 
 Python-based tests including AOT pre-compilation examples.

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(fly-opt)
+add_subdirectory(flydsl-lsp-server)

--- a/tools/flydsl-lsp-server/CMakeLists.txt
+++ b/tools/flydsl-lsp-server/CMakeLists.txt
@@ -1,0 +1,17 @@
+get_property(_backend_opt_libs GLOBAL PROPERTY FLYDSL_BACKEND_FLYOPT_LINK_LIBS)
+
+set(LIBS
+  MLIRFlyDialect
+  ${_backend_opt_libs}
+  MLIRLspServerLib
+  MLIRRegisterAllDialects
+  MLIRRegisterAllExtensions
+)
+
+add_llvm_tool(flydsl-lsp-server
+  flydsl-lsp-server.cpp
+)
+
+target_link_libraries(flydsl-lsp-server PRIVATE ${LIBS})
+llvm_map_components_to_libnames(llvm_libs Support)
+target_link_libraries(flydsl-lsp-server PRIVATE ${llvm_libs})

--- a/tools/flydsl-lsp-server/flydsl-lsp-server.cpp
+++ b/tools/flydsl-lsp-server/flydsl-lsp-server.cpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 FlyDSL Project Contributors
+//
+// FlyDSL MLIR Language Server entry point.
+//
+// Provides editor support (diagnostics, hover, go-to-definition, completion)
+// for FlyDSL `.mlir` files (e.g. tests/mlir and IR dumps) via upstream
+// MlirLspServerMain. This is not a Python DSL / kernel language server.
+//
+// Point the editor's MLIR LSP client at:
+//   build-fly/bin/flydsl-lsp-server
+
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/InitAllExtensions.h"
+#include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
+
+#include "mlir-c/IR.h"
+#include "mlir/CAPI/IR.h"
+
+#include "flydsl/Backend/Backend.h"
+#include "flydsl/Dialect/Fly/IR/FlyDialect.h"
+
+// Forward-declare per-backend CAPI dialect registration.
+// FLYDSL_BACKEND_COUNT and FLYDSL_BACKEND_0..N-1 are set by CMake.
+#define DECLARE_BACKEND(name)                                                                      \
+  extern "C" void flydsl_register_##name##_dialects(MlirDialectRegistry);
+FLYDSL_FOR_EACH_BACKEND(DECLARE_BACKEND)
+
+#define REGISTER_BACKEND_DIALECTS(name) flydsl_register_##name##_dialects(wrap(&registry));
+
+int main(int argc, char **argv) {
+  mlir::DialectRegistry registry;
+  mlir::registerAllDialects(registry);
+  mlir::registerAllExtensions(registry);
+  registry.insert<mlir::fly::FlyDialect>();
+  FLYDSL_FOR_EACH_BACKEND(REGISTER_BACKEND_DIALECTS)
+
+  return mlir::failed(mlir::MlirLspServerMain(argc, argv, registry));
+}


### PR DESCRIPTION
Thin MlirLspServerMain wrapper that registers Fly + backend dialects.
