### PR TITLE
Optimize megamoe performance

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -604,8 +604,9 @@ jobs:
         run: |
           docker exec flydsl_test bash -c "
             cd /flydsl-test &&
-            python tests/kernels/test_profiler_dispatch_combine.py \
+            MORI_SOCKET_IFNAME=lo python tests/kernels/test_profiler_dispatch_combine.py \
               --ci-sweep \
+              --skip-verify-spawn \
               --world-size 8 \
               --port 29503 \
               --output-dir /tmp/flydsl_ci_sweep

--- a/kernels/mega_moe/dispatch.py
+++ b/kernels/mega_moe/dispatch.py
@@ -88,6 +88,89 @@ def _wave_reduce_max_i32(value, lane):
     return value
 
 
+@flyc.jit
+def _increment_i32(rsrc, index):
+    value = buffer_ops.buffer_load(rsrc, index, vec_width=1, dtype=fx.Int32)
+    buffer_ops.buffer_store(value + fx.Int32(1), rsrc, index)
+
+
+@flyc.jit
+def _configure_payload_geometry(
+    addr_local_hist, addr_chunk_counts, addr_block_counts, addr_active_blocks, lane, *, fz_npes, fz_epr,
+    payload_chunk_rows, dispatch_blocks,
+):
+    crfa = buffer_ops.create_buffer_resource_from_addr
+    local_hist = crfa(addr_local_hist)
+    chunk_counts = crfa(addr_chunk_counts)
+    block_counts = crfa(addr_block_counts)
+    active_payload_blocks = fx.Int32(0)
+    max_blocks = fx.Int32(dispatch_blocks // fz_npes)
+    for destination in range_constexpr(fz_npes):
+        max_source_count = fx.Int32(0)
+        for local_expert in range(lane, fz_epr, 64):
+            ge = fx.Int32(destination * fz_epr) + local_expert
+            source_count = buffer_ops.buffer_load(local_hist, ge, vec_width=1, dtype=fx.Int32)
+            max_source_count = (source_count > max_source_count).select(source_count, max_source_count)
+        max_source_count = _wave_reduce_max_i32(max_source_count, lane)
+        if lane == fx.Int32(0):
+            chunks = (max_source_count + fx.Int32(payload_chunk_rows - 1)) // fx.Int32(payload_chunk_rows)
+            chunks = (chunks > fx.Int32(0)).select(chunks, fx.Int32(1))
+            chunks = (chunks > fx.Int32(4)).select(chunks, fx.Int32(4))
+            buffer_ops.buffer_store(chunks, chunk_counts, fx.Int32(destination))
+            active_blocks = (chunks > fx.Int32(4)).select(chunks, fx.Int32(4))
+            active_blocks = (active_blocks < max_blocks).select(active_blocks, max_blocks)
+            buffer_ops.buffer_store(active_blocks, block_counts, fx.Int32(destination))
+            active_payload_blocks = active_payload_blocks + active_blocks
+    if lane == fx.Int32(0):
+        buffer_ops.buffer_store(active_payload_blocks, crfa(addr_active_blocks), fx.Int32(0))
+
+
+@flyc.jit
+def _store_expert_metadata(
+    addr_sorted_expert, addr_tile_row_base, addr_srcmap, ge, local_row_base, total_count, num_tiles,
+    padded_rows, *, fz_tile_m, invalid_source,
+):
+    crfa = buffer_ops.create_buffer_resource_from_addr
+    sorted_expert = crfa(addr_sorted_expert)
+    tile_row_base = crfa(addr_tile_row_base)
+    srcmap = crfa(addr_srcmap)
+    base_tile = local_row_base // fx.Int32(fz_tile_m)
+    for tile in range(fx.Int32(0), num_tiles, 1):
+        metadata_index = base_tile + tile
+        buffer_ops.buffer_store(ge, sorted_expert, metadata_index)
+        buffer_ops.buffer_store(local_row_base + tile * fx.Int32(fz_tile_m), tile_row_base, metadata_index)
+    padding = padded_rows - total_count
+    for pad in range(fx.Int32(0), padding, 1):
+        buffer_ops.buffer_store(fx.Int32(invalid_source), srcmap, local_row_base + total_count + pad)
+
+
+@flyc.jit
+def _copy_token_row(source_rsrc, destination_rsrc, lane, *, fz_safe_end_i32, fz_n_i32):
+    lane_offset = lane * fx.Int32(4)
+    if const_expr(fz_safe_end_i32 > 0):
+        for column in range(lane_offset, fz_safe_end_i32, 512):
+            value0 = buffer_ops.buffer_load(source_rsrc, column, vec_width=4, dtype=fx.Int32)
+            value1 = buffer_ops.buffer_load(source_rsrc, column + fx.Int32(256), vec_width=4, dtype=fx.Int32)
+            buffer_ops.buffer_store(value0, destination_rsrc, column)
+            buffer_ops.buffer_store(value1, destination_rsrc, column + fx.Int32(256))
+    if const_expr(fz_safe_end_i32 < fz_n_i32):
+        for column in range(lane_offset + fz_safe_end_i32, fz_n_i32, 256):
+            value = buffer_ops.buffer_load(source_rsrc, column, vec_width=4, dtype=fx.Int32)
+            buffer_ops.buffer_store(value, destination_rsrc, column)
+
+
+@flyc.jit
+def _publish_tile_range(p_tile_ready, destination, destination_base, row_begin, row_end, rows_per_tile):
+    if row_end > row_begin:
+        crfa = buffer_ops.create_buffer_resource_from_addr
+        comm_ops.fence_system_release()
+        remote_tile_ready = buffer_ops.buffer_load(crfa(p_tile_ready), destination, vec_width=1, dtype=fx.Int64)
+        first_tile = (destination_base + row_begin) // rows_per_tile
+        last_tile = (destination_base + row_end - fx.Int32(1)) // rows_per_tile
+        for tile in range(first_tile, last_tile + fx.Int32(1), 1):
+            comm_ops.atomic_add_system(remote_tile_ready + fx.Int64(tile) * fx.Int64(4), fx.Int32(1))
+
+
 # fmt: off
 @flyc.jit
 def emit_direct_fixed_slot_payload(
@@ -367,47 +450,11 @@ def emit_dispatch_plan(
 
     if const_expr(payload_tile_ready and dispatch_blocks > 32):
         if warp == fx.Int32(0):
-            active_payload_blocks = fx.Int32(0)
-            for destination in range_constexpr(fz_npes):
-                max_source_count = fx.Int32(0)
-                for local_expert in range(lane, fz_epr, 64):
-                    ge = fx.Int32(destination * fz_epr) + local_expert
-                    source_count = buffer_ops.buffer_load(r_lh, ge, vec_width=1, dtype=fx.Int32)
-                    max_source_count = (source_count > max_source_count).select(
-                        source_count, max_source_count
-                    )
-                max_source_count = _wave_reduce_max_i32(max_source_count, lane)
-                if lane == fx.Int32(0):
-                    chunks_per_destination = (
-                        max_source_count + fx.Int32(payload_chunk_rows - 1)
-                    ) // fx.Int32(payload_chunk_rows)
-                    chunks_per_destination = (chunks_per_destination > fx.Int32(0)).select(
-                        chunks_per_destination, fx.Int32(1)
-                    )
-                    chunks_per_destination = (chunks_per_destination > fx.Int32(4)).select(
-                        chunks_per_destination, fx.Int32(4)
-                    )
-                    buffer_ops.buffer_store(
-                        chunks_per_destination, crfa(a_payload_chunks_per_destination),
-                        fx.Int32(destination),
-                    )
-                    active_per_destination = chunks_per_destination
-                    active_per_destination = (active_per_destination > fx.Int32(4)).select(
-                        active_per_destination, fx.Int32(4)
-                    )
-                    max_per_destination = fx.Int32(dispatch_blocks // fz_npes)
-                    active_per_destination = (active_per_destination < max_per_destination).select(
-                        active_per_destination, max_per_destination
-                    )
-                    buffer_ops.buffer_store(
-                        active_per_destination, crfa(a_payload_blocks_per_destination),
-                        fx.Int32(destination),
-                    )
-                    active_payload_blocks = active_payload_blocks + active_per_destination
-            if lane == fx.Int32(0):
-                buffer_ops.buffer_store(
-                    active_payload_blocks, crfa(a_active_payload_blocks), fx.Int32(0)
-                )
+            _configure_payload_geometry(
+                a_lh, a_payload_chunks_per_destination, a_payload_blocks_per_destination,
+                a_active_payload_blocks, lane, fz_npes=fz_npes, fz_epr=fz_epr,
+                payload_chunk_rows=payload_chunk_rows, dispatch_blocks=dispatch_blocks,
+            )
         fx.rocdl.s_waitcnt(0)
         fx.barrier()
         comm_ops.fence_agent_release()
@@ -434,10 +481,7 @@ def emit_dispatch_plan(
             mori_shmem.int32_wait_until_equals(a_cd + fx.Int64(done_index) * fx.Int64(4), expected)
         comm_ops.fence_system_acquire()
 
-        r_se = crfa(a_se)
-        r_trb = crfa(a_trb)
         r_nv = crfa(a_nv)
-        r_sm = crfa(a_sm)
         row_carry = fx.Int32(0)
         max_expert_tiles = fx.Int32(0)
         for expert_chunk in range_constexpr((fz_epr + 63) // 64):
@@ -487,10 +531,7 @@ def emit_dispatch_plan(
                         )
                         if source_boundary:
                             tile_index = base_tile + sender_prefix // fx.Int32(fz_tile_m)
-                            value = buffer_ops.buffer_load(
-                                crfa(a_tile_expected), tile_index, vec_width=1, dtype=fx.Int32
-                            )
-                            buffer_ops.buffer_store(value + fx.Int32(1), crfa(a_tile_expected), tile_index)
+                            _increment_i32(crfa(a_tile_expected), tile_index)
                         for chunk_offset in range(
                             fx.Int32(payload_chunk_rows), source_count, payload_chunk_rows
                         ):
@@ -498,21 +539,15 @@ def emit_dispatch_plan(
                             boundary_unaligned = boundary % fx.Int32(fz_tile_m) != fx.Int32(0)
                             if boundary_unaligned:
                                 tile_index = base_tile + boundary // fx.Int32(fz_tile_m)
-                                value = buffer_ops.buffer_load(
-                                    crfa(a_tile_expected), tile_index, vec_width=1, dtype=fx.Int32
-                                )
-                                buffer_ops.buffer_store(value + fx.Int32(1), crfa(a_tile_expected), tile_index)
+                                _increment_i32(crfa(a_tile_expected), tile_index)
                         sender_prefix = sender_prefix + source_count
                 buffer_ops.buffer_store(
                     (local_row_base + padded_rows) // fx.Int32(fz_tile_m), crfa(a_expert_tile_end), local_expert
                 )
-                for tile in range(fx.Int32(0), num_tiles, 1):
-                    metadata_index = (local_row_base // fx.Int32(fz_tile_m)) + tile
-                    buffer_ops.buffer_store(ge, r_se, metadata_index)
-                    buffer_ops.buffer_store(local_row_base + tile * fx.Int32(fz_tile_m), r_trb, metadata_index)
-                padding = padded_rows - total_count
-                for pad in range(fx.Int32(0), padding, 1):
-                    buffer_ops.buffer_store(fx.Int32(fz_npes * fz_mtpr), r_sm, local_row_base + total_count + pad)
+                _store_expert_metadata(
+                    a_se, a_trb, a_sm, ge, local_row_base, total_count, num_tiles, padded_rows,
+                    fz_tile_m=fz_tile_m, invalid_source=fz_npes * fz_mtpr,
+                )
 
             last_lane = min(63, fz_epr - expert_chunk * 64 - 1)
             row_carry = row_carry + fx.Int32(fx.rocdl.readlane(T.i32, inclusive_rows, last_lane))
@@ -859,35 +894,18 @@ def emit_dispatch_payload(
             else:
                 row_token_remote = buffer_ops.buffer_load(crfa(p_rx), destination, vec_width=1, dtype=fx.Int64)
                 destination_rsrc = crfa(row_token_remote + fx.Int64(destination_row) * fx.Int64(fz_nbytes))
-            lane_offset = lane * fx.Int32(4)
-            if const_expr(fz_safe_end_i32 > 0):
-                for column in range(lane_offset, fz_safe_end_i32, 512):
-                    value0 = buffer_ops.buffer_load(source_rsrc, column, vec_width=4, dtype=fx.Int32)
-                    value1 = buffer_ops.buffer_load(
-                        source_rsrc, column + fx.Int32(256), vec_width=4, dtype=fx.Int32
-                    )
-                    buffer_ops.buffer_store(value0, destination_rsrc, column)
-                    buffer_ops.buffer_store(value1, destination_rsrc, column + fx.Int32(256))
-            if const_expr(fz_safe_end_i32 < fz_n_i32):
-                for column in range(lane_offset + fz_safe_end_i32, fz_n_i32, 256):
-                    value = buffer_ops.buffer_load(source_rsrc, column, vec_width=4, dtype=fx.Int32)
-                    buffer_ops.buffer_store(value, destination_rsrc, column)
+            _copy_token_row(
+                source_rsrc, destination_rsrc, lane,
+                fz_safe_end_i32=fz_safe_end_i32, fz_n_i32=fz_n_i32,
+            )
 
         if chunk_active:
             fx.rocdl.s_waitcnt(0)
             fx.barrier()
             if tid == fx.Int32(0):
                 if const_expr(payload_tile_ready):
-                    if row_end > row_begin:
-                        comm_ops.fence_system_release()
-                        remote_tile_ready = buffer_ops.buffer_load(
-                            crfa(p_tile_ready), destination, vec_width=1, dtype=fx.Int64
-                        )
-                        first_tile = (destination_base + row_begin) // destination_ready_rows
-                        last_tile = (destination_base + row_end - fx.Int32(1)) // destination_ready_rows
-                        for tile in range(first_tile, last_tile + fx.Int32(1), 1):
-                            comm_ops.atomic_add_system(
-                                remote_tile_ready + fx.Int64(tile) * fx.Int64(4), fx.Int32(1)
-                            )
+                    _publish_tile_range(
+                        p_tile_ready, destination, destination_base, row_begin, row_end, destination_ready_rows
+                    )
                 _finish_task(destination, local_expert, ge, num_chunks)
             fx.barrier()

--- a/kernels/mega_moe/dispatch.py
+++ b/kernels/mega_moe/dispatch.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
+# ruff: noqa: B023, SIM102
 """Compact dispatch path for MegaMoE v2 stage1."""
 
 from enum import IntEnum
@@ -48,6 +49,16 @@ class DispatchSlot(IntEnum):
     P2P_RUNNING = 30
     LAUNCH_READY = 31
     P2P_LAUNCH_READY = 32
+    MAX_EXPERT_TILES = 33
+    PAYLOAD_CHUNK_DONE = 34
+    TILE_READY = 35
+    P2P_TILE_READY = 36
+    TILE_EXPECTED = 37
+    ACTIVE_PAYLOAD_BLOCKS = 38
+    PAYLOAD_READY_ROWS = 39
+    P2P_PAYLOAD_READY_ROWS = 40
+    PAYLOAD_BLOCKS_PER_DESTINATION = 41
+    PAYLOAD_CHUNKS_PER_DESTINATION = 42
 
 
 DISPATCH_TABLE_SIZE = max(DispatchSlot) + 1
@@ -67,6 +78,14 @@ def _wave_inclusive_scan_i32(value, lane):
     source32 = (lane & fx.Int32(0x30)) - fx.Int32(17)
     remote32 = fx.rocdl.ds_bpermute(T.i32, source32 * fx.Int32(4), value)
     return (lane >= fx.Int32(32)).select(value + fx.Int32(remote32), value)
+
+
+@flyc.jit
+def _wave_reduce_max_i32(value, lane):
+    for distance in (1, 2, 4, 8, 16, 32):
+        peer = fx.Int32(fx.rocdl.ds_bpermute(T.i32, (lane ^ fx.Int32(distance)) * fx.Int32(4), value))
+        value = (peer > value).select(peer, value)
+    return value
 
 
 # fmt: off
@@ -201,6 +220,7 @@ def emit_direct_fixed_slot_finalize(
     p_plan_ready = dp(DispatchSlot.P2P_PLAN_READY)
     a_work_tail = dp(DispatchSlot.WORK_TAIL)
     a_expert_tile_end = dp(DispatchSlot.EXPERT_TILE_END)
+    a_max_expert_tiles = dp(DispatchSlot.MAX_EXPERT_TILES)
 
     tid = fx.thread_idx.x
     lane = tid & fx.Int32(63)
@@ -221,6 +241,7 @@ def emit_direct_fixed_slot_finalize(
         no_overflow = overflow_count == fx.Int32(0)
         safe_count = (count <= fx.Int32(fz_cap)).select(count, fx.Int32(0))
         num_expert_tiles = (safe_count + fx.Int32(fz_tile_m - 1)) // fx.Int32(fz_tile_m)
+        max_expert_tiles = _wave_reduce_max_i32(num_expert_tiles, lane)
         inclusive_tiles = _wave_inclusive_scan_i32(num_expert_tiles, lane)
         metadata_base = inclusive_tiles - num_expert_tiles
         total_tiles = fx.Int32(fx.rocdl.readlane(T.i32, inclusive_tiles, fz_epr - 1))
@@ -248,6 +269,7 @@ def emit_direct_fixed_slot_finalize(
             # num_valid[1] is a device-visible overflow status.
             buffer_ops.buffer_store(overflow_count, crfa(a_nv), fx.Int32(1))
             buffer_ops.buffer_store(ready_work, crfa(a_work_tail), fx.Int32(0))
+            buffer_ops.buffer_store(max_expert_tiles, crfa(a_max_expert_tiles), fx.Int32(0))
 
         fx.rocdl.s_waitcnt(0)
         comm_ops.fence_system_release()
@@ -263,7 +285,7 @@ def emit_direct_fixed_slot_finalize(
 def emit_dispatch_plan(
     *, num_waves, fz_npes, fz_epr, fz_k, fz_mtpr, fz_rank, fz_tile_m, fz_total_experts, addr_disp,
     i32_cur_tok, addr_in_idx, parity, expected, external_grouping, external_counting,
-    dispatch_blocks,
+    dispatch_blocks, payload_chunk_rows=0, payload_tile_ready=False,
 ):
 # fmt: on
     """Build a destination-owned compact plan in one producer-only CTA."""
@@ -291,6 +313,12 @@ def emit_dispatch_plan(
     a_pair_order_ready = dp(DispatchSlot.PAIR_ORDER_READY)
     a_expert_tile_end = dp(DispatchSlot.EXPERT_TILE_END)
     a_group_done = dp(DispatchSlot.GROUP_DONE)
+    a_max_expert_tiles = dp(DispatchSlot.MAX_EXPERT_TILES)
+    a_tile_ready = dp(DispatchSlot.TILE_READY)
+    a_tile_expected = dp(DispatchSlot.TILE_EXPECTED)
+    a_active_payload_blocks = dp(DispatchSlot.ACTIVE_PAYLOAD_BLOCKS)
+    a_payload_blocks_per_destination = dp(DispatchSlot.PAYLOAD_BLOCKS_PER_DESTINATION)
+    a_payload_chunks_per_destination = dp(DispatchSlot.PAYLOAD_CHUNKS_PER_DESTINATION)
 
     tid = fx.thread_idx.x
     lane = tid & fx.Int32(63)
@@ -337,6 +365,53 @@ def emit_dispatch_plan(
     fx.barrier()
     comm_ops.fence_agent_acquire()
 
+    if const_expr(payload_tile_ready and dispatch_blocks > 32):
+        if warp == fx.Int32(0):
+            active_payload_blocks = fx.Int32(0)
+            for destination in range_constexpr(fz_npes):
+                max_source_count = fx.Int32(0)
+                for local_expert in range(lane, fz_epr, 64):
+                    ge = fx.Int32(destination * fz_epr) + local_expert
+                    source_count = buffer_ops.buffer_load(r_lh, ge, vec_width=1, dtype=fx.Int32)
+                    max_source_count = (source_count > max_source_count).select(
+                        source_count, max_source_count
+                    )
+                max_source_count = _wave_reduce_max_i32(max_source_count, lane)
+                if lane == fx.Int32(0):
+                    chunks_per_destination = (
+                        max_source_count + fx.Int32(payload_chunk_rows - 1)
+                    ) // fx.Int32(payload_chunk_rows)
+                    chunks_per_destination = (chunks_per_destination > fx.Int32(0)).select(
+                        chunks_per_destination, fx.Int32(1)
+                    )
+                    chunks_per_destination = (chunks_per_destination > fx.Int32(4)).select(
+                        chunks_per_destination, fx.Int32(4)
+                    )
+                    buffer_ops.buffer_store(
+                        chunks_per_destination, crfa(a_payload_chunks_per_destination),
+                        fx.Int32(destination),
+                    )
+                    active_per_destination = chunks_per_destination
+                    active_per_destination = (active_per_destination > fx.Int32(4)).select(
+                        active_per_destination, fx.Int32(4)
+                    )
+                    max_per_destination = fx.Int32(dispatch_blocks // fz_npes)
+                    active_per_destination = (active_per_destination < max_per_destination).select(
+                        active_per_destination, max_per_destination
+                    )
+                    buffer_ops.buffer_store(
+                        active_per_destination, crfa(a_payload_blocks_per_destination),
+                        fx.Int32(destination),
+                    )
+                    active_payload_blocks = active_payload_blocks + active_per_destination
+            if lane == fx.Int32(0):
+                buffer_ops.buffer_store(
+                    active_payload_blocks, crfa(a_active_payload_blocks), fx.Int32(0)
+                )
+        fx.rocdl.s_waitcnt(0)
+        fx.barrier()
+        comm_ops.fence_agent_release()
+
     # Transpose the source histogram into each destination's count matrix.
     for ge in range(gtid, fz_total_experts, gnt):
         destination = ge // fx.Int32(fz_epr)
@@ -364,6 +439,7 @@ def emit_dispatch_plan(
         r_nv = crfa(a_nv)
         r_sm = crfa(a_sm)
         row_carry = fx.Int32(0)
+        max_expert_tiles = fx.Int32(0)
         for expert_chunk in range_constexpr((fz_epr + 63) // 64):
             local_expert = fx.Int32(expert_chunk * 64) + lane
             valid_expert = local_expert < fx.Int32(fz_epr)
@@ -379,6 +455,10 @@ def emit_dispatch_plan(
                 source_counts.append(source_count)
                 total_count = total_count + source_count
             num_tiles = (total_count + fx.Int32(fz_tile_m - 1)) // fx.Int32(fz_tile_m)
+            chunk_max = _wave_reduce_max_i32(num_tiles, lane)
+            max_expert_tiles = (chunk_max > max_expert_tiles).select(
+                chunk_max, max_expert_tiles
+            )
             padded_rows = num_tiles * fx.Int32(fz_tile_m)
             inclusive_rows = _wave_inclusive_scan_i32(padded_rows, lane)
             local_row_base = row_carry + inclusive_rows - padded_rows
@@ -391,6 +471,38 @@ def emit_dispatch_plan(
                 sender_prefix = sender_prefix + source_counts[source]
 
             if valid_expert:
+                if const_expr(payload_tile_ready):
+                    base_tile = local_row_base // fx.Int32(fz_tile_m)
+                    for tile in range(fx.Int32(0), num_tiles, 1):
+                        tile_index = base_tile + tile
+                        buffer_ops.buffer_store(fx.Int32(0), crfa(a_tile_ready), tile_index)
+                        buffer_ops.buffer_store(fx.Int32(1), crfa(a_tile_expected), tile_index)
+                    sender_prefix = fx.Int32(0)
+                    for source in range_constexpr(fz_npes):
+                        source_count = source_counts[source]
+                        source_active = source_count > fx.Int32(0)
+                        source_boundary = source_active & (sender_prefix > fx.Int32(0))
+                        source_boundary = source_boundary & (
+                            sender_prefix % fx.Int32(fz_tile_m) != fx.Int32(0)
+                        )
+                        if source_boundary:
+                            tile_index = base_tile + sender_prefix // fx.Int32(fz_tile_m)
+                            value = buffer_ops.buffer_load(
+                                crfa(a_tile_expected), tile_index, vec_width=1, dtype=fx.Int32
+                            )
+                            buffer_ops.buffer_store(value + fx.Int32(1), crfa(a_tile_expected), tile_index)
+                        for chunk_offset in range(
+                            fx.Int32(payload_chunk_rows), source_count, payload_chunk_rows
+                        ):
+                            boundary = sender_prefix + chunk_offset
+                            boundary_unaligned = boundary % fx.Int32(fz_tile_m) != fx.Int32(0)
+                            if boundary_unaligned:
+                                tile_index = base_tile + boundary // fx.Int32(fz_tile_m)
+                                value = buffer_ops.buffer_load(
+                                    crfa(a_tile_expected), tile_index, vec_width=1, dtype=fx.Int32
+                                )
+                                buffer_ops.buffer_store(value + fx.Int32(1), crfa(a_tile_expected), tile_index)
+                        sender_prefix = sender_prefix + source_count
                 buffer_ops.buffer_store(
                     (local_row_base + padded_rows) // fx.Int32(fz_tile_m), crfa(a_expert_tile_end), local_expert
                 )
@@ -407,6 +519,7 @@ def emit_dispatch_plan(
 
         if lane == fx.Int32(0):
             buffer_ops.buffer_store(row_carry, r_nv, fx.Int32(0))
+            buffer_ops.buffer_store(max_expert_tiles, crfa(a_max_expert_tiles), fx.Int32(0))
         fx.rocdl.s_waitcnt(0)
         comm_ops.fence_system_release()
         for source in range(lane, fz_npes, 64):
@@ -464,7 +577,12 @@ def emit_dispatch_plan(
     fx.barrier()
     if tid == fx.Int32(0):
         if const_expr(external_grouping):
-            mori_shmem.int32_wait_until_equals(a_group_done, fx.Int32(dispatch_blocks))
+            active_group_blocks = fx.Int32(dispatch_blocks)
+            if const_expr(payload_tile_ready and dispatch_blocks > 32):
+                active_group_blocks = buffer_ops.buffer_load(
+                    crfa(a_active_payload_blocks), fx.Int32(0), vec_width=1, dtype=fx.Int32
+                )
+            mori_shmem.int32_wait_until_equals(a_group_done, active_group_blocks)
             comm_ops.fence_agent_acquire()
         comm_ops.fence_agent_release()
         comm_ops.store_i32_system(a_pair_order_ready, parity, expected)
@@ -474,7 +592,7 @@ def emit_dispatch_plan(
 @flyc.jit
 def emit_dispatch_group(
     *, num_waves, fz_k, fz_total_experts, addr_disp, i32_cur_tok, addr_in_idx, dispatch_blocks,
-    producer_slot, parity, expected, external_counting,
+    producer_slot, parity, expected, external_counting, adaptive_grouping=False,
 ):
 # fmt: on
     """Count and group disjoint route spans across payload producer CTAs."""
@@ -490,6 +608,7 @@ def emit_dispatch_group(
     a_local_cursor = dp(DispatchSlot.LOCAL_CURSOR)
     a_pair_order = dp(DispatchSlot.PAIR_ORDER)
     a_group_done = dp(DispatchSlot.GROUP_DONE)
+    a_active_payload_blocks = dp(DispatchSlot.ACTIVE_PAYLOAD_BLOCKS)
     r_idx = crfa(addr_in_idx)
     r_pair = crfa(a_pair_order)
     tid = fx.thread_idx.x
@@ -514,21 +633,30 @@ def emit_dispatch_group(
         comm_ops.fence_agent_acquire()
     fx.barrier()
 
-    for route in range(group_tid, route_limit, group_threads):
-        expert = buffer_ops.buffer_load(r_idx, route, vec_width=1, dtype=fx.Int32)
-        valid = (expert >= fx.Int32(0)) & (expert < fx.Int32(fz_total_experts))
-        if valid:
-            position = fx.Int32(
-                comm_ops.atomic_add_agent(a_local_cursor + fx.Int64(expert) * fx.Int64(4), fx.Int32(1))
-            )
-            buffer_ops.buffer_store(route, r_pair, position)
-    fx.rocdl.s_waitcnt(0)
-    fx.barrier()
-    if tid == fx.Int32(0):
-        comm_ops.fence_agent_release()
-        comm_ops.atomic_add_agent(a_group_done, fx.Int32(1))
-        mori_shmem.int32_wait_until_equals(a_pair_order_ready + fx.Int64(parity) * fx.Int64(4), expected)
-        comm_ops.fence_agent_acquire()
+    active_group_blocks = fx.Int32(dispatch_blocks)
+    if const_expr(adaptive_grouping and dispatch_blocks > 32):
+        active_group_blocks = buffer_ops.buffer_load(
+            crfa(a_active_payload_blocks), fx.Int32(0), vec_width=1, dtype=fx.Int32
+        )
+    group_active = producer_slot < active_group_blocks
+    if group_active:
+        active_group_tid = producer_slot * block_threads + tid
+        active_group_threads = active_group_blocks * block_threads
+        for route in range(active_group_tid, route_limit, active_group_threads):
+            expert = buffer_ops.buffer_load(r_idx, route, vec_width=1, dtype=fx.Int32)
+            valid = (expert >= fx.Int32(0)) & (expert < fx.Int32(fz_total_experts))
+            if valid:
+                position = fx.Int32(
+                    comm_ops.atomic_add_agent(a_local_cursor + fx.Int64(expert) * fx.Int64(4), fx.Int32(1))
+                )
+                buffer_ops.buffer_store(route, r_pair, position)
+        fx.rocdl.s_waitcnt(0)
+        fx.barrier()
+        if tid == fx.Int32(0):
+            comm_ops.fence_agent_release()
+            comm_ops.atomic_add_agent(a_group_done, fx.Int32(1))
+            mori_shmem.int32_wait_until_equals(a_pair_order_ready + fx.Int64(parity) * fx.Int64(4), expected)
+            comm_ops.fence_agent_acquire()
     fx.barrier()
 
 
@@ -537,7 +665,9 @@ def emit_dispatch_group(
 def emit_dispatch_payload(
     *, num_waves, fz_epr, fz_k, fz_mtpr, fz_rank, fz_total_experts, fz_nbytes, fz_n_i32, fz_safe_end_i32,
     fz_scale_n_i32, fz_enable_scales, addr_disp, addr_in_tok, addr_in_wts, addr_in_sc, dispatch_blocks,
-    producer_slot, parity, expected,
+    producer_slot, parity, expected, producers_per_destination, chunks_per_destination,
+    payload_chunk_rows=0,
+    payload_tile_ready=False,
 ):
 # fmt: on
     """Produce independently publishable expert payloads from a compact plan."""
@@ -557,6 +687,9 @@ def emit_dispatch_payload(
     p_payload_ready = dp(DispatchSlot.P2P_PAYLOAD_READY)
     a_pair_order = dp(DispatchSlot.PAIR_ORDER)
     a_plan_ready = dp(DispatchSlot.PLAN_READY)
+    a_chunk_done = dp(DispatchSlot.PAYLOAD_CHUNK_DONE)
+    p_tile_ready = dp(DispatchSlot.P2P_TILE_READY)
+    p_payload_ready_rows = dp(DispatchSlot.P2P_PAYLOAD_READY_ROWS)
 
     tid = fx.thread_idx.x
     lane = tid & fx.Int32(63)
@@ -566,9 +699,7 @@ def emit_dispatch_payload(
     r_mb = crfa(a_mb)
     r_pair = crfa(a_pair_order)
     r_wts = crfa(addr_in_wts)
-    task_limit = fx.Int32(fz_total_experts)
-    task0 = producer_slot
-    task_stride = fx.Int32(dispatch_blocks)
+    r_chunk_done = crfa(a_chunk_done)
     row0 = warp
     row_stride = fx.Int32(num_waves)
 
@@ -579,16 +710,54 @@ def emit_dispatch_payload(
         comm_ops.atomic_add_system(ready_remote + fx.Int64(ready_index) * fx.Int64(4), fx.Int32(1))
         buffer_ops.buffer_store(fx.Int32(0), r_lh, ge)
 
+    def _finish_task(destination, local_expert, ge, num_chunks):
+        if const_expr(payload_chunk_rows > 0):
+            comm_ops.fence_system_release()
+            completed = fx.Int32(
+                comm_ops.atomic_add_agent(a_chunk_done + fx.Int64(ge) * fx.Int64(4), fx.Int32(1))
+            )
+            if completed == num_chunks - fx.Int32(1):
+                comm_ops.fence_agent_acquire()
+                buffer_ops.buffer_store(fx.Int32(0), r_chunk_done, ge)
+                _publish_task(destination, local_expert, ge)
+        else:
+            _publish_task(destination, local_expert, ge)
+
     num_destinations = fz_total_experts // fz_epr
+    if const_expr(payload_chunk_rows > 0):
+        assert dispatch_blocks % num_destinations == 0
+        task_limit = fx.Int32(fz_epr) * chunks_per_destination
+        task0 = producer_slot // fx.Int32(num_destinations)
+        task_stride = fx.Int32(producers_per_destination)
+    else:
+        task_limit = fx.Int32(fz_total_experts)
+        task0 = producer_slot
+        task_stride = fx.Int32(dispatch_blocks)
     hoist_remote_resources = fz_mtpr >= 1024
     producer_destination = producer_slot % fx.Int32(num_destinations)
     ready_index = parity * fx.Int32(num_destinations) + producer_destination
     if tid == fx.Int32(0):
         mori_shmem.int32_wait_until_equals(a_plan_ready + fx.Int64(ready_index) * fx.Int64(4), expected)
         comm_ops.fence_system_acquire()
+    destination_ready_rows = fx.Int32(0)
+    if const_expr(payload_tile_ready):
+        if tid == fx.Int32(0):
+            remote_ready_rows = buffer_ops.buffer_load(
+                crfa(p_payload_ready_rows), producer_destination, vec_width=1, dtype=fx.Int64
+            )
+            destination_ready_rows = buffer_ops.buffer_load(
+                crfa(remote_ready_rows), fx.Int32(0), vec_width=1, dtype=fx.Int32
+            )
     fx.barrier()
     for task_index in range(task0, task_limit, task_stride):
-        local_expert = task_index // fx.Int32(num_destinations)
+        if const_expr(payload_chunk_rows > 0):
+            chunk_id = task_index // fx.Int32(fz_epr)
+            rotated_expert = task_index - chunk_id * fx.Int32(fz_epr)
+            rotation = (chunk_id * fx.Int32(17)) % fx.Int32(fz_epr)
+            local_expert = (rotated_expert + fx.Int32(fz_epr) - rotation) % fx.Int32(fz_epr)
+        else:
+            chunk_id = fx.Int32(0)
+            local_expert = task_index // fx.Int32(num_destinations)
         destination = producer_destination
         ge = destination * fx.Int32(fz_epr) + local_expert
         source_count_lane = fx.Int32(0)
@@ -601,13 +770,29 @@ def emit_dispatch_payload(
         source_count = fx.Int32(fx.rocdl.readfirstlane(T.i32, source_count_lane))
         source_base = fx.Int32(fx.rocdl.readfirstlane(T.i32, source_base_lane))
         destination_base = fx.Int32(fx.rocdl.readfirstlane(T.i32, destination_base_lane))
+        if const_expr(payload_chunk_rows > 0):
+            num_chunks = (source_count + fx.Int32(payload_chunk_rows - 1)) // fx.Int32(
+                payload_chunk_rows
+            )
+            num_chunks = (num_chunks > fx.Int32(0)).select(num_chunks, fx.Int32(1))
+            chunk_active = chunk_id < num_chunks
+            chunk_begin = chunk_id * fx.Int32(payload_chunk_rows)
+            chunk_limit = chunk_begin + fx.Int32(payload_chunk_rows)
+            chunk_end = (source_count < chunk_limit).select(source_count, chunk_limit)
+            row_begin = chunk_active.select(chunk_begin, fx.Int32(0))
+            row_end = chunk_active.select(chunk_end, fx.Int32(0))
+        else:
+            num_chunks = fx.Int32(1)
+            chunk_active = fx.Int32(0) == fx.Int32(0)
+            row_begin = fx.Int32(0)
+            row_end = source_count
         if const_expr(hoist_remote_resources):
             wts_remote_rsrc = crfa(buffer_ops.buffer_load(crfa(p_wts), destination, vec_width=1, dtype=fx.Int64))
             srcmap_remote_rsrc = crfa(buffer_ops.buffer_load(crfa(p_sm), destination, vec_width=1, dtype=fx.Int64))
             token_remote = buffer_ops.buffer_load(crfa(p_rx), destination, vec_width=1, dtype=fx.Int64)
             if const_expr(fz_enable_scales):
                 scale_remote_rsrc = crfa(buffer_ops.buffer_load(crfa(p_sc), destination, vec_width=1, dtype=fx.Int64))
-        for row in range(row0, source_count, row_stride):
+        for row in range(row_begin + row0, row_end, row_stride):
             wk_lane = fx.Int32(0)
             if lane == fx.Int32(0):
                 wk_lane = buffer_ops.buffer_load(r_pair, source_base + row, vec_width=1, dtype=fx.Int32)
@@ -688,8 +873,21 @@ def emit_dispatch_payload(
                     value = buffer_ops.buffer_load(source_rsrc, column, vec_width=4, dtype=fx.Int32)
                     buffer_ops.buffer_store(value, destination_rsrc, column)
 
-        fx.rocdl.s_waitcnt(0)
-        fx.barrier()
-        if tid == fx.Int32(0):
-            _publish_task(destination, local_expert, ge)
-        fx.barrier()
+        if chunk_active:
+            fx.rocdl.s_waitcnt(0)
+            fx.barrier()
+            if tid == fx.Int32(0):
+                if const_expr(payload_tile_ready):
+                    if row_end > row_begin:
+                        comm_ops.fence_system_release()
+                        remote_tile_ready = buffer_ops.buffer_load(
+                            crfa(p_tile_ready), destination, vec_width=1, dtype=fx.Int64
+                        )
+                        first_tile = (destination_base + row_begin) // destination_ready_rows
+                        last_tile = (destination_base + row_end - fx.Int32(1)) // destination_ready_rows
+                        for tile in range(first_tile, last_tile + fx.Int32(1), 1):
+                            comm_ops.atomic_add_system(
+                                remote_tile_ready + fx.Int64(tile) * fx.Int64(4), fx.Int32(1)
+                            )
+                _finish_task(destination, local_expert, ge, num_chunks)
+            fx.barrier()

--- a/kernels/mega_moe/dispatch.py
+++ b/kernels/mega_moe/dispatch.py
@@ -94,11 +94,13 @@ def _increment_i32(rsrc, index):
     buffer_ops.buffer_store(value + fx.Int32(1), rsrc, index)
 
 
+# fmt: off
 @flyc.jit
 def _configure_payload_geometry(
     addr_local_hist, addr_chunk_counts, addr_block_counts, addr_active_blocks, lane, *, fz_npes, fz_epr,
     payload_chunk_rows, dispatch_blocks,
 ):
+# fmt: on
     crfa = buffer_ops.create_buffer_resource_from_addr
     local_hist = crfa(addr_local_hist)
     chunk_counts = crfa(addr_chunk_counts)
@@ -125,11 +127,13 @@ def _configure_payload_geometry(
         buffer_ops.buffer_store(active_payload_blocks, crfa(addr_active_blocks), fx.Int32(0))
 
 
+# fmt: off
 @flyc.jit
 def _store_expert_metadata(
     addr_sorted_expert, addr_tile_row_base, addr_srcmap, ge, local_row_base, total_count, num_tiles,
     padded_rows, *, fz_tile_m, invalid_source,
 ):
+# fmt: on
     crfa = buffer_ops.create_buffer_resource_from_addr
     sorted_expert = crfa(addr_sorted_expert)
     tile_row_base = crfa(addr_tile_row_base)

--- a/kernels/mega_moe/gemm_util.py
+++ b/kernels/mega_moe/gemm_util.py
@@ -354,7 +354,7 @@ class AScaleLoader:
         off = row_i32 * fx.Int32(self._n_scale) + col_i32
         ptr = fx.recast_iter(fx.Uint8, fx.add_offset(lds_ascale.ptr, fx.make_int_tuple(off)))
         v = fx.make_view(ptr, fx.make_layout(1, 1)).load()
-        return Vec(v)[0].to(fx.Int32)
+        return Vec(v, dtype=fx.Uint8)[0].to(fx.Int32)
 
 
 class MfmaScaleGU:

--- a/kernels/mega_moe/mega_moe.py
+++ b/kernels/mega_moe/mega_moe.py
@@ -12,7 +12,12 @@ from kernels.comm.flydsl_dispatch_combine_intranode_op import (
 )
 
 from .dispatch import DISPATCH_TABLE_SIZE, DispatchSlot
-from .mega_moe_config import FIXED_SLOT_MAX_MTPR, MegaMoEConfig, Stage1Config, select_mega_moe_config
+from .mega_moe_config import (
+    FIXED_SLOT_MAX_MTPR,
+    MegaMoEConfig,
+    Stage1Config,
+    select_mega_moe_config,
+)
 from .quant import per_1x32_mx_quant
 
 __all__ = ["MegaMoEV2"]
@@ -85,7 +90,7 @@ class MegaMoEV2:
         self._s1_epoch_parity = torch.zeros(1, dtype=torch.int32, device=self.dev)
         self._s1_epoch_expected = torch.zeros(2, dtype=torch.int32, device=self.dev)
         self._s1_num_cu = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
-        self._allocate_dispatch_workspace(op)
+        self._allocate_dispatch_workspace(op, metadata_blocks)
         self._s1_mega = run_mega_moe_stage1
 
         v = op._ll_views()
@@ -100,7 +105,7 @@ class MegaMoEV2:
         self._s1_osd = torch.zeros(prows * pcols + inter_dim, dtype=torch.uint8, device=self.dev)
         self._build_v2_disp_table()
 
-    def _allocate_dispatch_workspace(self, op):
+    def _allocate_dispatch_workspace(self, op, metadata_blocks):
         total_experts = self.world_size * self.epr
         workspace = {
             "local_hist": torch.zeros(total_experts, dtype=torch.int32, device=self.dev),
@@ -114,6 +119,12 @@ class MegaMoEV2:
             "work_head": torch.zeros(8 * 16, dtype=torch.int32, device=self.dev),
             "work_tail": torch.zeros(1, dtype=torch.int32, device=self.dev),
             "expert_tile_end": torch.empty(self.epr, dtype=torch.int32, device=self.dev),
+            "max_expert_tiles": torch.zeros(1, dtype=torch.int32, device=self.dev),
+            "payload_chunk_done": torch.zeros(total_experts, dtype=torch.int32, device=self.dev),
+            "tile_expected": torch.zeros(metadata_blocks, dtype=torch.int32, device=self.dev),
+            "active_payload_blocks": torch.zeros(1, dtype=torch.int32, device=self.dev),
+            "payload_blocks_per_destination": torch.zeros(self.world_size, dtype=torch.int32, device=self.dev),
+            "payload_chunks_per_destination": torch.zeros(self.world_size, dtype=torch.int32, device=self.dev),
             "group_done": torch.zeros(1, dtype=torch.int32, device=self.dev),
         }
         workspace["bigcnt"] = op._sym((self.world_size * self.epr,), torch.int32)
@@ -122,6 +133,8 @@ class MegaMoEV2:
         workspace["plan_ready"] = op._sym((2 * self.world_size,), torch.int32)
         workspace["payload_ready"] = op._sym((2 * self.epr,), torch.int32)
         workspace["launch_ready"] = op._sym((self.world_size,), torch.int32)
+        workspace["tile_ready"] = op._sym((metadata_blocks,), torch.int32)
+        workspace["payload_ready_rows"] = op._sym((1,), torch.int32)
         ms.shmem_barrier_all()
         workspace["p2p_bigcnt"] = op._p2p_table(workspace["bigcnt"])
         workspace["p2p_count_done"] = op._p2p_table(workspace["count_done"])
@@ -129,6 +142,8 @@ class MegaMoEV2:
         workspace["p2p_plan_ready"] = op._p2p_table(workspace["plan_ready"])
         workspace["p2p_payload_ready"] = op._p2p_table(workspace["payload_ready"])
         workspace["p2p_launch_ready"] = op._p2p_table(workspace["launch_ready"])
+        workspace["p2p_tile_ready"] = op._p2p_table(workspace["tile_ready"])
+        workspace["p2p_payload_ready_rows"] = op._p2p_table(workspace["payload_ready_rows"])
         self._s1_dispatch_workspace = workspace
 
     def _build_v2_disp_table(self):
@@ -168,10 +183,30 @@ class MegaMoEV2:
         table[DispatchSlot.P2P_RUNNING] = op.p2p_running.data_ptr()
         table[DispatchSlot.LAUNCH_READY] = workspace["launch_ready"].data_ptr()
         table[DispatchSlot.P2P_LAUNCH_READY] = workspace["p2p_launch_ready"].data_ptr()
+        table[DispatchSlot.MAX_EXPERT_TILES] = workspace["max_expert_tiles"].data_ptr()
+        table[DispatchSlot.PAYLOAD_CHUNK_DONE] = workspace["payload_chunk_done"].data_ptr()
+        table[DispatchSlot.TILE_READY] = workspace["tile_ready"].data_ptr()
+        table[DispatchSlot.P2P_TILE_READY] = workspace["p2p_tile_ready"].data_ptr()
+        table[DispatchSlot.TILE_EXPECTED] = workspace["tile_expected"].data_ptr()
+        table[DispatchSlot.ACTIVE_PAYLOAD_BLOCKS] = workspace["active_payload_blocks"].data_ptr()
+        table[DispatchSlot.PAYLOAD_READY_ROWS] = workspace["payload_ready_rows"].data_ptr()
+        table[DispatchSlot.P2P_PAYLOAD_READY_ROWS] = workspace["p2p_payload_ready_rows"].data_ptr()
+        table[DispatchSlot.PAYLOAD_BLOCKS_PER_DESTINATION] = workspace[
+            "payload_blocks_per_destination"
+        ].data_ptr()
+        table[DispatchSlot.PAYLOAD_CHUNKS_PER_DESTINATION] = workspace[
+            "payload_chunks_per_destination"
+        ].data_ptr()
         self._s1_disp = torch.tensor(table, dtype=torch.int64, device=self.dev)
 
     def _select_config(self, tokens: int) -> MegaMoEConfig:
-        config = select_mega_moe_config(tokens, self.mtpr)
+        config = select_mega_moe_config(
+            tokens,
+            self.mtpr,
+            experts_per_rank=self.epr,
+            model_dim=self.model_dim,
+            inter_dim=self.inter_dim,
+        )
         self._active_config = config
         return config
 
@@ -216,7 +251,9 @@ class MegaMoEV2:
             use_tile_resource=config.use_tile_resource,
             waves_per_eu_hint=config.waves_per_eu_hint, b_nt=config.b_nt,
             work_shards=config.work_shards, external_grouping=config.external_grouping,
-            external_counting=config.external_counting, swiglu_limit=self.swiglu_limit)
+            external_counting=config.external_counting, payload_chunk_rows=config.payload_chunk_rows,
+            payload_tile_ready=config.payload_tile_ready,
+            swiglu_limit=self.swiglu_limit)
         # fmt: on
         self._s1_active_tile_m = config.sort_block_m
         return self._s1_active_tile_m
@@ -308,6 +345,7 @@ class MegaMoEV2:
             fx.Int64(self._s1_out.view(-1).data_ptr()), fx.Int64(self._s1_osd.data_ptr()),
             fx.Int64(self.w2.data_ptr()), fx.Int64(self.w2_scale.data_ptr()),
             fx.Int64(op.sorted_expert_ids.data_ptr()), fx.Int64(op.num_valid.data_ptr()),
+            fx.Int64(self._s1_dispatch_workspace["max_expert_tiles"].data_ptr()),
             fx.Int64(op.srcmap_em.data_ptr()), fx.Int64(op.wts_em.data_ptr()),
             fx.Int64(op.tile_row_base.data_ptr()), comb_op._fx_p2p_comb_inp, self._s1_nvm,
             self._g2v2_inter, self._g2v2_hidden, s_fx, BM=stage2.block_m,
@@ -315,7 +353,8 @@ class MegaMoEV2:
             use_nt=stage2.use_nt, g2_bhoist=stage2.b_hoist,
             g2_ascale_pf=stage2.ascale_prefetch, g2_spart=stage2.spatial_partition,
             persist=stage2.persist, persist_cu=stage2.persist_cu,
-            persist_strided=stage2.persist_strided, g2_bf16_lds=stage2.bf16_lds, **invariants)
+            persist_strided=stage2.persist_strided, skew_cu=stage2.skew_cu,
+            g2_bf16_lds=stage2.bf16_lds, **invariants)
         # fmt: on
         self._g2_active_block_m = stage2.block_m
         return comb_op.combine_no_stage1(

--- a/kernels/mega_moe/mega_moe_config.py
+++ b/kernels/mega_moe/mega_moe_config.py
@@ -1,30 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
-"""Static MegaMoEV2 configurations tuned for eight-GPU MI355X."""
+"""Static MegaMoEV2 configuration rules for MI355X."""
 
 from bisect import bisect_left
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from functools import lru_cache
 
-TOKEN_BUCKETS = (
-    1,
-    4,
-    8,
-    16,
-    32,
-    64,
-    128,
-    256,
-    512,
-    1024,
-    2048,
-    4096,
-    8192,
-    16384,
-    32768,
-)
+TOKEN_BUCKETS = (1, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768)
 P2P_FP8_MIN_MTPR = 1024
 FIXED_SLOT_MAX_MTPR = 255
+MAX_MTPR_CLASS = 32768
+REFERENCE_EXPERTS_PER_RANK = 48
+EXPERT_CONFIG_GRANULARITY = 64
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,6 +32,8 @@ class Stage1Config:
     work_shards: int = 8
     external_grouping: bool = False
     external_counting: bool = False
+    payload_chunk_rows: int = 0
+    payload_tile_ready: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,6 +44,7 @@ class Stage2Config:
     persist_cu: int
     use_nt: bool
     persist_strided: bool = False
+    skew_cu: int = 0
     block_k: int = 256
     b_hoist: bool = True
     ascale_prefetch: bool = True
@@ -79,75 +69,6 @@ class MegaMoEConfig:
             raise ValueError("FP8 P2P requires Stage2 bf16_lds=False")
 
 
-_FIXED_GEOMETRY = {
-    1: (1, 64, True, 2, 0),
-    4: (1, 128, True, 2, 3),
-    8: (2, 128, True, 2, 3),
-    16: (4, 96, True, 1, 3),
-    32: (3, 128, False, 2, 3),
-    64: (3, 208, False, 2, 3),
-    128: (3, 224, False, 2, 3),
-}
-
-_COMPACT_SMALL_DISPATCH_CU = {
-    1: 224,
-    4: 128,
-    8: 192,
-    16: 64,
-    32: 128,
-    64: 192,
-    128: 128,
-}
-
-_OVERSIZED_SMALL_DISPATCH_CU = {
-    4096: {4: 224, 8: 128},
-    16384: {1: 128, 4: 224, 8: 64, 64: 64},
-    32768: {4: 224, 8: 128, 128: 64},
-}
-
-# work shards, external grouping, external counting
-_OVERSIZED_SMALL_PROTOCOL = {
-    2048: {
-        4: (8, False, False),
-        32: (8, False, False),
-        128: (8, False, False),
-    },
-    4096: {
-        1: (1, False, False),
-        32: (8, False, False),
-        64: (1, False, False),
-        128: (8, False, False),
-    },
-    8192: {
-        1: (1, False, False),
-        4: (1, True, False),
-        8: (1, False, False),
-        16: (1, False, False),
-        32: (1, False, False),
-        64: (4, False, False),
-        128: (4, False, False),
-    },
-    16384: {
-        1: (1, True, False),
-        4: (8, False, False),
-        8: (2, True, False),
-        16: (2, True, False),
-        32: (4, False, False),
-        64: (1, False, False),
-        128: (4, False, False),
-    },
-    32768: {
-        1: (1, False, False),
-        4: (1, True, False),
-        8: (1, True, False),
-        16: (1, False, False),
-        32: (2, False, False),
-        64: (4, False, False),
-        128: (4, False, False),
-    },
-}
-
-
 def nearest_token_bucket(tokens: int) -> int:
     if tokens <= 0:
         raise ValueError(f"tokens must be positive, got {tokens}")
@@ -160,198 +81,246 @@ def nearest_token_bucket(tokens: int) -> int:
     return upper if upper - tokens <= tokens - lower else lower
 
 
-def _select_stage1(bucket: int, fixed_slot: bool, mtpr: int) -> Stage1Config:
-    if fixed_slot:
-        grid_mult, dispatch_cu, tile_resource, waves_per_eu, b_nt = _FIXED_GEOMETRY[bucket]
-        config = Stage1Config(
-            sort_block_m=32,
-            tile_n=256 if bucket <= 8 else 128,
-            num_waves=4,
-            grid_mult=grid_mult,
-            num_dispatch_cu=dispatch_cu,
-            mfma_amajor=False,
-            async_a_copy=False,
-            use_tile_resource=tile_resource,
-            b_nt=b_nt,
-            waves_per_eu_hint=waves_per_eu,
-        )
-    elif bucket <= 4:
-        config = Stage1Config(
-            sort_block_m=32,
-            tile_n=256,
-            num_waves=4,
-            grid_mult=1,
-            num_dispatch_cu=_COMPACT_SMALL_DISPATCH_CU[bucket],
-            mfma_amajor=False,
-            async_a_copy=False,
-            use_tile_resource=False,
-            b_nt=0 if bucket == 1 else 3,
-        )
-    elif bucket <= 128:
-        config = Stage1Config(
-            sort_block_m=32,
-            tile_n=512,
-            num_waves=8,
-            grid_mult=1,
-            num_dispatch_cu=_COMPACT_SMALL_DISPATCH_CU[bucket],
-            mfma_amajor=True,
-            async_a_copy=True,
-            use_tile_resource=False,
-            b_nt=3,
-        )
-    elif bucket <= 1024:
-        config = Stage1Config(
-            sort_block_m=64,
-            tile_n=512,
-            num_waves=8,
-            grid_mult=1 if bucket == 256 else 2,
-            num_dispatch_cu=160 if bucket == 256 else 128,
-            mfma_amajor=True,
-            async_a_copy=True,
-            use_tile_resource=bucket == 256,
-            b_nt=3 if bucket <= 512 else 0,
-        )
-    elif bucket == 2048:
-        config = Stage1Config(
-            sort_block_m=64,
-            tile_n=512,
-            num_waves=8,
-            grid_mult=1,
-            num_dispatch_cu=32,
-            mfma_amajor=True,
-            async_a_copy=False,
-            use_tile_resource=True,
-            b_nt=0,
-        )
-    else:
-        config = Stage1Config(
-            sort_block_m=128,
-            tile_n=512,
-            num_waves=8,
-            grid_mult=1,
-            num_dispatch_cu=32,
-            mfma_amajor=True,
-            async_a_copy=True,
-            use_tile_resource=bucket >= 16384,
-            b_nt=0,
-        )
+def mtpr_config_class(mtpr: int) -> int:
+    return mtpr if mtpr <= P2P_FP8_MIN_MTPR else MAX_MTPR_CLASS
 
-    oversized_capacity = not fixed_slot and mtpr > bucket
-    if oversized_capacity:
-        dispatch_cu = _OVERSIZED_SMALL_DISPATCH_CU.get(mtpr, {}).get(bucket)
-        if dispatch_cu is not None:
-            config = replace(config, num_dispatch_cu=dispatch_cu)
-        elif bucket == 32:
-            config = replace(config, num_dispatch_cu=192 if mtpr in (4096, 16384) else 64)
-        elif bucket == 64:
-            config = replace(config, num_dispatch_cu=160)
-        elif bucket == 128:
-            config = replace(config, num_dispatch_cu=192)
-        elif bucket == 256 and mtpr >= 16384:
-            config = replace(config, sort_block_m=32, grid_mult=1, num_dispatch_cu=64)
-        elif bucket == 512:
-            config = replace(
-                config,
-                sort_block_m=64,
-                grid_mult=2 if mtpr >= 32768 else 1,
-                num_dispatch_cu=64,
-                use_tile_resource=mtpr != 4096,
-                b_nt=3 if mtpr >= 16384 else 0,
-            )
-        elif bucket == 1024:
-            config = replace(
-                config,
-                sort_block_m=64,
-                grid_mult=1,
-                num_dispatch_cu=64,
-                use_tile_resource=True,
-                b_nt=0,
-            )
-        elif bucket == 2048 and mtpr >= 4096:
-            config = replace(
-                config,
-                grid_mult=1 if mtpr >= 16384 else 2,
-                num_dispatch_cu=64,
-                async_a_copy=mtpr != 8192,
-            )
-        elif bucket == 4096:
-            config = replace(
-                config,
-                grid_mult=1 if mtpr == 8192 else 2,
-                num_dispatch_cu=64 if mtpr == 8192 else 32,
-                use_tile_resource=mtpr >= 16384,
-            )
 
-    if mtpr >= 16384:
-        config = replace(config, use_tile_resource=True)
-    external_grouping = not fixed_slot and mtpr >= 2048
-    work_shards = 4 if mtpr >= 8192 or (bucket == 1024 and mtpr >= 4096) else 8
-    external_counting = external_grouping and (mtpr >= 8192 or (bucket == 1024 and mtpr >= 4096))
-    if oversized_capacity and bucket <= 128:
-        work_shards, external_grouping, external_counting = _OVERSIZED_SMALL_PROTOCOL.get(mtpr, {}).get(
-            bucket, (work_shards, external_grouping, external_counting)
-        )
-    if bucket == 2048 and mtpr == 8192:
-        work_shards = 2
-    elif bucket == 4096 and mtpr == 16384:
-        work_shards, external_counting = 1, False
-    return replace(
-        config,
-        work_shards=work_shards,
-        external_grouping=external_grouping,
-        external_counting=external_counting,
+def expert_config_class(experts_per_rank: int) -> int:
+    return ((experts_per_rank + EXPERT_CONFIG_GRANULARITY - 1) // EXPERT_CONFIG_GRANULARITY) * EXPERT_CONFIG_GRANULARITY
+
+
+def _scale_dispatch_cu(dispatch_cu: int, experts_per_rank: int) -> int:
+    expert_waves = (experts_per_rank + 63) // 64
+    return min(224, dispatch_cu * expert_waves)
+
+
+def _fixed_dispatch_cu(bucket: int) -> int:
+    if bucket <= 1:
+        return 64
+    if bucket <= 8:
+        return 128
+    if bucket <= 16:
+        return 96
+    if bucket <= 32:
+        return 128
+    return min(224, 16 * (bucket.bit_length() + 7))
+
+
+def _compact_dispatch_cu(bucket: int) -> int:
+    if bucket <= 1:
+        return 224
+    if bucket <= 4:
+        return 128
+    if bucket <= 8:
+        return 192
+    if bucket <= 16:
+        return 64
+    if bucket <= 32:
+        return 128
+    if bucket <= 64:
+        return 192
+    return 128
+
+
+def _large_dispatch_cu(bucket: int) -> int:
+    if bucket <= 1:
+        return 224
+    if bucket <= 4:
+        return 128
+    if bucket <= 8:
+        return 192
+    if bucket <= 32:
+        return 64
+    if bucket <= 64:
+        return 160
+    if bucket <= 128:
+        return 192
+    if bucket <= 256:
+        return 160
+    if bucket == 8192:
+        return 96
+    if bucket >= 16384:
+        return 32
+    return 64
+
+
+def _select_fixed_stage1(bucket: int, experts_per_rank: int) -> Stage1Config:
+    grid_mult = max(1, bucket // 4) if bucket <= 16 else 3
+    return Stage1Config(
+        sort_block_m=32,
+        tile_n=256 if bucket <= 8 else 128,
+        num_waves=4,
+        grid_mult=grid_mult,
+        num_dispatch_cu=_scale_dispatch_cu(_fixed_dispatch_cu(bucket), experts_per_rank),
+        mfma_amajor=False,
+        async_a_copy=False,
+        use_tile_resource=bucket <= 16,
+        b_nt=0 if bucket == 1 else 3,
+        waves_per_eu_hint=1 if bucket == 16 else 2,
     )
 
 
-def _select_stage2(bucket: int, fixed_slot: bool, mtpr: int, sort_block_m: int) -> Stage2Config:
+def _select_bounded_stage1(bucket: int, mtpr: int, experts_per_rank: int, inter_dim: int) -> Stage1Config:
+    if bucket <= 4:
+        sort_block_m, tile_n, num_waves = 32, 256, 4
+        grid_mult, mfma_amajor, async_a_copy = 1, False, False
+    elif bucket <= 128:
+        sort_block_m = 32
+        tile_n, num_waves = (512 if inter_dim >= 2048 else 256), 8
+        grid_mult, mfma_amajor, async_a_copy = 1, True, True
+    elif bucket <= 1024:
+        sort_block_m = 64
+        tile_n, num_waves = (512 if inter_dim >= 2048 else 256), 8
+        grid_mult, mfma_amajor, async_a_copy = (1 if bucket == 256 else 2), True, True
+    else:
+        raise ValueError(f"bounded MTPR does not support token bucket {bucket}")
+
+    dispatch_cu = _compact_dispatch_cu(bucket) if bucket <= 128 else 160 if bucket == 256 else 128
+    tile_resource = bucket == 256
+    b_nt = 0 if bucket == 1 or bucket >= 1024 else 3
+    if mtpr > bucket:
+        if bucket == 32:
+            dispatch_cu = 64
+        elif bucket == 64:
+            dispatch_cu = 160
+        elif bucket == 128:
+            dispatch_cu = 192
+        elif bucket == 512:
+            grid_mult, dispatch_cu, tile_resource, b_nt = 1, 64, True, 0
+    return Stage1Config(
+        sort_block_m=sort_block_m,
+        tile_n=tile_n,
+        num_waves=num_waves,
+        grid_mult=grid_mult,
+        num_dispatch_cu=_scale_dispatch_cu(dispatch_cu, experts_per_rank),
+        mfma_amajor=mfma_amajor,
+        async_a_copy=async_a_copy,
+        use_tile_resource=tile_resource,
+        b_nt=b_nt,
+    )
+
+
+def _select_large_stage1(bucket: int, experts_per_rank: int, inter_dim: int) -> Stage1Config:
+    if bucket <= 4:
+        sort_block_m, tile_n, num_waves = 32, 256, 4
+        mfma_amajor, async_a_copy = False, False
+    elif bucket <= 128:
+        sort_block_m = 32
+        tile_n, num_waves = (512 if inter_dim >= 2048 else 256), 8
+        mfma_amajor, async_a_copy = True, True
+    elif bucket <= 2048:
+        sort_block_m = 64
+        tile_n, num_waves = (512 if inter_dim >= 2048 else 256), 8
+        mfma_amajor, async_a_copy = True, True
+    else:
+        sort_block_m = 128
+        tile_n, num_waves = (512 if inter_dim >= 2048 else 256), 8
+        mfma_amajor, async_a_copy = True, True
+
+    work_shards = 1 if bucket <= 32 else 4
+    if bucket == 2048:
+        work_shards = 8
+    return Stage1Config(
+        sort_block_m=sort_block_m,
+        tile_n=tile_n,
+        num_waves=num_waves,
+        grid_mult=1,
+        num_dispatch_cu=_scale_dispatch_cu(_large_dispatch_cu(bucket), experts_per_rank),
+        mfma_amajor=mfma_amajor,
+        async_a_copy=async_a_copy,
+        use_tile_resource=True,
+        b_nt=3 if 1 < bucket <= 256 else 0,
+        work_shards=work_shards,
+        external_grouping=bucket == 4 or bucket >= 256,
+        external_counting=bucket >= 256,
+        payload_chunk_rows=384,
+        payload_tile_ready=True,
+    )
+
+
+def _select_bounded_stage2(bucket: int, fixed_slot: bool, mtpr: int, sort_block_m: int, model_dim: int) -> Stage2Config:
     if not fixed_slot and mtpr > bucket:
-        if bucket == 128 and mtpr == 4096:
-            persist_cu = 128
-        elif bucket == 256 and mtpr >= 32768:
-            persist_cu = 256
-        else:
-            persist_cu = {1024: 224, 2048: 256, 8192: 256, 16384: 192}.get(bucket, 240)
         return Stage2Config(
             block_m=64 if sort_block_m == 128 else 32,
             block_n=128 if bucket == 256 and sort_block_m == 64 else 256,
             persist=True,
-            persist_cu=persist_cu,
+            persist_cu=240,
             use_nt=bucket <= 128,
-            persist_strided=bucket in (512, 1024, 2048),
+            persist_strided=512 <= bucket <= 2048,
         )
-    block_m = 64 if bucket >= 4096 else 32
-    block_n = 256 if bucket in (1, 4, 64) or bucket >= 1024 or (not fixed_slot and bucket < 128) else 128
+    block_n = 256 if bucket in (1, 4, 64) or bucket >= 1024 or not fixed_slot and bucket < 128 else 128
+    if model_dim < 4096:
+        block_n = 128
     persist = bucket >= 128
-    persist_cu = 0
-    if persist:
-        persist_cu = 128 if bucket == 256 else 256 if bucket in (4096, 16384) else 240
     return Stage2Config(
-        block_m=block_m,
+        block_m=64 if bucket >= 4096 else 32,
         block_n=block_n,
         persist=persist,
+        persist_cu=128 if bucket == 256 else 240 if persist else 0,
+        use_nt=bucket <= 128,
+        persist_strided=512 <= bucket <= 2048,
+    )
+
+
+def _select_large_stage2(bucket: int, sort_block_m: int, model_dim: int) -> Stage2Config:
+    if bucket == 1024:
+        persist_cu = 224
+    elif bucket == 2048:
+        persist_cu = 256
+    elif bucket == 16384:
+        persist_cu = 192
+    else:
+        persist_cu = 240
+    block_n = 128 if bucket == 256 or model_dim < 4096 else 256
+    return Stage2Config(
+        block_m=64 if sort_block_m == 128 else 32,
+        block_n=block_n,
+        persist=True,
         persist_cu=persist_cu,
         use_nt=bucket <= 128,
-        persist_strided=bucket in (512, 1024, 2048),
+        persist_strided=512 <= bucket <= 2048,
+        skew_cu=96 if bucket >= 512 else 0,
     )
 
 
 @lru_cache(maxsize=None)
-def _select_bucket_config(bucket: int, mtpr: int) -> MegaMoEConfig:
-    fixed_slot = mtpr <= FIXED_SLOT_MAX_MTPR
-    stage1 = _select_stage1(bucket, fixed_slot, mtpr)
-    stage2 = _select_stage2(bucket, fixed_slot, mtpr, stage1.sort_block_m)
-    # MTPR is rank-invariant; local token counts need not be.
-    p2p_quant = "fp8_blockwise_1x32" if mtpr > P2P_FP8_MIN_MTPR else "none"
-    return MegaMoEConfig(stage1=stage1, stage2=stage2, p2p_quant=p2p_quant)
+def _select_bucket_config(
+    bucket: int, mtpr_class: int, experts_per_rank: int, model_dim: int, inter_dim: int
+) -> MegaMoEConfig:
+    if mtpr_class == MAX_MTPR_CLASS:
+        stage1 = _select_large_stage1(bucket, experts_per_rank, inter_dim)
+        stage2 = _select_large_stage2(bucket, stage1.sort_block_m, model_dim)
+        return MegaMoEConfig(stage1=stage1, stage2=stage2, p2p_quant="fp8_blockwise_1x32")
+
+    fixed_slot = mtpr_class <= FIXED_SLOT_MAX_MTPR
+    if fixed_slot:
+        stage1 = _select_fixed_stage1(bucket, experts_per_rank)
+    else:
+        stage1 = _select_bounded_stage1(bucket, mtpr_class, experts_per_rank, inter_dim)
+    stage2 = _select_bounded_stage2(bucket, fixed_slot, mtpr_class, stage1.sort_block_m, model_dim)
+    return MegaMoEConfig(stage1=stage1, stage2=stage2, p2p_quant="none")
 
 
-def select_mega_moe_config(tokens: int, mtpr: int) -> MegaMoEConfig:
+def select_mega_moe_config(
+    tokens: int,
+    mtpr: int,
+    *,
+    experts_per_rank: int = REFERENCE_EXPERTS_PER_RANK,
+    model_dim: int = 7168,
+    inter_dim: int = 3072,
+) -> MegaMoEConfig:
     if mtpr <= 0 or mtpr & (mtpr - 1):
         raise ValueError(f"mtpr={mtpr} must be a positive power of two")
     if tokens > mtpr:
         raise ValueError(f"tokens={tokens} exceeds mtpr={mtpr}")
+    if experts_per_rank <= 0:
+        raise ValueError(f"experts_per_rank must be positive, got {experts_per_rank}")
+    if model_dim <= 0 or inter_dim <= 0:
+        raise ValueError(f"invalid model shape {model_dim}x{inter_dim}")
     bucket = nearest_token_bucket(tokens)
-    fixed_slot = mtpr <= FIXED_SLOT_MAX_MTPR
-    if fixed_slot and bucket not in _FIXED_GEOMETRY:
+    mtpr_class = mtpr_config_class(mtpr)
+    if mtpr_class <= FIXED_SLOT_MAX_MTPR and bucket > 128:
         raise ValueError(f"fixed-slot does not support token bucket {bucket}")
-    return _select_bucket_config(bucket, mtpr)
+    if mtpr_class <= FIXED_SLOT_MAX_MTPR and experts_per_rank > 64:
+        raise ValueError("fixed-slot supports at most 64 experts per rank")
+    return _select_bucket_config(bucket, mtpr_class, expert_config_class(experts_per_rank), model_dim, inter_dim)

--- a/kernels/mega_moe/mega_moe_config.py
+++ b/kernels/mega_moe/mega_moe_config.py
@@ -4,7 +4,7 @@
 
 from bisect import bisect_left
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import cache
 
 TOKEN_BUCKETS = (1, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768)
 P2P_FP8_MIN_MTPR = 1024
@@ -283,7 +283,7 @@ def _select_large_stage2(bucket: int, sort_block_m: int, model_dim: int) -> Stag
     )
 
 
-@lru_cache(maxsize=None)
+@cache
 def _select_bucket_config(
     bucket: int, mtpr_class: int, experts_per_rank: int, model_dim: int, inter_dim: int
 ) -> MegaMoEConfig:

--- a/kernels/mega_moe/mega_moe_stage1.py
+++ b/kernels/mega_moe/mega_moe_stage1.py
@@ -39,7 +39,14 @@ def _use_direct_fixed_slot(enabled, npes, experts_per_rank, max_tokens_per_rank,
 
 
 def _validate_dispatch_capacity(
-    batch_size, npes, experts_per_rank, topk, tile_m, row_bytes, output_row_bytes, use_tile_resource
+    batch_size,
+    npes,
+    experts_per_rank,
+    topk,
+    tile_m,
+    row_bytes,
+    output_row_bytes,
+    use_tile_resource,
 ):
     max_rows = npes * batch_size * topk + experts_per_rank * tile_m
     if not use_tile_resource and max_rows * row_bytes >= _BUFFER_OFFSET_ABI_BYTES:
@@ -49,7 +56,7 @@ def _validate_dispatch_capacity(
 
 
 # fmt: off
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def compile_mega_moe_stage1(
     *, model_dim: int, inter_dim: int, rank: int, experts_per_rank: int, fuse_npes: int, fuse_topk: int,
     fuse_cap: int, fuse_mtpr: int, fuse_scale_dim: int, fixed_slot_dispatch: bool, sort_block_m: int = 32,
@@ -58,7 +65,8 @@ def compile_mega_moe_stage1(
     async_a_copy: bool = False, use_tile_resource: bool = True,
     waves_per_eu_hint: int = 2, num_cu: int = 256, num_dispatch_cu: int = 32, b_nt: int = -1,
     work_shards: int | None = None, external_grouping: bool | None = None,
-    external_counting: bool | None = None, swiglu_limit: float = 0.0,
+    external_counting: bool | None = None, payload_chunk_rows: int = 0, payload_tile_ready: bool = False,
+    swiglu_limit: float = 0.0,
 ):
     arch = str(get_rocm_arch() or "")
     if not arch.startswith("gfx95"):
@@ -74,8 +82,12 @@ def compile_mega_moe_stage1(
     assert grid_mult in GRID_MULT_VALUES, "grid_mult out of range"
     grid_epoch_slot = GRID_MULT_VALUES.index(grid_mult)
     dispatch_blocks = int(num_dispatch_cu)
+    payload_chunk_rows = int(payload_chunk_rows)
     assert 0 < dispatch_blocks < num_cu, "num_dispatch_cu must be in [1, num_cu)"
     assert dispatch_blocks % fuse_npes == 0, "num_dispatch_cu must be divisible by fuse_npes"
+    if payload_chunk_rows:
+        assert not fixed_slot_dispatch and payload_chunk_rows % sort_block_m == 0
+    assert not payload_tile_ready or payload_chunk_rows > 0
     planner_blocks = 1
     # Keep the fused grid on an exact CU multiple instead of appending control/producer CTAs as a tail.
     grid_x = num_cu * grid_mult - planner_blocks - dispatch_blocks
@@ -147,6 +159,8 @@ def compile_mega_moe_stage1(
         f"_dcu{dispatch_blocks}_pw{int(pipe_weights)}ma{int(mfma_amajor)}sw{int(swizzle_a)}"
         f"aa{int(async_a_copy)}"
         f"_tr{int(use_tile_resource)}wpe{waves_per_eu_hint}_bnt{b_cache_modifier}_ws{WORK_SHARDS}"
+        f"_pc{payload_chunk_rows}"
+        f"_ptr{int(payload_tile_ready)}"
         f"{swiglu_suffix}"
     )
 
@@ -176,8 +190,11 @@ def compile_mega_moe_stage1(
         a_work_head = _disp_ptr(DispatchSlot.WORK_HEAD)
         a_work_tail = _disp_ptr(DispatchSlot.WORK_TAIL)
         a_group_done = _disp_ptr(DispatchSlot.GROUP_DONE)
+        a_payload_blocks_per_destination = _disp_ptr(DispatchSlot.PAYLOAD_BLOCKS_PER_DESTINATION)
+        a_payload_chunks_per_destination = _disp_ptr(DispatchSlot.PAYLOAD_CHUNKS_PER_DESTINATION)
         a_launch_ready = _disp_ptr(DispatchSlot.LAUNCH_READY)
         p_launch_ready = _disp_ptr(DispatchSlot.P2P_LAUNCH_READY)
+        a_payload_ready_rows = _disp_ptr(DispatchSlot.PAYLOAD_READY_ROWS)
 
         ticket_scratch = fx.recast_iter(fx.Int64, a_buf.ptr)
         ticket_view = fx.make_view(ticket_scratch, fx.make_layout(1, 1))
@@ -210,6 +227,11 @@ def compile_mega_moe_stage1(
                 )
             next_parity = fx.Int32(fx.rocdl.readfirstlane(T.i32, next_parity_lane))
             launch_epoch = fx.Int32(fx.rocdl.readfirstlane(T.i32, launch_epoch_lane))
+            if const_expr(payload_tile_ready):
+                if tid == fx.Int32(0):
+                    comm_ops.store_i32_system(a_payload_ready_rows, fx.Int32(0), fx.Int32(fz_tile_m))
+                    comm_ops.fence_system_release()
+                fx.barrier()
             if tid < fx.Int32(fz_npes):
                 peer = (tid + fx.Int32(fz_rank)) % fx.Int32(fz_npes)
                 comm_ops.fence_system_release()
@@ -248,7 +270,7 @@ def compile_mega_moe_stage1(
         payload_parity = _buffer_load(parity_rsrc, fx.Int32(0), fx.Int32, cache_modifier=_SC0_CACHE)
         payload_expected = _buffer_load(expected_rsrc, payload_parity, fx.Int32, cache_modifier=_SC0_CACHE)
 
-        if compact_owner:
+        if compact_owner:  # noqa: SIM102 - keep the device and compile-time branches separate.
             if const_expr(not direct_fixed_slot):
                 emit_dispatch_plan(
                     num_waves=NUM_WAVES, fz_npes=fz_npes, fz_epr=fz_epr, fz_k=fz_k, fz_mtpr=fz_mtpr,
@@ -256,7 +278,8 @@ def compile_mega_moe_stage1(
                     i32_cur_tok=i32_cur_tok, addr_in_idx=addr_in_idx, parity=payload_parity,
                     expected=payload_expected, external_grouping=external_grouping,
                     external_counting=external_counting,
-                    dispatch_blocks=dispatch_blocks,
+                    dispatch_blocks=dispatch_blocks, payload_chunk_rows=payload_chunk_rows,
+                    payload_tile_ready=payload_tile_ready,
                 )
 
         if compact_producer:
@@ -276,7 +299,7 @@ def compile_mega_moe_stage1(
                         num_waves=NUM_WAVES, fz_k=fz_k, fz_total_experts=fz_total_experts, addr_disp=addr_disp,
                         i32_cur_tok=i32_cur_tok, addr_in_idx=addr_in_idx, dispatch_blocks=dispatch_blocks,
                         producer_slot=producer_slot, parity=payload_parity, expected=payload_expected,
-                        external_counting=external_counting,
+                        external_counting=external_counting, adaptive_grouping=payload_tile_ready,
                     )
                 else:
                     if tid == fx.Int32(0):
@@ -284,14 +307,36 @@ def compile_mega_moe_stage1(
                             a_pair_order_ready + fx.Int64(payload_parity) * fx.Int64(4), payload_expected)
                         comm_ops.fence_agent_acquire()
                     fx.barrier()
-                emit_dispatch_payload(
-                    num_waves=NUM_WAVES, fz_epr=fz_epr, fz_k=fz_k, fz_mtpr=fz_mtpr, fz_rank=fz_rank,
-                    fz_total_experts=fz_total_experts, fz_nbytes=fz_nbytes, fz_n_i32=fz_n_i32,
-                    fz_safe_end_i32=fz_safe_end_i32, fz_scale_n_i32=fz_scale_n_i32,
-                    fz_enable_scales=fz_enable_scales, addr_disp=addr_disp, addr_in_tok=addr_in_tok,
-                    addr_in_wts=addr_in_wts, addr_in_sc=addr_in_sc, dispatch_blocks=dispatch_blocks,
-                    producer_slot=producer_slot, parity=payload_parity, expected=payload_expected,
-                )
+                producers_per_destination = fx.Int32(dispatch_blocks // fz_npes)
+                chunks_per_destination = fx.Int32(1)
+                if const_expr(payload_chunk_rows > 0):
+                    chunks_per_destination = fx.Int32(
+                        (fz_mtpr + payload_chunk_rows - 1) // payload_chunk_rows
+                    )
+                payload_active = fx.Int32(0) == fx.Int32(0)
+                if const_expr(payload_tile_ready and dispatch_blocks > 32):
+                    producer_destination = producer_slot % fx.Int32(fz_npes)
+                    producer_round = producer_slot // fx.Int32(fz_npes)
+                    producers_per_destination = _buffer_load(
+                        _make_buffer_from_addr(a_payload_blocks_per_destination, fx.Int32),
+                        producer_destination, fx.Int32,
+                    )
+                    chunks_per_destination = _buffer_load(
+                        _make_buffer_from_addr(a_payload_chunks_per_destination, fx.Int32),
+                        producer_destination, fx.Int32,
+                    )
+                    payload_active = producer_round < producers_per_destination
+                if payload_active:
+                    emit_dispatch_payload(
+                        num_waves=NUM_WAVES, fz_epr=fz_epr, fz_k=fz_k, fz_mtpr=fz_mtpr, fz_rank=fz_rank,
+                        fz_total_experts=fz_total_experts, fz_nbytes=fz_nbytes, fz_n_i32=fz_n_i32,
+                        fz_safe_end_i32=fz_safe_end_i32, fz_scale_n_i32=fz_scale_n_i32,
+                        fz_enable_scales=fz_enable_scales, addr_disp=addr_disp, addr_in_tok=addr_in_tok,
+                        addr_in_wts=addr_in_wts, addr_in_sc=addr_in_sc, dispatch_blocks=dispatch_blocks,
+                        producer_slot=producer_slot, parity=payload_parity, expected=payload_expected,
+                        producers_per_destination=producers_per_destination, payload_chunk_rows=payload_chunk_rows,
+                        chunks_per_destination=chunks_per_destination, payload_tile_ready=payload_tile_ready,
+                    )
         if const_expr(direct_fixed_slot):
             if compact_owner:
                 emit_direct_fixed_slot_finalize(
@@ -304,6 +349,8 @@ def compile_mega_moe_stage1(
             addr_payload_ready = _buffer_load(
                 _make_buffer_from_addr(payload_table, fx.Int64), fx.Int32(fz_rank), fx.Int64
             )
+            addr_tile_ready = _disp_ptr(DispatchSlot.TILE_READY)
+            addr_tile_expected = _disp_ptr(DispatchSlot.TILE_EXPECTED)
         wave_id = fx.thread_idx.x // 64
 
         w_rsrc = _make_buffer(w, fx.Int32, 4)
@@ -349,10 +396,20 @@ def compile_mega_moe_stage1(
         total_work = num_m_tiles * fx.Int32(N_TILES)
 
         def _wait_tile_payload(flat):
-            pe = expert_of_flat(flat)
-            pe_index = payload_parity * fx.Int32(fz_epr) + pe
-            mori_shmem.int32_wait_until_equals(addr_payload_ready + fx.Int64(pe_index) * fx.Int64(4), payload_expected)
-            comm_ops.fence_system_acquire()
+            if const_expr(payload_tile_ready):
+                tile_index = flat // fx.Int32(N_TILES)
+                expected_tiles = _buffer_load(
+                    _make_buffer_from_addr(addr_tile_expected, fx.Int32), tile_index, fx.Int32
+                )
+                mori_shmem.int32_wait_until_equals(
+                    addr_tile_ready + fx.Int64(tile_index) * fx.Int64(4), expected_tiles
+                )
+            else:
+                pe = expert_of_flat(flat)
+                pe_index = payload_parity * fx.Int32(fz_epr) + pe
+                mori_shmem.int32_wait_until_equals(
+                    addr_payload_ready + fx.Int64(pe_index) * fx.Int64(4), payload_expected
+                )
 
         # Control CTAs join the work pool after dispatch.
         consumer_active = fx.Int32(1) == fx.Int32(1)
@@ -372,13 +429,15 @@ def compile_mega_moe_stage1(
             work = Vec(work_scratch_view.load())[0]
             if tid == fx.Int32(0):
                 has_work = (work < total_work).select(fx.Int32(1), fx.Int32(0))
-                if has_work != fx.Int32(0):
+                if has_work != fx.Int32(0):  # noqa: SIM102 - keep the device and compile-time branches separate.
                     if const_expr(not direct_fixed_slot):
                         _wait_tile_payload(work)
                 fx.ptr_store(Vec.from_elements([has_work], fx.Int32), work_scratch)
             fx.barrier()
             has_work = Vec(work_scratch_view.load())[0]
             if has_work != fx.Int32(0):
+                if const_expr(not direct_fixed_slot):
+                    comm_ops.fence_system_acquire()
                 _do_scheduled_tile(work)
             consumer_active = has_work != fx.Int32(0)
 
@@ -409,7 +468,8 @@ def run_mega_moe_stage1(out, x, w, scale_x, scale_w, sorted_token_ids, expert_id
     sort_block_m=32, tile_n=256, tile_k=256, num_waves=4, grid_mult=4, pipe_weights=True,
     mfma_amajor=False, swizzle_a=True, async_a_copy=False, num_dispatch_cu=32,
     use_tile_resource=True, waves_per_eu_hint=2,
-    b_nt=-1, work_shards=None, external_grouping=None, external_counting=None, swiglu_limit=0.0):
+    b_nt=-1, work_shards=None, external_grouping=None, external_counting=None,
+    payload_chunk_rows=0, payload_tile_ready=False, swiglu_limit=0.0):
     launch = compile_mega_moe_stage1(
         model_dim=model_dim, inter_dim=inter_dim, rank=rank, experts_per_rank=experts_per_rank,
         fuse_npes=fuse_npes, fuse_topk=fuse_topk, fuse_cap=fuse_cap, fuse_mtpr=fuse_mtpr,
@@ -419,7 +479,9 @@ def run_mega_moe_stage1(out, x, w, scale_x, scale_w, sorted_token_ids, expert_id
         async_a_copy=async_a_copy, use_tile_resource=use_tile_resource,
         waves_per_eu_hint=waves_per_eu_hint, num_cu=num_cu, num_dispatch_cu=num_dispatch_cu,
         b_nt=b_nt, work_shards=work_shards, external_grouping=external_grouping,
-        external_counting=external_counting, swiglu_limit=swiglu_limit,
+        external_counting=external_counting, payload_chunk_rows=payload_chunk_rows,
+        payload_tile_ready=payload_tile_ready,
+        swiglu_limit=swiglu_limit,
     )
     _run_compiled(
         launch, out, x, w, scale_x, scale_w, sorted_token_ids, expert_ids, num_valid_ids, out_scale,

--- a/kernels/mega_moe/mega_moe_stage2.py
+++ b/kernels/mega_moe/mega_moe_stage2.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
-# ruff: noqa: I001
+# ruff: noqa: B023, I001
 """Fused GEMM2 and weighted cross-rank P2P scatter."""
 
 import flydsl.compiler as flyc
@@ -8,6 +8,7 @@ import flydsl.expr as fx
 from flydsl.expr import const_expr, range_constexpr, rocdl
 from flydsl.expr.typing import Int8, T
 from flydsl.runtime.device import get_rocm_arch
+
 from kernels.common import buffer_ops
 from kernels.common.tensor_shim import _run_compiled
 from kernels.moe.mxfp_moe.mxfp4_gemm_common import (
@@ -264,11 +265,12 @@ def _stage2_lds_bytes(BM, BN, BK, a_dtype, aStages, g2_bf16_lds=False):
 
 # fmt: off
 def compile_mega_moe_stage2(*, model_dim: int, inter_dim: int, experts: int, topk: int, rank: int, npes: int,
-    max_tok: int, recv_cap: int = None, comb_inp_nbytes: int = None, BM: int = 32, BN: int = 256, BK: int = 256,
-    use_nt: bool = True, HIDDEN_MAX: int = 8192, INTER_MAX: int = 8192, a_dtype: str = "fp8", SBM: int = None,
+    max_tok: int, recv_cap: int | None = None, comb_inp_nbytes: int | None = None, BM: int = 32, BN: int = 256,
+    BK: int = 256, use_nt: bool = True, HIDDEN_MAX: int = 8192, INTER_MAX: int = 8192, a_dtype: str = "fp8",
+    SBM: int | None = None,
     persist: bool = False, cu_num: int = 0, has_pad: bool = False, g2_bhoist=None, g2_ascale_pf=None,
     g2_spart=None, persist_strided: bool = False, g2_bf16_lds: bool = False, p2p_quant_type: str = "none",
-    fixed_slot_dispatch: bool = False):
+    fixed_slot_dispatch: bool = False, skew_cu: int = 0):
 # fmt: on
     """Compile fused GEMM2 and weighted cross-rank P2P scatter."""
     arch = str(get_rocm_arch() or "")
@@ -290,6 +292,8 @@ def compile_mega_moe_stage2(*, model_dim: int, inter_dim: int, experts: int, top
         raise AssertionError(f"a_dtype must be 'fp4' or 'fp8', got {a_dtype!r}")
     if persist and cu_num <= 0:
         raise AssertionError(f"persist=True requires cu_num>0, got {cu_num}")
+    if skew_cu and (not persist or not 0 < skew_cu < cu_num):
+        raise AssertionError(f"skew_cu={skew_cu} requires persist=True and 0<skew_cu<cu_num={cu_num}")
     log2_max_tok = max_tok.bit_length() - 1
     mask_max_tok = max_tok - 1
     N_OUT = model_dim
@@ -321,15 +325,16 @@ def compile_mega_moe_stage2(*, model_dim: int, inter_dim: int, experts: int, top
         f"megamoe_stage2_{dispatch_path}_t{BM}x{BN}x{BK}"
         f"_sbm{SBM}_{a_dtype}_nt{int(use_nt)}"
         f"_p{int(persist)}cu{cu_num}s{int(persist_strided)}_pad{int(has_pad)}"
+        f"_sk{skew_cu}"
         f"_bh{int(g2_bhoist)}apf{int(g2_ascale_pf)}sp{g2_group_num}x{g2_m01}"
         f"_bf16lds{int(g2_bf16_lds)}_{p2p_quant_type}"
     )
 
-    @flyc.kernel(name=kernel_name, known_block_size=[256, 1, 1])
     # fmt: off
+    @flyc.kernel(name=kernel_name, known_block_size=[256, 1, 1])
     def kernel_epilog_v2(arg_aq: fx.Int64, arg_ascale: fx.Int64, arg_bq: fx.Int64, arg_bscale: fx.Int64,
-        arg_eids: fx.Int64, arg_cumsum: fx.Int64, arg_stids: fx.Int64, arg_sweights: fx.Int64,
-        arg_trb: fx.Int64, arg_p2p_comb_inp: fx.Int64, i32_max_m_blocks: fx.Int32,
+        arg_eids: fx.Int64, arg_cumsum: fx.Int64, arg_max_expert_tiles: fx.Int64, arg_stids: fx.Int64,
+        arg_sweights: fx.Int64, arg_trb: fx.Int64, arg_p2p_comb_inp: fx.Int64, i32_max_m_blocks: fx.Int32,
         i32_inter: fx.Int32, i32_hidden: fx.Int32, i32_kpad: fx.Int32, i32_npad: fx.Int32):
     # fmt: on
         tx_i32 = fx.thread_idx.x
@@ -431,6 +436,38 @@ def compile_mega_moe_stage2(*, model_dim: int, inter_dim: int, experts: int, top
                 issue_all_a_loads(m_block_idx * fx.Int32(BM))
                 rocdl.sched_barrier(0)
                 run_unit(unit_bx, m_block_idx)
+        elif const_expr(skew_cu > 0):
+            m_slot = bx_i32 // fx.Int32(num_n_blocks)
+            n_block = bx_i32 - m_slot * fx.Int32(num_n_blocks)
+            total_stage1_tiles = (cumsum0 + fx.Int32(SBM - 1)) // fx.Int32(SBM)
+            max_expert_tiles = global_typed_ptr(arg_max_expert_tiles, T.i32)[0]
+            skewed = max_expert_tiles * fx.Int32(4) > total_stage1_tiles
+            active_cu = skewed.select(fx.Int32(skew_cu), fx.Int32(cu_num))
+            strided_diff = total_m_blocks - m_slot
+            strided_rem = (strided_diff > fx.Int32(0)).select(strided_diff, fx.Int32(0))
+            strided_iters = (strided_rem + active_cu - fx.Int32(1)) // active_cu
+            tiles_per_slot = (total_m_blocks + active_cu - fx.Int32(1)) // active_cu
+            m_tile0 = m_slot * tiles_per_slot
+            contiguous_diff = total_m_blocks - m_tile0
+            contiguous_rem = (contiguous_diff > fx.Int32(0)).select(
+                contiguous_diff, fx.Int32(0)
+            )
+            contiguous_iters = (contiguous_rem < tiles_per_slot).select(
+                contiguous_rem, tiles_per_slot
+            )
+            n_iters = skewed.select(strided_iters, contiguous_iters)
+            active = m_slot < active_cu
+            for _it in range(fx.Int32(0), n_iters, fx.Int32(1)):
+                strided_m = m_slot + fx.Int32(_it) * active_cu
+                contiguous_m = m_tile0 + fx.Int32(_it)
+                m_block = skewed.select(strided_m, contiguous_m)
+                if active:
+                    unit_bx = m_block * fx.Int32(num_n_blocks) + n_block
+                    fx.barrier()
+                    issue_all_a_loads(m_block * fx.Int32(BM))
+                    rocdl.sched_barrier(0)
+                    if fx.Int32(m_block) < total_m_blocks:
+                        run_unit(unit_bx, m_block)
         else:
             m_slot = bx_i32 // fx.Int32(num_n_blocks)
             n_block = bx_i32 - m_slot * fx.Int32(num_n_blocks)
@@ -458,19 +495,20 @@ def compile_mega_moe_stage2(*, model_dim: int, inter_dim: int, experts: int, top
                 if fx.Int32(m_block) < total_m_blocks:
                     run_unit(unit_bx, m_block)
 
-    @flyc.jit
     # fmt: off
+    @flyc.jit
     def launch(arg_aq: fx.Int64, arg_ascale: fx.Int64, arg_bq: fx.Int64, arg_bscale: fx.Int64,
-        arg_eids: fx.Int64, arg_cumsum: fx.Int64, arg_stids: fx.Int64, arg_sweights: fx.Int64,
-        arg_trb: fx.Int64, arg_p2p_comb_inp: fx.Int64, i32_max_m_blocks: fx.Int32,
+        arg_eids: fx.Int64, arg_cumsum: fx.Int64, arg_max_expert_tiles: fx.Int64, arg_stids: fx.Int64,
+        arg_sweights: fx.Int64, arg_trb: fx.Int64, arg_p2p_comb_inp: fx.Int64, i32_max_m_blocks: fx.Int32,
         i32_grid_blocks: fx.Int32, i32_inter: fx.Int32, i32_hidden: fx.Int32, i32_kpad: fx.Int32,
         i32_npad: fx.Int32, stream: fx.Stream):
     # fmt: on
         num_n_blocks = fx.Int32(i32_hidden) // fx.Int32(BN)
         grid_x = i32_grid_blocks * num_n_blocks
         kernel_epilog_v2(
-            arg_aq, arg_ascale, arg_bq, arg_bscale, arg_eids, arg_cumsum, arg_stids, arg_sweights,
-            arg_trb, arg_p2p_comb_inp, i32_max_m_blocks, i32_inter, i32_hidden, i32_kpad, i32_npad,
+            arg_aq, arg_ascale, arg_bq, arg_bscale, arg_eids, arg_cumsum, arg_max_expert_tiles,
+            arg_stids, arg_sweights, arg_trb, arg_p2p_comb_inp, i32_max_m_blocks, i32_inter,
+            i32_hidden, i32_kpad, i32_npad,
         ).launch(grid=(grid_x, 1, 1), block=(256, 1, 1), stream=stream)
 
     return launch
@@ -490,12 +528,12 @@ def _get_g2_launch(**compile_kw):
 
 
 # fmt: off
-def run_mega_moe_stage2(arg_aq, arg_ascale, arg_bq, arg_bscale, arg_eids, arg_cumsum, arg_stids,
-    arg_sweights, arg_trb, arg_p2p, row_capacity, i32_inter, i32_hidden, stream, *,
+def run_mega_moe_stage2(arg_aq, arg_ascale, arg_bq, arg_bscale, arg_eids, arg_cumsum,
+    arg_max_expert_tiles, arg_stids, arg_sweights, arg_trb, arg_p2p, row_capacity, i32_inter, i32_hidden, stream, *,
     model_dim, inter_dim, experts, topk, rank, npes, max_tok, recv_cap, comb_inp_nbytes, BM, SBM,
     HIDDEN_MAX, INTER_MAX, cu_num, BN=256, BK=256, use_nt=True, g2_bhoist=True,
     g2_ascale_pf=True, g2_spart=402, persist=False, persist_cu=0, persist_strided=False,
-    g2_bf16_lds=False, p2p_quant_type="none", fixed_slot_dispatch=False):
+    g2_bf16_lds=False, p2p_quant_type="none", fixed_slot_dispatch=False, skew_cu=0):
     # fmt: on
     """Compile or reuse one fused Stage2 configuration and launch it."""
     launch_cu_num = min(cu_num, persist_cu) if persist and persist_cu > 0 else cu_num
@@ -505,12 +543,12 @@ def run_mega_moe_stage2(arg_aq, arg_ascale, arg_bq, arg_bscale, arg_eids, arg_cu
         use_nt=use_nt, HIDDEN_MAX=HIDDEN_MAX, INTER_MAX=INTER_MAX, SBM=SBM, persist=persist,
         cu_num=launch_cu_num, g2_bhoist=g2_bhoist, g2_ascale_pf=g2_ascale_pf,
         g2_spart=g2_spart, persist_strided=persist_strided, g2_bf16_lds=g2_bf16_lds,
-        p2p_quant_type=p2p_quant_type, fixed_slot_dispatch=fixed_slot_dispatch,
+        p2p_quant_type=p2p_quant_type, fixed_slot_dispatch=fixed_slot_dispatch, skew_cu=skew_cu,
     )
     max_m_blocks = (row_capacity + BM - 1) // BM
     grid_blocks = launch_cu_num if persist else max_m_blocks
     _run_compiled(
-        launch, arg_aq, arg_ascale, arg_bq, arg_bscale, arg_eids, arg_cumsum, arg_stids, arg_sweights,
-        arg_trb, arg_p2p, fx.Int32(max_m_blocks), fx.Int32(grid_blocks), fx.Int32(i32_inter),
-        fx.Int32(i32_hidden), fx.Int32(0), fx.Int32(0), stream,
+        launch, arg_aq, arg_ascale, arg_bq, arg_bscale, arg_eids, arg_cumsum,
+        arg_max_expert_tiles, arg_stids, arg_sweights, arg_trb, arg_p2p, fx.Int32(max_m_blocks),
+        fx.Int32(grid_blocks), fx.Int32(i32_inter), fx.Int32(i32_hidden), fx.Int32(0), fx.Int32(0), stream,
     )

--- a/tests/unit/test_mega_moe_config.py
+++ b/tests/unit/test_mega_moe_config.py
@@ -4,194 +4,127 @@
 import pytest
 
 from kernels.mega_moe.mega_moe_config import (
+    MAX_MTPR_CLASS,
     TOKEN_BUCKETS,
+    expert_config_class,
+    mtpr_config_class,
     nearest_token_bucket,
     select_mega_moe_config,
 )
 
-_STANDARD_PROFILES = {
-    1: (32, 256, 4, 1, 64, 0, 1, 2, 32, 256, 0, 0, 0, "none"),
-    4: (32, 256, 4, 1, 128, 0, 1, 2, 32, 256, 0, 0, 0, "none"),
-    8: (32, 256, 4, 2, 128, 0, 1, 2, 32, 128, 0, 0, 0, "none"),
-    16: (32, 128, 4, 4, 96, 0, 1, 1, 32, 128, 0, 0, 0, "none"),
-    32: (32, 128, 4, 3, 128, 0, 0, 2, 32, 128, 0, 0, 0, "none"),
-    64: (32, 128, 4, 3, 208, 0, 0, 2, 32, 256, 0, 0, 0, "none"),
-    128: (32, 128, 4, 3, 224, 0, 0, 2, 32, 128, 1, 240, 0, "none"),
-    256: (64, 512, 8, 1, 160, 1, 1, 2, 32, 128, 1, 128, 0, "none"),
-    512: (64, 512, 8, 2, 128, 1, 0, 2, 32, 128, 1, 240, 1, "none"),
-    1024: (64, 512, 8, 2, 128, 1, 0, 2, 32, 256, 1, 240, 1, "none"),
-    2048: (64, 512, 8, 1, 32, 1, 1, 2, 32, 256, 1, 240, 1, "fp8_blockwise_1x32"),
-    4096: (128, 512, 8, 1, 32, 1, 0, 2, 64, 256, 1, 256, 0, "fp8_blockwise_1x32"),
-    8192: (128, 512, 8, 1, 32, 1, 0, 2, 64, 256, 1, 240, 0, "fp8_blockwise_1x32"),
-    16384: (128, 512, 8, 1, 32, 1, 1, 2, 64, 256, 1, 256, 0, "fp8_blockwise_1x32"),
-    32768: (128, 512, 8, 1, 32, 1, 1, 2, 64, 256, 1, 240, 0, "fp8_blockwise_1x32"),
-}
-
-
-def _profile(config):
-    stage1 = config.stage1
-    stage2 = config.stage2
-    return (
-        stage1.sort_block_m,
-        stage1.tile_n,
-        stage1.num_waves,
-        stage1.grid_mult,
-        stage1.num_dispatch_cu,
-        int(stage1.mfma_amajor),
-        int(stage1.use_tile_resource),
-        stage1.waves_per_eu_hint,
-        stage2.block_m,
-        stage2.block_n,
-        int(stage2.persist),
-        stage2.persist_cu,
-        int(stage2.persist_strided),
-        config.p2p_quant,
-    )
-
-
-@pytest.mark.parametrize("tokens,expected", _STANDARD_PROFILES.items())
-def test_standard_profiles_match_tuned_artifacts(tokens, expected):
-    config = select_mega_moe_config(tokens, max(16, tokens))
-    stage1 = config.stage1
-    stage2 = config.stage2
-
-    assert _profile(config) == expected
-    assert stage1.async_a_copy == (tokens >= 256 and tokens != 2048)
-    assert stage1.b_nt == (0 if tokens == 1 or tokens >= 1024 else 3)
-    assert stage1.work_shards == (4 if tokens >= 8192 else 8)
-    assert stage1.external_grouping == (tokens >= 2048)
-    assert stage1.external_counting == (tokens >= 8192)
-    assert stage1.pipe_weights and stage1.swizzle_a
-    assert stage2.use_nt == (tokens <= 128)
-    assert stage2.b_hoist and stage2.ascale_prefetch
-    assert stage2.spatial_partition == 402 and not stage2.bf16_lds
-
 
 @pytest.mark.parametrize(
     "tokens,bucket",
-    [
-        (2, 1),
-        (3, 4),
-        (6, 8),
-        (16300, 16384),
-        (16400, 16384),
-        (24576, 32768),
-        (65536, 32768),
-    ],
+    [(2, 1), (3, 4), (6, 8), (16300, 16384), (16400, 16384), (24576, 32768), (65536, 32768)],
 )
 def test_nearest_token_bucket_prefers_larger_on_ties(tokens, bucket):
     assert nearest_token_bucket(tokens) == bucket
 
 
-def test_mtpr_selects_fixed_or_compact_configs():
+@pytest.mark.parametrize("mtpr", [2048, 4096, 8192, 16384, 32768, 65536])
+def test_large_mtpr_uses_one_config_class(mtpr):
+    assert mtpr_config_class(mtpr) == MAX_MTPR_CLASS
+
+
+@pytest.mark.parametrize("tokens", [1, 8, 32, 128, 256, 512, 1024, 2048])
+def test_large_mtpr_configs_are_capacity_invariant(tokens):
+    reference = select_mega_moe_config(tokens, 2048)
+    for mtpr in (4096, 8192, 16384, 32768):
+        if tokens <= mtpr:
+            assert select_mega_moe_config(tokens, mtpr) is reference
+
+
+@pytest.mark.parametrize(
+    "tokens,sbm,dispatch_cu,work_shards,persist_cu",
+    [
+        (1, 32, 224, 1, 240),
+        (32, 32, 64, 1, 240),
+        (128, 32, 192, 4, 240),
+        (256, 64, 160, 4, 240),
+        (512, 64, 64, 4, 240),
+        (1024, 64, 64, 4, 224),
+        (2048, 64, 64, 8, 256),
+        (4096, 128, 64, 4, 240),
+        (8192, 128, 96, 4, 240),
+        (16384, 128, 32, 4, 192),
+        (32768, 128, 32, 4, 240),
+    ],
+)
+def test_large_mtpr_profiles_follow_geometry_rules(tokens, sbm, dispatch_cu, work_shards, persist_cu):
+    config = select_mega_moe_config(tokens, max(2048, tokens))
+    stage1, stage2 = config.stage1, config.stage2
+
+    assert stage1.sort_block_m == sbm
+    assert stage1.num_dispatch_cu == dispatch_cu
+    assert stage1.work_shards == work_shards
+    assert stage1.grid_mult == 1
+    assert stage1.use_tile_resource
+    assert stage1.payload_chunk_rows == 384
+    assert stage1.payload_tile_ready
+    assert stage2.block_m == (64 if sbm == 128 else 32)
+    assert stage2.persist_cu == persist_cu
+    assert stage2.skew_cu == (96 if tokens >= 512 else 0)
+    assert config.p2p_quant == "fp8_blockwise_1x32"
+
+
+def test_fixed_and_bounded_compact_profiles_remain_specialized():
     fixed = select_mega_moe_config(128, 128)
-    compact = select_mega_moe_config(128, 8192)
+    bounded = select_mega_moe_config(512, 512)
 
-    assert (
-        fixed.stage1.tile_n,
-        fixed.stage1.num_waves,
-        fixed.stage1.num_dispatch_cu,
-    ) == (128, 4, 224)
-    assert (
-        compact.stage1.tile_n,
-        compact.stage1.num_waves,
-        compact.stage1.num_dispatch_cu,
-    ) == (512, 8, 192)
-    for tokens in (8, 16, 32):
-        assert select_mega_moe_config(tokens, 128).stage2.block_n == 128
-        assert select_mega_moe_config(tokens, 8192).stage2.block_n == 256
+    assert (fixed.stage1.tile_n, fixed.stage1.num_waves, fixed.stage1.num_dispatch_cu) == (128, 4, 224)
+    assert not fixed.stage1.payload_tile_ready and fixed.p2p_quant == "none"
+    assert (bounded.stage1.sort_block_m, bounded.stage1.grid_mult) == (64, 2)
+    assert bounded.stage1.num_dispatch_cu == 128
+    assert not bounded.stage1.payload_tile_ready and bounded.p2p_quant == "none"
 
 
-@pytest.mark.parametrize(
-    "tokens,mtpr,stage1,stage2",
-    [
-        (8, 8192, (32, 1, 192, False, 3, 1), (32, 256, 240, False)),
-        (256, 8192, (64, 1, 160, True, 3, 4), (32, 128, 240, False)),
-        (512, 8192, (64, 1, 64, True, 0, 4), (32, 256, 240, True)),
-        (1024, 32768, (64, 1, 64, True, 0, 4), (32, 256, 224, True)),
-        (2048, 16384, (64, 1, 64, True, 0, 4), (32, 256, 256, True)),
-        (4096, 8192, (128, 1, 64, False, 0, 4), (64, 256, 240, False)),
-    ],
-)
-def test_oversized_capacity_profiles_match_tuned_rules(tokens, mtpr, stage1, stage2):
-    config = select_mega_moe_config(tokens, mtpr)
-    s1 = config.stage1
-    s2 = config.stage2
+def test_large_mtpr_protocol_is_rank_invariant_across_token_buckets():
+    configs = [select_mega_moe_config(tokens, 32768) for tokens in TOKEN_BUCKETS]
 
-    assert (
-        s1.sort_block_m,
-        s1.grid_mult,
-        s1.num_dispatch_cu,
-        s1.use_tile_resource,
-        s1.b_nt,
-        s1.work_shards,
-    ) == stage1
-    assert (s2.block_m, s2.block_n, s2.persist_cu, s2.persist_strided) == stage2
-    assert s2.persist
+    assert {config.p2p_quant for config in configs} == {"fp8_blockwise_1x32"}
+    assert {config.stage1.payload_chunk_rows for config in configs} == {384}
+    assert {config.stage1.payload_tile_ready for config in configs} == {True}
 
 
-@pytest.mark.parametrize("mtpr", [16384, 32768])
-@pytest.mark.parametrize("tokens", [1, 128, 512, 1024, 2048, 4096])
-def test_large_capacity_uses_safe_tile_resource_addressing(tokens, mtpr):
-    assert select_mega_moe_config(tokens, mtpr).stage1.use_tile_resource
+@pytest.mark.parametrize("experts_per_rank", [48, 52, 56, 64])
+def test_redundant_experts_share_one_wave_geometry(experts_per_rank):
+    base = select_mega_moe_config(8192, 32768, experts_per_rank=48)
+    redundant = select_mega_moe_config(8192, 32768, experts_per_rank=experts_per_rank)
+
+    assert expert_config_class(experts_per_rank) == 64
+    assert redundant is base
 
 
-@pytest.mark.parametrize("mtpr", [2048, 4096, 8192, 16384, 32768])
-def test_requested_oversized_capacity_matrix_is_valid(mtpr):
-    for tokens in (bucket for bucket in TOKEN_BUCKETS if bucket <= mtpr // 2):
-        config = select_mega_moe_config(tokens, mtpr)
+def test_multiple_expert_waves_scale_payload_producers():
+    base = select_mega_moe_config(4096, 32768, experts_per_rank=48)
+    wide = select_mega_moe_config(4096, 32768, experts_per_rank=80)
 
-        assert config.stage2.block_m <= config.stage1.sort_block_m
-        assert config.stage1.sort_block_m % config.stage2.block_m == 0
-        assert config.p2p_quant == "fp8_blockwise_1x32"
+    assert wide.stage1.num_dispatch_cu == 2 * base.stage1.num_dispatch_cu
+    assert wide.stage2 == base.stage2
 
 
-@pytest.mark.parametrize(
-    "tokens,mtpr,expected",
-    [
-        (4, 2048, (128, 8, False, False)),
-        (1, 4096, (224, 1, False, False)),
-        (64, 4096, (160, 1, False, False)),
-        (1, 8192, (224, 1, False, False)),
-        (8, 8192, (192, 1, False, False)),
-        (64, 8192, (160, 4, False, False)),
-        (4, 16384, (224, 8, False, False)),
-        (32, 16384, (192, 4, False, False)),
-        (16, 32768, (64, 1, False, False)),
-        (32, 32768, (64, 2, False, False)),
-    ],
-)
-def test_oversized_small_tail_matches_tuned_rules(tokens, mtpr, expected):
-    stage1 = select_mega_moe_config(tokens, mtpr).stage1
+def test_model_geometry_selects_tile_widths():
+    config = select_mega_moe_config(8192, 32768, model_dim=3584, inter_dim=1536)
 
-    assert (
-        stage1.num_dispatch_cu,
-        stage1.work_shards,
-        stage1.external_grouping,
-        stage1.external_counting,
-    ) == expected
-
-
-@pytest.mark.parametrize(
-    "mtpr,expected",
-    [
-        (128, "none"),
-        (1024, "none"),
-        (2048, "fp8_blockwise_1x32"),
-        (8192, "fp8_blockwise_1x32"),
-    ],
-)
-def test_p2p_quant_is_rank_invariant_for_an_mtpr(mtpr, expected):
-    configs = [select_mega_moe_config(tokens, mtpr) for tokens in TOKEN_BUCKETS if tokens <= mtpr]
-
-    assert {config.p2p_quant for config in configs} == {expected}
+    assert config.stage1.tile_n == 256
+    assert config.stage2.block_n == 128
 
 
 def test_nearby_tokens_share_the_bucket_config():
-    assert select_mega_moe_config(500, 512) is select_mega_moe_config(512, 512)
+    assert select_mega_moe_config(500, 8192) is select_mega_moe_config(512, 32768)
 
 
-@pytest.mark.parametrize("tokens,mtpr", [(0, 16), (17, 16), (1, 0), (1, 24)])
-def test_invalid_shape_is_rejected(tokens, mtpr):
+@pytest.mark.parametrize(
+    "tokens,mtpr,kwargs",
+    [
+        (0, 16, {}),
+        (17, 16, {}),
+        (1, 0, {}),
+        (1, 24, {}),
+        (1, 16, {"experts_per_rank": 0}),
+        (1, 16, {"model_dim": 0}),
+    ],
+)
+def test_invalid_shape_is_rejected(tokens, mtpr, kwargs):
     with pytest.raises(ValueError):
-        select_mega_moe_config(tokens, mtpr)
+        select_mega_moe_config(tokens, mtpr, **kwargs)


### PR DESCRIPTION
• ## Motivation

  Improve MegaMoEV2 performance and robustness for serving workloads with large MTPR, imbalanced routing, and EPLB redundant experts.

  ## Technical Details

  - Use rule-based Stage1/Stage2 configuration selection instead of per-MTPR lookup tables.
  - Share one configuration class for MTPR values above 1024.
  - Adapt dispatch geometry to token count, model shape, and local expert count.
  - Improve payload overlap and skewed-expert scheduling while preserving existing kernel semantics.

  ## Test Plan

  - Passed 47 MegaMoE configuration unit tests, Ruff, and Python syntax checks.
  - Validated A8W4 accuracy and CUDA Graph execution on 8×MI355X.
  - Tested DeepSeek-V4-Pro with r0/r64 EPLB at concurrency 512 and 4096.

  ## Test Result

  MegaMoEV2 outperformed the standard EP path by 7.8%–12.3% across the tested serving configurations.