### PR TITLE
[Fix] conv3d fp8: guard padded M rows in the epilogue store

### DIFF
--- a/kernels/conv/conv3d_implicit_fp8.py
+++ b/kernels/conv/conv3d_implicit_fp8.py
@@ -216,6 +216,9 @@ def compile_conv3d_implicit_fp8(n, c, d, h, width, k, kt, kh, kw, st, sh, sw, pt
 
     grid_m = (npq + TILE_M - 1) // TILE_M
     grid_n = (k + TILE_N - 1) // TILE_N
+    # Padded M rows only exist when npq is not tile-aligned; mirrors _row_chk in
+    # the BF16 kernel so aligned shapes emit no extra compare.
+    row_chk = npq % TILE_M != 0
     elem_ty = fx.Float8E4M3FN
 
     @flyc.kernel(known_block_size=[BLOCK_THREADS, 1, 1])
@@ -459,10 +462,10 @@ def compile_conv3d_implicit_fp8(n, c, d, h, width, k, kt, kh, kw, st, sh, sw, pt
                                 # Padded M rows (npq..grid_m*TILE_M) must not store: with the
                                 # n==1 layout col*dhw+row they alias real elements of a later
                                 # column and race legitimate stores from another block.
-                                row_valid = row < fx.Index(npq)
-                                buffer_ops.buffer_store(
-                                    out.to(fx.BFloat16), y_rsrc, off_ncdhw, mask=col_valid & row_valid
-                                )
+                                store_mask = col_valid
+                                if const_expr(row_chk):
+                                    store_mask = col_valid & (row < fx.Index(npq))
+                                buffer_ops.buffer_store(out.to(fx.BFloat16), y_rsrc, off_ncdhw, mask=store_mask)
 
         store_half_pair(acc00, acc01, 0)
         store_half_pair(acc10, acc11, 1)

--- a/kernels/conv/conv3d_implicit_fp8.py
+++ b/kernels/conv/conv3d_implicit_fp8.py
@@ -456,7 +456,13 @@ def compile_conv3d_implicit_fp8(n, c, d, h, width, k, kt, kh, kw, st, sh, sw, pt
                                     n_idx = row // dhw
                                     sp = row % dhw
                                     off_ncdhw = n_idx * (k * dhw) + col * dhw + sp
-                                buffer_ops.buffer_store(out.to(fx.BFloat16), y_rsrc, off_ncdhw, mask=col_valid)
+                                # Padded M rows (npq..grid_m*TILE_M) must not store: with the
+                                # n==1 layout col*dhw+row they alias real elements of a later
+                                # column and race legitimate stores from another block.
+                                row_valid = row < fx.Index(npq)
+                                buffer_ops.buffer_store(
+                                    out.to(fx.BFloat16), y_rsrc, off_ncdhw, mask=col_valid & row_valid
+                                )
 
         store_half_pair(acc00, acc01, 0)
         store_half_pair(acc10, acc11, 1)


### PR DESCRIPTION
## Problem

`tests/kernels/test_conv3d_implicit_fp8.py::test_conv3d_fp8_vs_fp8cast_reference[1-96-4-8-9-96-1-1]` fails intermittently on `linux-flydsl-mi355-1`, roughly once every few days. Two observed instances:

- https://github.com/ROCm/FlyDSL/actions/runs/31016862619/job/92345704976
- https://github.com/ROCm/FlyDSL/actions/runs/30984871048/job/92239635970

Both reported the identical `rel_err 3.075e-01` (`0.3075297176837921`), which ruled out a plain data race on the accumulators and pointed at a deterministic set of clobbered output elements.

## Root cause

The FP8 epilogue masks stores on the column bound only:

```python
buffer_ops.buffer_store(out.to(fx.BFloat16), y_rsrc, off_ncdhw, mask=col_valid)
```

For `n == 1` the output address fast path is `off = col * dhw + row`. The M rows added to pad `npq` up to a whole `TILE_M` are **not** out of bounds under that mapping — when `dhw == npq` they alias real elements of the *next* column:

```
col=0, row=288  ->  off = 288  ==  col=1, row=0
```

So they are perfectly legal addresses, not something the hardware OOB check suppresses. Those padded rows carry a zero accumulator (A is zeroed by the im2col mask), so they race legitimate stores issued by another block and silently zero part of the output. Whichever block writes last wins — hence the intermittency.

For shape `(1,96,4,8,9,96)` with `padding=1`: `npq=288`, `TILE_M=128` → `grid_m=3`, 96 padded rows, and `dhw == npq == 288`, making **32.99%** of the output clobberable. `3.075e-01` is the deterministic error when every clobberable element loses the race.

## Fix

Add the row bound to the store mask, mirroring what the BF16 kernel and the FP8 split-K path already do.

## Verification

On gfx950 (MI355X), same shape, 200 iterations:

| | failures | worst rel_err |
|---|---|---|
| before | 12/200 | 3.075e-01 |
| after | 0/200 | 1.11e-05 |

The set of zeroed offsets was checked against the predicted padded-row alias set and matched exactly (9120 offsets, `all such offsets in predicted set: True`).

`tests/kernels/test_conv3d_implicit_fp8.py` + `tests/kernels/test_conv3d_implicit.py`: 33 passed.

I swept all 7 parametrized shapes in the test file — only this one triggers the bug. The others either have `padrows == 0` or `dhw != npq`, so the padded rows do not alias into the live region. The exposure is narrow, but when it hits it silently corrupts output rather than failing loudly.

## Notes

- The BF16 kernel is unaffected: `kernels/conv/conv3d_implicit.py` already guards rows via `_row_chk = npq % TILE_M != 0`.
- The FP8 split-K path already checks `row < npq` for its atomics ("Atomics ignore hardware OOB suppression; guard explicitly"). Only the non-atomic FP8 store was missing the equivalent check.