### PR TITLE
[ROCDL] Accept IntegerAttr in the wait-counter for backward compatibility

### DIFF
--- a/python/flydsl/expr/rocdl/utils.py
+++ b/python/flydsl/expr/rocdl/utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 FlyDSL Project Contributors
 
+from ..._mlir import ir
 from ..numeric import Numeric
 
 
@@ -13,9 +14,16 @@ def normalize_s_waitcnt_field(name, value, maximum):
     Wait counters are encoded into an instruction's immediate field, so the
     value has to be known at compile time; a run-time ``Integer`` is rejected
     rather than silently materialised as a constant.
+
+    An ``ir.IntegerAttr`` is also accepted: the ODS-generated ROCDL builders
+    these wrappers shadow take ``Union[int, IntegerAttr]``, so callers written
+    against the raw builders keep working.
     """
     if value is None:
         return maximum
+
+    if isinstance(value, ir.IntegerAttr):
+        value = value.value
 
     if isinstance(value, Numeric):
         if not value.is_static():


### PR DESCRIPTION
`flydsl.expr.rocdl` re-exports every ODS-generated ROCDL builder, and the wait-counter operands of those builders are typed `Union[int, IntegerAttr]`. The DSL wrappers in `universal.py` shadow some of those names (`s_waitcnt` today, `wait_asyncmark` next), so callers that used to pass an `IntegerAttr` to the raw builder started getting a `TypeError`.

Let `normalize_s_waitcnt_field` unwrap an `IntegerAttr`; a non-integer attribute still hits the existing `TypeError`.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
