### PR TITLE
[compiler] isolate mutable state across dynamic if branches

### DIFF
--- a/python/flydsl/compiler/ast_rewriter.py
+++ b/python/flydsl/compiler/ast_rewriter.py
@@ -738,9 +738,11 @@ class ReplaceIfWithDispatch(Transformer):
 
         def _emit_branch(fn, block, label):
             with ir.InsertionPoint(block):
-                branch_result = ReplaceIfWithDispatch._call_branch(fn, result_names, result_values)
+                branch_inputs = _pack_states(state_raw, exemplar)
+                branch_result = ReplaceIfWithDispatch._call_branch(fn, result_names, branch_inputs)
+                branch_map = dict(zip(result_names, branch_inputs))
                 branch_values = ReplaceIfWithDispatch._normalize_branch_result(
-                    branch_result, result_names, result_map, label
+                    branch_result, result_names, branch_map, label
                 )
                 scf.YieldOp(
                     _unpack_branch_outputs(result_names, branch_values, exemplar, label),

--- a/tests/system/test_dynamic_controlflow_list_carry_e2e.py
+++ b/tests/system/test_dynamic_controlflow_list_carry_e2e.py
@@ -49,6 +49,20 @@ def _run_if_list(Out: fx.Tensor, flag: fx.Int32, stream: fx.Stream = fx.Stream(N
     _kernel_if_list(Out, flag).launch(grid=(1, 1, 1), block=(1, 1, 1), stream=stream.value)
 
 
+@flyc.kernel
+def _kernel_if_inplace_list(Out: fx.Tensor, flag: fx.Int32):
+    lst = [fx.Int32(1), fx.Int32(2)]
+    if flag > fx.Int32(0):
+        lst[0] = fx.Int32(10)
+    Out[0] = lst[0]
+    Out[1] = lst[1]
+
+
+@flyc.jit
+def _run_if_inplace_list(Out: fx.Tensor, flag: fx.Int32, stream: fx.Stream = fx.Stream(None)):
+    _kernel_if_inplace_list(Out, flag).launch(grid=(1, 1, 1), block=(1, 1, 1), stream=stream.value)
+
+
 # ── dynamic for carrying a list ─────────────────────────────────────────────
 
 
@@ -285,6 +299,18 @@ class TestDynamicControlFlowListCarryE2E:
         _run_if_list(t_out, fx.Int32(0))  # flag==0 -> else keeps original list
         torch.cuda.synchronize()
         assert out[0].item() == 1 and out[1].item() == 2, out.tolist()
+
+    def test_if_inplace_list_taken(self):
+        out, t_out = _out(2)
+        _run_if_inplace_list(t_out, fx.Int32(1))
+        torch.cuda.synchronize()
+        assert out.tolist() == [10, 2], out.tolist()
+
+    def test_if_inplace_list_not_taken(self):
+        out, t_out = _out(2)
+        _run_if_inplace_list(t_out, fx.Int32(0))
+        torch.cuda.synchronize()
+        assert out.tolist() == [1, 2], out.tolist()
 
     def test_for_list(self):
         out, t_out = _out(2)

--- a/tests/unit/test_dynamic_controlflow_list_carry.py
+++ b/tests/unit/test_dynamic_controlflow_list_carry.py
@@ -74,6 +74,46 @@ def test_if_carries_list():
         assert "-> (i32, i32)" in text
 
 
+def test_if_inplace_list_updates_do_not_contaminate_branches():
+    with Context(), Location.unknown():
+        module = Module.create()
+        i1 = IntegerType.get_signless(1)
+        with InsertionPoint(module.body):
+            f = func.FuncOp("if_inplace_list", FunctionType.get([i1], []))
+            entry = f.add_entry_block()
+            with InsertionPoint(entry):
+                cond = entry.arguments[0]
+                original_first = _i32(1)
+                lst = [original_first, _i32(2)]
+                branch_inputs = []
+
+                def then_branch(names, branch_lst):
+                    branch_inputs.append(branch_lst)
+                    branch_lst[0] = _i32(10)
+                    return {"lst": branch_lst}
+
+                def else_branch(names, branch_lst):
+                    branch_inputs.append(branch_lst)
+                    assert branch_lst[0].ir_value().owner == original_first.ir_value().owner
+                    return {"lst": branch_lst}
+
+                out = ReplaceIfWithDispatch.scf_if_dispatch(
+                    cond,
+                    then_branch,
+                    else_branch,
+                    result_names=("lst",),
+                    result_values=(lst,),
+                )
+                assert lst[0] is original_first
+                assert branch_inputs[0] is not lst
+                assert branch_inputs[1] is not lst
+                assert branch_inputs[0] is not branch_inputs[1]
+                assert isinstance(out, list) and len(out) == 2
+                func.ReturnOp([])
+
+        assert module.operation.verify()
+
+
 def test_if_carries_nested_list():
     with Context(), Location.unknown():
         module = Module.create()


### PR DESCRIPTION
# [compiler] isolate mutable state across dynamic if branches

## Motivation

Dynamic `if` already carries Python containers (`list` / `dict` /
`SimpleNamespace` / nested) as `scf.if` results by unpacking their leaves into
SSA values. That is enough for whole-container rebinding such as
`lst = [a, b]`, but not for in-place updates:

```python
lst = [fx.Int32(1), fx.Int32(2)]
if flag > fx.Int32(0):
    lst[0] = fx.Int32(10)
```

Both branches of `scf_if_dispatch` previously received the **same** Python
container object. During tracing, an in-place write in the then-branch mutated
the shared object before the else-branch ran, so the else-branch observed the
updated element even though its SSA path never assigned it. The resulting
`scf.if` therefore merged contaminated state and produced wrong values when the
condition was false.

This PR clones the mutable container structure once per branch before the
branch body runs, so in-place updates stay local to that branch’s tracing
inputs. DSL / IR leaves are shared by identity (they are already SSA-managed);
only the Python container skeleton is duplicated.

## Technical Details

- Add `_clone_mutable_state` in `python/flydsl/compiler/ast_rewriter.py`.
  It deep-clones `list`, `dict`, `SimpleNamespace`, and `tuple` structure while
  preserving cycles via an `id`-keyed memo and leaving non-container leaves
  (DSL values, IR values, scalars) untouched.
- In `ReplaceIfWithDispatch.scf_if_dispatch`, each dynamic branch now receives
  `branch_inputs = _clone_mutable_state(result_values)` instead of the shared
  entry `result_values`.
- `_normalize_branch_result` falls back through that per-branch map, so a
  name omitted from a branch return dict resolves to the branch’s own clone,
  not the contaminated entry container.

## Test Plan

- Unit: `tests/unit/test_dynamic_controlflow_list_carry.py::test_if_inplace_list_updates_do_not_contaminate_branches`
  asserts then/else receive distinct clones, the entry list is untouched, and
  the else-branch still sees the original element after the then-branch stores.
- E2E: `tests/system/test_dynamic_controlflow_list_carry_e2e.py`
  - `test_if_inplace_list_taken` → `[10, 2]`
  - `test_if_inplace_list_not_taken` → `[1, 2]`
- Existing list-carry unit / e2e suites for rebinding and nested containers.

## Test Result

- New unit + e2e inplace-list tests pass.
- Existing dynamic control-flow list-carry suites remain green.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

