### PR TITLE
[gfx1250] Migrate gemm kernels to the stable DSL API

### DIFF
--- a/kernels/gemm/gemm_a8w4_mxscale_gfx1250.py
+++ b/kernels/gemm/gemm_a8w4_mxscale_gfx1250.py
@@ -5,8 +5,8 @@
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import const_expr, range_constexpr, rocdl, tdm_ops
-from flydsl.expr.rocdl import cluster
+from flydsl.expr import const_expr, range_constexpr, rocdl
+from flydsl.expr.rocdl import cluster, tdm_ops
 from flydsl.expr.typing import Constexpr, T
 from flydsl.expr.typing import Vector as Vec
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
@@ -116,10 +116,12 @@ def launch_gemm_a8w4_mxscale(
         mn_oob = i32_m - blk_m  # valid M rows (A / C)
         sa_oob = (i32_m + 31) // 32 - blk_m // 32  # valid M-supers (scale-A)
 
-        base_ptr = fx.SharedAllocator(static=False).allocate(ARENA_B)._ptr
+        arena = fx.SharedAllocator(static=False)
+        arena.allocate(ARENA_B)
+        base_ptr = arena.base_ptr
 
         def _bidx(p):
-            return fx.index_cast(T.index, fx.ptrtoint(p))
+            return fx.Int64(fx.ptrtoint(p))
 
         def _buf_ptr(s):
             return fx.add_offset(base_ptr, s * PITCH)
@@ -213,7 +215,7 @@ def launch_gemm_a8w4_mxscale(
 
         def load_a(buf, wm, ks):
             row = wmb + wm * 16 + lane16
-            b0 = fx.index_cast(T.index, row * A_LDS_ROW + ks * WMMA_K + kgrp * 16)
+            b0 = fx.Int64(row * A_LDS_ROW + ks * WMMA_K + kgrp * 16)
             v = [Vec(lds_load_b128(buf, b0 + 32 * j)) for j in range_constexpr(4)]
             v01 = v[0].shuffle(v[1], list(range(8)))
             v23 = v[2].shuffle(v[3], list(range(8)))
@@ -221,7 +223,7 @@ def launch_gemm_a8w4_mxscale(
 
         def load_b(buf, wn, ks):
             nbl = wnb // 16 + wn
-            b0 = fx.index_cast(T.index, STAGE_A + nbl * B_LDS_ROW + ks * 1024 + kgrp * 256 + lane16 * 16)
+            b0 = fx.Int64(STAGE_A + nbl * B_LDS_ROW + ks * 1024 + kgrp * 256 + lane16 * 16)
             v0 = Vec(lds_load_b128(buf, b0))
             v1 = Vec(lds_load_b128(buf, b0 + 512))
             return v0.shuffle(v1, list(range(8)))
@@ -229,19 +231,19 @@ def launch_gemm_a8w4_mxscale(
         def load_sa(buf, wm, ks):
             row = wmb + wm * 16 + lane16
             word = (row // 32) * SC_WORDS + ks * 32 + (row % 32)
-            return lds_load_b32(buf, fx.index_cast(T.index, SA_OFF + word * 4))[0]
+            return lds_load_b32(buf, fx.Int64(SA_OFF + word * 4))[0]
 
         def load_sb(buf, wn, ks):
             col = wnb + wn * 16 + lane16
             word = (col // 32) * SC_WORDS + ks * 32 + (col % 32)
-            return lds_load_b32(buf, fx.index_cast(T.index, SB_OFF + word * 4))[0]
+            return lds_load_b32(buf, fx.Int64(SB_OFF + word * 4))[0]
 
         wmma_atom = fx.make_mma_atom(
             fx.rocdl.WMMAScale(WMMA_M, WMMA_N, WMMA_K, fx.Float4E2M1FN, fx.Float8E4M3FN, fx.Float32)
         )
         c_frags = [fx.make_rmem_tensor(8, fx.Float32) for _ in range_constexpr(n_acc)]
         for cf in c_frags:
-            cf.store(fx.constant_vector(0.0, T.vec(8, T.f32)))
+            cf.store(Vec.filled(8, 0.0, fx.Float32))
 
         def _rmem(n, v):
             t = fx.make_rmem_tensor(n, fx.Int32)

--- a/kernels/gemm/gemm_a8w8_gfx1250.py
+++ b/kernels/gemm/gemm_a8w8_gfx1250.py
@@ -7,8 +7,8 @@ import math
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import const_expr, range_constexpr, rocdl, tdm_ops
-from flydsl.expr.rocdl import cluster
+from flydsl.expr import const_expr, range_constexpr, rocdl
+from flydsl.expr.rocdl import cluster, tdm_ops
 from flydsl.expr.typing import Constexpr, T
 from flydsl.expr.typing import Vector as Vec
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
@@ -128,10 +128,12 @@ def launch_gemm_a8w8(
             nb_oob = (i32_n // 128 - blk_n // 128) if not ALIGNED_N else None
             stride_ask64 = fx.Int64(i32_stride_ascale_k)
 
-        base_ptr = fx.SharedAllocator(static=False).allocate(ARENA_B)._ptr
+        arena = fx.SharedAllocator(static=False)
+        arena.allocate(ARENA_B)
+        base_ptr = arena.base_ptr
 
         def _bidx(p):
-            return fx.index_cast(T.index, fx.ptrtoint(p))
+            return fx.Int64(fx.ptrtoint(p))
 
         def _buf_ptr(s):
             return fx.add_offset(base_ptr, s * PITCH)
@@ -186,11 +188,11 @@ def launch_gemm_a8w8(
 
             W_SA, W_SB = 2 % num_waves, 3 % num_waves
             sa_off0 = blk_m64
-            sb_off0 = blk_n64 // 128 * (fx.Int64(i32_k) // 128)
+            sb_off0 = blk_n64 // 128 * (k64 // 128)
             gSA = _gv(arg_scale_a, sa_off0, (K_WS, tile_m), (tile_m, 1))
             atomSA = _tdm1(gSA, None, mn_oob, stride_ask64, a_mask)
             gSB = _gv(arg_scale_b, sb_off0, (N_BLOCKS, K_WS), (K_WS, 1))
-            atomSB = _tdm1(gSB, nb_oob, None, fx.Int64(i32_k) // 128, b_mask)
+            atomSB = _tdm1(gSB, nb_oob, None, k64 // 128, b_mask)
 
         def _wcopy(w, atom, gt, lv, imm_offset):
             if wave == w:
@@ -198,13 +200,13 @@ def launch_gemm_a8w8(
 
         def issue(s, kt):
             pa = _buf_ptr(s)
-            _wcopy(W_A, atomA, gA, _lv(pa, (tile_m, tile_k), (A_LDS_ROW, 1)), fx.Int64(kt) * fx.Int64(tile_k))
+            _wcopy(W_A, atomA, gA, _lv(pa, (tile_m, tile_k), (A_LDS_ROW, 1)), fx.Int64(kt) * tile_k)
             _wcopy(
                 W_B,
                 atomB,
                 gB,
                 _lv(fx.add_offset(pa, STAGE_A), (tile_n // 16, tile_k * 16), (B_LDS_ROW, 1)),
-                fx.Int64(kt) * fx.Int64(tile_k * 16),
+                fx.Int64(kt) * (tile_k * 16),
             )
             if const_expr(is_bsc):
                 _wcopy(
@@ -219,7 +221,7 @@ def launch_gemm_a8w8(
                     atomSB,
                     gSB,
                     _lv(fx.add_offset(pa, SB_OFF), (N_BLOCKS, K_WS), (K_WS, 1)),
-                    fx.Int64(kt) * fx.Int64(K_WS),
+                    fx.Int64(kt) * K_WS,
                 )
 
         wmb = wave_m * warp_tile_m
@@ -227,7 +229,7 @@ def launch_gemm_a8w8(
 
         def load_a(buf, wm, ks):
             row = wmb + wm * 16 + lane16
-            b0 = fx.index_cast(T.index, row * A_LDS_ROW + ks * WMMA_K + kgrp * 16)
+            b0 = fx.Int64(row * A_LDS_ROW + ks * WMMA_K + kgrp * 16)
             v = [Vec(lds_load_b128(buf, b0 + 32 * j)) for j in range_constexpr(4)]
             v01 = v[0].shuffle(v[1], list(range(8)))
             v23 = v[2].shuffle(v[3], list(range(8)))
@@ -235,7 +237,7 @@ def launch_gemm_a8w8(
 
         def load_b(buf, wn, ks):
             nbl = wnb // 16 + wn
-            b0 = fx.index_cast(T.index, STAGE_A + nbl * B_LDS_ROW + ks * 2048 + kgrp * 256 + lane16 * 16)
+            b0 = fx.Int64(STAGE_A + nbl * B_LDS_ROW + ks * 2048 + kgrp * 256 + lane16 * 16)
             v = [Vec(lds_load_b128(buf, b0 + 512 * j)) for j in range_constexpr(4)]
             v01 = v[0].shuffle(v[1], list(range(8)))
             v23 = v[2].shuffle(v[3], list(range(8)))
@@ -266,7 +268,7 @@ def launch_gemm_a8w8(
             wmma_atom = fx.make_mma_atom(fx.rocdl.WMMA(WMMA_M, WMMA_N, WMMA_K, fx.Float8E4M3FN, fx.Float32))
         c_frags = [fx.make_rmem_tensor(8, fx.Float32) for _ in range_constexpr(n_acc)]
         for cf in c_frags:
-            cf.store(fx.constant_vector(0.0, T.vec(8, T.f32)))
+            cf.store(Vec.filled(8, 0.0, fx.Float32))
 
         def _rmem(n, v):
             t = fx.make_rmem_tensor(n, fx.Int32)

--- a/kernels/gemm/gemm_a8w8_gfx1250.py
+++ b/kernels/gemm/gemm_a8w8_gfx1250.py
@@ -13,7 +13,6 @@ from flydsl.expr.typing import Constexpr, T
 from flydsl.expr.typing import Vector as Vec
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import check_smem_capacity
-from kernels.common import buffer_ops
 from kernels.common.gfx1250_cluster import compute_mcast_masks
 
 from .gemm_common_gfx1250 import (
@@ -25,11 +24,11 @@ from .gemm_common_gfx1250 import (
 
 @flyc.jit
 def launch_gemm_a8w8(
-    arg_c: fx.Tensor,
+    arg_c: fx.Pointer,
     arg_a: fx.Pointer,
     arg_b: fx.Pointer,
-    arg_scale_a: fx.Tensor,
-    arg_scale_b: fx.Tensor,
+    arg_scale_a: fx.Pointer,
+    arg_scale_b: fx.Pointer,
     i32_m: fx.Int32,
     stream: fx.Stream,
     N: fx.Int32,
@@ -48,11 +47,6 @@ def launch_gemm_a8w8(
     cluster_n: Constexpr[int],
     is_bsc: Constexpr[bool],
 ):
-    """PTPC (per-token/per-channel fp32 scale) when ``is_bsc`` is False, 128x128
-    E8M0 blockscale (per-K-tile scale, ``stride_ascale_k``-strided A-scale) when True.
-    """
-
-    num_waves = m_warp * n_warp
     use_cluster = cluster_m > 1 or cluster_n > 1
     WMMA_M = WMMA_N = 16
     WMMA_K = 128
@@ -63,6 +57,7 @@ def launch_gemm_a8w8(
     wmma_m_rep = warp_tile_m // WMMA_M
     wmma_n_rep = warp_tile_n // WMMA_N
     n_acc = wmma_m_rep * wmma_n_rep
+    num_waves = m_warp * n_warp
     block = num_waves * WAVE
 
     LDS_PAD_A = 16
@@ -84,22 +79,19 @@ def launch_gemm_a8w8(
     AB_PITCH = ((STAGE_A + STAGE_B + 1023) // 1024) * 1024
     BSC_PITCH = ((SB_OFF + STAGE_SB + 1023) // 1024) * 1024
     PITCH = BSC_PITCH if is_bsc else AB_PITCH
-
-    C_STORE_B = ((tile_m * tile_n * 2 + 127) // 128) * 128
+    out_cls = fx.Float16 if out_is_f16 else fx.BFloat16
+    C_STORE_B = (tile_m * tile_n * 2 + 127) // 128 * 128
     ARENA_B = max(num_buffers * PITCH, C_STORE_B)
     check_smem_capacity(ARENA_B, str(get_hip_arch()))
-
-    # Quadrant schedule needs an even A/B warp-rep split with enough accumulators
-    # to hide LDS-load-to-WMMA latency; row-major streaming is the safe fallback.
     use_quadrant = (wmma_m_rep % 2 == 0) and (wmma_n_rep % 2 == 0) and (n_acc >= 8)
 
     @flyc.kernel(known_block_size=[block, 1, 1])
     def kernel_gemm_a8w8(
-        arg_c: fx.Tensor,
+        arg_c: fx.Pointer,
         arg_a: fx.Pointer,
         arg_b: fx.Pointer,
-        arg_scale_a: fx.Tensor,
-        arg_scale_b: fx.Tensor,
+        arg_scale_a: fx.Pointer,
+        arg_scale_b: fx.Pointer,
         i32_m: fx.Int32,
         i32_n: fx.Int32,
         i32_k: fx.Int32,
@@ -154,11 +146,11 @@ def launch_gemm_a8w8(
 
         gA_base = fx.recast_iter(fx.Int8, arg_a)
         gB_base = fx.recast_iter(fx.Int8, arg_b)
+        gC_base = fx.recast_iter(fx.PointerType.get(out_cls.ir_type, arg_c.address_space), arg_c)
+        a_off0 = blk_m64 * lda64
+        b_off0 = blk_n64 // 16 * (k64 * 16)
 
         W_A, W_B = 0, 1
-        a_off0 = blk_m64 * lda64
-        b_off0 = (blk_n64 // 16) * (k64 * 16)
-
         gA = _gv(gA_base, a_off0, (tile_m, tile_k), (tile_k, 1))
         atomA = fx.atom_set_value(
             fx.rocdl.make_tdm_atom(
@@ -194,10 +186,10 @@ def launch_gemm_a8w8(
 
             W_SA, W_SB = 2 % num_waves, 3 % num_waves
             sa_off0 = blk_m64
-            sb_off0 = (blk_n64 // 128) * (fx.Int64(i32_k) // 128)
-            gSA = _gv(fx.get_iter(arg_scale_a), sa_off0, (K_WS, tile_m), (tile_m, 1))  # static placeholder layout
-            atomSA = _tdm1(gSA, None, mn_oob, stride_ask64, a_mask)  # real (runtime) stride
-            gSB = _gv(fx.get_iter(arg_scale_b), sb_off0, (N_BLOCKS, K_WS), (K_WS, 1))
+            sb_off0 = blk_n64 // 128 * (fx.Int64(i32_k) // 128)
+            gSA = _gv(arg_scale_a, sa_off0, (K_WS, tile_m), (tile_m, 1))
+            atomSA = _tdm1(gSA, None, mn_oob, stride_ask64, a_mask)
+            gSB = _gv(arg_scale_b, sb_off0, (N_BLOCKS, K_WS), (K_WS, 1))
             atomSB = _tdm1(gSB, nb_oob, None, fx.Int64(i32_k) // 128, b_mask)
 
         def _wcopy(w, atom, gt, lv, imm_offset):
@@ -250,7 +242,6 @@ def launch_gemm_a8w8(
             return v01.shuffle(v23, list(range(16)))
 
         def _bcast_byte(byte):
-            # WMMA_SCALE operand encoding wants the same scale byte in all 4 lanes.
             return byte.to(fx.Int32) * fx.Int32(0x01010101)
 
         def load_sa(pbuf, wm, ks):
@@ -288,8 +279,7 @@ def launch_gemm_a8w8(
             else:
                 fx.gemm(wmma_atom, c_frags[idx], wt, act, c_frags[idx])
 
-        DS_A = DS_B = 4  # ds_load_b128 reads per A/B fragment
-
+        DS_A = DS_B = 4
         front_wm = (wmma_m_rep + 1) // 2
         _FRONT = list(range(front_wm))
         _BACK = list(range(front_wm, wmma_m_rep))
@@ -387,10 +377,9 @@ def launch_gemm_a8w8(
                 nxt_ks = ks + 1 if const_expr(ks + 1 < K_WS) else None
                 pf = ks == 0 and prefetch_kt is not None
                 a_top = [_rmem(16, load_a(buf, wm, ks)) for wm in range_constexpr(HALF_M)]
-                # PTPC's own wait counts differ from BSC's (BSC has 2 extra scale
-                # loader waves contributing outstanding LDS traffic) - both sides
-                # must wait here, just for a different depth.
-                rocdl.s_wait_dscnt((DS_A * HALF_M + 2 * DS_B * HALF_N) if is_bsc else 0)
+
+                if const_expr(is_bsc):
+                    rocdl.s_wait_dscnt(DS_A * HALF_M + 2 * DS_B * HALF_N)
                 rocdl.sched_barrier(0)
                 _emit_block(0, 0, a_top, b_left, sa_k, sb_k)
                 if const_expr(pf and QUAD_PREFETCH_EARLY):
@@ -399,7 +388,8 @@ def launch_gemm_a8w8(
                     rocdl.sched_barrier(0)
                 a_bot = [_rmem(16, load_a(buf, HALF_M + wm, ks)) for wm in range_constexpr(HALF_M)]
                 b_right = _load_b_half(buf, HALF_N, ks)
-                rocdl.s_wait_dscnt((DS_A * HALF_M + DS_B * HALF_N) if is_bsc else (HALF_N * DS_B))
+                if const_expr(is_bsc):
+                    rocdl.s_wait_dscnt(DS_A * HALF_M + DS_B * HALF_N)
                 _emit_block(HALF_M, 0, a_bot, b_left, sa_k, sb_k)
                 if const_expr(pf and not QUAD_PREFETCH_EARLY):
                     rocdl.sched_barrier(0)
@@ -408,10 +398,8 @@ def launch_gemm_a8w8(
                 if const_expr(nxt_ks is not None):
                     nxt_b_left = _load_b_half(buf, 0, nxt_ks)
                     nxt_sb_k, nxt_sa_k = _load_scales(pbuf, nxt_ks)
-                if is_bsc:
+                if const_expr(is_bsc):
                     rocdl.s_wait_dscnt(DS_B * HALF_N if const_expr(nxt_ks is None) else _BS_DS)
-                else:
-                    rocdl.s_wait_dscnt(0 if const_expr(nxt_ks is None) else HALF_N * DS_B)
                 _emit_block(0, HALF_N, a_top, b_right, sa_k, sb_k)
                 if const_expr(is_bsc):
                     rocdl.s_wait_dscnt(0)
@@ -426,29 +414,52 @@ def launch_gemm_a8w8(
             else:
                 compute_ktile_row(buf, pbuf, prefetch_kt)
 
-        def epilogue_apply_ptpc_scale():
-            accs = [c_frags[idx].load().ir_value() for idx in range_constexpr(n_acc)]
-            sa_rsrc = buffer_ops.create_buffer_resource(
-                arg_scale_a, max_size=False, num_records_bytes=i32_m * fx.Int32(4)
+        def issue_ptpc_scale_loads():
+            gSA_base = fx.recast_iter(
+                fx.PointerType.get(fx.Float32.ir_type, arg_scale_a.address_space),
+                arg_scale_a,
             )
-            sb_rsrc = buffer_ops.create_buffer_resource(
-                arg_scale_b, max_size=False, num_records_bytes=i32_n * fx.Int32(4)
+            gSB_base = fx.recast_iter(
+                fx.PointerType.get(fx.Float32.ir_type, arg_scale_b.address_space),
+                arg_scale_b,
             )
-            sa = []
-            for wm in range_constexpr(wmma_m_rep):
-                row = blk_m + wmb + wm * 16 + lane16
-                sv = buffer_ops.buffer_load(sa_rsrc, row, vec_width=1, dtype=T.f32)
-                sa.append(Vec.from_elements([sv] * 8))
-            sb = []
-            for wn in range_constexpr(wmma_n_rep):
-                col0 = blk_n + wnb + wn * 16 + kgrp * 8
-                lo = Vec(buffer_ops.buffer_load(sb_rsrc, col0, vec_width=4, dtype=T.f32))
-                hi = Vec(buffer_ops.buffer_load(sb_rsrc, col0 + fx.Int32(4), vec_width=4, dtype=T.f32))
-                sb.append(Vec.from_elements([lo[0], lo[1], lo[2], lo[3], hi[0], hi[1], hi[2], hi[3]]))
+            sa_view = fx.Tensor(fx.make_view(gSA_base, fx.make_layout(i32_m, 1)))
+            sb_view = fx.Tensor(fx.make_view(gSB_base, fx.make_layout(i32_n, 1)))
+            sa_buf = fx.rocdl.make_buffer_tensor(sa_view, max_size=False, num_records_bytes=i32_m * fx.Int32(4))
+            sb_buf = fx.rocdl.make_buffer_tensor(sb_view, max_size=False, num_records_bytes=i32_n * fx.Int32(4))
+            sa_lay, sb_lay = (fx.make_layout(1, 1), fx.make_layout(4, 1))
+            sa_tiles = fx.logical_divide(sa_buf, sa_lay)
+            sb_tiles = fx.logical_divide(sb_buf, sb_lay)
+            sa_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Float32)
+            sb_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Float32)
+
+            def _issue(atom, tiles, lay, tile_idx):
+                r = fx.make_rmem_tensor(lay, fx.Float32)
+                fx.copy_atom_call(atom, fx.slice(tiles, (None, tile_idx)), r)
+                return r
+
+            sa_r = [
+                _issue(sa_atom, sa_tiles, sa_lay, blk_m + wmb + wm * 16 + lane16) for wm in range_constexpr(wmma_m_rep)
+            ]
+            col4 = bid_y * (tile_n // 4) + wave_n * (warp_tile_n // 4) + kgrp * 2
+            sb_r = [
+                (
+                    _issue(sb_atom, sb_tiles, sb_lay, col4 + wn * 4),
+                    _issue(sb_atom, sb_tiles, sb_lay, col4 + wn * 4 + 1),
+                )
+                for wn in range_constexpr(wmma_n_rep)
+            ]
+            return sa_r, sb_r
+
+        def epilogue_apply_ptpc_scale(scale_regs):
+            sa_r, sb_r = scale_regs
+            accs = [c_frags[idx].load() for idx in range_constexpr(n_acc)]
+            sa = [Vec.from_elements([sa_r[wm].load()[0]] * 8) for wm in range_constexpr(wmma_m_rep)]
+            sb = [sb_r[wn][0].load().shuffle(sb_r[wn][1].load(), list(range(8))) for wn in range_constexpr(wmma_n_rep)]
             for wm in range_constexpr(wmma_m_rep):
                 for wn in range_constexpr(wmma_n_rep):
                     idx = wm * wmma_n_rep + wn
-                    accs[idx] = (Vec(accs[idx]) * sb[wn] * sa[wm]).ir_value()
+                    accs[idx] = accs[idx] * sb[wn] * sa[wm]
             return accs
 
         if const_expr(use_cluster):
@@ -464,30 +475,32 @@ def launch_gemm_a8w8(
             compute_ktile(buf, pbuf, kt + (num_buffers - 1))
             if const_expr(use_cluster) and kt % num_buffers == num_buffers - 1:
                 cluster.cluster_barrier()
+        scale_regs = None
         for j in range_constexpr(num_buffers - 1):
             kt = n_steady + j
             s = kt % num_buffers
             pbuf = _buf_ptr(s)
             buf = _bidx(pbuf)
             pipeline_fence(outstanding=(num_buffers - 2 - j), use_cluster=False)
+            if const_expr(not is_bsc and j == num_buffers - 2):
+                scale_regs = issue_ptpc_scale_loads()
             compute_ktile(buf, pbuf, None)
 
         accs = None
         if const_expr(is_bsc):
-            accs = [c_frags[idx].load().ir_value() for idx in range_constexpr(n_acc)]
+            accs = [c_frags[idx].load() for idx in range_constexpr(n_acc)]
         pipeline_fence(outstanding=0, use_cluster=use_cluster)
         if const_expr(not is_bsc):
-            accs = epilogue_apply_ptpc_scale()
-        oc = fx.Float16 if out_is_f16 else fx.BFloat16
+            accs = epilogue_apply_ptpc_scale(scale_regs)
         for wm in range_constexpr(wmma_m_rep):
             row_rel = wmb + wm * 16 + lane16
             for wn in range_constexpr(wmma_n_rep):
                 col_rel = wnb + wn * 16 + kgrp * 8
-                h = Vec(accs[wm * wmma_n_rep + wn]).to(oc)
+                h = accs[wm * wmma_n_rep + wn].to(out_cls)
                 fx.ptr_store(h.bitcast(fx.Int8), base_ptr + (row_rel * tile_n + col_rel) * 2)
         workgroup_barrier(use_cluster=False)
         c_off_rt = blk_m64 * ldc64 + blk_n64
-        gtC = _gv(fx.get_iter(arg_c), c_off_rt, (tile_m, tile_n), (tile_n, 1))
+        gtC = _gv(gC_base, c_off_rt, (tile_m, tile_n), (tile_n, 1))
         atomC = fx.rocdl.make_tdm_atom(
             gtC,
             [mn_oob, None],
@@ -495,7 +508,11 @@ def launch_gemm_a8w8(
             num_warps=num_waves,
             early_timeout=False,
         )
-        fx.copy(atomC, _lv(fx.recast_iter(oc, base_ptr), (tile_m, tile_n), (tile_n, 1)), gtC)
+        fx.copy(
+            atomC,
+            _lv(fx.recast_iter(out_cls, base_ptr), (tile_m, tile_n), (tile_n, 1)),
+            gtC,
+        )
         tdm_ops.tensor_wait(0)
 
     gx = (i32_m + (tile_m - 1)) // tile_m

--- a/kernels/gemm/gemm_common_gfx1250.py
+++ b/kernels/gemm/gemm_common_gfx1250.py
@@ -3,8 +3,8 @@
 import math as _math
 
 import flydsl.expr as fx
-from flydsl.expr import gpu, rocdl, tdm_ops
-from flydsl.expr.rocdl import cluster
+from flydsl.expr import gpu, rocdl
+from flydsl.expr.rocdl import cluster, tdm_ops
 from flydsl.expr.typing import T
 
 
@@ -22,8 +22,7 @@ def make_lds_copy_ops(bits):
     )
 
     def _view(lds_base_idx, byte_offset):
-        byte_offset = fx.index_cast(T.index, byte_offset)
-        addr_i32 = fx.index_cast(T.i32, lds_base_idx + byte_offset)
+        addr_i32 = fx.Int32(lds_base_idx) + fx.Int32(byte_offset)
         ptr = fx.inttoptr(ptr_ty, addr_i32)
         return fx.Tensor(fx.make_view(ptr, layout))
 

--- a/kernels/gemm/gemm_common_gfx1250.py
+++ b/kernels/gemm/gemm_common_gfx1250.py
@@ -10,7 +10,8 @@ from flydsl.expr.typing import T
 
 def make_lds_copy_ops(bits):
     """Create one reusable layout/copy atom and return its load/store callables."""
-    assert bits in (32, 64, 128), f"bits must be 32/64/128, got {bits}"
+    if bits not in (32, 64, 128):
+        raise ValueError(f"bits must be 32/64/128, got {bits}")
     elem_count = bits // fx.Int32.width
     layout = fx.make_layout(elem_count, 1)
     atom = fx.make_copy_atom(fx.UniversalCopy(bits), fx.Int32)

--- a/kernels/moe/moe_a8w4_mxscale_gfx1250.py
+++ b/kernels/moe/moe_a8w4_mxscale_gfx1250.py
@@ -317,9 +317,8 @@ def launch_moe_gemm_a8w4(
         wnb = wave_n * warp_tile_n
 
         lds_load_b32, _ = make_lds_copy_ops(32)
-        lds_load_b128, _ = make_lds_copy_ops(128)
+        lds_load_b128, lds_store_b128 = make_lds_copy_ops(128)
         _, lds_store_b64 = make_lds_copy_ops(64)
-        _, lds_store_b128 = make_lds_copy_ops(128)
 
         def load_a(buf, wm, ksl):
             row = wmb + wm * 16 + lane16

--- a/kernels/moe/moe_a8w4_mxscale_gfx1250.py
+++ b/kernels/moe/moe_a8w4_mxscale_gfx1250.py
@@ -8,8 +8,8 @@ from collections import namedtuple
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import const_expr, range_constexpr, rocdl, tdm_ops
-from flydsl.expr.rocdl import cluster
+from flydsl.expr import const_expr, range_constexpr, rocdl
+from flydsl.expr.rocdl import cluster, tdm_ops
 from flydsl.expr.typing import Constexpr, T
 from flydsl.expr.typing import Vector as Vec
 from kernels.common.gfx1250_cluster import compute_mcast_masks
@@ -188,10 +188,12 @@ def launch_moe_gemm_a8w4(
         # Per-expert A-data OOB: bound to the owning expert's valid-row
         mn_oob = tile_map[(expert < n_experts).select(expert, n_experts - 1)] - blk_m
 
-        base_ptr = fx.SharedAllocator(static=False).allocate(ARENA_B)._ptr
+        arena = fx.SharedAllocator(static=False)
+        arena.allocate(ARENA_B)
+        base_ptr = arena.base_ptr
 
         def ptr_to_idx(p):
-            return fx.index_cast(T.index, fx.ptrtoint(p))
+            return fx.Int32(fx.ptrtoint(p))
 
         stC_idx = ptr_to_idx(base_ptr)
 
@@ -344,7 +346,7 @@ def launch_moe_gemm_a8w4(
         wmma_atom = fx.make_mma_atom(fx.rocdl.WMMAScale(WMMA_M, WMMA_N, WMMA_K, fx.Float4E2M1FN, ACT_ELEM, fx.Float32))
         c_frags = [fx.make_rmem_tensor(8, fx.Float32) for _ in range_constexpr(n_acc)]
         for cf in c_frags:
-            cf.store(fx.constant_vector(0.0, T.vec(8, T.f32)))
+            cf.store(Vec.filled(8, 0.0, fx.Float32))
 
         def to_rmem(n, v):
             t = fx.make_rmem_tensor(n, fx.Int32)

--- a/tests/kernels/test_gemm_fp8fp4_gfx1250.py
+++ b/tests/kernels/test_gemm_fp8fp4_gfx1250.py
@@ -274,11 +274,11 @@ def _build_a8w8_ptpc_case(
 
     def make_args(stream):
         return (
-            c_gpu,
+            flyc.from_c_void_p(fx.Uint8, c_gpu.data_ptr()),
             flyc.from_c_void_p(fx.Uint8, a_gpu.data_ptr()),
             flyc.from_c_void_p(fx.Uint8, b_gpu.data_ptr()),
-            sa_gpu,
-            sb_gpu,
+            flyc.from_c_void_p(fx.Uint8, sa_gpu.data_ptr()),
+            flyc.from_c_void_p(fx.Uint8, sb_gpu.data_ptr()),
             M,
             stream,
             N,
@@ -384,11 +384,11 @@ def _build_a8w8_blockscale_case(
 
     def make_args(stream):
         return (
-            c_gpu,
+            flyc.from_c_void_p(fx.Int8, c_gpu.data_ptr(), assumed_align=16),
             flyc.from_c_void_p(fx.Int8, a_gpu.data_ptr(), assumed_align=16),
             flyc.from_c_void_p(fx.Int8, b_gpu.data_ptr(), assumed_align=16),
-            as_gpu,
-            bs_gpu,
+            flyc.from_c_void_p(fx.Int8, as_gpu.data_ptr(), assumed_align=16),
+            flyc.from_c_void_p(fx.Int8, bs_gpu.data_ptr(), assumed_align=16),
             M,
             stream,
             N,


### PR DESCRIPTION
## Motivation

Switch gfx1250 gemm kernels to the stable API, and restore a PTPC epilogue prefetch optimization dropped in an earlier refactor.

## Technical Details

- Replace internal/private FlyDSL calls (`index_cast`, `SharedAllocator._ptr`, `constant_vector`) with their stable equivalents
- Split PTPC epilogue into issue + load stages so scale loads are issued one iteration early, overlapping with compute as before.

## Test Plan

Run `pytest tests/kernels/test_gemm_fp8fp4_gfx1250.py` and `pytest tests/kernels/test_moe_a8w4_mxscale_gfx1250.py`.


## Test Result

All tests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
