### PR TITLE
[CI] Skip amdgpu repo during manylinux image dnf install

### DIFF
--- a/.github/workflows/Dockerfile.manylinux_2_28
+++ b/.github/workflows/Dockerfile.manylinux_2_28
@@ -34,8 +34,9 @@ COPY --from=python-source /opt/python /opt/python
 # Copy patchelf binary (statically linked, required by auditwheel)
 COPY --from=python-source /usr/local/bin/patchelf /usr/local/bin/patchelf
 
-# Install build dependencies
-RUN dnf install -y \
+# Install build dependencies. ROCm is already in the base image; skip the amdgpu
+# repo so dnf does not hit flaky repo.radeon.com metadata fetches on CI.
+RUN dnf install -y --disablerepo=amdgpu \
       ninja-build \
       gcc \
       gcc-c++ \


### PR DESCRIPTION
## Summary
- Fix scheduled FlyDSL CI build failure when the prebuilt manylinux image is missing from GHCR.
- `dnf install` in `.github/workflows/Dockerfile.manylinux_2_28` now uses `--disablerepo=amdgpu` so CI does not depend on flaky `repo.radeon.com` metadata fetches.
- ROCm is already present in `rocm/dev-almalinux-8:*-complete`; the packages installed here (`gcc`, `git`, `ninja-build`, etc.) come from AlmaLinux repos.

## Root cause (verified from run 31988204507)
1. `docker pull ghcr.io/rocm/flydsl-manylinux_2_28:rocm7.2-cp310-cp314` failed: image not found
2. CI fell back to local `docker build`
3. Build failed at Dockerfile step 5/7 because `dnf install` timed out refreshing the `amdgpu` repo metadata from `repo.radeon.com`

## Test plan
- [ ] CI `build / build` job passes on this PR (should rebuild the manylinux image and get past the `dnf install` step)
- [ ] Built image still contains expected build tools (`gcc`, `git`, `ninja-build`, `cmake` via pip)


Made with [Cursor](https://cursor.com)