### PR TITLE
[Test] Run every RUN line in the MLIR FileCheck harness

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -107,16 +107,20 @@ if [ -z "${FILECHECK}" ] || [ ! -x "${FILECHECK}" ]; then
 else
 
 for f in $(find "${REPO_ROOT}/tests/mlir" -name "*.mlir" -type f 2>/dev/null | sort); do
-    run_line=$(grep '^// RUN:' "$f" | head -1 | sed 's|^// RUN: *||')
-    [ -z "$run_line" ] && continue
-    cmd=$(echo "$run_line" | sed "s|%fly-opt|${FLY_OPT}|g; s|%FileCheck|${FILECHECK}|g; s|%s|${f}|g; s|FileCheck|${FILECHECK}|g")
-    if eval "$cmd" > /tmp/filecheck_out.log 2>&1; then
-        echo "  PASS  ${f#${REPO_ROOT}/tests/mlir/}"
-    else
-        echo "  FAIL  ${f#${REPO_ROOT}/tests/mlir/}"
-        tail -5 /tmp/filecheck_out.log | sed 's/^/        /'
-        exit 1
-    fi
+    # A file may carry several RUN lines, typically one per --check-prefix. Run
+    # every one of them: only checking the first silently skips the rest.
+    mapfile -t run_lines < <(grep '^// RUN:' "$f" | sed 's|^// RUN: *||')
+    [ ${#run_lines[@]} -eq 0 ] && continue
+    for run_line in "${run_lines[@]}"; do
+        cmd=$(echo "$run_line" | sed "s|%fly-opt|${FLY_OPT}|g; s|%FileCheck|${FILECHECK}|g; s|%s|${f}|g; s|FileCheck|${FILECHECK}|g")
+        if ! eval "$cmd" > /tmp/filecheck_out.log 2>&1; then
+            echo "  FAIL  ${f#${REPO_ROOT}/tests/mlir/}"
+            echo "        RUN: ${run_line}"
+            tail -5 /tmp/filecheck_out.log | sed 's/^/        /'
+            exit 1
+        fi
+    done
+    echo "  PASS  ${f#${REPO_ROOT}/tests/mlir/}"
 done
 
 fi

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -112,7 +112,19 @@ for f in $(find "${REPO_ROOT}/tests/mlir" -name "*.mlir" -type f 2>/dev/null | s
     mapfile -t run_lines < <(grep '^// RUN:' "$f" | sed 's|^// RUN: *||')
     [ ${#run_lines[@]} -eq 0 ] && continue
     for run_line in "${run_lines[@]}"; do
-        cmd=$(echo "$run_line" | sed "s|%fly-opt|${FLY_OPT}|g; s|%FileCheck|${FILECHECK}|g; s|%s|${f}|g; s|FileCheck|${FILECHECK}|g")
+        # Map every substitution to a placeholder first, then expand. Expanding
+        # in place would let a later rule rewrite text an earlier one inserted:
+        # with `%FileCheck`, the bare-FileCheck rule would match inside the path
+        # just substituted and yield `/usr/bin//usr/bin/FileCheck`. `%FileCheck`
+        # must also be consumed before the bare form, or it degrades to `%<path>`.
+        cmd=$(echo "$run_line" | sed \
+            -e "s|%fly-opt|@FLY_OPT@|g" \
+            -e "s|%FileCheck|@FILECHECK@|g" \
+            -e "s|FileCheck|@FILECHECK@|g" \
+            -e "s|%s|@SRC@|g" \
+            -e "s|@FLY_OPT@|${FLY_OPT}|g" \
+            -e "s|@FILECHECK@|${FILECHECK}|g" \
+            -e "s|@SRC@|${f}|g")
         if ! eval "$cmd" > /tmp/filecheck_out.log 2>&1; then
             echo "  FAIL  ${f#${REPO_ROOT}/tests/mlir/}"
             echo "        RUN: ${run_line}"

--- a/tests/mlir/Conversion/buffer_copy_lds.mlir
+++ b/tests/mlir/Conversion/buffer_copy_lds.mlir
@@ -108,9 +108,9 @@ func.func @test_buffer_copy_lds_const_imm_offset(
   %atom = fly.make_copy_atom {valBits = 32 : i32} : !fly.copy_atom<!fly_rocdl.cdna3.buffer_copy_lds<32>, 32>
   %c128 = arith.constant 128 : i32
   %a1 = fly.atom.set_value(%atom, "imm_offset", %c128) : (!fly.copy_atom<!fly_rocdl.cdna3.buffer_copy_lds<32>, 32>, i32) -> !fly.copy_atom<!fly_rocdl.cdna3.buffer_copy_lds<32>, 32>
+  // The trailing `0` is the cache-policy attribute, not an SSA operand.
   // LLVM-DAG: %[[C128:.*]] = llvm.mlir.constant(128 : i32) : i32
-  // LLVM-DAG: %[[C0:.*]] = llvm.mlir.constant(0 : i32) : i32
-  // LLVM: rocdl.raw.ptr.buffer.load.lds %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[C128]], %[[C0]]
+  // LLVM: rocdl.raw.ptr.buffer.load.lds %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[C128]], 0
   fly.copy_atom_call(%a1, %src, %dst) : (!fly.copy_atom<!fly_rocdl.cdna3.buffer_copy_lds<32>, 32>, !fly.memref<f32, #fly_rocdl.buffer_desc, 1:1>, !fly.memref<f32, shared, 1:1>) -> ()
   return
 }
@@ -128,13 +128,13 @@ func.func @test_buffer_copy_lds_const_both(
   %c256 = arith.constant 256 : i32
   %a1 = fly.atom.set_value(%atom, "soffset", %c64) : (!fly.copy_atom<!fly_rocdl.cdna3.buffer_copy_lds<32>, 32>, i32) -> !fly.copy_atom<!fly_rocdl.cdna3.buffer_copy_lds<32>, 32>
   %a2 = fly.atom.set_value(%a1, "imm_offset", %c256) : (!fly.copy_atom<!fly_rocdl.cdna3.buffer_copy_lds<32>, 32>, i32) -> !fly.copy_atom<!fly_rocdl.cdna3.buffer_copy_lds<32>, 32>
-  // soffset = 64 * 4 (f32 elem bytes), imm_offset = 256 (constant)
+  // soffset = 64 * 4 (f32 elem bytes), imm_offset = 256 (constant); the trailing
+  // `0` is the cache-policy attribute, not an SSA operand.
   // LLVM-DAG: %[[C4:.*]] = llvm.mlir.constant(4 : i32) : i32
   // LLVM-DAG: %[[C64:.*]] = llvm.mlir.constant(64 : i32) : i32
   // LLVM-DAG: %[[C256:.*]] = llvm.mlir.constant(256 : i32) : i32
-  // LLVM-DAG: %[[C0:.*]] = llvm.mlir.constant(0 : i32) : i32
   // LLVM: %[[SOFF:.*]] = llvm.mul %[[C64]], %[[C4]]
-  // LLVM: rocdl.raw.ptr.buffer.load.lds %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SOFF]], %[[C256]], %[[C0]]
+  // LLVM: rocdl.raw.ptr.buffer.load.lds %{{.*}}, %{{.*}}, %{{.*}}, %[[SOFF]], %[[C256]], 0
   fly.copy_atom_call(%a2, %src, %dst) : (!fly.copy_atom<!fly_rocdl.cdna3.buffer_copy_lds<32>, 32>, !fly.memref<f32, #fly_rocdl.buffer_desc, 1:1>, !fly.memref<f32, shared, 1:1>) -> ()
   return
 }


### PR DESCRIPTION
scripts/run_tests.sh took only the first `// RUN:` line of each .mlir file (`grep ... | head -1`), so any file with more than one RUN line had its remaining lines silently skipped. buffer_copy_lds.mlir is the only such file today, and its second RUN line (`--check-prefix=LLVM`) has been failing unnoticed: the ROCDL `raw.ptr.buffer.load.lds` `aux` operand became an attribute upstream, so it no longer matches the `%[[C0]]` SSA capture.

Iterate over all RUN lines and report which one failed, then fix the two stale LLVM-prefix CHECK lines to match the current `..., %[[IMM]], 0` form.

Verified by extracting the harness section and running it against the built fly-opt: green after the CHECK fix, and red (naming the failing RUN line) with the CHECK fix reverted, confirming the second line is now actually executed.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
