### PR TITLE
[cleanup] Migrate kernels to fx.copy / .llvm_ptr; expand kernel-code-cleanup skill

### DIFF
--- a/.claude/skills/kernel-code-cleanup/SKILL.md
+++ b/.claude/skills/kernel-code-cleanup/SKILL.md
@@ -3,9 +3,11 @@ name: kernel-code-cleanup
 description: >
   Modernize FlyDSL kernels: replace raw MLIR dialects (arith, scf, vector, llvm,
   memref, math), ArithValue, redundant fx.* wrapping, fx.Index, buffer_ops,
-  SmemPtr/SmemAllocator, per-tile *_atom_call, and raw rocdl.mfma_* with the
+  SmemPtr/SmemAllocator, copy_atom_call/mma_atom_call (loop or single atom), and raw rocdl.mfma_* with the
   current fx.* surface (fx types, Python control flow, make_buffer_tensor,
-  SharedAllocator, fx.copy/fx.gemm, local @flyc.jit if/else). Also trims comments
+  SharedAllocator, fx.copy/fx.gemm, make_layout_tv/make_tiled_copy TV layouts,
+  to_llvm_ptr, arch-dispatched fx.rocdl.s_waitcnt, local @flyc.jit if/else). Also
+  trims comments
   and dead code and applies the _run_compiled fast launch path. Use when
   reviewing, cleaning, or migrating existing kernels.
 allowed-tools: Read Edit Bash Grep Glob Agent
@@ -93,7 +95,7 @@ idx  = tx
 ## 2. `buffer_ops` → `make_buffer_tensor` + copy atoms
 
 `create_buffer_resource` + manual offsets is legacy. Build a buffer-resource view
-with `fx.rocdl.make_buffer_tensor()`, then use layout ops + `fx.copy_atom_call`;
+with `fx.rocdl.make_buffer_tensor()`, then use layout ops + `fx.copy` (§7b);
 the OOB-checked V# descriptor is built for you.
 
 ```python
@@ -105,7 +107,7 @@ buffer_ops.buffer_store(data, rsrc, row * N + col)
 bufA = fx.rocdl.make_buffer_tensor(A)
 tA   = fx.make_view(fx.get_iter(bufA), fx.make_layout((M, K), (K, 1)))
 copy = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Float32)
-fx.copy_atom_call(copy, fx.slice(tA, (None, tid)), rA)   # after partitioning tA
+fx.copy(copy, fx.slice(tA, (None, tid)), rA)   # after partitioning tA (§7b: prefer fx.copy)
 ```
 
 - `make_buffer_tensor(tensor, max_size=True)` mirrors `create_buffer_resource`;
@@ -160,6 +162,60 @@ Runtime bounds must be typed (`fx.Int64`) or the rewriter unrolls and drops
 - `memref.*` → layout tensors/views + copy atoms.
 - `math.*` → `fx` math helpers (`expr/math.py`); keep `math_dialect.fma` etc. only
   where no wrapper exists.
+
+### 3b. `fly.ptr` → `!llvm.ptr` (backend-resolved address space)
+
+When you hold an `fx` pointer (`fly.ptr`) and need a raw `!llvm.ptr` at a hard
+boundary, use the DSL primitive — it maps the pointer's semantic address space to
+the backend's LLVM address-space number for you. Don't hand-build one with a
+hardcoded `<1>` / `<3>` via `IntToPtrOp`.
+
+```python
+# Before (hardcoded address space)
+p = buffer_ops.create_llvm_ptr(lds_addr, address_space=3)
+p = mem_ops._create_llvm_ptr(val, address_space=1)   # a.k.a. mem_ops.to_llvm_ptr
+# After
+p = ptr.llvm_ptr          # property on an fx pointer
+p = fx.to_llvm_ptr(ptr)   # equivalent free function; backend resolves the AS
+```
+
+- Applies only when you already have a `fly.ptr`. A raw int/index address (e.g. an
+  LDS byte offset with no pointer form) still needs manual construction — note it.
+- `mem_ops.get_llvm_ptr` / `element_ptr` also fold in `+ offset*dtype_bytes`
+  arithmetic; keep the offset math (layout views / `get_element_ptr`) and only swap
+  the final ptr cast for `.llvm_ptr`.
+
+### 3c. Manual `s_waitcnt` bitfields → `fx.rocdl.s_waitcnt(vmcnt=/lgkmcnt=/expcnt=)`
+
+Hand-encoding a wait-counter bitfield (or calling `rocdl.s_waitcnt(magic)` with a
+raw number) is arch-fragile — the field widths differ per arch (CDNA3 `lgkmcnt`
+max 15 vs RDNA 63). The keyword form of `fx.rocdl.s_waitcnt`
+(`expr/rocdl/universal.py`) is arch-dispatched across gfx942/gfx950/gfx11xx/gfx120x
+and packs the correct bitfield for you.
+
+```python
+# Before
+rocdl.s_waitcnt(_encode_waitcnt(lgkmcnt=0))   # per-kernel encoder
+rocdl.s_waitcnt(0)                             # raw "wait for everything"
+_s_waitcnt(0xC07F)                             # magic LGKMCNT_0_ONLY bitfield
+# After
+fx.rocdl.s_waitcnt(lgkmcnt=0)                  # wait for LDS/SMEM only
+fx.rocdl.s_waitcnt(vmcnt=0, lgkmcnt=0)         # wait for all
+fx.rocdl.s_waitcnt(lgkmcnt=0)
+```
+
+- Unset fields default to "no wait" (their per-arch max) — name only the counters
+  you need.
+- Delete the now-unused per-kernel `_encode_waitcnt` / `_s_waitcnt` shims and magic
+  `*CNT_*` constants once your changes make them dead.
+- `sched_barrier` / `sched_group_barrier` have no keyword fx wrapper — keep raw
+  `rocdl.sched_barrier(...)`. The legacy raw form stays available as positional
+  `fx.rocdl.s_waitcnt(bitfield)` for a boundary the keyword form can't express;
+  localize it.
+- **Scheduler-sensitive.** `s_waitcnt` placement drives hot-loop pipelining in
+  tuned attention/GEMM kernels — an op-identical swap can still shift the schedule.
+  Verify perf (median-based), not just correctness, and don't mass-migrate
+  pervasively-tuned kernels (e.g. `flash_attn_gfx950.py`, `mla_fwd_decode_*`).
 
 ---
 
@@ -239,8 +295,8 @@ the atom is arch-dispatched (MFMA on CDNA3/4, WMMA on gfx11/gfx1250).
 c_frag = rocdl.mfma_f32_16x16x16f16(T.vec(4, T.f32), [a_frag, b_frag, c_frag, 0, 0, 0])
 # After
 mma = fx.make_mma_atom(fx.rocdl.MFMA(16, 16, 16, fx.Float16))   # → f32 acc
-fx.gemm(mma, frag_C, frag_A, frag_B, frag_C)                    # d, a, b, c
-fx.mma_atom_call(mma, frag_C, frag_A, frag_B, frag_C)           # single tile
+fx.gemm(mma, frag_C, frag_A, frag_B, frag_C)                    # d, a, b, c (prefer this)
+fx.mma_atom_call(mma, frag_C, frag_A, frag_B, frag_C)           # single tile — prefer fx.gemm (§7b)
 ```
 
 - `fx.rocdl.MFMA(m, n, k, elem_ty_ab, elem_ty_acc=None)` picks the intrinsic from
@@ -254,28 +310,78 @@ fx.mma_atom_call(mma, frag_C, frag_A, frag_B, frag_C)           # single tile
 
 ---
 
-## 7. Per-tile `*_atom_call` → `fx.copy` / `fx.gemm`
+## 7. Tiled copy/MMA: build from a TV layout, iterate with `fx.copy` / `fx.gemm`
 
-`copy_atom_call` / `mma_atom_call` issue a single atom instance. `fx.copy` /
-`fx.gemm` iterate the atom over a tiled/partitioned layout and take atom state as
-kwargs — no hand-written loop or `atom_set_value`.
+### 7a. Build the tiled copy/MMA (TV layout)
+
+A tiled copy is a copy atom laid over a **thread-value (TV) layout** plus a tiler.
+Build the TV layout from separate thread/value layouts with `fx.make_layout_tv`
+(returns `(tile_mn, tv_layout)`), pass both to `fx.make_tiled_copy`, slice
+per-thread with `.get_slice(tid)`, then partition the tensor. See
+`examples/02-tiledCopy.py`.
 
 ```python
-# Before
+# thread + value layouts -> (tile_mn, tv_layout) -> tiled copy
+thr_layout = fx.make_layout((4, 1), (1, 1))
+val_layout = fx.make_layout((1, 8), (1, 1))
+copy_atom  = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Float32)
+tile_mn, tv_layout = fx.make_layout_tv(thr_layout, val_layout)
+tiled_copy = fx.make_tiled_copy(copy_atom, tv_layout, tile_mn)
+thr_copy   = tiled_copy.get_slice(tid)
+part_src   = thr_copy.partition_S(bA)   # bA = fx.slice(fx.zipped_divide(A, tile), (None, bid))
+part_dst   = thr_copy.partition_D(bB)
+frag       = fx.make_fragment_like(part_src)
+```
+
+- `fx.make_tiled_copy_tv(atom, thr_layout, val_layout)` is the one-call shortcut
+  for the `make_layout_tv` + `make_tiled_copy` pair above. Prefer it, or the
+  explicit two-liner, over hand-building a TV layout inline in `make_tiled_copy`.
+- For copies matched to an MMA operand layout, do **not** hand-build a TV layout —
+  use `fx.make_tiled_copy_A/B/C(copy_atom, tiled_mma)` (they read the atom's
+  `tv_layout_{A,B,C}_tiled`), then `.get_slice(tid)` + `partition_S` /
+  `.retile(frag)`. See `examples/03-tiledMma.py`.
+- Build the MMA with `fx.make_tiled_mma(mma_atom, atom_layout)`; slice with
+  `.thr_slice(tid)` / `.get_slice(tid)` and make fragments via
+  `make_fragment_{A,B,C}`.
+- Layouts passed to `make_layout_tv` must be **static** (compile-time) — plain
+  Python-int shapes/strides in `make_layout`.
+
+### 7b. Prefer `fx.copy` / `fx.gemm` over `*_atom_call` — even for a single atom
+
+`fx.copy` / `fx.gemm` iterate the atom over a tiled/partitioned layout and take
+atom state as kwargs — no hand-written loop or `atom_set_value`. Prefer them over
+`copy_atom_call` / `mma_atom_call` **not just for loops but for single-atom sites
+too**: `fx.copy(atom, src, dst)` issues the same one atom over the single-tile
+partition — behavior-preserving and **perf-neutral** (identical ISA; the compiler
+lowers it to the same single copy/MMA). Migrate the whole family, not only loops.
+
+```python
+# Before — loop
 for k in range_constexpr(K_TILES):
     fx.copy_atom_call(copy_atom, part_src[k], frag[k])
 for k in range_constexpr(K_TILES):
     fx.mma_atom_call(mma, frag_C, frag_A[k], frag_B[k], frag_C)
-# After
-fx.copy(copy_atom, part_src, frag)
+# Before — single atom (helpers, one tile)
+fx.copy_atom_call(copy_atom, fx.slice(tiles, (None, idx)), r)
+fx.mma_atom_call(mma, frag_C, frag_A, frag_B, frag_C)
+# After — same in both cases
+fx.copy(copy_atom, part_src, frag)                                     # loop or single
+fx.copy(copy_atom, fx.slice(tiles, (None, idx)), r)                    # single-atom swap
 fx.gemm(mma, frag_C, frag_A, frag_B, frag_C)
 fx.gemm(mma, frag_C, frag_A, frag_B, frag_C, scale_a=sa, scale_b=sb)   # atom state as kwargs
 ```
 
 - `fx.copy` for partitioned tensors (`partition_S`/`partition_D` / tiled divide);
   `fx.gemm` for the MMA loop (accumulator-first order).
-- Keep `*_atom_call` for a genuine single atom instance — that's the lower-level
-  primitive, not legacy.
+- Single-atom swap is a **textual one-for-one** (`fx.copy_atom_call(a, s, d)` →
+  `fx.copy(a, s, d)`); no TV layout needed. Don't manufacture a bogus TV layout for
+  a degenerate single-tile load whose thread→data mapping is a mandatory swizzle —
+  just pass the existing single-tile slice to `fx.copy`.
+- **Keep** `copy_atom_call_ssa` / `mma_atom_call_ssa` (the SSA-*returning* variants
+  are a different primitive) and any raw atom call whose operands have no tensor/
+  partition form to pass. Everything else → `fx.copy` / `fx.gemm`.
+- Perf-neutral by construction, but for scheduler-tuned hot loops still diff
+  numerics cold and spot-check perf (median-of-7).
 
 ---
 
@@ -339,6 +445,8 @@ def _run_compiled(exe, *args):             # in-tree
    grep -nE "SmemPtr|SmemAllocator|\.finalize\(\)" <file>
    grep -nE "fx\.(Int32|Int64|Float32)\(fx\.(Int32|Int64|Float32)\(" <file>
    grep -nE "rocdl\.mfma_|\bmfma_(f32|i32)_|copy_atom_call|mma_atom_call" <file>
+   grep -nE "create_llvm_ptr|_create_llvm_ptr|get_llvm_ptr|IntToPtrOp" <file>
+   grep -nE "s_waitcnt\(|_encode_waitcnt|_s_waitcnt|CNT_[0-9A-Z_]*=|0x[Cc]07[Ff]" <file>
    ```
 2. **Triage:** do mechanical swaps (operators, casts, `vector.extract/bitcast`)
    first; structural ones (control flow, `buffer_ops` offsets, MMA loops) next.
@@ -365,12 +473,15 @@ def _run_compiled(exe, *args):             # in-tree
 | `arith.mulf/addf/trunc_f/select` | `*`, `+`, `.to(ty)`, `.select(...)` |
 | `vector.extract/bitcast/splat` | `fx.Vector(v)[i]` / `.bitcast(ty)` / `.filled(...)` |
 | `scf.ForOp` / `scf.IfOp` | `range_constexpr` / `range(..., init=)` / Python `if` / `const_expr` |
-| `buffer_ops.*` + offsets | `fx.rocdl.make_buffer_tensor` + layout + `fx.copy_atom_call` |
+| `buffer_ops.*` + offsets | `fx.rocdl.make_buffer_tensor` + layout + `fx.copy` |
 | raw `llvm`/`memref` access | `fx.make_view` / `fx.get_iter` / `SharedAllocator` |
+| `create_llvm_ptr(v, address_space=N)` / manual `IntToPtrOp` | `ptr.llvm_ptr` / `fx.to_llvm_ptr(ptr)` (backend-resolved AS) |
+| `rocdl.s_waitcnt(_encode_waitcnt(...))` / magic bitfield | `fx.rocdl.s_waitcnt(vmcnt=/lgkmcnt=/expcnt=)` (arch-dispatched) |
 | `SmemAllocator`/`SmemPtr` + `finalize()` | `@fx.struct` + `fx.SharedAllocator().allocate(...).peek().view(...)` |
 | `scf.IfOp(_raw(cond))` branch w/ outputs | branch helpers + local `@flyc.jit` |
 | `fx.Int32(fx.Int32(x))` / wrapping const ints | plain Python int; wrap once |
 | `rocdl.mfma_*` raw intrinsic | `fx.make_mma_atom(fx.rocdl.MFMA(...))` + `fx.gemm` |
-| per-tile `*_atom_call` loop | `fx.copy` / `fx.gemm` (state as kwargs) |
+| hand-built TV layout in `make_tiled_copy` | `fx.make_layout_tv` + `fx.make_tiled_copy` / `make_tiled_copy_tv`; `_A/_B/_C` for MMA operands |
+| `*_atom_call` (loop *or* single atom) | `fx.copy` / `fx.gemm` (state as kwargs); keep only `*_atom_call_ssa` |
 | restated/dead/stale comments, blank runs | delete; keep *why*; aim for net LOC drop |
 | per-call `@flyc.jit` on a hot path | `_run_compiled(exe, *args)` fast dispatch |

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -3279,10 +3279,10 @@ class DualwaveKernelContext:
         lds = fx.SharedAllocator().allocate(shared_storage).peek()
         self.lds = lds
         self.lds_kv_base_idx = fx.Index(fx.ptrtoint(lds.kv.ptr))
-        self.lds_kv_base_ptr = buffer_ops.create_llvm_ptr(self.lds_kv_base_idx, address_space=3)
+        self.lds_kv_base_ptr = lds.kv.ptr.llvm_ptr
         if const_expr(self.traits.PAGED):
             self.lds_bt_base_idx = fx.Index(fx.ptrtoint(lds.bt.ptr))
-            self.lds_bt_base_ptr = buffer_ops.create_llvm_ptr(self.lds_bt_base_idx, address_space=3)
+            self.lds_bt_base_ptr = lds.bt.ptr.llvm_ptr
         else:
             self.lds_bt_base_ptr = None
 
@@ -4367,11 +4367,11 @@ class DualwaveFp8KernelContext:
         lds = fx.SharedAllocator().allocate(shared_storage).peek()
         self.lds = lds
         self.lds_kv_base_idx = fx.Index(fx.ptrtoint(lds.kv.ptr))
-        self.lds_kv_base_ptr = buffer_ops.create_llvm_ptr(self.lds_kv_base_idx, address_space=3)
+        self.lds_kv_base_ptr = lds.kv.ptr.llvm_ptr
         self.lds_vt_base_idx = fx.Index(fx.ptrtoint(lds.vt.ptr))
-        self.lds_vt_base_ptr = buffer_ops.create_llvm_ptr(self.lds_vt_base_idx, address_space=3)
+        self.lds_vt_base_ptr = lds.vt.ptr.llvm_ptr
         self.lds_q_base_idx = fx.Index(fx.ptrtoint(lds.q.ptr))
-        self.lds_q_base_ptr = buffer_ops.create_llvm_ptr(self.lds_q_base_idx, address_space=3)
+        self.lds_q_base_ptr = lds.q.ptr.llvm_ptr
 
     def init_thread_mapping(self):
         _init_dualwave_thread_mapping(self)

--- a/kernels/attention/fused_rope_cache_kernel.py
+++ b/kernels/attention/fused_rope_cache_kernel.py
@@ -139,14 +139,14 @@ def build_fused_rope_cache_module(
         # Helper: load a VEC_WIDTH vector from a divided 1D tensor at given index
         def load_vec(div_tensor, idx, atom=None):
             r = fx.make_rmem_tensor(vec_lay, elem_dtype)
-            fx.copy_atom_call(atom or copy_atom, fx.slice(div_tensor, (None, idx)), r)
+            fx.copy(atom or copy_atom, fx.slice(div_tensor, (None, idx)), r)
             return fx.memref_load_vec(r)
 
         # Helper: store a VEC_WIDTH vector to a divided 1D tensor at given index
         def store_vec(val, div_tensor, idx, atom=None):
             r = fx.make_rmem_tensor(vec_lay, elem_dtype)
             fx.memref_store_vec(val, r)
-            fx.copy_atom_call(atom or copy_atom, r, fx.slice(div_tensor, (None, idx)))
+            fx.copy(atom or copy_atom, r, fx.slice(div_tensor, (None, idx)))
 
         # Helper: get the rotary-pair element via ds_bpermute (LDS cross-lane shuffle).
         # For NeoX RoPE, the pair of thread tid is tid XOR vecs_per_half.
@@ -276,8 +276,8 @@ def build_fused_rope_cache_module(
                         vs_div = fx.logical_divide(vs_buf, f32_lay)
                         r_ks = fx.make_rmem_tensor(f32_lay, fx.Float32)
                         r_vs = fx.make_rmem_tensor(f32_lay, fx.Float32)
-                        fx.copy_atom_call(f32_copy_atom, fx.slice(ks_div, (None, 0)), r_ks)
-                        fx.copy_atom_call(f32_copy_atom, fx.slice(vs_div, (None, 0)), r_vs)
+                        fx.copy(f32_copy_atom, fx.slice(ks_div, (None, 0)), r_ks)
+                        fx.copy(f32_copy_atom, fx.slice(vs_div, (None, 0)), r_vs)
                         k_scale_val = fx.memref_load_vec(r_ks)[0]
                         v_scale_val = fx.memref_load_vec(r_vs)[0]
                         k_rcp = fx.rocdl.rcp(T.f32, k_scale_val)

--- a/kernels/attention/qk_norm_rope_quant.py
+++ b/kernels/attention/qk_norm_rope_quant.py
@@ -280,7 +280,7 @@ def _build_kernel(
 
         def load_vec(div_tensor, idx, *, layout=full_lay, atom=full_atom, dt=elem_dtype):
             r = fx.make_rmem_tensor(layout, dt)
-            fx.copy_atom_call(atom, fx.slice(div_tensor, (None, idx)), r)
+            fx.copy(atom, fx.slice(div_tensor, (None, idx)), r)
             return fx.memref_load_vec(r)
 
         bid_x = fx.block_idx.x  # 0..H-1 (Q head) or H (KV)

--- a/kernels/gemm/mxfp4_preshuffle.py
+++ b/kernels/gemm/mxfp4_preshuffle.py
@@ -326,12 +326,12 @@ def launch_gemm(
             for ni in range_constexpr(num_acc_n):
                 for kh in range_constexpr(k_halves):
                     lo = fx.make_rmem_tensor(4, Int32)
-                    fx.copy_atom_call(b_copy, bq_views[ni][lane_div_16, lane_mod_16, kt, kh, 0, None], lo)
+                    fx.copy(b_copy, bq_views[ni][lane_div_16, lane_mod_16, kt, kh, 0, None], lo)
                     if const_expr(b_dtype == "fp4"):
                         ops.append(lo)
                     else:  # fp8: lo ++ hi -> i32[B_NDW]
                         hi = fx.make_rmem_tensor(4, Int32)
-                        fx.copy_atom_call(b_copy, bq_views[ni][lane_div_16, lane_mod_16, kt, kh, 1, None], hi)
+                        fx.copy(b_copy, bq_views[ni][lane_div_16, lane_mod_16, kt, kh, 1, None], hi)
                         t = fx.make_rmem_tensor(B_NDW, Int32)
                         t.store(Vec(fx.memref_load_vec(lo)).shuffle(Vec(fx.memref_load_vec(hi)), list(range(B_NDW))))
                         ops.append(t)

--- a/kernels/gemm/preshuffle_gemm.py
+++ b/kernels/gemm/preshuffle_gemm.py
@@ -459,8 +459,8 @@ def compile_preshuffle_gemm(
 
         # ── Pipeline stage (double-buffered B via split fragments) ─
         def mma_kloop(a_stage, cur_frag_B):
+            fx.copy(uni_copy, pA_s2r_stages[a_stage], frag_A_retile)
             for ki in range_constexpr(k_iters):
-                fx.copy(uni_copy, pA_s2r_stages[a_stage][None, None, ki], frag_A_retile[None, None, ki])
                 k_coord = ki if (use_mfma_scale_128 or use_mfma_k32) else (None, ki)
                 fx.gemm(tiled_mma, frag_C, frag_A[None, None, k_coord], cur_frag_B[None, None, k_coord], frag_C)
 
@@ -578,7 +578,7 @@ def compile_preshuffle_gemm(
                 s_b = []
                 for ni in range_constexpr(num_acc_n):
                     f = fx.make_rmem_tensor(1, Float32)
-                    fx.copy_atom_call(
+                    fx.copy(
                         epi_copy_32b,
                         sb_buf[None, fx.Int32(by_n + (ni * num_waves + wave_id) * 16 + lane_mod_16)],
                         f,
@@ -592,7 +592,7 @@ def compile_preshuffle_gemm(
                 for mi in range_constexpr(m_repeat):
                     f = fx.make_rmem_tensor(4, Float32)
                     grp = (bx_m + mi * 16 + lane_div_16 * 4) // 4
-                    fx.copy_atom_call(epi_copy_128b, sa_buf[None, fx.Int32(grp)], f)
+                    fx.copy(epi_copy_128b, sa_buf[None, fx.Int32(grp)], f)
                     s_a.append(Vec(f.load()))
             if const_expr(_has_bias):
                 # Per-column bias (out_dtype), one scalar per N-block, shared across rows.
@@ -600,7 +600,7 @@ def compile_preshuffle_gemm(
                 bias = []
                 for ni in range_constexpr(num_acc_n):
                     f = fx.make_rmem_tensor(1, out_elem_cls)
-                    fx.copy_atom_call(
+                    fx.copy(
                         epi_copy_16b,
                         bias_buf[None, fx.Int32(by_n + (ni * num_waves + wave_id) * 16 + lane_mod_16)],
                         f,

--- a/kernels/moe/mxfp_moe/gemm1.py
+++ b/kernels/moe/mxfp_moe/gemm1.py
@@ -246,7 +246,7 @@ def _gemm1_body(
         # ds_read_b128 straight into an i32[4] register fragment (kept as a tensor
         # so it can feed fx.gemm directly).
         r = fx.make_rmem_tensor(i32x4_reg_lay, fx.Int32)
-        fx.copy_atom_call(i32x4_copy_atom, fx.slice(s_aq_i32x4_tiles, (None, tile_idx)), r)
+        fx.copy(i32x4_copy_atom, fx.slice(s_aq_i32x4_tiles, (None, tile_idx)), r)
         return r
 
     def issue_a_ds_read(slot):
@@ -559,11 +559,11 @@ def _gemm1_body(
     def acc_store(idx, value):
         r = fx.make_rmem_tensor(acc_reg_lay, fx.Float32)
         r.store(fx.Vector.from_elements([fx.Float32(value)], fx.Float32))
-        fx.copy_atom_call(acc_copy_atom, r, fx.slice(acc_flat_tiles, (None, idx)))
+        fx.copy(acc_copy_atom, r, fx.slice(acc_flat_tiles, (None, idx)))
 
     def acc_load(idx):
         r = fx.make_rmem_tensor(acc_reg_lay, fx.Float32)
-        fx.copy_atom_call(acc_copy_atom, fx.slice(acc_flat_tiles, (None, idx)), r)
+        fx.copy(acc_copy_atom, fx.slice(acc_flat_tiles, (None, idx)), r)
         return r.load()[0]
 
     for i in range_constexpr(kMChunks):

--- a/kernels/moe/mxfp_moe/gemm2.py
+++ b/kernels/moe/mxfp_moe/gemm2.py
@@ -525,7 +525,7 @@ def _gemm2_body(
                 lds_row = lane_row + fx.Int32(i * 16)
                 byte_off = fx.Int32(slot * _slot_bytes) + lds_row * fx.Int32(KH_TILE) + lds_col
                 r = fx.make_rmem_tensor(lds_a_read_lay, fx.Int32)
-                fx.copy_atom_call(lds_a_read_atom, fx.slice(s_aq_i32x4_tiles, (None, byte_off // fx.Int32(16))), r)
+                fx.copy(lds_a_read_atom, fx.slice(s_aq_i32x4_tiles, (None, byte_off // fx.Int32(16))), r)
                 a[i][k] = r
         return a
 

--- a/kernels/moe/mxfp_moe/mxfp4_gemm_common.py
+++ b/kernels/moe/mxfp_moe/mxfp4_gemm_common.py
@@ -103,7 +103,7 @@ def _global_i32_load(tiles, idx):
     # Atom/types must be built with an active MLIR trace context, not as globals.
     atom = fx.make_copy_atom(fx.UniversalCopy32b(), fx.Int32)
     r = fx.make_rmem_tensor(fx.make_layout(1, 1), fx.Int32)
-    fx.copy_atom_call(atom, fx.slice(tiles, (None, idx)), r)
+    fx.copy(atom, fx.slice(tiles, (None, idx)), r)
     return r.load()[0]
 
 
@@ -122,7 +122,7 @@ def _scalar_store(tiles, idx, value, numeric_cls):
     atom = fx.make_copy_atom(fx.UniversalCopy(numeric_cls.width), numeric_cls)
     r = fx.make_rmem_tensor(fx.make_layout(1, 1), numeric_cls)
     r.store(fx.Vector.from_elements([numeric_cls(value)], numeric_cls))
-    fx.copy_atom_call(atom, r, fx.slice(tiles, (None, idx)))
+    fx.copy(atom, r, fx.slice(tiles, (None, idx)))
 
 
 def _layout_idx(layout, *coords):

--- a/kernels/moe/topk_gating_softmax_kernel.py
+++ b/kernels/moe/topk_gating_softmax_kernel.py
@@ -277,7 +277,7 @@ def _emit_topk_gating_softmax_body(
         """Load ELEMS_PER_ATOM contiguous elements starting at atom_index."""
         view = fx.slice(divided, (None, atom_index))
         r = fx.memref_alloca(atom_reg_ty_in, atom_reg_lay_in)
-        fx.copy_atom_call(copy_atom_in, view, r)
+        fx.copy(copy_atom_in, view, r)
         return fx.memref_load_vec(r)
 
     def _store_scalar_f32(divided, index, val):
@@ -285,7 +285,7 @@ def _emit_topk_gating_softmax_body(
         v = fx.Vector.from_elements([val], fx.Float32)
         fx.memref_store_vec(v, r)
         view = fx.slice(divided, (None, index))
-        fx.copy_atom_call(copy_atom_f32, r, view)
+        fx.copy(copy_atom_f32, r, view)
 
     def _store_scalar_i32(divided, index, val):
         # `divided` is a logical_divide of a torch.float32-viewed buffer,
@@ -297,7 +297,7 @@ def _emit_topk_gating_softmax_body(
         v = fx.Vector.from_elements([val_f32], fx.Float32)
         fx.memref_store_vec(v, r)
         view = fx.slice(divided, (None, index))
-        fx.copy_atom_call(copy_atom_f32, r, view)
+        fx.copy(copy_atom_f32, r, view)
 
     # Pass 1: load this thread's VPT experts + per-thread max
     col_idx_list = []
@@ -523,7 +523,7 @@ def build_topk_gating_softmax_module(
             """Load ELEMS_PER_ATOM contiguous elements starting at atom_index."""
             view = fx.slice(divided, (None, atom_index))
             r = fx.make_rmem_tensor(ELEMS_PER_ATOM, elem_dtype)
-            fx.copy_atom_call(copy_atom_in, view, r)
+            fx.copy(copy_atom_in, view, r)
             return fx.memref_load_vec(r)
 
         def _store_scalar_f32(divided, index, val):
@@ -531,7 +531,7 @@ def build_topk_gating_softmax_module(
             v = fx.Vector.from_elements([val], fx.Float32)
             fx.memref_store_vec(v, r)
             view = fx.slice(divided, (None, index))
-            fx.copy_atom_call(copy_atom_f32, r, view)
+            fx.copy(copy_atom_f32, r, view)
 
         def _store_scalar_i32(divided, index, val):
             # `divided` is a logical_divide of a torch.float32-viewed buffer,
@@ -543,7 +543,7 @@ def build_topk_gating_softmax_module(
             v = fx.Vector.from_elements([val_f32], fx.Float32)
             fx.memref_store_vec(v, r)
             view = fx.slice(divided, (None, index))
-            fx.copy_atom_call(copy_atom_f32, r, view)
+            fx.copy(copy_atom_f32, r, view)
 
         # ==================================================================
         # Pass 1: Load this thread's VPT experts + per-thread max

--- a/kernels/norm/layernorm_kernel.py
+++ b/kernels/norm/layernorm_kernel.py
@@ -48,7 +48,7 @@ def _make_reduction_storage(red_slots: int):
 def _load_scalar(copy_atom, elem_dtype, divided_tensor, index):
     view = fx.slice(divided_tensor, (None, index))
     r = fx.make_rmem_tensor(1, elem_dtype)
-    fx.copy_atom_call(copy_atom, view, r)
+    fx.copy(copy_atom, view, r)
     return fx.memref_load_vec(r)[0]
 
 
@@ -57,19 +57,19 @@ def _store_scalar(copy_atom, elem_dtype, store_dtype, divided_tensor, index, val
     ts = full(1, store_dtype(val), store_dtype)
     fx.memref_store_vec(ts, r)
     view = fx.slice(divided_tensor, (None, index))
-    fx.copy_atom_call(copy_atom, r, view)
+    fx.copy(copy_atom, r, view)
 
 
 def _load_vec(copy_atom, vec_width, elem_dtype, div_tensor, idx):
     r = fx.make_rmem_tensor(vec_width, elem_dtype)
-    fx.copy_atom_call(copy_atom, fx.slice(div_tensor, (None, idx)), r)
+    fx.copy(copy_atom, fx.slice(div_tensor, (None, idx)), r)
     return fx.memref_load_vec(r)
 
 
 def _store_vec(copy_atom, vec_width, elem_dtype, val, div_tensor, idx):
     r = fx.make_rmem_tensor(vec_width, elem_dtype)
     fx.memref_store_vec(val, r)
-    fx.copy_atom_call(copy_atom, r, fx.slice(div_tensor, (None, idx)))
+    fx.copy(copy_atom, r, fx.slice(div_tensor, (None, idx)))
 
 
 def _to_elem_scalar(dtype_str: str, elem_dtype, y):
@@ -102,7 +102,7 @@ def _store_yscale(scale_copy_atom, yscale_div, index, val):
     r = fx.make_rmem_tensor(1, fx.Float32)
     ts = full(1, fx.Float32(val), fx.Float32)
     fx.memref_store_vec(ts, r)
-    fx.copy_atom_call(scale_copy_atom, r, fx.slice(yscale_div, (None, index)))
+    fx.copy(scale_copy_atom, r, fx.slice(yscale_div, (None, index)))
 
 
 def _quant_dtype_to_elem_type(dtype_str: str):

--- a/kernels/norm/rmsnorm_common.py
+++ b/kernels/norm/rmsnorm_common.py
@@ -55,7 +55,7 @@ def make_single_reduction_storage(red_slots: int):
 def load_scalar(copy_atom, elem_dtype, divided_tensor, index):
     view = fx.slice(divided_tensor, (None, index))
     r = fx.make_rmem_tensor(1, elem_dtype)
-    fx.copy_atom_call(copy_atom, view, r)
+    fx.copy(copy_atom, view, r)
     return fx.memref_load_vec(r)[0]
 
 
@@ -64,12 +64,12 @@ def store_scalar(copy_atom, elem_dtype, divided_tensor, index, val):
     ts = fx.Vector.filled(1, val, elem_dtype)
     fx.memref_store_vec(ts, r)
     view = fx.slice(divided_tensor, (None, index))
-    fx.copy_atom_call(copy_atom, r, view)
+    fx.copy(copy_atom, r, view)
 
 
 def load_vec(copy_atom, vec_width, elem_dtype, div_tensor, idx):
     r = fx.make_rmem_tensor(vec_width, elem_dtype)
-    fx.copy_atom_call(copy_atom, fx.slice(div_tensor, (None, idx)), r)
+    fx.copy(copy_atom, fx.slice(div_tensor, (None, idx)), r)
     return fx.memref_load_vec(r)
 
 
@@ -88,7 +88,7 @@ def load_weight_vec(copy_atom, weight_dtype_str, weight_elem_dtype, div_tensor, 
 def store_vec(copy_atom, vec_width, elem_dtype, val, div_tensor, idx):
     r = fx.make_rmem_tensor(vec_width, elem_dtype)
     fx.memref_store_vec(val, r)
-    fx.copy_atom_call(copy_atom, r, fx.slice(div_tensor, (None, idx)))
+    fx.copy(copy_atom, r, fx.slice(div_tensor, (None, idx)))
 
 
 def to_elem_scalar(dtype_str: str, elem_dtype, y):

--- a/kernels/norm/softmax_kernel.py
+++ b/kernels/norm/softmax_kernel.py
@@ -119,13 +119,13 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
 
             def _load_vec(div_tensor, idx):
                 r = fx.make_rmem_tensor(vec_width, elem_dtype)
-                fx.copy_atom_call(copy_atom, fx.slice(div_tensor, (None, idx)), r)
+                fx.copy(copy_atom, fx.slice(div_tensor, (None, idx)), r)
                 return fx.memref_load_vec(r)
 
             def _store_vec(val, div_tensor, idx):
                 r = fx.make_rmem_tensor(vec_width, elem_dtype)
                 fx.memref_store_vec(val, r)
-                fx.copy_atom_call(copy_atom, r, fx.slice(div_tensor, (None, idx)))
+                fx.copy(copy_atom, r, fx.slice(div_tensor, (None, idx)))
 
             # 1. Load + compute local max
             row_buffer = []
@@ -185,7 +185,7 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
             def _load_scalar(divided, index):
                 view = fx.slice(divided, (None, index))
                 r = fx.make_rmem_tensor(1, elem_dtype)
-                fx.copy_atom_call(copy_atom_s, view, r)
+                fx.copy(copy_atom_s, view, r)
                 return fx.memref_load_vec(r)[0]
 
             def _store_scalar(divided, index, val):
@@ -193,7 +193,7 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
                 ts = full(1, elem_dtype(val), elem_dtype)
                 fx.memref_store_vec(ts, r)
                 view = fx.slice(divided, (None, index))
-                fx.copy_atom_call(copy_atom_s, r, view)
+                fx.copy(copy_atom_s, r, view)
 
             # 1. Load + max
             row_buffer = []


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup migrating kernels to the current `fx.*` surface, plus documentation of the migrations in the `kernel-code-cleanup` skill. All changes are one-for-one API swaps; validated cold + benchmarked on gfx950 (CDNA4).

### 1. `create_llvm_ptr(idx, address_space=3)` → `.llvm_ptr` (`flash_attn_utils.py`)
The two `init_lds` methods that hold a real `fly.ptr` from `SharedAllocator` now use the `to_llvm_ptr` op (#921): `lds.<field>.ptr.llvm_ptr`. The backend resolves `Shared` → LLVM `<3>`, matching the old hardcoded value. Other `create_llvm_ptr`/`get_llvm_ptr`/`IntToPtrOp` sites hold raw int/index addresses or memrefs (no `fly.ptr`) and are correctly left on the legacy helpers.

### 2. per-tile `fx.copy_atom_call` → `fx.copy` (11 files)
Every single-tile `fx.copy_atom_call(atom, src, dst)` swapped to `fx.copy` across norm (rmsnorm/softmax/layernorm), attention (rope), topk gating, mxfp_moe (gemm1/gemm2/common), and preshuffle GEMM. `fx.copy` iterates the same atom over the single-tile partition = one atom call = behavior-preserving. The one genuinely fused copy-in-gemm-loop (`preshuffle_gemm.py` `mma_kloop`) was hoisted to a single whole-fragment `fx.copy`; the compiler folds it back into the MFMA loop. `copy_atom_call_ssa` and swizzle/ABI-coupled single-atom loads left as-is (no meaningful TV layout).

### 3. skill docs (`kernel-code-cleanup/SKILL.md`)
Added the three migrations to the skill: §3b `fly.ptr`→`!llvm.ptr`, §3c manual `s_waitcnt` bitfields → arch-dispatched `fx.rocdl.s_waitcnt`, §7a building tiled copies from a TV layout (`make_layout_tv`/`make_tiled_copy`/`_A/_B/_C`), plus quick-ref rows and grep patterns.

## Validation (gfx950, cold `FLYDSL_RUNTIME_ENABLE_CACHE=0`)
- **Accuracy:** flash_attn fwd 33; rmsnorm 30, softmax 1, layernorm 14, topk_gating 1, fused_rope_cache 78, preshuffle_gemm 50, mxfp_moe variants+stage2 24 — all pass. (`qk_norm_rope_quant.py` has no test → compile-validated only.)
- **Perf (median-of-7, ±14% gfx950 noise):**
  - llvm_ptr flash-attn: bf16 0.994×, fp8 1.002× — parity.
  - preshuffle_gemm mma_kloop hoist (M=N=4096 K=8192 fp8): 145.0 → 144.5 µs (1895 → 1902 TFLOPS, +0.4%) — parity.

## Notes
- Conflict resolution on `mxfp_moe/gemm2.py`: kept origin/main's newer A-LDS swizzle addressing (`byte_off // 16`) and applied the `fx.copy` swap on top.
- The `buffer_ops` → `fx.copy` port was investigated separately and found to be a no-op on CDNA: the clean dense-tile ports already landed in #913; remaining `buffer_ops` sites are scalar/gather/ABI-coupled (non-portable), and the only dense-A/B candidates are RDNA kernels not runnable/benchmarkable on gfx950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
