### PR TITLE
split fly-canonicalize into form canonicalize + fly-fold-static

### DIFF
--- a/.claude/skills/add-target-atom-op/SKILL.md
+++ b/.claude/skills/add-target-atom-op/SKILL.md
@@ -375,7 +375,7 @@ wrapper like `MFMA_CDNA5(m, n, k, elem, ...)` in `python/flydsl/expr/rocdl/unive
 
 ```mlir
 // RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize \
-// RUN:   --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
+// RUN:   --fly-fold-static --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
 // CHECK: rocdl.mfma.f32.16x16x32f16
 ```
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ Python Function (@flyc.kernel / @flyc.jit)
    ┌──────────────────────────────────────────────────────────┐
    │ A. pre_binary_fragments  (Fly → ROCDL)                   │
    │    fly-rewrite-func-signature → fly-canonicalize →       │
-   │    fly-layout-lowering → fly-int-swizzle-simplify →      │
+   │    fly-fold-static → fly-layout-lowering →               │
+   │    fly-int-swizzle-simplify →                            │
    │    canonicalize → fly-convert-atom-call-to-ssa-form →    │
    │    fly-promote-regmem-to-vectorssa →                     │
    │    convert-fly-to-rocdl → canonicalize →                 │

--- a/docs/api/compiler.rst
+++ b/docs/api/compiler.rst
@@ -52,6 +52,7 @@ On first call, ``@flyc.jit`` runs the following pipeline:
 
       - ``fly-rewrite-func-signature``
       - ``fly-canonicalize``
+      - ``fly-fold-static``
       - ``fly-layout-lowering``
       - ``fly-int-swizzle-simplify``
       - ``canonicalize``
@@ -116,5 +117,6 @@ The ``fly-opt`` tool is a command-line interface for running MLIR passes on
 .. code-block:: bash
 
    fly-opt --fly-canonicalize input.mlir
+   fly-opt --fly-fold-static input.mlir
    fly-opt --fly-layout-lowering input.mlir
    fly-opt --help

--- a/docs/architecture_guide.md
+++ b/docs/architecture_guide.md
@@ -170,6 +170,7 @@ Python Function (@flyc.kernel / @flyc.jit)
    │ Stage A — pre_binary_fragments  (Fly → ROCDL)          │
    │   fly-rewrite-func-signature                           │
    │   fly-canonicalize                                     │
+   │   fly-fold-static                                      │
    │   fly-layout-lowering                                  │
    │   fly-int-swizzle-simplify                             │
    │   canonicalize                                         │
@@ -215,28 +216,29 @@ external LLVM toolchain only for Stage C (`gpu-module-to-binary`).
 | # | Pass | Description |
 |---|---|---|
 | 1 | `fly-rewrite-func-signature` | Rewrite DSL types at function and SCF control-flow boundaries; lowers `IntTuple` / `Layout` / `ComposedLayout` / `CoordTensor` / `MemRef` to packed LLVM struct types and reconstructs them in the body via constructor ops. |
-| 2 | `fly-canonicalize` | FlyDSL-specific canonicalization (folds `!fly.layout` algebra when shapes are static). |
-| 3 | `fly-layout-lowering` | Lowers layout algebra (`fly.crd2idx`, partitions, divides) to concrete `arith` + `vector` ops. |
-| 4 | `fly-int-swizzle-simplify` | Algebraically simplifies the swizzle-shaped arith sequences emitted by `applySwizzle`. |
-| 5 | `canonicalize` | Standard MLIR canonicalization (constant folding, etc.). |
-| 6 | `fly-convert-atom-call-to-ssa-form` | Converts `copy_atom_call` / `mma_atom_call` to their SSA counterparts; promotes register tensors to vector SSA values. |
-| 7 | `fly-promote-regmem-to-vectorssa` | Promotes `fly.make_ptr(register)` memory semantics to vector SSA values (requires #6). |
-| 8 | `convert-fly-to-rocdl` | Lowers remaining Fly ops to MLIR upstream + ROCDL dialects (copy atoms → `rocdl.buffer_load/store`, or gfx1250 TDM → `rocdl.tensor.load.to.lds` / `store.from.lds`; MMA atoms → `rocdl.mfma.*` on CDNA, `rocdl.wmma.*` on gfx11/gfx1250). |
-| 9 | `canonicalize` | Second canonicalization round after ROCDL lowering. |
-| 10 | `gpu.module(convert-scf-to-cf, cse, convert-gpu-to-rocdl{chipset=gfxNNN ...}, fly-rocdl-cluster-attr)` | Inside the GPU module: SCF→CF, CSE, GPU intrinsics→ROCDL, then `fly-rocdl-cluster-attr` injects `amdgpu-cluster-dims` into the `llvm.func` `passthrough`. |
+| 2 | `fly-canonicalize` | Normalizes `fly.make_shape`, `fly.make_stride`, and `fly.make_coord` constructors to `fly.make_int_tuple`. |
+| 3 | `fly-fold-static` | Rebuilds fully static Fly operation results using each type's existing materialization strategy. |
+| 4 | `fly-layout-lowering` | Lowers layout algebra (`fly.crd2idx`, partitions, divides) to concrete `arith` + `vector` ops. |
+| 5 | `fly-int-swizzle-simplify` | Algebraically simplifies the swizzle-shaped arith sequences emitted by `applySwizzle`. |
+| 6 | `canonicalize` | Standard MLIR canonicalization (constant folding, etc.). |
+| 7 | `fly-convert-atom-call-to-ssa-form` | Converts `copy_atom_call` / `mma_atom_call` to their SSA counterparts; promotes register tensors to vector SSA values. |
+| 8 | `fly-promote-regmem-to-vectorssa` | Promotes `fly.make_ptr(register)` memory semantics to vector SSA values (requires #7). |
+| 9 | `convert-fly-to-rocdl` | Lowers remaining Fly ops to MLIR upstream + ROCDL dialects (copy atoms → `rocdl.buffer_load/store`, or gfx1250 TDM → `rocdl.tensor.load.to.lds` / `store.from.lds`; MMA atoms → `rocdl.mfma.*` on CDNA, `rocdl.wmma.*` on gfx11/gfx1250). |
+| 10 | `canonicalize` | Second canonicalization round after ROCDL lowering. |
+| 11 | `gpu.module(convert-scf-to-cf, cse, convert-gpu-to-rocdl{chipset=gfxNNN ...}, fly-rocdl-cluster-attr)` | Inside the GPU module: SCF→CF, CSE, GPU intrinsics→ROCDL, then `fly-rocdl-cluster-attr` injects `amdgpu-cluster-dims` into the `llvm.func` `passthrough`. |
 
 **Stage B — `binary_prep_fragments`** (LLVM lowering, host + kernel)
 
 | # | Pass | Description |
 |---|---|---|
-| 11 | `rocdl-attach-target{chip=gfxNNN ...}` | Attaches `#rocdl.target<chip=gfxNNN>` (plus `fast`/`unsafe-math`/`wave64` options) to the GPU module for codegen. |
-| 12 | `convert-scf-to-cf` | Host-side SCF → ControlFlow. |
-| 13 | `convert-cf-to-llvm` | ControlFlow → LLVM dialect. |
-| 14 | `gpu-to-llvm{use-bare-pointers-for-host=true use-bare-pointers-for-kernels=true}` | GPU types and host launcher → LLVM. |
-| 15 | `convert-vector-to-llvm` | Vector → LLVM. |
-| 16 | `convert-arith-to-llvm` | Arith → LLVM. |
-| 17 | `convert-func-to-llvm` | Func → LLVM. |
-| 18 | `reconcile-unrealized-casts` | Final cast cleanup. |
+| 12 | `rocdl-attach-target{chip=gfxNNN ...}` | Attaches `#rocdl.target<chip=gfxNNN>` (plus `fast`/`unsafe-math`/`wave64` options) to the GPU module for codegen. |
+| 13 | `convert-scf-to-cf` | Host-side SCF → ControlFlow. |
+| 14 | `convert-cf-to-llvm` | ControlFlow → LLVM dialect. |
+| 15 | `gpu-to-llvm{use-bare-pointers-for-host=true use-bare-pointers-for-kernels=true}` | GPU types and host launcher → LLVM. |
+| 16 | `convert-vector-to-llvm` | Vector → LLVM. |
+| 17 | `convert-arith-to-llvm` | Arith → LLVM. |
+| 18 | `convert-func-to-llvm` | Func → LLVM. |
+| 19 | `reconcile-unrealized-casts` | Final cast cleanup. |
 
 When `FLYDSL_DEBUG_ENABLE_DEBUG_INFO=1`, Stage B appends
 `ensure-debug-info-scope-on-llvm-func{emission-kind=LineTablesOnly}` after
@@ -246,7 +248,7 @@ When `FLYDSL_DEBUG_ENABLE_DEBUG_INFO=1`, Stage B appends
 
 | # | Pass | Description |
 |---|---|---|
-| 19 | `gpu-module-to-binary{format=fatbin opts="..."}` | Invokes the LLVM AMDGPU backend and emits an HSA fatbin. |
+| 20 | `gpu-module-to-binary{format=fatbin opts="..."}` | Invokes the LLVM AMDGPU backend and emits an HSA fatbin. |
 
 `gpu-kernel-outlining` is no longer a pass in the runtime pipeline — kernel
 outlining happens during Python tracing, when `@flyc.kernel` emits

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -111,7 +111,8 @@ then compiles it through the Fly MLIR pipeline. The pass list is built by
       ┌──────────────────────────────────────────────────────────┐
       │ A. pre_binary_fragments  (Fly → ROCDL)                   │
       │    fly-rewrite-func-signature → fly-canonicalize →       │
-      │    fly-layout-lowering → fly-int-swizzle-simplify →      │
+      │    fly-fold-static → fly-layout-lowering →               │
+      │    fly-int-swizzle-simplify →                            │
       │    canonicalize → fly-convert-atom-call-to-ssa-form →    │
       │    fly-promote-regmem-to-vectorssa →                     │
       │    convert-fly-to-rocdl → canonicalize →                 │

--- a/docs/testing_benchmarking_guide.md
+++ b/docs/testing_benchmarking_guide.md
@@ -35,7 +35,7 @@ MLIR-based tests organized by category, verified using the `fly-opt` tool. Valid
 |---|---|---|
 | `LayoutAlgebra/` | `coalesce.mlir`, `composition.mlir`, `construction.mlir`, `coordinate.mlir`, `divide.mlir`, `int_tuple.mlir`, `product.mlir`, `size_cosize.mlir` | Layout algebra operations |
 | `Conversion/` | `gpu_ops.mlir`, `memref_alloca.mlir`, `memref_ops.mlir`, `mma_atom.mlir`, `pointer_ops.mlir`, `type_conversion.mlir` | Dialect conversion passes |
-| `Transforms/` | `canonicalize.mlir`, `layout_lowering.mlir` | Transformation passes |
+| `Transforms/` | `canonicalize.mlir`, `fold_static.mlir`, `layout_lowering.mlir` | Transformation passes |
 
 **Running individually:**
 ```bash

--- a/include/flydsl/Dialect/Fly/Transforms/Passes.td
+++ b/include/flydsl/Dialect/Fly/Transforms/Passes.td
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2025 FlyDSL Project Contributors
+// Copyright (c) 2026 FlyDSL Project Contributors
 
 #ifndef FLY_PASSES
 #define FLY_PASSES
@@ -35,9 +35,18 @@ def FlyRewriteFuncSignaturePass : Pass<"fly-rewrite-func-signature"> {
 }
 
 def FlyCanonicalizePass : Pass<"fly-canonicalize"> {
-  let summary = "Canonicalize Pattern";
+  let summary = "Canonicalize Fly constructors to int-tuple form";
   let description = [{
-    Canonicalize Fly operations.
+    Rewrites `fly.make_shape`, `fly.make_stride`, and `fly.make_coord`
+    constructors to the canonical `fly.make_int_tuple` form.
+  }];
+}
+
+def FlyFoldStaticPass : Pass<"fly-fold-static"> {
+  let summary = "Rebuild statically known Fly operation results";
+  let description = [{
+    Rebuilds operation results whose Fly types are fully static using the
+    type-specific materialization provided by `MayStaticTypeInterface`.
   }];
 }
 

--- a/lib/Dialect/Fly/CMakeLists.txt
+++ b/lib/Dialect/Fly/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_dialect_library(MLIRFlyDialect
   Utils/PointerUtils.cpp
   Transforms/LayoutLowering.cpp
   Transforms/Canonicalize.cpp
+  Transforms/FoldStatic.cpp
   Transforms/RewriteFuncSignature.cpp
   Transforms/ConvertAtomCallToSSAForm.cpp
   Transforms/PromoteRegMemToVectorSSA.cpp

--- a/lib/Dialect/Fly/Transforms/Canonicalize.cpp
+++ b/lib/Dialect/Fly/Transforms/Canonicalize.cpp
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2025 FlyDSL Project Contributors
+// Copyright (c) 2026 FlyDSL Project Contributors
 
-#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/IR/SymbolTable.h"
-#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -35,29 +32,6 @@ class RewriteToMakeIntTuple final : public OpRewritePattern<IntTupleLikeOp> {
   }
 };
 
-class RebuildStaticValue : public RewritePattern {
-public:
-  RebuildStaticValue(MLIRContext *context, PatternBenefit benefit = 1)
-      : RewritePattern(MatchAnyOpTypeTag(), benefit, context) {}
-
-  LogicalResult matchAndRewrite(Operation *op, PatternRewriter &rewriter) const override {
-    if (op->getNumResults() != 1)
-      return failure();
-    Type resultType = op->getResult(0).getType();
-
-    auto mayStatic = dyn_cast<MayStaticTypeInterface>(resultType);
-    if (!mayStatic || !mayStatic.isStatic())
-      return failure();
-
-    Value rebuild = mayStatic.rebuildStaticValue(rewriter, op->getLoc(), op->getResult(0));
-    if (!rebuild)
-      return failure();
-
-    rewriter.replaceOp(op, rebuild);
-    return success();
-  }
-};
-
 class FlyCanonicalizePass : public mlir::fly::impl::FlyCanonicalizePassBase<FlyCanonicalizePass> {
 public:
   using mlir::fly::impl::FlyCanonicalizePassBase<FlyCanonicalizePass>::FlyCanonicalizePassBase;
@@ -68,7 +42,6 @@ public:
 
     patterns.add<RewriteToMakeIntTuple<MakeShapeOp>, RewriteToMakeIntTuple<MakeStrideOp>,
                  RewriteToMakeIntTuple<MakeCoordOp>>(context);
-    patterns.add<RebuildStaticValue>(context);
 
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
       signalPassFailure();

--- a/lib/Dialect/Fly/Transforms/FoldStatic.cpp
+++ b/lib/Dialect/Fly/Transforms/FoldStatic.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 FlyDSL Project Contributors
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "flydsl/Dialect/Fly/IR/FlyDialect.h"
+#include "flydsl/Dialect/Fly/Transforms/Passes.h"
+
+using namespace mlir;
+using namespace mlir::fly;
+
+namespace mlir {
+namespace fly {
+#define GEN_PASS_DEF_FLYFOLDSTATICPASS
+#include "flydsl/Dialect/Fly/Transforms/Passes.h.inc"
+} // namespace fly
+} // namespace mlir
+
+namespace {
+
+class RebuildStaticValue : public RewritePattern {
+public:
+  RebuildStaticValue(MLIRContext *context, PatternBenefit benefit = 1)
+      : RewritePattern(MatchAnyOpTypeTag(), benefit, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op, PatternRewriter &rewriter) const override {
+    if (op->getNumResults() != 1)
+      return failure();
+    Type resultType = op->getResult(0).getType();
+
+    auto mayStatic = dyn_cast<MayStaticTypeInterface>(resultType);
+    if (!mayStatic || !mayStatic.isStatic())
+      return failure();
+
+    Value rebuild = mayStatic.rebuildStaticValue(rewriter, op->getLoc(), op->getResult(0));
+    if (!rebuild)
+      return failure();
+
+    rewriter.replaceOp(op, rebuild);
+    return success();
+  }
+};
+
+class FlyFoldStaticPass : public mlir::fly::impl::FlyFoldStaticPassBase<FlyFoldStaticPass> {
+public:
+  using mlir::fly::impl::FlyFoldStaticPassBase<FlyFoldStaticPass>::FlyFoldStaticPassBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+
+    patterns.add<RebuildStaticValue>(context);
+
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace

--- a/python/flydsl/compiler/backends/rocm.py
+++ b/python/flydsl/compiler/backends/rocm.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2025 FlyDSL Project Contributors
+# Copyright (c) 2026 FlyDSL Project Contributors
 
 from typing import List, Tuple
 
@@ -80,6 +80,7 @@ class RocmBackend(BaseBackend):
         pre_binary_fragments = [
             "fly-rewrite-func-signature",
             "fly-canonicalize",
+            "fly-fold-static",
             "fly-layout-lowering",
             "fly-int-swizzle-simplify",
             "canonicalize",

--- a/tests/mlir/Conversion/buffer_copy_lds.mlir
+++ b/tests/mlir/Conversion/buffer_copy_lds.mlir
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2025 FlyDSL Project Contributors
-// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
-// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl --convert-arith-to-llvm --canonicalize | FileCheck %s --check-prefix=LLVM
+// Copyright (c) 2026 FlyDSL Project Contributors
+// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-fold-static --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
+// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-fold-static --fly-layout-lowering --convert-fly-to-rocdl --convert-arith-to-llvm --canonicalize | FileCheck %s --check-prefix=LLVM
 
 // BufferCopyLDS (buffer_desc -> shared) lowering tests
 

--- a/tests/mlir/Conversion/copy_atom_stateful.mlir
+++ b/tests/mlir/Conversion/copy_atom_stateful.mlir
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2025 FlyDSL Project Contributors
-// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
+// Copyright (c) 2026 FlyDSL Project Contributors
+// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-fold-static --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
 
 // Stateful CopyAtom lowering tests
 

--- a/tests/mlir/Conversion/memref_ops.mlir
+++ b/tests/mlir/Conversion/memref_ops.mlir
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2025 FlyDSL Project Contributors
-// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
+// Copyright (c) 2026 FlyDSL Project Contributors
+// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-fold-static --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
 
 // MemRef load/store lowering tests:
 //   - Scalar: fly.memref.load/store -> llvm.getelementptr + llvm.load/store

--- a/tests/mlir/Conversion/mma_atom.mlir
+++ b/tests/mlir/Conversion/mma_atom.mlir
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2025 FlyDSL Project Contributors
-// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
+// Copyright (c) 2026 FlyDSL Project Contributors
+// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-fold-static --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
 
 // MMA atom call lowering tests:
 //   fly.mma_atom_call -> rocdl.mfma intrinsic

--- a/tests/mlir/Conversion/mma_atom_stateful.mlir
+++ b/tests/mlir/Conversion/mma_atom_stateful.mlir
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2025 FlyDSL Project Contributors
-// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
+// Copyright (c) 2026 FlyDSL Project Contributors
+// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-fold-static --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
 
 // Stateful MmaAtom lowering tests (CDNA4 MFMA_Scale).
 //   fly.make_mma_atom   -> default (0, 0) state

--- a/tests/mlir/Conversion/mma_scale_gfx1250.mlir
+++ b/tests/mlir/Conversion/mma_scale_gfx1250.mlir
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2025 FlyDSL Project Contributors
-// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
+// Copyright (c) 2026 FlyDSL Project Contributors
+// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-fold-static --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
 
 // gfx1250 MX-scaled WMMA atom lowering (E8M0 block scale, V_WMMA_SCALE).
 //   fly.make_mma_atom  -> default (0, 0) scale state (!llvm.struct<(i32, i32)>)

--- a/tests/mlir/Conversion/wmma_gfx11.mlir
+++ b/tests/mlir/Conversion/wmma_gfx11.mlir
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 FlyDSL Project Contributors
-// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
+// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-fold-static --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
 
 // GFX11 (RDNA3 / RDNA3.5) WMMA wave32 atom lowering tests:
 //   fly.mma_atom_call -> rocdl.wmma.f32.16x16x16.bf16 intrinsic

--- a/tests/mlir/Conversion/wmma_gfx120x.mlir
+++ b/tests/mlir/Conversion/wmma_gfx120x.mlir
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 FlyDSL Project Contributors
-// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
+// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-fold-static --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
 
 // GFX120X (RDNA4: gfx1200 / gfx1201) WMMA wave32 atom lowering tests:
 //   fly.mma_atom_call -> rocdl.wmma.f32.16x16x16.{f16,bf16} intrinsic

--- a/tests/mlir/Conversion/wmma_gfx1250.mlir
+++ b/tests/mlir/Conversion/wmma_gfx1250.mlir
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 FlyDSL Project Contributors
-// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
+// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-fold-static --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
 
 // gfx1250 plain WMMA atom lowering for the int4 (iu4) config:
 //   16x16x32, (i4, i4) -> i32  =>  rocdl.wmma.i32.16x16x32.iu4

--- a/tests/mlir/Transforms/canonicalize.mlir
+++ b/tests/mlir/Transforms/canonicalize.mlir
@@ -1,56 +1,31 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2025 FlyDSL Project Contributors
+// Copyright (c) 2026 FlyDSL Project Contributors
 // RUN: %fly-opt %s --fly-canonicalize | FileCheck %s
 
-// Tests for fly-canonicalize pass:
-//   - Static argument folding (fly.static -> fly.make_int_tuple)
-//   - Constant propagation through layout construction
+// Tests for fly-canonicalize constructor normalization.
 
 // -----
 
-// CHECK-LABEL: @test_static_to_make_int_tuple
-func.func @test_static_to_make_int_tuple() -> !fly.int_tuple<(4, 8)> {
-  // fly-canonicalize folds fly.static into fly.make_int_tuple with no dynamic args
-  %0 = fly.static {elems = [4 : i32, 8 : i32]} : !fly.int_tuple<(4, 8)>
-  // CHECK: fly.make_int_tuple() : () -> !fly.int_tuple<(4,8)>
-  return %0 : !fly.int_tuple<(4, 8)>
+// CHECK-LABEL: @test_make_shape
+func.func @test_make_shape(%m: i32, %n: i32) -> !fly.int_tuple<(?, ?)> {
+  // CHECK: fly.make_int_tuple(%{{.*}}, %{{.*}}) : (i32, i32) -> !fly.int_tuple<(?,?)>
+  // CHECK-NOT: fly.make_shape
+  %0 = fly.make_shape(%m, %n) : (i32, i32) -> !fly.int_tuple<(?, ?)>
+  return %0 : !fly.int_tuple<(?, ?)>
 }
 
-// CHECK-LABEL: @test_make_layout_canonicalized
-func.func @test_make_layout_canonicalized() -> !fly.layout<(4, 8) : (1, 4)> {
-  %s = fly.static {elems = [4 : i32, 8 : i32]} : !fly.int_tuple<(4, 8)>
-  %d = fly.static {elems = [1 : i32, 4 : i32]} : !fly.int_tuple<(1, 4)>
-  %layout = fly.make_layout(%s, %d) : (!fly.int_tuple<(4, 8)>, !fly.int_tuple<(1, 4)>) -> !fly.layout<(4, 8) : (1, 4)>
-  // CHECK: fly.make_int_tuple
-  // CHECK: fly.make_layout
-  // CHECK: return
-  return %layout : !fly.layout<(4, 8) : (1, 4)>
+// CHECK-LABEL: @test_make_stride
+func.func @test_make_stride(%s0: i32, %s1: i32) -> !fly.int_tuple<(?, ?)> {
+  // CHECK: fly.make_int_tuple(%{{.*}}, %{{.*}}) : (i32, i32) -> !fly.int_tuple<(?,?)>
+  // CHECK-NOT: fly.make_stride
+  %0 = fly.make_stride(%s0, %s1) : (i32, i32) -> !fly.int_tuple<(?, ?)>
+  return %0 : !fly.int_tuple<(?, ?)>
 }
 
-// CHECK-LABEL: @test_3d_static_canonicalized
-func.func @test_3d_static_canonicalized() -> !fly.int_tuple<(2, 4, 8)> {
-  %0 = fly.static {elems = [2 : i32, 4 : i32, 8 : i32]} : !fly.int_tuple<(2, 4, 8)>
-  // CHECK: fly.make_int_tuple() : () -> !fly.int_tuple<(2,4,8)>
-  return %0 : !fly.int_tuple<(2, 4, 8)>
-}
-
-// CHECK-LABEL: @test_size_static
-func.func @test_size_static() -> !fly.int_tuple<32> {
-  %s = fly.static {elems = [4 : i32, 8 : i32]} : !fly.int_tuple<(4, 8)>
-  %size = fly.size(%s) : (!fly.int_tuple<(4, 8)>) -> !fly.int_tuple<32>
-  // CHECK: return
-  return %size : !fly.int_tuple<32>
-}
-
-// CHECK-LABEL: @test_composition_static
-func.func @test_composition_static() -> !fly.layout<(2, 4) : (1, 2)> {
-  %s1 = fly.static {elems = [4 : i32, 8 : i32]} : !fly.int_tuple<(4, 8)>
-  %d1 = fly.static {elems = [1 : i32, 4 : i32]} : !fly.int_tuple<(1, 4)>
-  %outer = fly.make_layout(%s1, %d1) : (!fly.int_tuple<(4, 8)>, !fly.int_tuple<(1, 4)>) -> !fly.layout<(4, 8) : (1, 4)>
-  %s2 = fly.static {elems = [2 : i32, 4 : i32]} : !fly.int_tuple<(2, 4)>
-  %d2 = fly.static {elems = [1 : i32, 2 : i32]} : !fly.int_tuple<(1, 2)>
-  %inner = fly.make_layout(%s2, %d2) : (!fly.int_tuple<(2, 4)>, !fly.int_tuple<(1, 2)>) -> !fly.layout<(2, 4) : (1, 2)>
-  %result = fly.composition(%outer, %inner) : (!fly.layout<(4, 8) : (1, 4)>, !fly.layout<(2, 4) : (1, 2)>) -> !fly.layout<(2, 4) : (1, 2)>
-  // CHECK: return
-  return %result : !fly.layout<(2, 4) : (1, 2)>
+// CHECK-LABEL: @test_make_coord
+func.func @test_make_coord(%c0: i32, %c1: i32) -> !fly.int_tuple<(?, ?)> {
+  // CHECK: fly.make_int_tuple(%{{.*}}, %{{.*}}) : (i32, i32) -> !fly.int_tuple<(?,?)>
+  // CHECK-NOT: fly.make_coord
+  %0 = fly.make_coord(%c0, %c1) : (i32, i32) -> !fly.int_tuple<(?, ?)>
+  return %0 : !fly.int_tuple<(?, ?)>
 }

--- a/tests/mlir/Transforms/fold_static.mlir
+++ b/tests/mlir/Transforms/fold_static.mlir
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 FlyDSL Project Contributors
+// RUN: %fly-opt %s --fly-fold-static | FileCheck %s
+
+// Tests for fly-fold-static pass:
+//   - Static argument folding (fly.static -> fly.make_int_tuple)
+//   - Constant propagation through layout construction
+
+// -----
+
+// CHECK-LABEL: @test_static_to_make_int_tuple
+func.func @test_static_to_make_int_tuple() -> !fly.int_tuple<(4, 8)> {
+  // fly-fold-static rebuilds fly.static as fly.make_int_tuple with no dynamic args
+  %0 = fly.static {elems = [4 : i32, 8 : i32]} : !fly.int_tuple<(4, 8)>
+  // CHECK: fly.make_int_tuple() : () -> !fly.int_tuple<(4,8)>
+  return %0 : !fly.int_tuple<(4, 8)>
+}
+
+// CHECK-LABEL: @test_make_layout_canonicalized
+func.func @test_make_layout_canonicalized() -> !fly.layout<(4, 8) : (1, 4)> {
+  %s = fly.static {elems = [4 : i32, 8 : i32]} : !fly.int_tuple<(4, 8)>
+  %d = fly.static {elems = [1 : i32, 4 : i32]} : !fly.int_tuple<(1, 4)>
+  %layout = fly.make_layout(%s, %d) : (!fly.int_tuple<(4, 8)>, !fly.int_tuple<(1, 4)>) -> !fly.layout<(4, 8) : (1, 4)>
+  // CHECK: fly.make_int_tuple
+  // CHECK: fly.make_layout
+  // CHECK: return
+  return %layout : !fly.layout<(4, 8) : (1, 4)>
+}
+
+// CHECK-LABEL: @test_3d_static_canonicalized
+func.func @test_3d_static_canonicalized() -> !fly.int_tuple<(2, 4, 8)> {
+  %0 = fly.static {elems = [2 : i32, 4 : i32, 8 : i32]} : !fly.int_tuple<(2, 4, 8)>
+  // CHECK: fly.make_int_tuple() : () -> !fly.int_tuple<(2,4,8)>
+  return %0 : !fly.int_tuple<(2, 4, 8)>
+}
+
+// CHECK-LABEL: @test_size_static
+func.func @test_size_static() -> !fly.int_tuple<32> {
+  %s = fly.static {elems = [4 : i32, 8 : i32]} : !fly.int_tuple<(4, 8)>
+  %size = fly.size(%s) : (!fly.int_tuple<(4, 8)>) -> !fly.int_tuple<32>
+  // CHECK: return
+  return %size : !fly.int_tuple<32>
+}
+
+// CHECK-LABEL: @test_composition_static
+func.func @test_composition_static() -> !fly.layout<(2, 4) : (1, 2)> {
+  %s1 = fly.static {elems = [4 : i32, 8 : i32]} : !fly.int_tuple<(4, 8)>
+  %d1 = fly.static {elems = [1 : i32, 4 : i32]} : !fly.int_tuple<(1, 4)>
+  %outer = fly.make_layout(%s1, %d1) : (!fly.int_tuple<(4, 8)>, !fly.int_tuple<(1, 4)>) -> !fly.layout<(4, 8) : (1, 4)>
+  %s2 = fly.static {elems = [2 : i32, 4 : i32]} : !fly.int_tuple<(2, 4)>
+  %d2 = fly.static {elems = [1 : i32, 2 : i32]} : !fly.int_tuple<(1, 2)>
+  %inner = fly.make_layout(%s2, %d2) : (!fly.int_tuple<(2, 4)>, !fly.int_tuple<(1, 2)>) -> !fly.layout<(2, 4) : (1, 2)>
+  %result = fly.composition(%outer, %inner) : (!fly.layout<(4, 8) : (1, 4)>, !fly.layout<(2, 4) : (1, 2)>) -> !fly.layout<(2, 4) : (1, 2)>
+  // CHECK: return
+  return %result : !fly.layout<(2, 4) : (1, 2)>
+}

--- a/tests/unit/test_layout_algebra.py
+++ b/tests/unit/test_layout_algebra.py
@@ -23,7 +23,8 @@ pytestmark = [pytest.mark.l1b_target_dialect, pytest.mark.rocm_lower]
 
 
 FLY_PIPELINE = (
-    "builtin.module(fly-canonicalize,fly-layout-lowering,fly-canonicalize,convert-fly-to-rocdl,canonicalize,cse)"
+    "builtin.module(fly-canonicalize,fly-fold-static,fly-layout-lowering,"
+    "fly-canonicalize,fly-fold-static,convert-fly-to-rocdl,canonicalize,cse)"
 )
 
 

--- a/tests/unit/test_static_vs_dynamic.py
+++ b/tests/unit/test_static_vs_dynamic.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2025 FlyDSL Project Contributors
+# Copyright (c) 2026 FlyDSL Project Contributors
 
 """Static vs dynamic layout types test (mirrors a reference notebook Cell 11).
 
@@ -27,7 +27,8 @@ pytestmark = [pytest.mark.l1b_target_dialect, pytest.mark.rocm_lower]
 
 
 FLY_PIPELINE = (
-    "builtin.module(fly-canonicalize,fly-layout-lowering,fly-canonicalize,convert-fly-to-rocdl,canonicalize,cse)"
+    "builtin.module(fly-canonicalize,fly-fold-static,fly-layout-lowering,"
+    "fly-canonicalize,fly-fold-static,convert-fly-to-rocdl,canonicalize,cse)"
 )
 
 


### PR DESCRIPTION
## Summary

Split `fly-canonicalize` into two conceptually independent passes:

1. `fly-canonicalize` — `MakeShape` / `MakeStride` / `MakeCoord` → `MakeIntTuple`
2. `fly-fold-static` — move `RebuildStaticValue` here (static rebuild / materialization)

This PR is **behavior-preserving**: relocate existing patterns, update the
pipeline and tests, and keep IR semantics equivalent.

Loosely inspired by CUTLASS keeping static folding as its own pass.

## Why

These are different jobs and should not share one pass name:

| Pattern | Job |
|---------|-----|
| `RewriteToMakeIntTuple` | Form normalize (can apply to dynamic values) |
| `RebuildStaticValue` | Rebuild only when the result type is fully static |

Splitting makes docs, FileCheck, and future static-fold enhancements clearer.

## Changes

- New `fly-fold-static`; `fly-canonicalize` only keeps Make*→IntTuple
- Pipeline order (same former `fly-canonicalize` slot):

```text
… -> fly-canonicalize -> fly-fold-static -> fly-layout-lowering -> …
```

  Form normalize first, then static fold.
- Move static FileCheck cases to `tests/mlir/Transforms/fold_static.mlir`
- Update ROCm backend pipeline, Conversion RUN lines, unit-test pipelines, and docs
- **Non-goals:** no DCE, no `equal`/`elem_less`->i1 folding, no materialization policy change

## Test plan

- [ ] `fly-opt` exposes `--fly-fold-static`
- [ ] `tests/mlir/Transforms/canonicalize.mlir`
- [ ] `tests/mlir/Transforms/fold_static.mlir`
- [ ] Affected `tests/mlir/Conversion/*.mlir` FileCheck
- [ ] `tests/unit/test_layout_algebra.py` / `test_static_vs_dynamic.py`