### PR TITLE
[CI] Track Softmax backward in the benchmark dashboard

### DIFF
--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -64,6 +64,17 @@ SKIP_COUNT=0
 SOFTMAX_SHAPES='
 32768,8192,bf16
 '
+# Softmax backward: one shape per register-residency tier, since the tier is
+# selected by N and a regression can hit one tier without touching the others.
+# All three are in the correctness sweep in tests/kernels/test_softmax_bwd.py.
+# M is chosen for occupancy, not just tier coverage: the widest tier at M=64 fills
+# 0.25 workgroups per CU on a 256-CU gfx950 and swings 24% run to run, which would
+# flap the dashboard rather than report it. At M=1024 the same tier holds ~1%.
+SOFTMAX_BWD_SHAPES='
+1024,8192,bf16
+256,32768,bf16
+1024,65536,bf16
+'
 LAYERNORM_SHAPES='
 32768,8192,bf16
 '
@@ -207,13 +218,14 @@ _usage() {
 Usage:
   bash scripts/run_benchmark.sh                  # run all benchmarks (default)
   bash scripts/run_benchmark.sh softmax          # run only softmax
+  bash scripts/run_benchmark.sh softmax_bwd      # run only softmax backward
   bash scripts/run_benchmark.sh layernorm moe    # run only selected benchmarks
   bash scripts/run_benchmark.sh --only softmax,moe
   bash scripts/run_benchmark.sh --output_csv /tmp/bench.csv
   bash scripts/run_benchmark.sh --list
 
 Supported ops:
-  softmax | layernorm | rmsnorm | flash_attn | mla | gemm | moe
+  softmax | softmax_bwd | layernorm | rmsnorm | flash_attn | mla | gemm | moe
   (gemm includes preshuffle GEMM, A16W16 GEMM, and FP8 8-wave row-scale GEMM)
 USAGE
 }
@@ -304,6 +316,7 @@ _normalize_op() {
   op="${1:-}"
   case "${op}" in
     layernorm) echo "layernorm" ;;
+    softmax_bwd|softmax-bwd|softmax_backward|softmax-backward) echo "softmax_bwd" ;;
     flash|flash_attn|flash-attn|flash_attn_func|fmha) echo "flash_attn" ;;
     mla|mla_decode|mla-decode) echo "mla" ;;
     *) echo "${op}" ;;
@@ -311,8 +324,9 @@ _normalize_op() {
 }
 
 # Default: run softmax, norms, attention, GEMM, and MoE unless user selected a subset.
-# Use positional args or --only to enable others: softmax, layernorm, rmsnorm, flash_attn, mla, gemm, moe
+# Use positional args or --only to enable others: softmax, softmax_bwd, layernorm, rmsnorm, flash_attn, mla, gemm, moe
 RUN_SOFTMAX=1
+RUN_SOFTMAX_BWD=1
 RUN_LAYERNORM=1
 RUN_RMSNORM=1
 RUN_FLASH_ATTN=1
@@ -322,6 +336,7 @@ RUN_MOE=1
 
 _enable_only_ops() {
   RUN_SOFTMAX=0
+  RUN_SOFTMAX_BWD=0
   RUN_LAYERNORM=0
   RUN_RMSNORM=0
   RUN_FLASH_ATTN=0
@@ -332,6 +347,7 @@ _enable_only_ops() {
     op="$(_normalize_op "${op}")"
     case "${op}" in
       softmax) RUN_SOFTMAX=1 ;;
+      softmax_bwd) RUN_SOFTMAX_BWD=1 ;;
       layernorm) RUN_LAYERNORM=1 ;;
       rmsnorm) RUN_RMSNORM=1 ;;
       flash_attn) RUN_FLASH_ATTN=1 ;;
@@ -370,6 +386,7 @@ if [ "$#" -gt 0 ]; then
         ;;
       --list)
         echo "softmax"
+        echo "softmax_bwd"
         echo "layernorm"
         echo "rmsnorm"
         echo "flash_attn"
@@ -577,6 +594,29 @@ if [ "${RUN_SOFTMAX}" -eq 1 ]; then
       _fail_or_skip "${log}" "softmax"
     fi
     row="$(_py_parse_and_emit softmax "${M}x${N}" "${dtype}" "${log}")"
+    # row is tab-separated; default IFS includes tabs.
+    set -- $row
+    _emit_row "$1" "$2" "$3" "$4" "$5"
+  done
+fi
+
+# Softmax backward (log -> parse -> one row per residency tier)
+if [ "${RUN_SOFTMAX_BWD}" -eq 1 ]; then
+  for shape in $SOFTMAX_BWD_SHAPES; do
+    oldIFS=$IFS
+    IFS=,
+    # shellcheck disable=SC2086 # intentional word-splitting on IFS=,
+    set -- $shape
+    IFS=$oldIFS
+    M=$1; N=$2; dtype=$3
+    export ROCDSL_SOFTMAX_BWD_SHAPES="$shape"
+    log="${BENCH_LOG_DIR}/softmax_bwd_${M}x${N}_${dtype}.log"
+    if python3 tests/kernels/test_softmax_bwd.py >"${log}" 2>&1; then
+      SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+    else
+      _fail_or_skip "${log}" "softmax_bwd"
+    fi
+    row="$(_py_parse_and_emit softmax_bwd "${M}x${N}" "${dtype}" "${log}")"
     # row is tab-separated; default IFS includes tabs.
     set -- $row
     _emit_row "$1" "$2" "$3" "$4" "$5"

--- a/tests/kernels/test_softmax_bwd.py
+++ b/tests/kernels/test_softmax_bwd.py
@@ -61,6 +61,7 @@ _BWD_CONFIGS = (
     (128, 32768, "f32"),  # vectorized, Y-only buffering -- middle tier
     (256, 32768, "bf16"),  # vectorized, Y-only buffering -- middle tier
     (64, 65536, "bf16"),  # vectorized, no buffering -- widest tier
+    (1024, 65536, "bf16"),  # widest tier at realistic occupancy (benchmarked shape)
 )
 
 


### PR DESCRIPTION
## Summary

Adds Softmax backward to `scripts/run_benchmark.sh` so it appears on the CI performance
dashboard, with one row per register-residency tier. Follow-up to #1019, which landed the
kernel with no benchmark coverage.

## Motivation

Nothing observes the backward kernel after merge today. Two reasons it is worth tracking:

- **Register residency is selected by `N`.** `softmax_bwd_buffered_operands` picks between
  full buffering, Y-only buffering, and no buffering, so a change in register pressure can
  regress one tier and leave the others flat. A single representative row would miss that,
  which is why this adds three.
- **#1002 is open.** The `exp2` fastmath flag is dropped and the op lowers through OCML on
  gfx950, inflating instruction count and VGPR pressure. When that is fixed, a baseline is
  what turns "it should be faster now" into a number.

The forward kernel is already tracked, so a fwd/bwd pair also makes a compiler-driven
regression attributable to one side.

## Changes

`scripts/run_benchmark.sh` only — the standard op registration (shape list, usage text,
alias normalization, default enable, `--only` handling, `--list`, driver loop), mirroring the
existing `softmax` block.

Plus one line in `tests/kernels/test_softmax_bwd.py`, explained below.

**No dashboard change is required.** `.github/dashboard/ingest/parse_bench.py` parses
whatever rows the benchmark table emits (`^op shape dtype TB/s TFLOPS$`) rather than a fixed
op list, so an op reaches the dashboard purely by appearing in the driver's output.

**No test-harness change is required either.** #1019 already gave the backward test the same
stdout contract as the forward one: `ROCDSL_SOFTMAX_BWD_SHAPES` override, a single
`Bandwidth: X GB/s` line per config, a `__main__` entry point, and `SystemExit(1)` on
failure.

### Shape selection: M is chosen for occupancy, not just tier coverage

My first attempt reused the widest-tier shape straight from the correctness sweep,
`64x65536`. Measuring it made that a bad choice — 5 runs each on a gfx950 (MI355X) confirmed
idle across a 15-sample window before the run:

| shape | tier | blocks/CU | median TB/s | run-to-run spread |
|---|---|---|---|---|
| `1024x8192` | fully buffered | 4.0 | 5.899 | 0.9% |
| `256x32768` | Y-only buffering | 1.0 | 3.717 | 0.5% |
| `64x65536` | no buffering | **0.25** | 1.574 | **24.6%** |
| `1024x65536` | no buffering | 4.0 | 3.405 | 1.0% |

At `M=64` the grid fills a quarter of the 256 CUs, so the row measures launch and occupancy
jitter rather than the kernel. A row that swings 24% between consecutive runs on an idle
device would flap the dashboard red at its `-3%` threshold and train people to ignore it —
worse than not tracking the tier at all.

`1024x65536` exercises the same no-buffering tier at 1.0% spread, so the driver uses that.
It was not in `_BWD_CONFIGS`, so this PR adds it there too: every benchmarked shape should
also be a tested shape. The cost is nil (26 tests in 3.4 s, versus 25 in 4.0 s before).

## Performance

Not a performance change — this only adds measurement. Output on gfx950:

```
op                     shape                              dtype            TB/s     TFLOPS
softmax                32768x8192                         bf16            5.942          -
softmax_bwd            1024x8192                          bf16            5.888          -
softmax_bwd            256x32768                          bf16            4.654          -
softmax_bwd            1024x65536                         bf16            3.443          -
```

CI cost is roughly 3 shapes x (compile + 110 iterations); all three are smaller in total
elements than the single existing forward row.

Under #924's policy these land as report-only until thresholds are calibrated, which is the
right default. I have noted the incoming rows on that issue.

## Testing

- [x] Unit tests added/updated
- [x] Performance benchmarks run
- [ ] Tested on MI300X

- `bash -n scripts/run_benchmark.sh`; `--list` shows `softmax_bwd`
- `run_benchmark.sh --only softmax_bwd` and `--only softmax,softmax_bwd`: 4/4 rows emitted,
  correct ordering, no failures
- `--output_csv` produces well-formed rows for `compare_benchmark.py`
- Fed the real driver output through `parse_bench.parse_log()`: all three rows ingest as
  `metric=TB/s, status=ok`
- `.github/dashboard/ingest` suites: 21 passed
- `tests/kernels/test_softmax_bwd.py`: 26 passed, 1 deselected
- `scripts/check_python_style.sh --fix --include-local`: clean

### Not verified here

- **gfx942 and Navi.** This machine has 8x MI355X only. The shape choice above is calibrated
  against gfx950's 256 CUs; on a different CU count the occupancy argument shifts, though
  `M=1024` stays comfortably occupied on any current part.
- A full default `run_benchmark.sh` run (all ops) was not executed; `softmax_bwd` registration
  follows the identical pattern as the seven existing ops and was exercised through `--only`.

## Dependencies

- [x] No new third-party dependencies added

## Breaking Changes

None. New op is additive; every existing row, shape and output format is unchanged.

## Pre-existing bug found while verifying (not fixed here)

`--only <list>` silently discards every flag after it. The branch does `set -- $1` to split
the comma list, which replaces the whole positional argument list:

```console
$ bash scripts/run_benchmark.sh --output_csv /tmp/a.csv --only softmax_bwd
$ ls /tmp/a.csv        # written

$ bash scripts/run_benchmark.sh --only softmax_bwd --output_csv /tmp/b.csv
$ ls /tmp/b.csv        # missing, no error
```

`--only=<list>` has the same shape. Anyone generating a baseline CSV with the flags in that
order gets no CSV and no diagnostic. Out of scope for this PR; happy to send a separate
one-line fix (save the flag list before `set --`) if useful.
