### PR TITLE
CI: upgrade PyTorch images to ROCm 7.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ on:
       docker_image:
         description: 'Docker base image for test'
         type: string
-        default: "rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.8.0"
+        default: "rocm/pytorch:rocm7.14_ubuntu24.04_py3.11_pytorch_release_2.12.0@sha256:05743468394cc8f9cce06822635836a31ddfd5956bac36976666d7057713441d"
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: true
@@ -35,7 +35,7 @@ jobs:
     if: ${{ !(inputs.skip_tests || false) }}
     uses: ./.github/workflows/test-whl.yaml
     with:
-      docker_image: ${{ inputs.docker_image || 'rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.8.0' }}
+      docker_image: ${{ inputs.docker_image || 'rocm/pytorch:rocm7.14_ubuntu24.04_py3.11_pytorch_release_2.12.0@sha256:05743468394cc8f9cce06822635836a31ddfd5956bac36976666d7057713441d' }}
     permissions:
       contents: read
 

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -316,9 +316,7 @@ jobs:
         run: |
           docker exec flydsl_test bash -c "rm -rf /tmp/aiter && git clone --depth 1 --recursive --shallow-submodules https://github.com/ROCm/aiter.git /tmp/aiter"
           docker exec flydsl_test bash -c "python3 -c \"from pathlib import Path; src = Path('/tmp/aiter/requirements.txt'); dst = Path('/tmp/aiter/requirements-flydsl-ci.txt'); lines = [line for line in src.read_text().splitlines() if line.strip() and not line.strip().startswith('flydsl==')]; dst.write_text('\\n'.join(lines) + '\\n')\" && python3 -m pip install -r /tmp/aiter/requirements-flydsl-ci.txt"
-          docker exec flydsl_test bash -c "python3 -m pip uninstall -y triton pytorch-triton pytorch-triton-rocm triton-rocm amd-triton || true"
-          docker exec flydsl_test bash -c "python3 -m pip install --extra-index-url https://pypi.amd.com/triton/rocm-7.2.0/simple/ triton"
-          docker exec flydsl_test bash -c "python3 -c 'import triton; assert tuple(map(int, triton.__version__.split(\"+\", 1)[0].split(\".\")[:3])) >= (3, 6, 0), triton.__version__; print(\"Installed triton\", triton.__version__)'"
+          docker exec flydsl_test bash -c "python3 -c 'import torch; import triton; assert tuple(map(int, triton.__version__.split(\"+\", 1)[0].split(\".\")[:3])) >= (3, 6, 0), triton.__version__; print(\"Using image Triton\", triton.__version__, \"with PyTorch\", torch.__version__)'"
 
       - name: Run tests
         timeout-minutes: 60

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -21,8 +21,9 @@ concurrency:
 
 env:
   DOCKER_IMAGE: "rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0@sha256:c38eeda81d85f00fbe35d3d50ce42ce59c524e87d810624f4eb5c52fddb3b9ad"
+  LLVM_BUILD_PROFILE: "amd-minimal"
   # Bump when the container or LLVM build environment changes incompatibly.
-  MLIR_CACHE_VERSION: "rocm7.14-ubuntu24.04-py3.12-amd-minimal-v1"
+  MLIR_CACHE_VERSION: "rocm7.14-ubuntu24.04-py3.12-v1"
   GITHUB_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
   # PRs compare against their exact base; main pushes compare against the previous commit.
@@ -147,7 +148,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: mlir_install.tgz
-          key: mlir-install-${{ runner.os }}-${{ runner.arch }}-${{ env.MLIR_CACHE_VERSION }}-${{ hashFiles('flydsl-test/thirdparty/llvm-build-info.json', 'flydsl-test/thirdparty/llvm-rocdl-lld-argv0.patch', 'flydsl-test/scripts/build_llvm.sh') }}
+          key: mlir-install-${{ runner.os }}-${{ runner.arch }}-${{ env.MLIR_CACHE_VERSION }}-${{ env.LLVM_BUILD_PROFILE }}-${{ hashFiles('flydsl-test/thirdparty/llvm-build-info.json', 'flydsl-test/thirdparty/llvm-rocdl-lld-argv0.patch', 'flydsl-test/scripts/build_llvm.sh') }}
 
       - name: Start MLIR build container
         run: |
@@ -170,6 +171,10 @@ jobs:
           docker exec flydsl_mlir_cache bash -c "python3 -m pip install ninja>=1.11.1"
           docker exec flydsl_mlir_cache bash -c "python3 -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ 'rocm[devel]==7.14.0' && rocm-sdk init"
           docker exec flydsl_mlir_cache bash -c "git config --global --add safe.directory /flydsl-test"
+          sdk_root="$(docker exec flydsl_mlir_cache rocm-sdk path --root)"
+          test -n "${sdk_root}"
+          docker exec flydsl_mlir_cache test -d "${sdk_root}"
+          printf 'ROCM_PATH=%s\n' "${sdk_root}" >>"${GITHUB_ENV}"
 
       - name: Use cached MLIR install
         if: steps.mlir-cache.outputs.cache-hit == 'true'
@@ -181,13 +186,13 @@ jobs:
 
       - name: Build LLVM once
         if: steps.mlir-cache.outputs.cache-hit != 'true'
+        # A cold LLVM build measures ~10 min on these runners. Fail fast instead
+        # of letting a stalled fetch or build hold the GPU runner until the
+        # job-level timeout.
+        timeout-minutes: 45
         run: |
           set -ex
-          docker exec flydsl_mlir_cache bash -c '
-            export ROCM_PATH="$(rocm-sdk path --root)"
-            export LLVM_ENABLE_PROJECTS=mlir
-            export LLVM_TARGETS_TO_BUILD="X86;AMDGPU"
-            export LLVM_ENABLE_RUNTIMES=
+          docker exec -e LLVM_BUILD_PROFILE -e ROCM_PATH flydsl_mlir_cache bash -c '
             cd /flydsl-test
             bash scripts/build_llvm.sh
           '
@@ -200,9 +205,9 @@ jobs:
           docker exec \
             -e BASE_REPO_NAME \
             -e BASE_COMMIT_SHA \
+            -e ROCM_PATH \
             flydsl_mlir_cache bash -c '
               export MLIR_PATH=/llvm-project/mlir_install
-              export ROCM_PATH="$(rocm-sdk path --root)"
               export PATH="$(rocm-sdk path --bin):$PATH"
               export CMAKE_PREFIX_PATH="$(rocm-sdk path --cmake)${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
               cd /flydsl-test
@@ -210,7 +215,11 @@ jobs:
             '
           docker cp flydsl_mlir_cache:/tmp/flydsl-ci-wheels ./flydsl-ci-wheels
           (cd flydsl-ci-wheels/pr && sha256sum -c SHA256SUMS)
-          (cd flydsl-ci-wheels/base && sha256sum -c SHA256SUMS)
+          if [ -d flydsl-ci-wheels/base ]; then
+            (cd flydsl-ci-wheels/base && sha256sum -c SHA256SUMS)
+          else
+            echo "::warning title=Baseline wheel unavailable::Uploading PR wheel without an exact base benchmark."
+          fi
           (cd flydsl-ci-wheels/tools && sha256sum -c SHA256SUMS)
 
       - name: Save shared MLIR cache
@@ -232,7 +241,6 @@ jobs:
           path: flydsl-ci-wheels
           if-no-files-found: error
           retention-days: 1
-          compression-level: 0
 
       - name: Clean up MLIR build container
         if: always()
@@ -293,7 +301,11 @@ jobs:
       - name: Verify FlyDSL CI wheels
         run: |
           (cd flydsl-ci-wheels/pr && sha256sum -c SHA256SUMS)
-          (cd flydsl-ci-wheels/base && sha256sum -c SHA256SUMS)
+          if [ -d flydsl-ci-wheels/base ]; then
+            (cd flydsl-ci-wheels/base && sha256sum -c SHA256SUMS)
+          else
+            echo "::warning title=Baseline wheel unavailable::Exact base benchmark will be skipped."
+          fi
           (cd flydsl-ci-wheels/tools && sha256sum -c SHA256SUMS)
 
       - name: Start CI container
@@ -335,13 +347,18 @@ jobs:
           docker exec flydsl_test bash -c "python3 -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ 'rocm[devel]==7.14.0' && rocm-sdk init"
           docker exec flydsl_test bash -c "python3 -m pip install -U 'hypothesis>=6.82.0'"
           docker exec flydsl_test bash -c "git config --global --add safe.directory /flydsl-test && cd /flydsl-test && git log"
+          sdk_root="$(docker exec flydsl_test rocm-sdk path --root)"
+          test -n "${sdk_root}"
+          docker exec flydsl_test test -d "${sdk_root}"
+          printf 'ROCM_PATH=%s\n' "${sdk_root}" >>"${GITHUB_ENV}"
 
       - name: Install FlyDSL CI wheel
         run: |
           docker exec flydsl_test bash -c "python3 -m pip install --force-reinstall --no-deps /flydsl-ci-wheels/pr/*.whl"
           docker exec flydsl_test bash -c "mkdir -p /flydsl-test/build-fly/bin && cp /flydsl-ci-wheels/pr/fly-opt /flydsl-test/build-fly/bin/fly-opt && chmod +x /flydsl-test/build-fly/bin/fly-opt"
           docker exec flydsl_test bash -c "cp /flydsl-ci-wheels/tools/FileCheck /usr/local/bin/FileCheck && chmod +x /usr/local/bin/FileCheck"
-          docker exec flydsl_test bash -c 'export ROCM_PATH="$(rocm-sdk path --root)" && python3 -c "import flydsl; from flydsl._mlir.ir import Context; print(\"Installed FlyDSL CI wheel\")"'
+          docker exec -e ROCM_PATH flydsl_test bash -c "/flydsl-test/build-fly/bin/fly-opt --version"
+          docker exec -e ROCM_PATH flydsl_test bash -c 'python3 -c "import flydsl; from flydsl._mlir.ir import Context; print(\"Installed FlyDSL CI wheel\")"'
 
       - name: Prepare aiter
         if: ${{ !contains(matrix.runners, 'navi') }}
@@ -353,7 +370,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 60
         run: |
-          docker exec flydsl_test bash -c 'export ROCM_PATH="$(rocm-sdk path --root)" && export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-} && export AITER_REPO=/tmp/aiter && cd /flydsl-test && RUN_TESTS_FULL=1 bash scripts/run_tests.sh'
+          docker exec -e ROCM_PATH flydsl_test bash -c 'export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-} && export AITER_REPO=/tmp/aiter && cd /flydsl-test && RUN_TESTS_FULL=1 bash scripts/run_tests.sh'
 
       - name: Show tests logs
         if: failure()
@@ -370,9 +387,8 @@ jobs:
       - name: Run benchmarks
         id: benchmarks
         run: |
-          docker exec -i flydsl_test bash <<'BASH'
+          docker exec -i -e ROCM_PATH flydsl_test bash <<'BASH'
           set -e -o pipefail
-          export ROCM_PATH="$(rocm-sdk path --root)"
           export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
           export AITER_REPO=/tmp/aiter
           cd /flydsl-test
@@ -388,6 +404,7 @@ jobs:
           docker exec -i \
             -e BASE_REPO_NAME \
             -e BASE_COMMIT_SHA \
+            -e ROCM_PATH \
             flydsl_test bash <<'BASH'
           set -u
           cd /flydsl-test
@@ -396,7 +413,9 @@ jobs:
           git worktree prune || true
           base_repo_url="https://github.com/${BASE_REPO_NAME}.git"
 
-          if git fetch "${base_repo_url}" "${BASE_COMMIT_SHA}" --no-tags --depth=1; then
+          if [ ! -d /flydsl-ci-wheels/base ]; then
+            echo "::warning title=Benchmark baseline unavailable::Base wheel was not produced; skipping exact main comparison."
+          elif git fetch "${base_repo_url}" "${BASE_COMMIT_SHA}" --no-tags --depth=1; then
             commit="$(git rev-parse FETCH_HEAD)"
             label="main"
             worktree="/tmp/flydsl-bench-main"
@@ -415,7 +434,6 @@ jobs:
                 mkdir -p build-fly/bin
                 cp /flydsl-ci-wheels/base/fly-opt build-fly/bin/fly-opt
                 chmod +x build-fly/bin/fly-opt
-                export ROCM_PATH="$(rocm-sdk path --root)"
                 export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
                 export AITER_REPO=/tmp/aiter
                 BENCH_LOG_DIR="${log_dir}" bash scripts/run_benchmark.sh 2>&1 | tee "${output}"
@@ -452,7 +470,6 @@ jobs:
                   set -e -o pipefail
                   cd "${worktree}"
                   python3 -m pip install --only-binary=:all: "flydsl==${package_version}" 2>&1 | tail -5
-                  export ROCM_PATH="$(rocm-sdk path --root)"
                   export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
                   export AITER_REPO=/tmp/aiter
                   BENCH_LOG_DIR="${log_dir}" bash scripts/run_benchmark.sh 2>&1 | tee "${output}"
@@ -533,9 +550,9 @@ jobs:
   # fail-fast: false ensures both runners always complete even if one fails.
   # ---------------------------------------------------------------------------
   multi-gpu:
-    needs: [test, detect-changes]
+    needs: [test, detect-changes, prepare-mlir]
     name: Multi-GPU Communication Operator Tests (${{ matrix.runners }})
-    timeout-minutes: 240
+    timeout-minutes: 120
     env:
       # Keep checkout independent of runner-local git-cache rewrites.
       GIT_CONFIG_GLOBAL: /dev/null
@@ -544,7 +561,7 @@ jobs:
     # detect-changes failure falls back to running).
     if: |
       !cancelled() &&
-      needs.test.result == 'success' &&
+      needs.prepare-mlir.result == 'success' &&
       (needs.detect-changes.result != 'success' ||
        needs.detect-changes.outputs.code_changed == 'true') && (
         (github.event_name == 'pull_request' &&
@@ -580,7 +597,11 @@ jobs:
       - name: Verify FlyDSL CI wheels
         run: |
           (cd flydsl-ci-wheels/pr && sha256sum -c SHA256SUMS)
-          (cd flydsl-ci-wheels/base && sha256sum -c SHA256SUMS)
+          if [ -d flydsl-ci-wheels/base ]; then
+            (cd flydsl-ci-wheels/base && sha256sum -c SHA256SUMS)
+          else
+            echo "::warning title=Baseline wheel unavailable::Exact base benchmark will be skipped."
+          fi
           (cd flydsl-ci-wheels/tools && sha256sum -c SHA256SUMS)
 
       - name: Start CI container
@@ -616,18 +637,23 @@ jobs:
           docker exec flydsl_test bash -c "python3 -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ 'rocm[devel]==7.14.0' && rocm-sdk init"
           docker exec flydsl_test bash -c "python3 -m pip install -U 'hypothesis>=6.82.0'"
           docker exec flydsl_test bash -c "git config --global --add safe.directory /flydsl-test && cd /flydsl-test && git log"
+          sdk_root="$(docker exec flydsl_test rocm-sdk path --root)"
+          test -n "${sdk_root}"
+          docker exec flydsl_test test -d "${sdk_root}"
+          printf 'ROCM_PATH=%s\n' "${sdk_root}" >>"${GITHUB_ENV}"
 
       - name: Install FlyDSL CI wheel
         run: |
           docker exec flydsl_test bash -c "python3 -m pip install --force-reinstall --no-deps /flydsl-ci-wheels/pr/*.whl"
           docker exec flydsl_test bash -c "mkdir -p /flydsl-test/build-fly/bin && cp /flydsl-ci-wheels/pr/fly-opt /flydsl-test/build-fly/bin/fly-opt && chmod +x /flydsl-test/build-fly/bin/fly-opt"
           docker exec flydsl_test bash -c "cp /flydsl-ci-wheels/tools/FileCheck /usr/local/bin/FileCheck && chmod +x /usr/local/bin/FileCheck"
-          docker exec flydsl_test bash -c 'export ROCM_PATH="$(rocm-sdk path --root)" && python3 -c "import flydsl; from flydsl._mlir.ir import Context; print(\"Installed FlyDSL CI wheel\")"'
+          docker exec -e ROCM_PATH flydsl_test bash -c "/flydsl-test/build-fly/bin/fly-opt --version"
+          docker exec -e ROCM_PATH flydsl_test bash -c 'python3 -c "import flydsl; from flydsl._mlir.ir import Context; print(\"Installed FlyDSL CI wheel\")"'
 
       - name: Install mori (for shmem regression test)
         timeout-minutes: 15
         run: |
-          docker exec flydsl_test bash -c "
+          docker exec -e ROCM_PATH flydsl_test bash -c "
             apt-get install -y libpci-dev libibverbs-dev libgrpc++1.51 libgrpc29 &&
             python3 -m pip install amd_mori &&
             MORI_PRECOMPILE=1 python3 -c 'import mori'
@@ -636,8 +662,7 @@ jobs:
       - name: Run multi-GPU shmem regression test
         timeout-minutes: 10
         run: |
-          docker exec flydsl_test bash -c "
-            export ROCM_PATH=\$(rocm-sdk path --root)
+          docker exec -e ROCM_PATH flydsl_test bash -c "
             cd /flydsl-test
             python3 -m pytest tests/kernels/test_flydsl_shmem.py \
               -m multi_gpu -v --no-header --tb=short
@@ -646,8 +671,7 @@ jobs:
       - name: Run multi-GPU dispatch/combine CI sweep (8-GPU, accuracy + cudagraph perf)
         timeout-minutes: 30
         run: |
-          docker exec flydsl_test bash -c "
-            export ROCM_PATH=\$(rocm-sdk path --root) &&
+          docker exec -e ROCM_PATH flydsl_test bash -c "
             cd /flydsl-test &&
             MORI_SOCKET_IFNAME=lo python tests/kernels/test_profiler_dispatch_combine.py \
               --ci-sweep \
@@ -661,8 +685,7 @@ jobs:
       - name: Run multi-GPU MegaMoEV2 A8W4 v4_pro accuracy tests
         timeout-minutes: 45
         run: |
-          docker exec flydsl_test bash -c "
-            export ROCM_PATH=\$(rocm-sdk path --root) &&
+          docker exec -e ROCM_PATH flydsl_test bash -c "
             cd /flydsl-test &&
             python3 -c 'import torch; n = torch.cuda.device_count(); assert n >= 8, f\"requires 8 GPUs, found {n}\"' &&
             python3 -m pytest \
@@ -673,8 +696,7 @@ jobs:
       - name: Run multi-GPU allreduce tests
         timeout-minutes: 30
         run: |
-          docker exec flydsl_test bash -c "
-            export ROCM_PATH=\$(rocm-sdk path --root)
+          docker exec -e ROCM_PATH flydsl_test bash -c "
             cd /flydsl-test
             python3 -m pytest tests/kernels/test_allreduce.py \
               -m multi_gpu -v --no-header --tb=short
@@ -683,8 +705,7 @@ jobs:
       - name: Run allreduce benchmark (PR)
         timeout-minutes: 30
         run: |
-          docker exec flydsl_test bash -c "
-            export ROCM_PATH=\$(rocm-sdk path --root)
+          docker exec -e ROCM_PATH flydsl_test bash -c "
             cd /flydsl-test
             python3 tests/kernels/test_allreduce.py \
               --world_size 8 --iters 51 --warmup 5 \
@@ -703,6 +724,10 @@ jobs:
             -e BASE_COMMIT_SHA \
             flydsl_test bash -c "
             set -e -o pipefail
+            if [ ! -d /flydsl-ci-wheels/base ]; then
+              echo '::warning title=Benchmark baseline unavailable::Base wheel was not produced.'
+              exit 1
+            fi
             cd /flydsl-test
             git fetch \"https://github.com/\${BASE_REPO_NAME}.git\" \"\${BASE_COMMIT_SHA}\" --no-tags --depth=1
             git worktree add --detach /tmp/flydsl-main FETCH_HEAD
@@ -719,8 +744,7 @@ jobs:
         timeout-minutes: 30
         continue-on-error: true
         run: |
-          docker exec flydsl_test bash -c "
-            export ROCM_PATH=\$(rocm-sdk path --root)
+          docker exec -e ROCM_PATH flydsl_test bash -c "
             cp /flydsl-test/tests/kernels/test_allreduce.py \
                /tmp/flydsl-main/tests/kernels/test_allreduce.py
             cd /tmp/flydsl-main

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -170,6 +170,7 @@ jobs:
           docker exec flydsl_mlir_cache bash -c "apt-get update && apt-get install -y cmake build-essential patchelf"
           docker exec flydsl_mlir_cache bash -c "python3 -m pip install -U pip setuptools wheel"
           docker exec flydsl_mlir_cache bash -c "python3 -m pip install ninja>=1.11.1"
+          docker exec flydsl_mlir_cache bash -c "python3 -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ 'rocm[devel]==7.14.0' && rocm-sdk init"
           docker exec flydsl_mlir_cache bash -c "git config --global --add safe.directory /flydsl-test"
 
       - name: Build LLVM once
@@ -184,7 +185,7 @@ jobs:
       - name: Validate MLIR with FlyDSL build
         if: steps.mlir-cache.outputs.cache-hit != 'true'
         run: |
-          docker exec flydsl_mlir_cache bash -c "export MLIR_PATH=/llvm-project/mlir_install && cd /flydsl-test && python3 -m pip install -e . --use-pep517"
+          docker exec flydsl_mlir_cache bash -c 'export MLIR_PATH=/llvm-project/mlir_install && export PATH="$(rocm-sdk path --bin):$PATH" && export CMAKE_PREFIX_PATH="$(rocm-sdk path --cmake)${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}" && cd /flydsl-test && python3 -m pip install -e . --use-pep517'
 
       - name: Save shared MLIR cache from main
         if: >-
@@ -290,6 +291,7 @@ jobs:
           docker exec flydsl_test bash -c "apt-get update && apt-get install -y cmake build-essential patchelf"
           docker exec flydsl_test bash -c "python3 -m pip install -U pip setuptools wheel"
           docker exec flydsl_test bash -c "python3 -m pip install ninja>=1.11.1"
+          docker exec flydsl_test bash -c "python3 -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ 'rocm[devel]==7.14.0' && rocm-sdk init"
           docker exec flydsl_test bash -c "python3 -m pip install -U 'hypothesis>=6.82.0'"
           docker exec flydsl_test bash -c "git config --global --add safe.directory /flydsl-test && cd /flydsl-test && git log"
     
@@ -307,7 +309,7 @@ jobs:
 
       - name: Build FlyDSL (uses MLIR install prefix)
         run: |
-          docker exec flydsl_test bash -c "export MLIR_PATH=/llvm-project/mlir_install && cd /flydsl-test && python3 -m pip install -e . --use-pep517"
+          docker exec flydsl_test bash -c 'export MLIR_PATH=/llvm-project/mlir_install && export PATH="$(rocm-sdk path --bin):$PATH" && export CMAKE_PREFIX_PATH="$(rocm-sdk path --cmake)${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}" && cd /flydsl-test && python3 -m pip install -e . --use-pep517'
 
       - name: Prepare aiter
         if: ${{ !contains(matrix.runners, 'navi') }}
@@ -562,6 +564,7 @@ jobs:
           docker exec flydsl_test bash -c "apt-get update && apt-get install -y cmake build-essential patchelf"
           docker exec flydsl_test bash -c "python3 -m pip install -U pip setuptools wheel"
           docker exec flydsl_test bash -c "python3 -m pip install ninja>=1.11.1"
+          docker exec flydsl_test bash -c "python3 -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ 'rocm[devel]==7.14.0' && rocm-sdk init"
           docker exec flydsl_test bash -c "python3 -m pip install -U 'hypothesis>=6.82.0'"
           docker exec flydsl_test bash -c "git config --global --add safe.directory /flydsl-test && cd /flydsl-test && git log"
 
@@ -579,7 +582,7 @@ jobs:
 
       - name: Build FlyDSL (uses MLIR install prefix)
         run: |
-          docker exec flydsl_test bash -c "export MLIR_PATH=/llvm-project/mlir_install && cd /flydsl-test && python3 -m pip install -e . --use-pep517"
+          docker exec flydsl_test bash -c 'export MLIR_PATH=/llvm-project/mlir_install && export PATH="$(rocm-sdk path --bin):$PATH" && export CMAKE_PREFIX_PATH="$(rocm-sdk path --cmake)${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}" && cd /flydsl-test && python3 -m pip install -e . --use-pep517'
 
       - name: Install mori (for shmem regression test)
         timeout-minutes: 15

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -22,7 +22,7 @@ concurrency:
 env:
   DOCKER_IMAGE: "rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0@sha256:c38eeda81d85f00fbe35d3d50ce42ce59c524e87d810624f4eb5c52fddb3b9ad"
   # Bump when the container or LLVM build environment changes incompatibly.
-  MLIR_CACHE_VERSION: "rocm7.14-ubuntu24.04-py3.12-v1"
+  MLIR_CACHE_VERSION: "rocm7.14-ubuntu24.04-py3.12-v2"
   GITHUB_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
   # PRs compare against their exact base; main pushes compare against the previous commit.
@@ -147,7 +147,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: mlir_install.tgz
-          key: mlir-install-${{ runner.os }}-${{ runner.arch }}-${{ env.MLIR_CACHE_VERSION }}-${{ hashFiles('flydsl-test/thirdparty/llvm-build-info.json', 'flydsl-test/scripts/build_llvm.sh') }}
+          key: mlir-install-${{ runner.os }}-${{ runner.arch }}-${{ env.MLIR_CACHE_VERSION }}-${{ hashFiles('flydsl-test/thirdparty/llvm-build-info.json', 'flydsl-test/thirdparty/llvm-rocdl-lld-argv0.patch', 'flydsl-test/scripts/build_llvm.sh') }}
 
       - name: Start MLIR build container
         if: steps.mlir-cache.outputs.cache-hit != 'true'
@@ -177,7 +177,7 @@ jobs:
         if: steps.mlir-cache.outputs.cache-hit != 'true'
         run: |
           set -ex
-          docker exec flydsl_mlir_cache bash -c "cd /flydsl-test && bash scripts/build_llvm.sh"
+          docker exec flydsl_mlir_cache bash -c 'export ROCM_PATH="$(rocm-sdk path --root)" && cd /flydsl-test && bash scripts/build_llvm.sh'
           docker exec flydsl_mlir_cache bash -c "ls -la /llvm-project/mlir_install/lib/cmake/mlir"
           docker cp flydsl_mlir_cache:/llvm-project/mlir_install.tgz ./mlir_install.tgz
           test -s ./mlir_install.tgz

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -20,9 +20,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOCKER_IMAGE: "rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.9.1"
+  DOCKER_IMAGE: "rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0@sha256:c38eeda81d85f00fbe35d3d50ce42ce59c524e87d810624f4eb5c52fddb3b9ad"
   # Bump when the container or LLVM build environment changes incompatibly.
-  MLIR_CACHE_VERSION: "rocm7.2-ubuntu24.04-py3.12-v1"
+  MLIR_CACHE_VERSION: "rocm7.14-ubuntu24.04-py3.12-v1"
   GITHUB_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
   # PRs compare against their exact base; main pushes compare against the previous commit.

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -22,7 +22,7 @@ concurrency:
 env:
   DOCKER_IMAGE: "rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0@sha256:c38eeda81d85f00fbe35d3d50ce42ce59c524e87d810624f4eb5c52fddb3b9ad"
   # Bump when the container or LLVM build environment changes incompatibly.
-  MLIR_CACHE_VERSION: "rocm7.14-ubuntu24.04-py3.12-v2"
+  MLIR_CACHE_VERSION: "rocm7.14-ubuntu24.04-py3.12-amd-minimal-v1"
   GITHUB_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
   # PRs compare against their exact base; main pushes compare against the previous commit.
@@ -118,9 +118,9 @@ jobs:
           echo "Docs-only change: GPU tests skipped (check-signal=${CHECK_SIGNAL_RESULT}); reporting 'test (${{ matrix.runners }})' as passed."
 
   # ---------------------------------------------------------------------------
-  # Prepare one shared MLIR install before GPU jobs. Restore or build LLVM once,
-  # then publish a short-lived artifact for every GPU job in the current run.
-  # Only main persists rebuilt installs in the cross-run cache.
+  # Prepare one shared MLIR install, then build current/base FlyDSL wheels once.
+  # GPU jobs consume the compact wheels instead of transferring the full MLIR
+  # install. Main and trusted same-repository PRs persist rebuilt MLIR caches.
   # ---------------------------------------------------------------------------
   prepare-mlir:
     needs: [check-signal, detect-changes]
@@ -130,7 +130,7 @@ jobs:
           && (needs.detect-changes.result != 'success'
               || needs.detect-changes.outputs.code_changed == 'true') }}
     runs-on: linux-flydsl-mi325-1
-    timeout-minutes: 90
+    timeout-minutes: 150
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -150,7 +150,6 @@ jobs:
           key: mlir-install-${{ runner.os }}-${{ runner.arch }}-${{ env.MLIR_CACHE_VERSION }}-${{ hashFiles('flydsl-test/thirdparty/llvm-build-info.json', 'flydsl-test/thirdparty/llvm-rocdl-lld-argv0.patch', 'flydsl-test/scripts/build_llvm.sh') }}
 
       - name: Start MLIR build container
-        if: steps.mlir-cache.outputs.cache-hit != 'true'
         run: |
           docker ps -aq -f name=flydsl_mlir_cache | xargs -r docker stop | xargs -r docker rm || true
           docker run -dt --network=host --user root \
@@ -165,7 +164,6 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
       - name: Install MLIR build dependencies
-        if: steps.mlir-cache.outputs.cache-hit != 'true'
         run: |
           docker exec flydsl_mlir_cache bash -c "apt-get update && apt-get install -y cmake build-essential patchelf"
           docker exec flydsl_mlir_cache bash -c "python3 -m pip install -U pip setuptools wheel"
@@ -173,41 +171,71 @@ jobs:
           docker exec flydsl_mlir_cache bash -c "python3 -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ 'rocm[devel]==7.14.0' && rocm-sdk init"
           docker exec flydsl_mlir_cache bash -c "git config --global --add safe.directory /flydsl-test"
 
+      - name: Use cached MLIR install
+        if: steps.mlir-cache.outputs.cache-hit == 'true'
+        run: |
+          test -s ./mlir_install.tgz
+          docker cp ./mlir_install.tgz flydsl_mlir_cache:/tmp/mlir_install.tgz
+          docker exec flydsl_mlir_cache bash -c "mkdir -p /llvm-project && tar -xzf /tmp/mlir_install.tgz -C /llvm-project"
+          docker exec flydsl_mlir_cache bash -c "test -d /llvm-project/mlir_install/lib/cmake/mlir"
+
       - name: Build LLVM once
         if: steps.mlir-cache.outputs.cache-hit != 'true'
         run: |
           set -ex
-          docker exec flydsl_mlir_cache bash -c 'export ROCM_PATH="$(rocm-sdk path --root)" && cd /flydsl-test && bash scripts/build_llvm.sh'
+          docker exec flydsl_mlir_cache bash -c '
+            export ROCM_PATH="$(rocm-sdk path --root)"
+            export LLVM_ENABLE_PROJECTS=mlir
+            export LLVM_TARGETS_TO_BUILD="X86;AMDGPU"
+            export LLVM_ENABLE_RUNTIMES=
+            cd /flydsl-test
+            bash scripts/build_llvm.sh
+          '
           docker exec flydsl_mlir_cache bash -c "ls -la /llvm-project/mlir_install/lib/cmake/mlir"
           docker cp flydsl_mlir_cache:/llvm-project/mlir_install.tgz ./mlir_install.tgz
           test -s ./mlir_install.tgz
 
-      - name: Validate MLIR with FlyDSL build
-        if: steps.mlir-cache.outputs.cache-hit != 'true'
+      - name: Build current and base FlyDSL wheels
         run: |
-          docker exec flydsl_mlir_cache bash -c 'export MLIR_PATH=/llvm-project/mlir_install && export PATH="$(rocm-sdk path --bin):$PATH" && export CMAKE_PREFIX_PATH="$(rocm-sdk path --cmake)${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}" && cd /flydsl-test && python3 -m pip install -e . --use-pep517'
+          docker exec \
+            -e BASE_REPO_NAME \
+            -e BASE_COMMIT_SHA \
+            flydsl_mlir_cache bash -c '
+              export MLIR_PATH=/llvm-project/mlir_install
+              export ROCM_PATH="$(rocm-sdk path --root)"
+              export PATH="$(rocm-sdk path --bin):$PATH"
+              export CMAKE_PREFIX_PATH="$(rocm-sdk path --cmake)${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+              cd /flydsl-test
+              bash scripts/build_ci_wheels.sh
+            '
+          docker cp flydsl_mlir_cache:/tmp/flydsl-ci-wheels ./flydsl-ci-wheels
+          (cd flydsl-ci-wheels/pr && sha256sum -c SHA256SUMS)
+          (cd flydsl-ci-wheels/base && sha256sum -c SHA256SUMS)
+          (cd flydsl-ci-wheels/tools && sha256sum -c SHA256SUMS)
 
-      - name: Save shared MLIR cache from main
+      - name: Save shared MLIR cache
         if: >-
           steps.mlir-cache.outputs.cache-hit != 'true' &&
-          github.ref == 'refs/heads/main' &&
-          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+          ((github.ref == 'refs/heads/main' &&
+            (github.event_name == 'push' || github.event_name == 'workflow_dispatch')) ||
+           (github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository))
         uses: actions/cache/save@v4
         with:
           path: mlir_install.tgz
           key: ${{ steps.mlir-cache.outputs.cache-primary-key }}
 
-      - name: Upload prepared MLIR tarball for this run
+      - name: Upload FlyDSL CI wheels for this run
         uses: actions/upload-artifact@v4
         with:
-          name: mlir-install-${{ github.run_id }}
-          path: mlir_install.tgz
+          name: flydsl-ci-wheels-${{ github.run_id }}
+          path: flydsl-ci-wheels
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
 
       - name: Clean up MLIR build container
-        if: always() && steps.mlir-cache.outputs.cache-hit != 'true'
+        if: always()
         run: |
           docker stop flydsl_mlir_cache || true
           docker rm flydsl_mlir_cache || true
@@ -255,7 +283,19 @@ jobs:
           repository: ${{ env.GITHUB_REPO_NAME }}
           ref: ${{ env.GITHUB_COMMIT_SHA }}
           path: flydsl-test
-    
+
+      - name: Download FlyDSL CI wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: flydsl-ci-wheels-${{ github.run_id }}
+          path: flydsl-ci-wheels
+
+      - name: Verify FlyDSL CI wheels
+        run: |
+          (cd flydsl-ci-wheels/pr && sha256sum -c SHA256SUMS)
+          (cd flydsl-ci-wheels/base && sha256sum -c SHA256SUMS)
+          (cd flydsl-ci-wheels/tools && sha256sum -c SHA256SUMS)
+
       - name: Start CI container
         run: |
           echo "Clean up containers..."
@@ -276,6 +316,7 @@ jobs:
           echo "Starting container: flydsl_test:ci"
           docker run -dt --network=host --user root --device=/dev/kfd $DEVICE_FLAG "${GPU_ENV_ARGS[@]}" \
           -v "${GITHUB_WORKSPACE:-$PWD}/flydsl-test:/flydsl-test" \
+          -v "${GITHUB_WORKSPACE:-$PWD}/flydsl-ci-wheels:/flydsl-ci-wheels:ro" \
           --ipc=host --group-add video \
           --shm-size 16g \
           --cap-add=SYS_PTRACE \
@@ -294,22 +335,13 @@ jobs:
           docker exec flydsl_test bash -c "python3 -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ 'rocm[devel]==7.14.0' && rocm-sdk init"
           docker exec flydsl_test bash -c "python3 -m pip install -U 'hypothesis>=6.82.0'"
           docker exec flydsl_test bash -c "git config --global --add safe.directory /flydsl-test && cd /flydsl-test && git log"
-    
-      - name: Download prepared MLIR tarball
-        uses: actions/download-artifact@v4
-        with:
-          name: mlir-install-${{ github.run_id }}
 
-      - name: Use prepared MLIR install tarball
+      - name: Install FlyDSL CI wheel
         run: |
-          ls -lh mlir_install.tgz
-          docker cp mlir_install.tgz flydsl_test:/tmp/mlir_install.tgz
-          docker exec flydsl_test bash -c "rm -rf /llvm-project/mlir_install && mkdir -p /llvm-project && tar -xzf /tmp/mlir_install.tgz -C /llvm-project"
-          docker exec flydsl_test bash -c "ls -la /llvm-project/mlir_install/lib/cmake/mlir"
-
-      - name: Build FlyDSL (uses MLIR install prefix)
-        run: |
-          docker exec flydsl_test bash -c 'export MLIR_PATH=/llvm-project/mlir_install && export PATH="$(rocm-sdk path --bin):$PATH" && export CMAKE_PREFIX_PATH="$(rocm-sdk path --cmake)${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}" && cd /flydsl-test && python3 -m pip install -e . --use-pep517'
+          docker exec flydsl_test bash -c "python3 -m pip install --force-reinstall --no-deps /flydsl-ci-wheels/pr/*.whl"
+          docker exec flydsl_test bash -c "mkdir -p /flydsl-test/build-fly/bin && cp /flydsl-ci-wheels/pr/fly-opt /flydsl-test/build-fly/bin/fly-opt && chmod +x /flydsl-test/build-fly/bin/fly-opt"
+          docker exec flydsl_test bash -c "cp /flydsl-ci-wheels/tools/FileCheck /usr/local/bin/FileCheck && chmod +x /usr/local/bin/FileCheck"
+          docker exec flydsl_test bash -c 'export ROCM_PATH="$(rocm-sdk path --root)" && python3 -c "import flydsl; from flydsl._mlir.ir import Context; print(\"Installed FlyDSL CI wheel\")"'
 
       - name: Prepare aiter
         if: ${{ !contains(matrix.runners, 'navi') }}
@@ -321,7 +353,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 60
         run: |
-          docker exec flydsl_test bash -c "export PYTHONPATH=/tmp/aiter:\${PYTHONPATH:-} && export AITER_REPO=/tmp/aiter && cd /flydsl-test && RUN_TESTS_FULL=1 bash scripts/run_tests.sh"
+          docker exec flydsl_test bash -c 'export ROCM_PATH="$(rocm-sdk path --root)" && export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-} && export AITER_REPO=/tmp/aiter && cd /flydsl-test && RUN_TESTS_FULL=1 bash scripts/run_tests.sh'
 
       - name: Show tests logs
         if: failure()
@@ -340,6 +372,7 @@ jobs:
         run: |
           docker exec -i flydsl_test bash <<'BASH'
           set -e -o pipefail
+          export ROCM_PATH="$(rocm-sdk path --root)"
           export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
           export AITER_REPO=/tmp/aiter
           cd /flydsl-test
@@ -378,8 +411,11 @@ jobs:
               (
                 set -e -o pipefail
                 cd "${worktree}"
-                export MLIR_PATH=/llvm-project/mlir_install
-                python3 -m pip install -e . --use-pep517 2>&1 | tail -5
+                python3 -m pip install --force-reinstall --no-deps /flydsl-ci-wheels/base/*.whl 2>&1 | tail -5
+                mkdir -p build-fly/bin
+                cp /flydsl-ci-wheels/base/fly-opt build-fly/bin/fly-opt
+                chmod +x build-fly/bin/fly-opt
+                export ROCM_PATH="$(rocm-sdk path --root)"
                 export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
                 export AITER_REPO=/tmp/aiter
                 BENCH_LOG_DIR="${log_dir}" bash scripts/run_benchmark.sh 2>&1 | tee "${output}"
@@ -416,6 +452,7 @@ jobs:
                   set -e -o pipefail
                   cd "${worktree}"
                   python3 -m pip install --only-binary=:all: "flydsl==${package_version}" 2>&1 | tail -5
+                  export ROCM_PATH="$(rocm-sdk path --root)"
                   export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
                   export AITER_REPO=/tmp/aiter
                   BENCH_LOG_DIR="${log_dir}" bash scripts/run_benchmark.sh 2>&1 | tee "${output}"
@@ -498,7 +535,7 @@ jobs:
   multi-gpu:
     needs: [test, detect-changes]
     name: Multi-GPU Communication Operator Tests (${{ matrix.runners }})
-    timeout-minutes: 120
+    timeout-minutes: 240
     env:
       # Keep checkout independent of runner-local git-cache rewrites.
       GIT_CONFIG_GLOBAL: /dev/null
@@ -507,6 +544,7 @@ jobs:
     # detect-changes failure falls back to running).
     if: |
       !cancelled() &&
+      needs.test.result == 'success' &&
       (needs.detect-changes.result != 'success' ||
        needs.detect-changes.outputs.code_changed == 'true') && (
         (github.event_name == 'pull_request' &&
@@ -533,6 +571,18 @@ jobs:
           ref: ${{ env.GITHUB_COMMIT_SHA }}
           path: flydsl-test
 
+      - name: Download FlyDSL CI wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: flydsl-ci-wheels-${{ github.run_id }}
+          path: flydsl-ci-wheels
+
+      - name: Verify FlyDSL CI wheels
+        run: |
+          (cd flydsl-ci-wheels/pr && sha256sum -c SHA256SUMS)
+          (cd flydsl-ci-wheels/base && sha256sum -c SHA256SUMS)
+          (cd flydsl-ci-wheels/tools && sha256sum -c SHA256SUMS)
+
       - name: Start CI container
         run: |
           echo "Clean up containers..."
@@ -547,6 +597,7 @@ jobs:
 
           docker run -dt --network=host --user root --device=/dev/kfd $DEVICE_FLAG \
           -v "${GITHUB_WORKSPACE:-$PWD}/flydsl-test:/flydsl-test" \
+          -v "${GITHUB_WORKSPACE:-$PWD}/flydsl-ci-wheels:/flydsl-ci-wheels:ro" \
           --ipc=host --group-add video \
           --shm-size 16g \
           --cap-add=SYS_PTRACE \
@@ -566,21 +617,12 @@ jobs:
           docker exec flydsl_test bash -c "python3 -m pip install -U 'hypothesis>=6.82.0'"
           docker exec flydsl_test bash -c "git config --global --add safe.directory /flydsl-test && cd /flydsl-test && git log"
 
-      - name: Download prepared MLIR tarball
-        uses: actions/download-artifact@v4
-        with:
-          name: mlir-install-${{ github.run_id }}
-
-      - name: Use prepared MLIR install tarball
+      - name: Install FlyDSL CI wheel
         run: |
-          ls -lh mlir_install.tgz
-          docker cp mlir_install.tgz flydsl_test:/tmp/mlir_install.tgz
-          docker exec flydsl_test bash -c "rm -rf /llvm-project/mlir_install && mkdir -p /llvm-project && tar -xzf /tmp/mlir_install.tgz -C /llvm-project"
-          docker exec flydsl_test bash -c "ls -la /llvm-project/mlir_install/lib/cmake/mlir"
-
-      - name: Build FlyDSL (uses MLIR install prefix)
-        run: |
-          docker exec flydsl_test bash -c 'export MLIR_PATH=/llvm-project/mlir_install && export PATH="$(rocm-sdk path --bin):$PATH" && export CMAKE_PREFIX_PATH="$(rocm-sdk path --cmake)${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}" && cd /flydsl-test && python3 -m pip install -e . --use-pep517'
+          docker exec flydsl_test bash -c "python3 -m pip install --force-reinstall --no-deps /flydsl-ci-wheels/pr/*.whl"
+          docker exec flydsl_test bash -c "mkdir -p /flydsl-test/build-fly/bin && cp /flydsl-ci-wheels/pr/fly-opt /flydsl-test/build-fly/bin/fly-opt && chmod +x /flydsl-test/build-fly/bin/fly-opt"
+          docker exec flydsl_test bash -c "cp /flydsl-ci-wheels/tools/FileCheck /usr/local/bin/FileCheck && chmod +x /usr/local/bin/FileCheck"
+          docker exec flydsl_test bash -c 'export ROCM_PATH="$(rocm-sdk path --root)" && python3 -c "import flydsl; from flydsl._mlir.ir import Context; print(\"Installed FlyDSL CI wheel\")"'
 
       - name: Install mori (for shmem regression test)
         timeout-minutes: 15
@@ -595,6 +637,7 @@ jobs:
         timeout-minutes: 10
         run: |
           docker exec flydsl_test bash -c "
+            export ROCM_PATH=\$(rocm-sdk path --root)
             cd /flydsl-test
             python3 -m pytest tests/kernels/test_flydsl_shmem.py \
               -m multi_gpu -v --no-header --tb=short
@@ -604,6 +647,7 @@ jobs:
         timeout-minutes: 30
         run: |
           docker exec flydsl_test bash -c "
+            export ROCM_PATH=\$(rocm-sdk path --root) &&
             cd /flydsl-test &&
             MORI_SOCKET_IFNAME=lo python tests/kernels/test_profiler_dispatch_combine.py \
               --ci-sweep \
@@ -618,6 +662,7 @@ jobs:
         timeout-minutes: 45
         run: |
           docker exec flydsl_test bash -c "
+            export ROCM_PATH=\$(rocm-sdk path --root) &&
             cd /flydsl-test &&
             python3 -c 'import torch; n = torch.cuda.device_count(); assert n >= 8, f\"requires 8 GPUs, found {n}\"' &&
             python3 -m pytest \
@@ -629,6 +674,7 @@ jobs:
         timeout-minutes: 30
         run: |
           docker exec flydsl_test bash -c "
+            export ROCM_PATH=\$(rocm-sdk path --root)
             cd /flydsl-test
             python3 -m pytest tests/kernels/test_allreduce.py \
               -m multi_gpu -v --no-header --tb=short
@@ -638,6 +684,7 @@ jobs:
         timeout-minutes: 30
         run: |
           docker exec flydsl_test bash -c "
+            export ROCM_PATH=\$(rocm-sdk path --root)
             cd /flydsl-test
             python3 tests/kernels/test_allreduce.py \
               --world_size 8 --iters 51 --warmup 5 \
@@ -655,12 +702,15 @@ jobs:
             -e BASE_REPO_NAME \
             -e BASE_COMMIT_SHA \
             flydsl_test bash -c "
+            set -e -o pipefail
             cd /flydsl-test
             git fetch \"https://github.com/\${BASE_REPO_NAME}.git\" \"\${BASE_COMMIT_SHA}\" --no-tags --depth=1
             git worktree add --detach /tmp/flydsl-main FETCH_HEAD
             cd /tmp/flydsl-main
-            export MLIR_PATH=/llvm-project/mlir_install
-            python3 -m pip install -e . --use-pep517 2>&1 | tail -5
+            python3 -m pip install --force-reinstall --no-deps /flydsl-ci-wheels/base/*.whl 2>&1 | tail -5
+            mkdir -p build-fly/bin
+            cp /flydsl-ci-wheels/base/fly-opt build-fly/bin/fly-opt
+            chmod +x build-fly/bin/fly-opt
           "
 
       - name: Run allreduce benchmark (main)
@@ -670,6 +720,7 @@ jobs:
         continue-on-error: true
         run: |
           docker exec flydsl_test bash -c "
+            export ROCM_PATH=\$(rocm-sdk path --root)
             cp /flydsl-test/tests/kernels/test_allreduce.py \
                /tmp/flydsl-main/tests/kernels/test_allreduce.py
             cd /tmp/flydsl-main

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -68,7 +68,7 @@ jobs:
     needs: [validate_tag, build]
     uses: ./.github/workflows/test-whl.yaml
     with:
-      docker_image: rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.8.0
+      docker_image: rocm/pytorch:rocm7.14_ubuntu24.04_py3.11_pytorch_release_2.12.0@sha256:05743468394cc8f9cce06822635836a31ddfd5956bac36976666d7057713441d
     permissions:
       contents: read
 

--- a/scripts/build_ci_wheels.sh
+++ b/scripts/build_ci_wheels.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 : "${MLIR_PATH:?MLIR_PATH must point to the prepared MLIR install}"
+: "${ROCM_PATH:?ROCM_PATH must point to the ROCm SDK root}"
 : "${BASE_REPO_NAME:?BASE_REPO_NAME must be set}"
 : "${BASE_COMMIT_SHA:?BASE_COMMIT_SHA must be set}"
 
@@ -19,70 +20,145 @@ if [[ ! "${BASE_COMMIT_SHA}" =~ ^[0-9a-fA-F]{40}$ && "${BASE_COMMIT_SHA}" != "ma
   exit 2
 fi
 
-PYTHON_BIN="${PYTHON_BIN:-python3}"
+PYTHON_REQUESTED="${PYTHON_BIN:-python3}"
+if ! PYTHON_BIN="$(command -v "${PYTHON_REQUESTED}")"; then
+  echo "Python interpreter not found: ${PYTHON_REQUESTED}" >&2
+  exit 1
+fi
+PYTHON_VERSION="$("${PYTHON_BIN}" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+if [[ ! "${PYTHON_VERSION}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "Unable to determine Python major.minor version: ${PYTHON_VERSION}" >&2
+  exit 1
+fi
+PYTHON_SUFFIX="${PYTHON_VERSION//./}"
+PYTHON_BIN_ENV="PY${PYTHON_SUFFIX}_BIN"
 OUTPUT_DIR="${CI_WHEEL_OUTPUT_DIR:-/tmp/flydsl-ci-wheels}"
 VENV_ROOT="${CI_WHEEL_VENV_ROOT:-/tmp/flydsl-ci-wheel-venvs}"
 BASE_WORKTREE="${CI_BASE_WORKTREE:-/tmp/flydsl-ci-base}"
 
+echo "Building CI wheels with Python ${PYTHON_VERSION} (${PYTHON_BIN})"
 rm -rf "${OUTPUT_DIR}"
 mkdir -p "${OUTPUT_DIR}"
+
+smoke_test_rocdl() {
+  local chip input output
+  local smoke_dir="${CI_ROCDL_SMOKE_DIR:-/tmp/flydsl-rocdl-smoke}"
+
+  if [[ ! -x "${MLIR_PATH}/bin/mlir-opt" ]]; then
+    echo "mlir-opt not found: ${MLIR_PATH}/bin/mlir-opt" >&2
+    return 1
+  fi
+
+  rm -rf "${smoke_dir}"
+  mkdir -p "${smoke_dir}"
+  for chip in gfx942 gfx950; do
+    input="${smoke_dir}/${chip}-input.mlir"
+    output="${smoke_dir}/${chip}-output.mlir"
+    cat >"${input}" <<MLIR
+module attributes {gpu.container_module} {
+  gpu.module @test [#rocdl.target<chip = "${chip}">] {
+    llvm.func @kernel() attributes {gpu.kernel, rocdl.kernel} {
+      llvm.return
+    }
+  }
+}
+MLIR
+
+    "${MLIR_PATH}/bin/mlir-opt" "${input}" \
+      --pass-pipeline='builtin.module(gpu-module-to-binary{format=fatbin})' \
+      -o "${output}"
+    grep -q "gpu.binary" "${output}"
+    grep -q "bin = " "${output}"
+    echo "ROCDL to HSACO smoke test passed for ${chip}"
+  done
+  rm -rf "${smoke_dir}"
+}
 
 build_wheel() {
   local source_dir="$1"
   local label="$2"
   local destination="${OUTPUT_DIR}/${label}"
   local wheels=()
-  local fly_opt="${source_dir}/build-fly/build_py312/bin/fly-opt"
+  local fly_opt="${source_dir}/build-fly/build_py${PYTHON_SUFFIX}/bin/fly-opt"
 
   echo "Building ${label} wheel from ${source_dir}"
-  (
+  if ! (
     cd "${source_dir}"
-    PYTHON_VERSIONS=3.12 \
-      PY312_BIN="${PYTHON_BIN}" \
+    env \
+      PYTHON_VERSIONS="${PYTHON_VERSION}" \
+      "${PYTHON_BIN_ENV}=${PYTHON_BIN}" \
       VENV_ROOT="${VENV_ROOT}" \
       ALLOW_ANY_GLIBC=1 \
       MLIR_PATH="${MLIR_PATH}" \
       bash scripts/build_wheels.sh
-  )
+  ); then
+    return 1
+  fi
 
   shopt -s nullglob
   wheels=("${source_dir}"/dist/*.whl)
   shopt -u nullglob
   if [[ "${#wheels[@]}" -ne 1 ]]; then
     echo "Expected exactly one ${label} wheel, found ${#wheels[@]}" >&2
-    exit 1
+    return 1
   fi
   if [[ ! -x "${fly_opt}" ]]; then
     echo "fly-opt not found: ${fly_opt}" >&2
-    exit 1
+    return 1
   fi
 
-  mkdir -p "${destination}"
-  cp "${wheels[0]}" "${destination}/"
-  cp "${fly_opt}" "${destination}/fly-opt"
+  mkdir -p "${destination}" || return 1
+  cp "${wheels[0]}" "${destination}/" || return 1
+  cp "${fly_opt}" "${destination}/fly-opt" || return 1
   (
     cd "${destination}"
     sha256sum ./*.whl fly-opt >SHA256SUMS
-  )
+  ) || return 1
 }
 
+smoke_test_rocdl
 build_wheel "${REPO_ROOT}" pr
 
-if [[ -e "${BASE_WORKTREE}" ]]; then
-  echo "Base worktree path already exists: ${BASE_WORKTREE}" >&2
-  exit 1
-fi
-
 base_repo_url="https://github.com/${BASE_REPO_NAME}.git"
-git -C "${REPO_ROOT}" fetch "${base_repo_url}" "${BASE_COMMIT_SHA}" --no-tags --depth=1
-git -C "${REPO_ROOT}" worktree add --detach "${BASE_WORKTREE}" FETCH_HEAD
 cleanup_base_worktree() {
   git -C "${REPO_ROOT}" worktree remove --force "${BASE_WORKTREE}" || true
+  git -C "${REPO_ROOT}" worktree prune || true
 }
-trap cleanup_base_worktree EXIT
-build_wheel "${BASE_WORKTREE}" base
-cleanup_base_worktree
-trap - EXIT
+
+build_base_wheel() {
+  if [[ "${BASE_COMMIT_SHA}" =~ ^0{40}$ ]]; then
+    echo "Base commit is unavailable for an initial push" >&2
+    return 1
+  fi
+
+  git -C "${REPO_ROOT}" worktree prune || true
+  if [[ -e "${BASE_WORKTREE}" ]]; then
+    echo "Base worktree path already exists: ${BASE_WORKTREE}" >&2
+    return 1
+  fi
+  if ! git -C "${REPO_ROOT}" fetch "${base_repo_url}" "${BASE_COMMIT_SHA}" --no-tags --depth=1; then
+    echo "Failed to fetch baseline ${BASE_REPO_NAME}@${BASE_COMMIT_SHA}" >&2
+    return 1
+  fi
+  if ! git -C "${REPO_ROOT}" worktree add --detach "${BASE_WORKTREE}" FETCH_HEAD; then
+    echo "Failed to create baseline worktree at ${BASE_WORKTREE}" >&2
+    return 1
+  fi
+
+  trap cleanup_base_worktree EXIT
+  if ! build_wheel "${BASE_WORKTREE}" base; then
+    cleanup_base_worktree
+    trap - EXIT
+    return 1
+  fi
+  cleanup_base_worktree
+  trap - EXIT
+}
+
+if ! build_base_wheel; then
+  rm -rf "${OUTPUT_DIR}/base"
+  echo "::warning title=Baseline wheel unavailable::PR tests will continue without the exact base benchmark."
+fi
 
 if [[ ! -x "${MLIR_PATH}/bin/FileCheck" ]]; then
   echo "FileCheck not found: ${MLIR_PATH}/bin/FileCheck" >&2
@@ -100,4 +176,7 @@ pr_wheels=("${OUTPUT_DIR}"/pr/*.whl)
 "${PYTHON_BIN}" -c "import flydsl; from flydsl._mlir.ir import Context; print('Validated FlyDSL CI wheel')"
 
 echo "FlyDSL CI wheel artifacts:"
-du -sh "${OUTPUT_DIR}" "${OUTPUT_DIR}/pr" "${OUTPUT_DIR}/base"
+du -sh "${OUTPUT_DIR}" "${OUTPUT_DIR}/pr"
+if [[ -d "${OUTPUT_DIR}/base" ]]; then
+  du -sh "${OUTPUT_DIR}/base"
+fi

--- a/scripts/build_ci_wheels.sh
+++ b/scripts/build_ci_wheels.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+: "${MLIR_PATH:?MLIR_PATH must point to the prepared MLIR install}"
+: "${BASE_REPO_NAME:?BASE_REPO_NAME must be set}"
+: "${BASE_COMMIT_SHA:?BASE_COMMIT_SHA must be set}"
+
+if [[ ! "${BASE_REPO_NAME}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "Invalid BASE_REPO_NAME: ${BASE_REPO_NAME}" >&2
+  exit 2
+fi
+if [[ ! "${BASE_COMMIT_SHA}" =~ ^[0-9a-fA-F]{40}$ && "${BASE_COMMIT_SHA}" != "main" ]]; then
+  echo "BASE_COMMIT_SHA must be a 40-character commit or main: ${BASE_COMMIT_SHA}" >&2
+  exit 2
+fi
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+OUTPUT_DIR="${CI_WHEEL_OUTPUT_DIR:-/tmp/flydsl-ci-wheels}"
+VENV_ROOT="${CI_WHEEL_VENV_ROOT:-/tmp/flydsl-ci-wheel-venvs}"
+BASE_WORKTREE="${CI_BASE_WORKTREE:-/tmp/flydsl-ci-base}"
+
+rm -rf "${OUTPUT_DIR}"
+mkdir -p "${OUTPUT_DIR}"
+
+build_wheel() {
+  local source_dir="$1"
+  local label="$2"
+  local destination="${OUTPUT_DIR}/${label}"
+  local wheels=()
+  local fly_opt="${source_dir}/build-fly/build_py312/bin/fly-opt"
+
+  echo "Building ${label} wheel from ${source_dir}"
+  (
+    cd "${source_dir}"
+    PYTHON_VERSIONS=3.12 \
+      PY312_BIN="${PYTHON_BIN}" \
+      VENV_ROOT="${VENV_ROOT}" \
+      ALLOW_ANY_GLIBC=1 \
+      MLIR_PATH="${MLIR_PATH}" \
+      bash scripts/build_wheels.sh
+  )
+
+  shopt -s nullglob
+  wheels=("${source_dir}"/dist/*.whl)
+  shopt -u nullglob
+  if [[ "${#wheels[@]}" -ne 1 ]]; then
+    echo "Expected exactly one ${label} wheel, found ${#wheels[@]}" >&2
+    exit 1
+  fi
+  if [[ ! -x "${fly_opt}" ]]; then
+    echo "fly-opt not found: ${fly_opt}" >&2
+    exit 1
+  fi
+
+  mkdir -p "${destination}"
+  cp "${wheels[0]}" "${destination}/"
+  cp "${fly_opt}" "${destination}/fly-opt"
+  (
+    cd "${destination}"
+    sha256sum ./*.whl fly-opt >SHA256SUMS
+  )
+}
+
+build_wheel "${REPO_ROOT}" pr
+
+if [[ -e "${BASE_WORKTREE}" ]]; then
+  echo "Base worktree path already exists: ${BASE_WORKTREE}" >&2
+  exit 1
+fi
+
+base_repo_url="https://github.com/${BASE_REPO_NAME}.git"
+git -C "${REPO_ROOT}" fetch "${base_repo_url}" "${BASE_COMMIT_SHA}" --no-tags --depth=1
+git -C "${REPO_ROOT}" worktree add --detach "${BASE_WORKTREE}" FETCH_HEAD
+cleanup_base_worktree() {
+  git -C "${REPO_ROOT}" worktree remove --force "${BASE_WORKTREE}" || true
+}
+trap cleanup_base_worktree EXIT
+build_wheel "${BASE_WORKTREE}" base
+cleanup_base_worktree
+trap - EXIT
+
+if [[ ! -x "${MLIR_PATH}/bin/FileCheck" ]]; then
+  echo "FileCheck not found: ${MLIR_PATH}/bin/FileCheck" >&2
+  exit 1
+fi
+mkdir -p "${OUTPUT_DIR}/tools"
+cp "${MLIR_PATH}/bin/FileCheck" "${OUTPUT_DIR}/tools/FileCheck"
+(
+  cd "${OUTPUT_DIR}/tools"
+  sha256sum FileCheck >SHA256SUMS
+)
+
+pr_wheels=("${OUTPUT_DIR}"/pr/*.whl)
+"${PYTHON_BIN}" -m pip install --force-reinstall --no-deps "${pr_wheels[0]}"
+"${PYTHON_BIN}" -c "import flydsl; from flydsl._mlir.ir import Context; print('Validated FlyDSL CI wheel')"
+
+echo "FlyDSL CI wheel artifacts:"
+du -sh "${OUTPUT_DIR}" "${OUTPUT_DIR}/pr" "${OUTPUT_DIR}/base"

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -17,6 +17,7 @@ LLVM_PACKAGE_INSTALL="${LLVM_PACKAGE_INSTALL:-1}"
 LLVM_BUILD_INFO="${REPO_ROOT}/thirdparty/llvm-build-info.json"
 LLVM_COMMIT_DEFAULT=$(python3 -c "import json; print(json.load(open('${LLVM_BUILD_INFO}'))['upstream']['llvm_hash'])")
 LLVM_REF="${LLVM_REF:-${LLVM_COMMIT:-$LLVM_COMMIT_DEFAULT}}"
+LLVM_PATCH="${REPO_ROOT}/thirdparty/llvm-rocdl-lld-argv0.patch"
 
 echo "Base directory: $BASE_DIR"
 echo "LLVM Source:    $LLVM_SRC_DIR"
@@ -48,6 +49,15 @@ else
     git fetch --depth 1 origin "${LLVM_REF}"
     git checkout FETCH_HEAD
 fi
+
+if git apply --reverse --check "${LLVM_PATCH}" >/dev/null 2>&1; then
+    echo "LLVM patch already applied: ${LLVM_PATCH}"
+else
+    echo "Applying LLVM patch: ${LLVM_PATCH}"
+    git apply --check "${LLVM_PATCH}"
+    git apply "${LLVM_PATCH}"
+fi
+
 LLVM_COMMIT_RESOLVED=$(git rev-parse HEAD)
 popd
 echo "LLVM Commit:    $LLVM_COMMIT_RESOLVED"

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -18,8 +18,25 @@ LLVM_BUILD_INFO="${REPO_ROOT}/thirdparty/llvm-build-info.json"
 LLVM_COMMIT_DEFAULT=$(python3 -c "import json; print(json.load(open('${LLVM_BUILD_INFO}'))['upstream']['llvm_hash'])")
 LLVM_REF="${LLVM_REF:-${LLVM_COMMIT:-$LLVM_COMMIT_DEFAULT}}"
 LLVM_PATCH="${REPO_ROOT}/thirdparty/llvm-rocdl-lld-argv0.patch"
-LLVM_ENABLE_PROJECTS="${LLVM_ENABLE_PROJECTS:-mlir;clang;lld}"
-LLVM_ENABLE_RUNTIMES="${LLVM_ENABLE_RUNTIMES-compiler-rt}"
+LLVM_BUILD_PROFILE="${LLVM_BUILD_PROFILE:-full}"
+
+case "${LLVM_BUILD_PROFILE}" in
+  full)
+    LLVM_ENABLE_PROJECTS="${LLVM_ENABLE_PROJECTS:-mlir;clang;lld}"
+    LLVM_TARGETS_TO_BUILD="${LLVM_TARGETS_TO_BUILD:-X86;NVPTX;AMDGPU}"
+    # Use `-` rather than `:-` so callers can explicitly disable runtimes.
+    LLVM_ENABLE_RUNTIMES="${LLVM_ENABLE_RUNTIMES-compiler-rt}"
+    ;;
+  amd-minimal)
+    LLVM_ENABLE_PROJECTS="mlir"
+    LLVM_TARGETS_TO_BUILD="X86;AMDGPU"
+    LLVM_ENABLE_RUNTIMES=
+    ;;
+  *)
+    echo "Unknown LLVM_BUILD_PROFILE: ${LLVM_BUILD_PROFILE}" >&2
+    exit 2
+    ;;
+esac
 
 echo "Base directory: $BASE_DIR"
 echo "LLVM Source:    $LLVM_SRC_DIR"
@@ -27,12 +44,22 @@ echo "LLVM Build:     $LLVM_BUILD_DIR"
 echo "LLVM Install:   $LLVM_INSTALL_DIR"
 echo "LLVM Tarball:   $LLVM_INSTALL_TGZ"
 echo "LLVM Ref:       $LLVM_REF"
+echo "LLVM Profile:   $LLVM_BUILD_PROFILE"
 echo "LLVM Projects:  $LLVM_ENABLE_PROJECTS"
-echo "LLVM Targets:   ${LLVM_TARGETS_TO_BUILD:-X86;NVPTX;AMDGPU}"
+echo "LLVM Targets:   $LLVM_TARGETS_TO_BUILD"
 echo "LLVM Runtimes:  ${LLVM_ENABLE_RUNTIMES:-<none>}"
 
 # 1. Clone LLVM
 LLVM_REMOTE="${LLVM_REMOTE:-https://github.com/llvm/llvm-project.git}"
+
+# A leftover partial ("promisor") clone is unusable here: every checkout, patch
+# and rev-parse would trigger per-blob lazy fetches against github.com. Unsetting
+# the config does not bring the missing blobs back, so start over instead.
+if [ -d "$LLVM_SRC_DIR/.git" ] && \
+   [ -n "$(git -C "$LLVM_SRC_DIR" config --get remote.origin.promisor || true)" ]; then
+    echo "Discarding partial (promisor) llvm-project checkout at ${LLVM_SRC_DIR} ..."
+    rm -rf "$LLVM_SRC_DIR"
+fi
 
 if [ ! -d "$LLVM_SRC_DIR" ]; then
     echo "Preparing llvm-project checkout for ${LLVM_REF} ..."
@@ -43,15 +70,26 @@ else
     pushd "$LLVM_SRC_DIR"
 fi
 
+# Plain shallow fetch. Do NOT add --filter=blob:none here: a blob-filtered fetch
+# of an arbitrary SHA makes the server build an uncached pack, and the checkout
+# that follows then lazily re-fetches every file in the tree one batch at a time.
+# Measured on CI: `--depth 1` alone downloads llvm-project in ~100s, while
+# `--depth 1 --filter=blob:none` did not finish within 100 minutes.
+LLVM_FETCH_ARGS=(--depth 1)
+
 if [[ "$LLVM_REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    echo "Checking for local LLVM commit ${LLVM_REF} ..."
     if ! git cat-file -e "${LLVM_REF}^{commit}" 2>/dev/null; then
         echo "Fetching commit ${LLVM_REF} ..."
-        git fetch --depth 1 origin "${LLVM_REF}"
+        git fetch "${LLVM_FETCH_ARGS[@]}" origin "${LLVM_REF}"
+    else
+        echo "LLVM commit ${LLVM_REF} is already available locally."
     fi
+    echo "Checking out LLVM commit ${LLVM_REF} ..."
     git checkout "${LLVM_REF}"
 else
     echo "Fetching ref ${LLVM_REF} ..."
-    git fetch --depth 1 origin "${LLVM_REF}"
+    git fetch "${LLVM_FETCH_ARGS[@]}" origin "${LLVM_REF}"
     git checkout FETCH_HEAD
 fi
 
@@ -87,7 +125,7 @@ else
     echo "Ninja not found. Using Unix Makefiles (this might be slower)."
 fi
 
-# Build only MLIR and necessary Clang tools, targeting native architecture, in Release mode
+# Build the selected LLVM projects and targets in Release mode.
 # Explicitly set nanobind directory if found to help CMake locate it
 NANOBIND_DIR=$(python3 -c "import nanobind; import os; print(os.path.dirname(nanobind.__file__) + '/cmake')")
 
@@ -95,7 +133,7 @@ cmake -G "$GENERATOR" \
     -S "$LLVM_SRC_DIR/llvm" \
     -B "$LLVM_BUILD_DIR" \
     -DLLVM_ENABLE_PROJECTS="${LLVM_ENABLE_PROJECTS}" \
-    -DLLVM_TARGETS_TO_BUILD="${LLVM_TARGETS_TO_BUILD:-X86;NVPTX;AMDGPU}" \
+    -DLLVM_TARGETS_TO_BUILD="${LLVM_TARGETS_TO_BUILD}" \
     -DLLVM_ENABLE_RUNTIMES="${LLVM_ENABLE_RUNTIMES}" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_STANDARD=17 \

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -18,6 +18,8 @@ LLVM_BUILD_INFO="${REPO_ROOT}/thirdparty/llvm-build-info.json"
 LLVM_COMMIT_DEFAULT=$(python3 -c "import json; print(json.load(open('${LLVM_BUILD_INFO}'))['upstream']['llvm_hash'])")
 LLVM_REF="${LLVM_REF:-${LLVM_COMMIT:-$LLVM_COMMIT_DEFAULT}}"
 LLVM_PATCH="${REPO_ROOT}/thirdparty/llvm-rocdl-lld-argv0.patch"
+LLVM_ENABLE_PROJECTS="${LLVM_ENABLE_PROJECTS:-mlir;clang;lld}"
+LLVM_ENABLE_RUNTIMES="${LLVM_ENABLE_RUNTIMES-compiler-rt}"
 
 echo "Base directory: $BASE_DIR"
 echo "LLVM Source:    $LLVM_SRC_DIR"
@@ -25,6 +27,9 @@ echo "LLVM Build:     $LLVM_BUILD_DIR"
 echo "LLVM Install:   $LLVM_INSTALL_DIR"
 echo "LLVM Tarball:   $LLVM_INSTALL_TGZ"
 echo "LLVM Ref:       $LLVM_REF"
+echo "LLVM Projects:  $LLVM_ENABLE_PROJECTS"
+echo "LLVM Targets:   ${LLVM_TARGETS_TO_BUILD:-X86;NVPTX;AMDGPU}"
+echo "LLVM Runtimes:  ${LLVM_ENABLE_RUNTIMES:-<none>}"
 
 # 1. Clone LLVM
 LLVM_REMOTE="${LLVM_REMOTE:-https://github.com/llvm/llvm-project.git}"
@@ -89,9 +94,9 @@ NANOBIND_DIR=$(python3 -c "import nanobind; import os; print(os.path.dirname(nan
 cmake -G "$GENERATOR" \
     -S "$LLVM_SRC_DIR/llvm" \
     -B "$LLVM_BUILD_DIR" \
-    -DLLVM_ENABLE_PROJECTS="mlir;clang;lld" \
+    -DLLVM_ENABLE_PROJECTS="${LLVM_ENABLE_PROJECTS}" \
     -DLLVM_TARGETS_TO_BUILD="${LLVM_TARGETS_TO_BUILD:-X86;NVPTX;AMDGPU}" \
-    -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
+    -DLLVM_ENABLE_RUNTIMES="${LLVM_ENABLE_RUNTIMES}" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_STANDARD=17 \
     -DLLVM_ENABLE_ASSERTIONS=ON \

--- a/thirdparty/llvm-rocdl-lld-argv0.patch
+++ b/thirdparty/llvm-rocdl-lld-argv0.patch
@@ -1,0 +1,14 @@
+diff --git a/mlir/lib/Target/LLVM/ROCDL/Target.cpp b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+--- a/mlir/lib/Target/LLVM/ROCDL/Target.cpp
++++ b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+@@ -361,9 +361,9 @@ mlir::ROCDL::linkObjectCode(ArrayRef<char> objectCode, StringRef lldPath,
+ 
+   llvm::FileRemover cleanupHsaco(tempHsacoFilename);
+ 
+   int lldResult = llvm::sys::ExecuteAndWait(
+       lldPath,
+-      {"ld.lld", "-shared", tempIsaBinaryFilename, "-o", tempHsacoFilename});
++      {lldPath, "-shared", tempIsaBinaryFilename, "-o", tempHsacoFilename});
+   if (lldResult != 0)
+     return emitError() << "lld invocation failed";
+ 


### PR DESCRIPTION
Use pinned PyTorch 2.12 release images for test and publish workflows, and invalidate the MLIR cache for the new runtime.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
