### PR TITLE
[Kernel] Fix single-accumulator RDNA3 GEMM tiles

### DIFF
--- a/kernels/gemm/rdna3_f16_gemm.py
+++ b/kernels/gemm/rdna3_f16_gemm.py
@@ -353,7 +353,14 @@ def create_wmma_gemm_module(
 
             results = yield list(s_accs)
 
-        accs = list(results[:n_acc])
+        # A one-atom tile carries one scf.for result. FlyDSL intentionally
+        # unwraps a single result to its value, while multiple results remain a
+        # sliceable sequence. Keep the kernel-side accumulator container stable
+        # in both cases so 16x16 tiles can reach the epilogue.
+        if const_expr(n_acc == 1):
+            accs = [results]
+        else:
+            accs = list(results[:n_acc])
 
         last_read_off = ((num_k_tiles - 1) % 2) * c_lds_buf_stride
         for rk in range_constexpr(reg_k):

--- a/tests/kernels/test_rdna_gemm.py
+++ b/tests/kernels/test_rdna_gemm.py
@@ -109,6 +109,37 @@ def test_f16_gemm_correctness(M, N, K, in_dtype, out_dtype):
     assert verify_output(C.float(), C_ref, atol=0.05, rtol=0.05)
 
 
+def test_f16_gemm_single_accumulator_loop_result():
+    """A 16x16 tile keeps one WMMA accumulator across the pipelined K loop."""
+    _requires_rdna3()
+
+    M, N, K = 16, 16, 64
+    torch.manual_seed(42)
+    launch_fn, block_m, block_n, block_k = _create_wmma_gemm_module_gfx11(
+        M,
+        N,
+        K,
+        in_dtype="bf16",
+        out_dtype="bf16",
+        reg_m=1,
+        reg_n=1,
+        reg_k=2,
+        waves_m=1,
+        waves_n=1,
+    )
+    assert (block_m, block_n, block_k) == (16, 16, 32)
+
+    A = torch.randn(M, K, dtype=torch.bfloat16, device="cuda") * 0.1
+    B_T = torch.randn(N, K, dtype=torch.bfloat16, device="cuda") * 0.1
+    C = torch.zeros(M, N, dtype=torch.bfloat16, device="cuda")
+
+    launch_fn(C, A, B_T, torch.cuda.current_stream())
+    torch.cuda.synchronize()
+
+    C_ref = A.float() @ B_T.float().T
+    assert verify_output(C.float(), C_ref, atol=0.05, rtol=0.05)
+
+
 def test_f16_gemm_stochastic_rounding():
     """BF16 GEMM with the stochastic-rounding epilogue: bounded, seed-varying, reproducible.
 


### PR DESCRIPTION
## Summary

- preserve the RDNA3 GEMM accumulator container when an `scf.for` has exactly one carried result
- add a native gfx11 regression for the resulting 16x16x32 one-atom tile

## Problem

On current `main` (`3df2d7c70059b53f352d83226f9ee8edeceecb33`), the public tile parameters admit `(reg_m, reg_n, reg_k, waves_m, waves_n)=(1,1,2,1,1)`. That produces one WMMA accumulator. FlyDSL returns the single post-loop result as the carried vector value, but the kernel always slices it as a sequence:

```text
TypeError: unsupported index type: <class 'slice'>
  rdna3_f16_gemm.py:356: accs = list(results[:n_acc])
```

The fix wraps that one result before the epilogue and leaves the existing multi-result path unchanged.

## Validation

Tested on a Radeon PRO W7900, native `gfx1100`, ROCm/HIP 7.2, PyTorch `2.9.1+gitff65f5b`, with `HSA_OVERRIDE_GFX_VERSION` unset.

- new focused regression: 1 passed
- related RDNA F16/BF16 suite: 23 passed, 7 deselected
- Ruff 0.16.2 format check and lint: passed
- BF16 correctness against FP32 torch accumulation passed for the five M16 DeepSeek-V4-aligned `(K,N)` rows: `(4096,1024)`, `(1024,4096)`, `(4096,512)`, `(4096,2048)`, and `(2048,4096)`
- generated ISA for M16/N512/K4096 is wave32, contains 8 static `v_wmma_f32_16x16x16_bf16` instructions, contains no scalar FMA fallback, and reports zero private segment/scratch

For bounded performance reconnaissance, the enabled 16x16x64 tile measured 17.735 us hot kernel p50 at M16/N512/K4096 versus 19.059 us for the previously buildable 16x32x64 control (200 captured launches, 4 replays/round, 31 rounds). It is not uniformly faster across all projection shapes, so this PR deliberately changes no default tile, autotune heuristic, or dispatch policy.

This only fixes a legal RDNA3 kernel configuration. It does not add M<16 tail handling or claim an end-to-end model speedup.