### PR TITLE
[Expr] Add type-aware extrema and integer ceiling division

### DIFF
--- a/.claude/skills/flydsl-kernel-authoring/SKILL.md
+++ b/.claude/skills/flydsl-kernel-authoring/SKILL.md
@@ -433,6 +433,9 @@ mask = fx.Int32(0xFF)                            # i32 constant (preferred)
 result = a + b
 result = a * scale
 result = cond.select(true_val, false_val)
+largest = fx.max(a, b)
+smallest = fx.min(a, b)
+tiles = fx.ceildiv(count, tile_size)  # signed/unsigned dispatch from typed operands
 
 # Keep direct arith.*FOp only when explicit fastmath flags are required.
 ```
@@ -484,7 +487,8 @@ Use `Vec.filled(...)` for splats and `Vec.from_elements(...)` for vectors from s
 | Add | `a + b` | Yes | Use direct FOp only for explicit fastmath |
 | Multiply | `a * b` | Yes | Use direct FOp only for explicit fastmath |
 | Negate | `-a` | Yes | |
-| Max | `a.maximumf(b)` | Yes | Good for ReLU |
+| Max / Min | `fx.max(a, b)` / `fx.min(a, b)` | Yes | Float forms propagate NaN; `fx.maxnumf` does not |
+| Integer ceil-div | `fx.ceildiv(a, b)` | Yes | Direct signed/unsigned op; distinct from layout `fx.ceil_div` |
 | Compare | `arith.cmpf(a, b, pred)` | Yes | Returns i1/vec<i1> |
 | Select | `cond.select(t, f)` | Yes | |
 | Abs | no direct helper | Use `-v`, comparison, and `cond.select(...)` |
@@ -783,7 +787,7 @@ vD = vAB + Vec(fx.memref_load_vec(rC))
 # --- ReLU: C = max(A, 0) ---
 vA = Vec(fx.memref_load_vec(rA))
 zero_vec = Vec.filled(vec_width, 0.0, fx.Float32)
-vC = vA.maximumf(zero_vec)
+vC = fx.max(vA, zero_vec)
 
 # --- Abs: C = |A| (arith.absf does NOT exist) ---
 vA = fx.memref_load_vec(rA)

--- a/.claude/skills/kernel-code-cleanup/SKILL.md
+++ b/.claude/skills/kernel-code-cleanup/SKILL.md
@@ -132,7 +132,10 @@ fx.copy(copy, fx.slice(tA, (None, tid)), rA)   # after partitioning tA (§7b: pr
 | `arith.index_cast(T.i32, v)` | `fx.Int32(v)` |
 | `arith.select(cond, t, f)` | `cond.select(t, f)` |
 | `arith.cmpi(slt, a, b)` | `a < b` |
-| `arith.maxnumf(a,b)` | `a.maximumf(b)` |
+| `arith.maximumf/minimumf(a,b)` | `fx.max(a, b)` / `fx.min(a, b)` |
+| `arith.maxsi/maxui/minsi/minui(a,b)` | `fx.max(a, b)` / `fx.min(a, b)` |
+| `arith.maxnumf(a,b)` | `fx.maxnumf(a, b)` — different NaN semantics from `fx.max` |
+| `arith.ceildivsi/ceildivui(a,b)` | `fx.ceildiv(a, b)` |
 
 Keep `arith.cmpf` / explicit `*FOp` only where no operator exists or fastmath is
 needed.
@@ -471,6 +474,7 @@ def _run_compiled(exe, *args):             # in-tree
 | `arith.unwrap(v)` / `_to_raw(v)` | `v.ir_value()` (boundary only) |
 | `fx.Index(n)` / `arith.index` / `arith.index_cast` | explicit `fx.Int64/Int32(...)` |
 | `arith.mulf/addf/trunc_f/select` | `*`, `+`, `.to(ty)`, `.select(...)` |
+| raw integer min/max or ceil-div | `fx.max` / `fx.min` / `fx.ceildiv` |
 | `vector.extract/bitcast/splat` | `fx.Vector(v)[i]` / `.bitcast(ty)` / `.filled(...)` |
 | `scf.ForOp` / `scf.IfOp` | `range_constexpr` / `range(..., init=)` / Python `if` / `const_expr` |
 | `buffer_ops.*` + offsets | `fx.rocdl.make_buffer_tensor` + layout + `fx.copy` |

--- a/.github/workflows/pre-checks.yaml
+++ b/.github/workflows/pre-checks.yaml
@@ -46,6 +46,12 @@ jobs:
           REVIEWDOG_REPORTER: ${{ github.event_name == 'pull_request' && 'github-pr-review' || 'github-check' }}
           REVIEWDOG_FILTER_MODE: ${{ github.event_name == 'pull_request' && 'diff_context' || 'nofilter' }}
 
+      - name: Reject new legacy typed arithmetic
+        run: python3 scripts/check_typed_arithmetic_usage.py
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
+          HEAD_SHA: ${{ github.sha }}
+
   cpp-style:
     name: Check C++ Code Style
     runs-on: ubuntu-24.04

--- a/docs/api_stability.md
+++ b/docs/api_stability.md
@@ -162,7 +162,7 @@ excludes it from the catalog above.
 | `fx.index_cast` | `fx.Index(x)` | v0.4 |
 | `fx.constant_vector` | `Numeric` and `Vector` member functions | v0.4 |
 | `fx.tdm_ops` and content reached through this alias | `fx.rocdl.tdm_ops`; the latter is a target-specific unstable path | v0.4 |
-| `fx.Numeric.maximumf`, `fx.Numeric.minimumf` | `fx.arith.maximumf(x, y)`, `fx.arith.minimumf(x, y)` | v0.4 |
+| `fx.Numeric.maximumf`, `fx.Numeric.minimumf` | `fx.max(x, y)`, `fx.min(x, y)` | v0.4 |
 | `fx.Numeric.shrui`, `fx.Numeric.addf` | `fx.arith.shrui(x, amount)`, `x + y` with a `fastmath` context | v0.4 |
 | `fx.Numeric.exp2` | `fx.math.exp2(x)` | v0.4 |
 | `fx.Numeric.shuffle_xor` | `fx.gpu.shuffle_xor(x, offset, width)` | v0.4 |

--- a/docs/kernel_authoring_guide.md
+++ b/docs/kernel_authoring_guide.md
@@ -201,6 +201,9 @@ result = a + b
 result = a * 2
 result = a // 4
 result = a % 16
+largest = fx.max(a, b)
+smallest = fx.min(a, b)
+tiles = fx.ceildiv(count, tile_size)
 
 # Cast (prefer DSL numeric constructors)
 i64_val = fx.Int64(int_val) # cast to 64-bit integer (fx.Index is deprecated)
@@ -216,6 +219,9 @@ result = a << 4
 ```
 
 Use direct `arith.*FOp(..., fastmath=...)` only where explicit fastmath flags are performance-critical.
+Use `fx.max` / `fx.min` for type-dispatched extrema and `fx.ceildiv` for
+overflow-safe integer ceil division. `fx.maxnumf` intentionally retains
+non-NaN-wins semantics, and `fx.ceil_div` remains the layout/int-tuple API.
 
 ### 4.2 Vector values (`Vector`)
 

--- a/docs/language/arithmetic_types.md
+++ b/docs/language/arithmetic_types.md
@@ -47,6 +47,33 @@ The following methods apply to both `Numeric` and `Vector`, and are elementwise 
 | `as_numeric` / `Numeric.from_python_value(value)` | build a `Numeric` from a Python value | `as_numeric(5)` → `Int32(5)` |
 | `Numeric.from_ir_type(ir_type)` | the `Numeric` type for an MLIR type | `Numeric.from_ir_type(T.f32())` → `Float32` |
 
+### Function-level typed arithmetic
+
+`fx.max`, `fx.min`, and `fx.ceildiv` normalize Python literals and DSL operands,
+resolve one common type, broadcast scalar operands to `Vector` shapes, and emit
+the dedicated MLIR operation for that type:
+
+| API | Float | Signed integer | Unsigned integer |
+|---|---|---|---|
+| `fx.max` | `arith.maximumf` | `arith.maxsi` | `arith.maxui` |
+| `fx.min` | `arith.minimumf` | `arith.minsi` | `arith.minui` |
+| `fx.ceildiv` | unsupported | `arith.ceildivsi` | `arith.ceildivui` |
+
+`fx.max` and `fx.min` are variadic and accept nested lists/tuples. Their float
+forms propagate NaN and order signed zero as `-0.0 < +0.0`. This is deliberately
+different from `fx.maxnumf`, which returns the non-NaN input when exactly one
+operand is NaN.
+
+`fx.ceildiv` rounds integer division toward positive infinity. It does not use
+`(a + b - 1) // b`, whose intermediate addition can overflow at run time, and
+it does not change the floor-division meaning of `//`. The similarly named
+`fx.ceil_div` remains the layout/int-tuple operation.
+
+Boolean inputs to `fx.max` / `fx.min` widen to `Int32`. Boolean, `Index`, float,
+and narrow storage-float inputs to `fx.ceildiv` are rejected. `Index` and narrow
+storage floats are also rejected by `fx.max` / `fx.min`; cast them to an
+explicit supported arithmetic type first.
+
 ### Vector
 
 `Vector` is a fixed-length sequence of `N` elements of a single `Numeric`

--- a/kernels/attention/pa_metadata.py
+++ b/kernels/attention/pa_metadata.py
@@ -971,7 +971,7 @@ def compile_pa_metadata_v1(
             # number of partition_size-token partitions for this batch =
             # ceil(context_len[batch_idx] / kv_granularity)
             ctxv = _load(ctx_rsrc, batch_idx)
-            return fx.Int32(arith.ceildivui(ctxv.ir_value(), c_kvg.ir_value()))
+            return fx.Int32(fx.ceildiv(fx.Uint32(ctxv), fx.Uint32(c_kvg)))
 
         def _store(rsrc, off, val):
             # NOTE: no masked stores — masked buffer_store sets OOB offset

--- a/kernels/common/utils.py
+++ b/kernels/common/utils.py
@@ -45,7 +45,7 @@ def cdiv(numer, denom):
     """Ceiling division for host integers and typed DSL integer values."""
     if isinstance(numer, (fx.Numeric, fx.Vector)) or isinstance(denom, (fx.Numeric, fx.Vector)):
         return fx.ceildiv(numer, denom)
-    return (numer + denom - 1) // denom
+    return -(-numer // denom)
 
 
 # Alias: several kernels historically spelled this ``ceildiv``.

--- a/kernels/common/utils.py
+++ b/kernels/common/utils.py
@@ -41,7 +41,10 @@ def exp2_f32_fast(value):
     return exp2_amdgcn_scalar(raw)
 
 
-def cdiv(numer: int, denom: int) -> int:
+def cdiv(numer, denom):
+    """Ceiling division for host integers and typed DSL integer values."""
+    if isinstance(numer, (fx.Numeric, fx.Vector)) or isinstance(denom, (fx.Numeric, fx.Vector)):
+        return fx.ceildiv(numer, denom)
     return (numer + denom - 1) // denom
 
 

--- a/kernels/moe/topk_gating_softmax_kernel.py
+++ b/kernels/moe/topk_gating_softmax_kernel.py
@@ -205,7 +205,7 @@ def _emit_topk_gating_softmax_body(
             off = fx.Int32(THREADS_PER_TOKEN // (2 << _sh))
             peer = w.shuffle_xor(off, width_i32)
             if mode == "max":
-                w = w.maximumf(peer)
+                w = fx.max(w, peer)
             else:
                 w = w.addf(peer, fastmath=fm_fast)
         return w
@@ -314,7 +314,7 @@ def _emit_topk_gating_softmax_body(
             val_e = vector.extract(as_ir_value(atom_vec), dynamic_position=[], static_position=[v])
             xv = val_e if dtype_str == "f32" else val_e.extf(compute_type)
             x_list.append(xv)
-            thread_max = thread_max.maximumf(xv)
+            thread_max = fx.max(thread_max, xv)
 
     group_max = group_reduce(thread_max, "max")
 
@@ -364,7 +364,7 @@ def _emit_topk_gating_softmax_body(
 
     # Pass 5: leader writes weights/indices/tei (with optional renorm).
     c_eps = fx.Float32(1e-20)
-    denom = selected_sum.maximumf(c_eps)
+    denom = fx.max(selected_sum, c_eps)
     inv_denom = c_one_f / denom
 
     if (expert_lane == fx.Int32(0)) & (global_token < i32_num_tokens):
@@ -467,7 +467,7 @@ def build_topk_gating_softmax_module(
                 off = fx.Int32(THREADS_PER_TOKEN // (2 << _sh))
                 peer = w.shuffle_xor(off, width_i32)
                 if mode == "max":
-                    w = w.maximumf(peer)
+                    w = fx.max(w, peer)
                 else:
                     w = w.addf(peer, fastmath=fm_fast)
             return w
@@ -568,7 +568,7 @@ def build_topk_gating_softmax_module(
                 val_e = vector.extract(as_ir_value(atom_vec), dynamic_position=[], static_position=[v])
                 xv = val_e if dtype_str == "f32" else val_e.extf(compute_type)
                 x_list.append(xv)
-                thread_max = thread_max.maximumf(xv)
+                thread_max = fx.max(thread_max, xv)
 
         group_max = group_reduce(thread_max, "max")
 
@@ -632,7 +632,7 @@ def build_topk_gating_softmax_module(
         # Pass 5: Leader writes weights/indices/tei (with optional renorm)
         # ==================================================================
         c_eps = fx.Float32(1e-20)
-        denom = selected_sum.maximumf(c_eps)
+        denom = fx.max(selected_sum, c_eps)
         inv_denom = c_one_f / denom
 
         # Inline the leader-active predicate so the AST rewriter recognises it

--- a/kernels/norm/layernorm_kernel.py
+++ b/kernels/norm/layernorm_kernel.py
@@ -837,7 +837,7 @@ def _build_layernorm_quant_module(
             for _sh_exp in range_constexpr(int(math.log2(WARP_SIZE))):
                 off = WARP_SIZE // (2 << _sh_exp)
                 peer = w.shuffle_xor(off, WARP_SIZE)
-                w = w.maximumf(peer)
+                w = fx.max(w, peer)
             return w
 
         def block_reduce_add2(val0, val1):
@@ -960,7 +960,7 @@ def _build_layernorm_quant_module(
                 y_local.append(y)
                 y_abs = (y.bitcast(fx.Uint32) & abs_mask).bitcast(fx.Float32)
                 tile_max = y_abs.reduce(ReductionOp.MAX)
-                thread_row_max = thread_row_max.maximumf(tile_max)
+                thread_row_max = fx.max(thread_row_max, tile_max)
 
             row_max = block_reduce_max(thread_row_max)
             scale = row_max / c_dtype_max
@@ -1050,7 +1050,7 @@ def _build_layernorm_quant_module(
                     s = s_e if dtype_str == "f32" else s_e.to(fx.Float32)
                     y = y * s
                 y_abs = _abs_scalar(y)
-                thread_row_max = thread_row_max.maximumf(is_valid.select(y_abs, c_zero_f))
+                thread_row_max = fx.max(thread_row_max, is_valid.select(y_abs, c_zero_f))
 
             row_max = block_reduce_max(thread_row_max)
             scale = row_max / c_dtype_max
@@ -1186,7 +1186,7 @@ def _build_fused_add_layernorm_quant_module(
             for _sh_exp in range_constexpr(int(math.log2(WARP_SIZE))):
                 off = WARP_SIZE // (2 << _sh_exp)
                 peer = w.shuffle_xor(off, WARP_SIZE)
-                w = w.maximumf(peer)
+                w = fx.max(w, peer)
             return w
 
         def block_reduce_add2(val0, val1):
@@ -1318,7 +1318,7 @@ def _build_fused_add_layernorm_quant_module(
                 y_local.append(y)
                 y_abs = (y.bitcast(fx.Uint32) & abs_mask).bitcast(fx.Float32)
                 tile_max = y_abs.reduce(ReductionOp.MAX)
-                thread_row_max = thread_row_max.maximumf(tile_max)
+                thread_row_max = fx.max(thread_row_max, tile_max)
 
             row_max = block_reduce_max(thread_row_max)
             scale = row_max / c_dtype_max
@@ -1420,7 +1420,7 @@ def _build_fused_add_layernorm_quant_module(
                     s = s_e if dtype_str == "f32" else s_e.to(fx.Float32)
                     y = y * s
                 y_abs = _abs_scalar(y)
-                thread_row_max = thread_row_max.maximumf(is_valid.select(y_abs, c_zero_f))
+                thread_row_max = fx.max(thread_row_max, is_valid.select(y_abs, c_zero_f))
 
             row_max = block_reduce_max(thread_row_max)
             scale = row_max / c_dtype_max

--- a/kernels/norm/rmsnorm_kernel.py
+++ b/kernels/norm/rmsnorm_kernel.py
@@ -794,7 +794,7 @@ def _build_rmsnorm_quant_module(
             for _sh_exp in range_constexpr(int(math.log2(WARP_SIZE))):
                 off = WARP_SIZE // (2 << _sh_exp)
                 peer = w.shuffle_xor(off, WARP_SIZE)
-                w = w.maximumf(peer)
+                w = fx.max(w, peer)
             return w
 
         def block_reduce_add(val):
@@ -919,7 +919,7 @@ def _build_rmsnorm_quant_module(
                 y_local.append(y)
                 y_abs = (y.bitcast(fx.Uint32) & abs_mask).bitcast(fx.Float32)
                 tile_max = y_abs.reduce(ReductionOp.MAX)
-                thread_row_max = thread_row_max.maximumf(tile_max)
+                thread_row_max = fx.max(thread_row_max, tile_max)
 
             row_max = block_reduce_max(thread_row_max)
             scale = row_max / c_dtype_max
@@ -1005,7 +1005,7 @@ def _build_rmsnorm_quant_module(
                     s = s_e if dtype_str == "f32" else s_e.to(fx.Float32)
                     y = y * s
                 y_abs = _abs_scalar(y)
-                thread_row_max = thread_row_max.maximumf(is_valid.select(y_abs, c_zero_f))
+                thread_row_max = fx.max(thread_row_max, is_valid.select(y_abs, c_zero_f))
 
             row_max = block_reduce_max(thread_row_max)
             scale = row_max / c_dtype_max
@@ -1163,7 +1163,7 @@ def _build_fused_add_rmsnorm_quant_module(
             for _sh_exp in range_constexpr(int(math.log2(WARP_SIZE))):
                 off = WARP_SIZE // (2 << _sh_exp)
                 peer = w.shuffle_xor(off, WARP_SIZE)
-                w = w.maximumf(peer)
+                w = fx.max(w, peer)
             return w
 
         def block_reduce_add(val):
@@ -1296,7 +1296,7 @@ def _build_fused_add_rmsnorm_quant_module(
                 y_local.append(y)
                 y_abs = (y.bitcast(fx.Uint32) & abs_mask).bitcast(fx.Float32)
                 tile_max = y_abs.reduce(ReductionOp.MAX)
-                thread_row_max = thread_row_max.maximumf(tile_max)
+                thread_row_max = fx.max(thread_row_max, tile_max)
 
             row_max = block_reduce_max(thread_row_max)
             scale = row_max / c_dtype_max
@@ -1395,7 +1395,7 @@ def _build_fused_add_rmsnorm_quant_module(
                     s = s_e if dtype_str == "f32" else s_e.to(fx.Float32)
                     y = y * s
                 y_abs = _abs_scalar(y)
-                thread_row_max = thread_row_max.maximumf(is_valid.select(y_abs, c_zero_f))
+                thread_row_max = fx.max(thread_row_max, is_valid.select(y_abs, c_zero_f))
 
             row_max = block_reduce_max(thread_row_max)
             scale = row_max / c_dtype_max

--- a/kernels/norm/softmax_kernel.py
+++ b/kernels/norm/softmax_kernel.py
@@ -67,7 +67,7 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
                 off = WARP_SIZE // (2 << _sh_exp)
                 peer = w.shuffle_xor(off, WARP_SIZE)
                 if const_expr(mode == "max"):
-                    w = w.maximumf(peer)
+                    w = fx.max(w, peer)
                 else:
                     w = w.addf(peer, fastmath=fm_fast)
             return w
@@ -137,7 +137,7 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
                 x = vec.to(fx.Float32)
                 row_buffer.append(x)
                 red_max = x.reduce(ReductionOp.MAX)
-                thread_max = thread_max.maximumf(red_max)
+                thread_max = fx.max(thread_max, red_max)
 
             global_max = block_reduce(thread_max, "max", s_red)
 
@@ -207,7 +207,7 @@ def build_softmax_module(M: int, N: int, dtype_str: str = "f32"):
                 val = val_e if dtype_str == "f32" else val_e.to(fx.Float32)
                 safe_val = is_valid.select(val, c_neg_inf)
                 row_buffer.append((safe_val, is_valid))
-                thread_max = thread_max.maximumf(safe_val)
+                thread_max = fx.max(thread_max, safe_val)
 
             global_max = block_reduce(thread_max, "max", s_red)
 

--- a/python/flydsl/expr/arith.py
+++ b/python/flydsl/expr/arith.py
@@ -13,6 +13,10 @@ Usage:
     # ArithValue operator overloading: c + 1, c * 2, c / 4, c % 16
 """
 
+import builtins
+import math as _math
+
+from .._mlir import ir
 from .._mlir.dialects.arith import *
 from .._mlir.dialects import arith
 from .math import dsl_math_wrap_result
@@ -33,6 +37,7 @@ from .utils.arith import (  # noqa: F401
     trunc_f,
     unwrap,
     xori,
+    resolve_fastmath,
 )
 from .typing import as_ir_value
 
@@ -47,9 +52,12 @@ __all__ = [
     # Binary ops
     "cmpi",
     "cmpf",
+    "max",
+    "min",
     "maxnumf",
     "maximumf",
     "minimumf",
+    "ceildiv",
     "shrui",
 ]
 
@@ -82,6 +90,203 @@ def cmpf(predicate, lhs, rhs, **kwargs):
         An ``i1`` comparison result.
     """
     return arith.cmpf(predicate, as_ir_value(lhs), as_ir_value(rhs), **kwargs)
+
+
+def _flatten_extreme_operands(operands):
+    flat = []
+    for operand in operands:
+        if isinstance(operand, (list, tuple)):
+            flat.extend(_flatten_extreme_operands(operand))
+        else:
+            flat.append(operand)
+    return flat
+
+
+def _normalize_typed_operand(value, operation):
+    from .numeric import Numeric, as_numeric
+    from .typing import Vector
+
+    if isinstance(value, (Numeric, Vector)):
+        return value
+    if isinstance(value, ir.Value):
+        try:
+            if isinstance(value.type, ir.VectorType):
+                return Vector(value)
+            return Numeric.from_ir_type(value.type)(value)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise TypeError(f"{operation} does not support raw value type {value.type}") from exc
+    if isinstance(value, (bool, int, float)):
+        return as_numeric(value)
+    raise TypeError(f"{operation} expects Numeric, Vector, ir.Value, or a numeric literal, got {type(value).__name__}")
+
+
+def _validated_operand_dtype(dtype, operation, *, bool_widen, integer_only):
+    from .numeric import BFloat16, Boolean, Float16, Float32, Float64, Index, Int32
+
+    if dtype is Index:
+        raise TypeError(f"{operation} does not support Index; cast to an explicit-width integer type")
+    if dtype is Boolean:
+        if not bool_widen:
+            raise TypeError(f"{operation} does not support Boolean operands")
+        return Int32
+    if integer_only and not dtype.is_integer:
+        raise TypeError(f"{operation} requires integer operands, got {dtype.__name__}")
+    if dtype.is_float and dtype not in (Float16, BFloat16, Float32, Float64):
+        raise TypeError(f"{operation} does not support narrow storage float {dtype.__name__}")
+    return dtype
+
+
+def _resolve_typed_operands(values, operation, *, bool_widen=False, integer_only=False):
+    from .numeric import Numeric, _resolve_numeric_type
+    from .typing import Vector
+
+    normalized = [_normalize_typed_operand(value, operation) for value in values]
+    dtypes = []
+    for value in normalized:
+        dtype = value.dtype if isinstance(value, Vector) else type(value)
+        dtypes.append(
+            _validated_operand_dtype(
+                dtype,
+                operation,
+                bool_widen=bool_widen,
+                integer_only=integer_only,
+            )
+        )
+
+    common_dtype = dtypes[0]
+    for dtype in dtypes[1:]:
+        common_dtype = _resolve_numeric_type(common_dtype, dtype)
+    if integer_only and not common_dtype.is_integer:
+        raise TypeError(f"{operation} requires integer operands, got {common_dtype.__name__}")
+
+    result_shape = None
+    for value in normalized:
+        if isinstance(value, Vector):
+            result_shape = (
+                value.shape if result_shape is None else Vector._infer_broadcast_shape(result_shape, value.shape)
+            )
+
+    prepared = []
+    for value, dtype in zip(normalized, dtypes, strict=True):
+        if isinstance(value, Vector):
+            item = value if value.dtype is dtype else value.to(dtype)
+            item = item if item.dtype is common_dtype else item.to(common_dtype)
+            if item.shape != result_shape:
+                item = item.broadcast_to(result_shape)
+        else:
+            item = value if type(value) is dtype else value.to(dtype)
+            item = item if type(item) is common_dtype else item.to(common_dtype)
+            if result_shape is not None:
+                item = Vector.filled(result_shape, item, common_dtype)
+        prepared.append(item)
+
+    all_static = result_shape is None and all(isinstance(value, Numeric) and value.is_static() for value in prepared)
+    return prepared, common_dtype, result_shape, all_static
+
+
+def _wrap_typed_result(result, dtype, shape):
+    if shape is None:
+        return dtype(result)
+    from .typing import Vector
+
+    return Vector(result, shape, dtype)
+
+
+def _fold_float_extreme(lhs, rhs, is_max):
+    if _math.isnan(lhs) or _math.isnan(rhs):
+        return float("nan")
+    if lhs == 0.0 and rhs == 0.0:
+        lhs_negative = _math.copysign(1.0, lhs) < 0.0
+        rhs_negative = _math.copysign(1.0, rhs) < 0.0
+        if is_max:
+            return -0.0 if lhs_negative and rhs_negative else 0.0
+        return -0.0 if lhs_negative or rhs_negative else 0.0
+    return builtins.max(lhs, rhs) if is_max else builtins.min(lhs, rhs)
+
+
+def _extreme(is_max, operands, *, fastmath=None, **kwargs):
+    operands = _flatten_extreme_operands(operands)
+    if not operands:
+        name = "max" if is_max else "min"
+        raise ValueError(f"fx.{name} requires at least one operand")
+
+    prepared, dtype, shape, all_static = _resolve_typed_operands(
+        operands,
+        "max" if is_max else "min",
+        bool_widen=True,
+    )
+    if len(prepared) == 1:
+        return prepared[0]
+
+    if all_static:
+        result = prepared[0].value
+        for operand in prepared[1:]:
+            if dtype.is_float:
+                result = _fold_float_extreme(result, operand.value, is_max)
+            else:
+                result = builtins.max(result, operand.value) if is_max else builtins.min(result, operand.value)
+        return dtype(result)
+
+    lhs = as_ir_value(prepared[0])
+    if dtype.is_float:
+        op = arith.maximumf if is_max else arith.minimumf
+        fastmath = resolve_fastmath(fastmath)
+        for operand in prepared[1:]:
+            lhs = op(lhs, as_ir_value(operand), fastmath=fastmath, **kwargs)
+    else:
+        if dtype.signed:
+            op = arith.maxsi if is_max else arith.minsi
+        else:
+            op = arith.maxui if is_max else arith.minui
+        for operand in prepared[1:]:
+            lhs = op(lhs, as_ir_value(operand), **kwargs)
+    return _wrap_typed_result(lhs, dtype, shape)
+
+
+@dsl_loc_tracing
+def max(*operands, fastmath=None, **kwargs):
+    """Return the type-promoted maximum of one or more numeric operands.
+
+    Floating-point operands use NaN-propagating ``arith.maximumf``. Signed and
+    unsigned integers use ``arith.maxsi`` and ``arith.maxui`` respectively.
+    """
+    return _extreme(True, operands, fastmath=fastmath, **kwargs)
+
+
+@dsl_loc_tracing
+def min(*operands, fastmath=None, **kwargs):
+    """Return the type-promoted minimum of one or more numeric operands.
+
+    Floating-point operands use NaN-propagating ``arith.minimumf``. Signed and
+    unsigned integers use ``arith.minsi`` and ``arith.minui`` respectively.
+    """
+    return _extreme(False, operands, fastmath=fastmath, **kwargs)
+
+
+@dsl_loc_tracing
+def ceildiv(lhs, rhs, **kwargs):
+    """Return integer ``lhs / rhs`` rounded toward positive infinity.
+
+    The operation dispatches to ``arith.ceildivsi`` or ``arith.ceildivui`` from
+    the promoted operand signedness. It is distinct from the layout/int-tuple
+    :func:`flydsl.expr.ceil_div` API.
+    """
+    prepared, dtype, shape, all_static = _resolve_typed_operands(
+        (lhs, rhs),
+        "ceildiv",
+        integer_only=True,
+    )
+    lhs, rhs = prepared
+    if all_static:
+        if rhs.value == 0:
+            raise ZeroDivisionError("fx.ceildiv division by zero")
+        if dtype.signed and lhs.value == -(1 << (dtype.width - 1)) and rhs.value == -1:
+            raise OverflowError("fx.ceildiv signed division overflow")
+        return dtype(-(-lhs.value // rhs.value))
+
+    op = arith.ceildivsi if dtype.signed else arith.ceildivui
+    result = op(as_ir_value(lhs), as_ir_value(rhs), **kwargs)
+    return _wrap_typed_result(result, dtype, shape)
 
 
 @dsl_loc_tracing

--- a/python/flydsl/expr/utils/arith.py
+++ b/python/flydsl/expr/utils/arith.py
@@ -511,6 +511,11 @@ class ArithValue(ir.Value):
         return arith.maximumf(self, _to_raw(other), fastmath=resolve_fastmath(fastmath))
 
     @dsl_loc_tracing
+    def minimumf(self, other, *, fastmath=None):
+        """Float minimum (NaN-propagating)."""
+        return arith.minimumf(self, _to_raw(other), fastmath=resolve_fastmath(fastmath))
+
+    @dsl_loc_tracing
     def rsqrt(self, *, fastmath=None):
         """Reciprocal square root: 1/sqrt(self)."""
         from ..._mlir.dialects import math as _math

--- a/scripts/check_typed_arithmetic_usage.py
+++ b/scripts/check_typed_arithmetic_usage.py
@@ -38,6 +38,7 @@ _ARITH_PARENTS = {
     "flydsl.expr",
     "flydsl._mlir.dialects",
 }
+_EXPR_MODULE = "flydsl.expr"
 _HUNK_RE = re.compile(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
 
 
@@ -58,12 +59,44 @@ def _dotted_name(node: ast.AST) -> str | None:
     return None
 
 
-def _arith_bindings(tree: ast.AST) -> tuple[set[str], dict[str, str]]:
+def _shadowing_bindings(tree: ast.AST) -> set[str]:
+    """Return names that may shadow a ``flydsl.expr`` module import."""
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            names.add(node.id)
+        elif isinstance(node, ast.arg):
+            names.add(node.arg)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            names.add(node.name)
+        elif isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name:
+            names.add(node.name)
+        elif isinstance(node, ast.MatchMapping) and node.rest:
+            names.add(node.rest)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name != _EXPR_MODULE:
+                    names.add(alias.asname or alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if not (node.module == "flydsl" and alias.name == "expr") and alias.name != "*":
+                    names.add(alias.asname or alias.name)
+    return names
+
+
+def _arith_bindings(tree: ast.AST) -> tuple[set[str], dict[str, str], set[str]]:
     module_aliases: set[str] = set()
     direct_aliases: dict[str, str] = {}
+    expr_module_aliases: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
-            if node.module in _ARITH_PARENTS:
+            if node.module == "flydsl":
+                for alias in node.names:
+                    if alias.name == "expr":
+                        expr_module_aliases.add(alias.asname or alias.name)
+            elif node.module in _ARITH_PARENTS:
                 for alias in node.names:
                     if alias.name == "arith":
                         module_aliases.add(alias.asname or alias.name)
@@ -73,14 +106,20 @@ def _arith_bindings(tree: ast.AST) -> tuple[set[str], dict[str, str]]:
                         direct_aliases[alias.asname or alias.name] = alias.name
         elif isinstance(node, ast.Import):
             for alias in node.names:
-                if alias.name in _ARITH_MODULES and alias.asname:
+                if alias.name == _EXPR_MODULE:
+                    expr_module_aliases.add(alias.asname or alias.name)
+                elif alias.name in _ARITH_MODULES and alias.asname:
                     module_aliases.add(alias.asname)
-    return module_aliases, direct_aliases
+    shadowed = _shadowing_bindings(tree)
+    expr_module_aliases = {
+        alias for alias in expr_module_aliases if alias not in shadowed and alias.split(".", 1)[0] not in shadowed
+    }
+    return module_aliases, direct_aliases, expr_module_aliases
 
 
 def scan_source(source: str, added_lines: set[int] | None = None) -> list[Violation]:
     tree = ast.parse(source)
-    module_aliases, direct_aliases = _arith_bindings(tree)
+    module_aliases, direct_aliases, expr_module_aliases = _arith_bindings(tree)
     violations = []
 
     for node in ast.walk(tree):
@@ -95,11 +134,11 @@ def scan_source(source: str, added_lines: set[int] | None = None) -> list[Violat
         replacement = None
         if isinstance(node.func, ast.Attribute):
             dotted = _dotted_name(node.func)
-            if node.func.attr in _METHOD_REPLACEMENTS:
+            owner = _dotted_name(node.func.value)
+            if node.func.attr in _METHOD_REPLACEMENTS and owner not in expr_module_aliases:
                 spelling = f".{node.func.attr}(...)"
                 replacement = _METHOD_REPLACEMENTS[node.func.attr]
             elif node.func.attr in _RAW_REPLACEMENTS:
-                owner = _dotted_name(node.func.value)
                 if owner in module_aliases or any(dotted == f"{module}.{node.func.attr}" for module in _ARITH_MODULES):
                     spelling = f"{owner}.{node.func.attr}(...)"
                     replacement = _RAW_REPLACEMENTS[node.func.attr]
@@ -113,21 +152,21 @@ def scan_source(source: str, added_lines: set[int] | None = None) -> list[Violat
     return violations
 
 
-def _added_kernel_lines(base: str, head: str) -> dict[Path, set[int]]:
-    result = subprocess.run(
-        ["git", "diff", "--unified=0", "--diff-filter=ACMR", base, head, "--", "kernels"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+def _parse_added_kernel_lines(diff: str) -> dict[Path, set[int]]:
+    """Return added Python line numbers from a zero-context git diff."""
     added: dict[Path, set[int]] = {}
     current_path = None
     next_line = None
 
-    for line in result.stdout.splitlines():
-        if line.startswith("+++ b/"):
-            current_path = Path(line[6:])
-            if current_path.suffix == ".py":
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            current_path = None
+            next_line = None
+            continue
+        if next_line is None and line.startswith("+++ "):
+            new_path = line[4:]
+            current_path = Path(new_path[2:]) if new_path.startswith("b/") else None
+            if current_path is not None and current_path.suffix == ".py":
                 added.setdefault(current_path, set())
             else:
                 current_path = None
@@ -138,14 +177,25 @@ def _added_kernel_lines(base: str, head: str) -> dict[Path, set[int]]:
             continue
         if current_path is None or next_line is None:
             continue
-        if line.startswith("+") and not line.startswith("+++"):
+        prefix = line[:1]
+        if prefix == "+":
             added[current_path].add(next_line)
             next_line += 1
-        elif line.startswith("-") and not line.startswith("---"):
+        elif prefix == "-":
             continue
-        else:
+        elif prefix == " ":
             next_line += 1
     return {path: lines for path, lines in added.items() if lines}
+
+
+def _added_kernel_lines(base: str, head: str) -> dict[Path, set[int]]:
+    result = subprocess.run(
+        ["git", "diff", "--unified=0", "--diff-filter=ACMR", base, head, "--", "kernels"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return _parse_added_kernel_lines(result.stdout)
 
 
 def _default_base(head: str) -> str:

--- a/scripts/check_typed_arithmetic_usage.py
+++ b/scripts/check_typed_arithmetic_usage.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Reject newly added legacy arithmetic spellings in kernel source."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+_RAW_REPLACEMENTS = {
+    "maximumf": "fx.max",
+    "minimumf": "fx.min",
+    "maxsi": "fx.max",
+    "maxui": "fx.max",
+    "minsi": "fx.min",
+    "minui": "fx.min",
+    "maxnumf": "fx.maxnumf",
+    "ceildivsi": "fx.ceildiv",
+    "ceildivui": "fx.ceildiv",
+}
+_METHOD_REPLACEMENTS = {
+    "maximumf": "fx.max",
+    "minimumf": "fx.min",
+}
+_ARITH_MODULES = {
+    "flydsl.expr.arith",
+    "flydsl._mlir.dialects.arith",
+}
+_ARITH_PARENTS = {
+    "flydsl.expr",
+    "flydsl._mlir.dialects",
+}
+_HUNK_RE = re.compile(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+@dataclass(frozen=True)
+class Violation:
+    line: int
+    column: int
+    spelling: str
+    replacement: str
+
+
+def _dotted_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _dotted_name(node.value)
+        return f"{parent}.{node.attr}" if parent else None
+    return None
+
+
+def _arith_bindings(tree: ast.AST) -> tuple[set[str], dict[str, str]]:
+    module_aliases: set[str] = set()
+    direct_aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module in _ARITH_PARENTS:
+                for alias in node.names:
+                    if alias.name == "arith":
+                        module_aliases.add(alias.asname or alias.name)
+            elif node.module in _ARITH_MODULES:
+                for alias in node.names:
+                    if alias.name in _RAW_REPLACEMENTS:
+                        direct_aliases[alias.asname or alias.name] = alias.name
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in _ARITH_MODULES and alias.asname:
+                    module_aliases.add(alias.asname)
+    return module_aliases, direct_aliases
+
+
+def scan_source(source: str, added_lines: set[int] | None = None) -> list[Violation]:
+    tree = ast.parse(source)
+    module_aliases, direct_aliases = _arith_bindings(tree)
+    violations = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        start = node.lineno
+        end = getattr(node, "end_lineno", start) or start
+        if added_lines is not None and not any(line in added_lines for line in range(start, end + 1)):
+            continue
+
+        spelling = None
+        replacement = None
+        if isinstance(node.func, ast.Attribute):
+            dotted = _dotted_name(node.func)
+            if node.func.attr in _METHOD_REPLACEMENTS:
+                spelling = f".{node.func.attr}(...)"
+                replacement = _METHOD_REPLACEMENTS[node.func.attr]
+            elif node.func.attr in _RAW_REPLACEMENTS:
+                owner = _dotted_name(node.func.value)
+                if owner in module_aliases or any(dotted == f"{module}.{node.func.attr}" for module in _ARITH_MODULES):
+                    spelling = f"{owner}.{node.func.attr}(...)"
+                    replacement = _RAW_REPLACEMENTS[node.func.attr]
+        elif isinstance(node.func, ast.Name) and node.func.id in direct_aliases:
+            raw_name = direct_aliases[node.func.id]
+            spelling = f"{node.func.id}(...)"
+            replacement = _RAW_REPLACEMENTS[raw_name]
+
+        if spelling is not None:
+            violations.append(Violation(start, node.col_offset + 1, spelling, replacement))
+    return violations
+
+
+def _added_kernel_lines(base: str, head: str) -> dict[Path, set[int]]:
+    result = subprocess.run(
+        ["git", "diff", "--unified=0", "--diff-filter=ACMR", base, head, "--", "kernels"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    added: dict[Path, set[int]] = {}
+    current_path = None
+    next_line = None
+
+    for line in result.stdout.splitlines():
+        if line.startswith("+++ b/"):
+            current_path = Path(line[6:])
+            if current_path.suffix == ".py":
+                added.setdefault(current_path, set())
+            else:
+                current_path = None
+            continue
+        match = _HUNK_RE.match(line)
+        if match:
+            next_line = int(match.group(1))
+            continue
+        if current_path is None or next_line is None:
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            added[current_path].add(next_line)
+            next_line += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            continue
+        else:
+            next_line += 1
+    return {path: lines for path, lines in added.items() if lines}
+
+
+def _default_base(head: str) -> str:
+    env_base = os.environ.get("BASE_SHA", "").strip()
+    if env_base and set(env_base) != {"0"}:
+        return env_base
+    return subprocess.check_output(["git", "merge-base", head, "origin/main"], text=True).strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", help="base commit; defaults to BASE_SHA or merge-base with origin/main")
+    parser.add_argument("--head", default=os.environ.get("HEAD_SHA", "HEAD"), help="head commit")
+    args = parser.parse_args()
+
+    base = args.base or _default_base(args.head)
+    files = _added_kernel_lines(base, args.head)
+    violations = []
+    for path, lines in files.items():
+        try:
+            source = path.read_text()
+            found = scan_source(source, lines)
+        except (OSError, SyntaxError) as exc:
+            print(f"{path}: unable to scan: {exc}")
+            return 2
+        violations.extend((path, violation) for violation in found)
+
+    if violations:
+        print("New legacy typed-arithmetic usage is not allowed:")
+        for path, violation in violations:
+            print(
+                f"  {path}:{violation.line}:{violation.column}: " f"{violation.spelling} -> use {violation.replacement}"
+            )
+        return 1
+
+    print(f"Typed arithmetic usage check passed ({base}..{args.head}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_typed_arith_ops.py
+++ b/tests/unit/test_typed_arith_ops.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+import math
+
+import pytest
+
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import func
+
+
+def _build_module(build_fn, arg_types=()):
+    with ir.Context() as ctx:
+        ctx.allow_unregistered_dialects = True
+        with ir.Location.unknown(ctx):
+            types = [ty() if callable(ty) else ty for ty in arg_types]
+            module = ir.Module.create()
+            with ir.InsertionPoint(module.body):
+                ftype = ir.FunctionType.get(types, [])
+                f = func.FuncOp("test", ftype)
+                with ir.InsertionPoint(f.add_entry_block()):
+                    build_fn(*f.entry_block.arguments)
+                    func.ReturnOp([])
+            module.operation.verify()
+            return str(module)
+
+
+def _static(call):
+    with ir.Context(), ir.Location.unknown():
+        return call()
+
+
+def _vector_type(size, element_type):
+    return lambda: ir.VectorType.get([size], element_type())
+
+
+@pytest.mark.l0_backend_agnostic
+def test_typed_arithmetic_exports():
+    assert fx.max is fx.arith.max
+    assert fx.min is fx.arith.min
+    assert fx.ceildiv is fx.arith.ceildiv
+    assert fx.ceildiv is not fx.ceil_div
+
+
+@pytest.mark.l0_backend_agnostic
+@pytest.mark.parametrize(
+    ("fn", "op_name"),
+    [
+        (fx.max, "arith.maximumf"),
+        (fx.min, "arith.minimumf"),
+    ],
+)
+def test_float_extreme_dispatch(fn, op_name):
+    def build(lhs, rhs):
+        result = fn(fx.Float32(lhs), fx.Float32(rhs))
+        assert isinstance(result, fx.Float32)
+
+    text = _build_module(build, [ir.F32Type.get, ir.F32Type.get])
+    assert op_name in text
+
+
+@pytest.mark.l0_backend_agnostic
+@pytest.mark.parametrize(
+    ("fn", "dtype", "op_name"),
+    [
+        (fx.max, fx.Int32, "arith.maxsi"),
+        (fx.min, fx.Int32, "arith.minsi"),
+        (fx.max, fx.Uint32, "arith.maxui"),
+        (fx.min, fx.Uint32, "arith.minui"),
+    ],
+)
+def test_integer_extreme_dispatch(fn, dtype, op_name):
+    def build(lhs, rhs):
+        result = fn(dtype(lhs), dtype(rhs))
+        assert isinstance(result, dtype)
+
+    text = _build_module(
+        build,
+        [
+            lambda: ir.IntegerType.get_signless(32),
+            lambda: ir.IntegerType.get_signless(32),
+        ],
+    )
+    assert op_name in text
+
+
+@pytest.mark.l0_backend_agnostic
+def test_extreme_resolves_common_type_before_reduction():
+    def build(a, b, c):
+        result = fx.max(fx.Int32(a), fx.Int64(b), fx.Int32(c))
+        assert isinstance(result, fx.Int64)
+
+    text = _build_module(
+        build,
+        [
+            lambda: ir.IntegerType.get_signless(32),
+            lambda: ir.IntegerType.get_signless(64),
+            lambda: ir.IntegerType.get_signless(32),
+        ],
+    )
+    assert text.count("arith.maxsi") == 2
+    assert "i64" in text
+
+
+@pytest.mark.l0_backend_agnostic
+def test_extreme_flattens_nested_lists_and_tuples():
+    def build(a, b, c):
+        result = fx.min([fx.Float32(a), (fx.Float32(b), [fx.Float32(c)])])
+        assert isinstance(result, fx.Float32)
+
+    text = _build_module(build, [ir.F32Type.get, ir.F32Type.get, ir.F32Type.get])
+    assert text.count("arith.minimumf") == 2
+
+
+@pytest.mark.l0_backend_agnostic
+def test_extreme_single_operand_returns_promoted_dsl_value():
+    result = _static(lambda: fx.max(True))
+    assert isinstance(result, fx.Int32)
+    assert int(result) == 1
+
+
+@pytest.mark.l0_backend_agnostic
+def test_extreme_empty_input_rejected():
+    with pytest.raises(ValueError, match="at least one operand"):
+        _static(fx.max)
+
+
+@pytest.mark.l0_backend_agnostic
+def test_extreme_static_nan_propagates_in_both_positions():
+    lhs_nan = _static(lambda: fx.max(fx.Float32(float("nan")), fx.Float32(1.0)))
+    rhs_nan = _static(lambda: fx.max(fx.Float32(1.0), fx.Float32(float("nan"))))
+    assert math.isnan(lhs_nan.value)
+    assert math.isnan(rhs_nan.value)
+
+
+@pytest.mark.l0_backend_agnostic
+def test_extreme_static_signed_zero_matches_maximum_minimum():
+    maximum = _static(lambda: fx.max(fx.Float32(-0.0), fx.Float32(0.0)))
+    minimum = _static(lambda: fx.min(fx.Float32(-0.0), fx.Float32(0.0)))
+    assert math.copysign(1.0, maximum.value) == 1.0
+    assert math.copysign(1.0, minimum.value) == -1.0
+
+
+@pytest.mark.l0_backend_agnostic
+def test_extreme_rejects_index_and_narrow_storage_float():
+    with pytest.raises(TypeError, match="does not support Index"):
+        _static(lambda: fx.max(fx.Index(1), fx.Index(2)))
+    with pytest.raises(TypeError, match="narrow storage float"):
+        _static(lambda: fx.max(fx.Float8E5M2(1.0), fx.Float8E5M2(2.0)))
+
+
+@pytest.mark.l0_backend_agnostic
+def test_extreme_vector_broadcast_and_type_promotion():
+    def build(raw_vector):
+        vector = fx.Vector(raw_vector, (2, 2), fx.Int32)
+        result = fx.max(vector, fx.Int64(7))
+        assert isinstance(result, fx.Vector)
+        assert result.shape == (2, 2)
+        assert result.dtype is fx.Int64
+
+    text = _build_module(build, [_vector_type(4, lambda: ir.IntegerType.get_signless(32))])
+    assert "arith.maxsi" in text
+    assert "vector<4xi64>" in text
+
+
+@pytest.mark.l0_backend_agnostic
+def test_extreme_explicit_fastmath_is_preserved():
+    def build(lhs, rhs):
+        fx.max(fx.Float32(lhs), fx.Float32(rhs), fastmath="contract")
+
+    text = _build_module(build, [ir.F32Type.get, ir.F32Type.get])
+    line = next(line for line in text.splitlines() if "arith.maximumf" in line)
+    assert "fastmath<contract>" in line
+
+
+@pytest.mark.l0_backend_agnostic
+def test_numeric_minimumf_compatibility_proxy():
+    def build(lhs, rhs):
+        result = fx.Float32(lhs).minimumf(fx.Float32(rhs))
+        assert isinstance(result, fx.Float32)
+
+    text = _build_module(build, [ir.F32Type.get, ir.F32Type.get])
+    assert "arith.minimumf" in text
+
+
+@pytest.mark.l0_backend_agnostic
+@pytest.mark.parametrize(
+    ("dtype", "op_name"),
+    [
+        (fx.Int32, "arith.ceildivsi"),
+        (fx.Uint32, "arith.ceildivui"),
+    ],
+)
+def test_ceildiv_dispatch(dtype, op_name):
+    def build(lhs, rhs):
+        result = fx.ceildiv(dtype(lhs), dtype(rhs))
+        assert isinstance(result, dtype)
+
+    text = _build_module(
+        build,
+        [
+            lambda: ir.IntegerType.get_signless(32),
+            lambda: ir.IntegerType.get_signless(32),
+        ],
+    )
+    assert op_name in text
+    assert "arith.addi" not in text
+    assert "arith.subi" not in text
+
+
+@pytest.mark.l0_backend_agnostic
+@pytest.mark.parametrize(
+    ("lhs", "rhs", "expected"),
+    [
+        (7, 2, 4),
+        (7, -2, -3),
+        (-7, 2, -3),
+        (-7, -2, 4),
+        (0, 3, 0),
+    ],
+)
+def test_signed_ceildiv_static(lhs, rhs, expected):
+    result = _static(lambda: fx.ceildiv(fx.Int32(lhs), fx.Int32(rhs)))
+    assert isinstance(result, fx.Int32)
+    assert int(result) == expected
+
+
+@pytest.mark.l0_backend_agnostic
+def test_unsigned_ceildiv_static_is_overflow_safe():
+    result = _static(lambda: fx.ceildiv(fx.Uint32(0xFFFFFFFF), fx.Uint32(2)))
+    assert isinstance(result, fx.Uint32)
+    assert int(result) == 0x80000000
+
+
+@pytest.mark.l0_backend_agnostic
+def test_ceildiv_static_undefined_cases_raise():
+    with pytest.raises(ZeroDivisionError):
+        _static(lambda: fx.ceildiv(fx.Uint32(1), fx.Uint32(0)))
+    with pytest.raises(OverflowError):
+        _static(lambda: fx.ceildiv(fx.Int32(-(1 << 31)), fx.Int32(-1)))
+
+
+@pytest.mark.l0_backend_agnostic
+def test_ceildiv_vector_broadcast_preserves_shape_and_unsignedness():
+    def build(raw_vector, divisor):
+        vector = fx.Vector(raw_vector, (2, 2), fx.Uint32)
+        result = fx.ceildiv(vector, fx.Uint32(divisor))
+        assert isinstance(result, fx.Vector)
+        assert result.shape == (2, 2)
+        assert result.dtype is fx.Uint32
+
+    text = _build_module(
+        build,
+        [
+            _vector_type(4, lambda: ir.IntegerType.get_signless(32)),
+            lambda: ir.IntegerType.get_signless(32),
+        ],
+    )
+    assert "arith.ceildivui" in text
+
+
+@pytest.mark.l0_backend_agnostic
+def test_ceildiv_rejects_non_integer_boolean_and_index_inputs():
+    with pytest.raises(TypeError, match="requires integer operands"):
+        _static(lambda: fx.ceildiv(fx.Float32(3.0), fx.Float32(2.0)))
+    with pytest.raises(TypeError, match="does not support Boolean"):
+        _static(lambda: fx.ceildiv(fx.Boolean(True), fx.Boolean(True)))
+    with pytest.raises(TypeError, match="does not support Index"):
+        _static(lambda: fx.ceildiv(fx.Index(3), fx.Index(2)))

--- a/tests/unit/test_typed_arith_ops.py
+++ b/tests/unit/test_typed_arith_ops.py
@@ -273,10 +273,33 @@ def test_ceildiv_rejects_non_integer_boolean_and_index_inputs():
 
 
 @pytest.mark.l0_backend_agnostic
-def test_kernel_cdiv_keeps_host_path_and_uses_typed_dynamic_op():
+@pytest.mark.parametrize(
+    ("numer", "denom", "expected"),
+    [
+        (7, 2, 4),
+        (7, -2, -3),
+        (-7, 2, -3),
+        (-7, -2, 4),
+        (0, -3, 0),
+    ],
+)
+def test_kernel_cdiv_host_path_rounds_toward_positive_infinity(numer, denom, expected):
     from kernels.common.utils import cdiv
 
-    assert cdiv(7, 3) == 3
+    assert cdiv(numer, denom) == expected
+
+
+@pytest.mark.l0_backend_agnostic
+def test_kernel_cdiv_host_path_rejects_zero_divisor():
+    from kernels.common.utils import cdiv
+
+    with pytest.raises(ZeroDivisionError):
+        cdiv(1, 0)
+
+
+@pytest.mark.l0_backend_agnostic
+def test_kernel_cdiv_uses_typed_dynamic_op():
+    from kernels.common.utils import cdiv
 
     def build(lhs, rhs):
         result = cdiv(fx.Int32(lhs), fx.Int32(rhs))

--- a/tests/unit/test_typed_arith_ops.py
+++ b/tests/unit/test_typed_arith_ops.py
@@ -270,3 +270,24 @@ def test_ceildiv_rejects_non_integer_boolean_and_index_inputs():
         _static(lambda: fx.ceildiv(fx.Boolean(True), fx.Boolean(True)))
     with pytest.raises(TypeError, match="does not support Index"):
         _static(lambda: fx.ceildiv(fx.Index(3), fx.Index(2)))
+
+
+@pytest.mark.l0_backend_agnostic
+def test_kernel_cdiv_keeps_host_path_and_uses_typed_dynamic_op():
+    from kernels.common.utils import cdiv
+
+    assert cdiv(7, 3) == 3
+
+    def build(lhs, rhs):
+        result = cdiv(fx.Int32(lhs), fx.Int32(rhs))
+        assert isinstance(result, fx.Int32)
+
+    text = _build_module(
+        build,
+        [
+            lambda: ir.IntegerType.get_signless(32),
+            lambda: ir.IntegerType.get_signless(32),
+        ],
+    )
+    assert "arith.ceildivsi" in text
+    assert "arith.addi" not in text

--- a/tests/unit/test_typed_arithmetic_guard.py
+++ b/tests/unit/test_typed_arithmetic_guard.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 FlyDSL Project Contributors
 
+from pathlib import Path
+
 import pytest
 
-from scripts.check_typed_arithmetic_usage import scan_source
+from scripts.check_typed_arithmetic_usage import _parse_added_kernel_lines, scan_source
 
 
 @pytest.mark.parametrize(
@@ -17,6 +19,8 @@ from scripts.check_typed_arithmetic_usage import scan_source
         "from flydsl._mlir.dialects import arith as raw\nresult = raw.ceildivui(a, b)",
         "from flydsl.expr.arith import maxsi as raw_max\nresult = raw_max(a, b)",
         "import flydsl.expr.arith as typed_arith\nresult = typed_arith.maxnumf(a, b)",
+        "import flydsl.expr as fx\ndef kernel(fx, peer):\n    return fx.maximumf(peer)",
+        "import flydsl.expr\n\ndef kernel(flydsl, peer):\n    return flydsl.expr.minimumf(peer)",
     ],
 )
 def test_guard_rejects_new_legacy_arithmetic(source):
@@ -29,6 +33,8 @@ def test_guard_rejects_new_legacy_arithmetic(source):
         "result = fx.max(a, b)",
         "result = fx.min(a, b)",
         "result = fx.maxnumf(a, b)",
+        "import flydsl.expr as fx\nresult = fx.maximumf(a, b)",
+        "from flydsl import expr as typed_fx\nresult = typed_fx.minimumf(a, b)",
         "result = fx.ceildiv(a, b)",
         "result = (a + b - 1) // b",
     ],
@@ -41,3 +47,38 @@ def test_guard_checks_only_added_lines():
     source = "old = value.maximumf(peer)\nnew = fx.max(value, peer)\n"
     assert scan_source(source, {2}) == []
     assert scan_source(source, {1})
+
+
+@pytest.mark.parametrize(
+    ("diff", "source"),
+    [
+        (
+            """\
+diff --git a/kernels/example.py b/kernels/example.py
+--- a/kernels/example.py
++++ b/kernels/example.py
+@@ -1,2 +1 @@
+--- separator
+-old = 0
++result = value.maximumf(peer)
+""",
+            "result = value.maximumf(peer)\n",
+        ),
+        (
+            """\
+diff --git a/kernels/example.py b/kernels/example.py
+--- a/kernels/example.py
++++ b/kernels/example.py
+@@ -1 +1 @@
+-old = 0
++++value.maximumf(peer)
+""",
+            "++value.maximumf(peer)\n",
+        ),
+    ],
+)
+def test_diff_parser_does_not_confuse_source_with_file_headers(diff, source):
+    path = Path("kernels/example.py")
+    added = _parse_added_kernel_lines(diff)
+    assert added == {path: {1}}
+    assert scan_source(source, added[path])

--- a/tests/unit/test_typed_arithmetic_guard.py
+++ b/tests/unit/test_typed_arithmetic_guard.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+import pytest
+
+from scripts.check_typed_arithmetic_usage import scan_source
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "result = value.maximumf(peer)",
+        "result = value.minimumf(peer)",
+        "from flydsl.expr import arith\nresult = arith.maximumf(a, b)",
+        "from flydsl._mlir.dialects import arith as raw\nresult = raw.ceildivui(a, b)",
+        "from flydsl.expr.arith import maxsi as raw_max\nresult = raw_max(a, b)",
+        "import flydsl.expr.arith as typed_arith\nresult = typed_arith.maxnumf(a, b)",
+    ],
+)
+def test_guard_rejects_new_legacy_arithmetic(source):
+    assert scan_source(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "result = fx.max(a, b)",
+        "result = fx.min(a, b)",
+        "result = fx.maxnumf(a, b)",
+        "result = fx.ceildiv(a, b)",
+        "result = (a + b - 1) // b",
+    ],
+)
+def test_guard_accepts_typed_arithmetic(source):
+    assert scan_source(source) == []
+
+
+def test_guard_checks_only_added_lines():
+    source = "old = value.maximumf(peer)\nnew = fx.max(value, peer)\n"
+    assert scan_source(source, {2}) == []
+    assert scan_source(source, {1})


### PR DESCRIPTION
Add fx.max, fx.min, and fx.ceildiv with common-type promotion,
scalar/vector broadcasting, and type-specific MLIR lowering.
Migrate audited norm, MoE, and attention kernels while preserving
maxnumf semantics and generated IR/ISA. Add compatibility coverage,
documentation, and a diff-scoped CI guard for deprecated or raw
arithmetic usage.
Align host cdiv with signed ceiling-division semantics and harden the
guard against diff parsing and import-alias edge cases.

Closes #994. Child of #934.