### PR TITLE
docs: add rocm-docs-core package to requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx-rtd-theme>=2.0
 myst-parser>=2.0
 sphinx-autodoc-typehints>=1.25
 sphinx-copybutton>=0.5
+rocm-docs-core[llms]


### PR DESCRIPTION
Fixes the local build of the docs.