### PR TITLE
[cleanup] Remove COMPILE_ONLY print from the JIT call path

### DIFF
--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -1578,7 +1578,6 @@ class JitFunction:
 
         # OUTSIDE lock: engine init + kernel launch
         if env.compile.compile_only:
-            print(f"[flydsl] COMPILE_ONLY=1, compilation succeeded (arch={get_backend().target.arch})")
             return None
 
         # The in-process CompiledArtifact cache above owns the ExecutionEngine/


### PR DESCRIPTION
## Summary

Drops the unconditional `print()` emitted on every `COMPILE_ONLY=1` invocation in
`JitFunction.__call__` (`python/flydsl/compiler/jit_function.py:1580`).

AOT / compile-only runs invoke this path once per kernel specialization, so the
message adds a line of raw stdout noise per compile with no diagnostic value —
success is already implied by the call returning without raising. It also bypassed
the project logger (`log()`), which every other message on this path uses.

## Changes

- `python/flydsl/compiler/jit_function.py`: remove the `[flydsl] COMPILE_ONLY=1, compilation succeeded (...)` print; `compile_only` now just returns `None`.

## Test plan

- No behavior change beyond the removed stdout line; `COMPILE_ONLY=1` still short-circuits before engine init and kernel launch.
- `python3 -m pytest tests/python/examples/ -v` (AOT compile/cache coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)