### PR TITLE
[FlyToROCDL] Honor fly pointer alignment in ptr.load/ptr.store lowering

### DIFF
--- a/kernels/attention/flash_attn_generic.py
+++ b/kernels/attention/flash_attn_generic.py
@@ -21,11 +21,9 @@ import os
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir import ir
 from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import const_expr, gpu, range_constexpr, rocdl
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
-from flydsl.utils.smem_allocator import SmemAllocator
 from kernels.attention.flash_attn_utils import (
     GenericFlashAttnContext,
     GenericGemmHelper,
@@ -39,6 +37,7 @@ from kernels.attention.flash_attn_utils import (
     _waitcnt_vm_n,
     scf_if_dispatch,
 )
+from kernels.common.kernels_common import dtype_to_elem_type
 
 
 def build_flash_attn_func_module_primary(
@@ -236,13 +235,11 @@ def build_flash_attn_func_module_primary(
     if sm_scale is None:
         sm_scale = 1.0 / host_math.sqrt(head_dim)
 
-    allocator = SmemAllocator(
-        None,
-        arch=gpu_arch,
-        global_sym_name=f"flash_attn_func_smem_{traits.PATH_TAG}",
-    )
-    lds_kv_offset = allocator._align(allocator.ptr, 16)
-    allocator.ptr = lds_kv_offset + traits.LDS_KV_TOTAL_SIZE * 2
+    _lds_elem_dtype = dtype_to_elem_type(traits.DTYPE_STR)
+
+    @fx.struct
+    class SharedStorage:
+        kv: fx.Array[_lds_elem_dtype, traits.LDS_KV_TOTAL_SIZE, 16]
 
     @flyc.kernel(known_block_size=[traits.BLOCK_SIZE, 1, 1])
     def flash_attn_generic_kernel(
@@ -260,7 +257,7 @@ def build_flash_attn_func_module_primary(
     ):
         # Make shape/mode traits visible to the JIT cache key.
         _ = _flash_attn_generic_cache_tag
-        ctx = GenericFlashAttnContext(traits, K, V, seq_len, seq_len_kv, allocator, lds_kv_offset)
+        ctx = GenericFlashAttnContext(traits, K, V, seq_len, seq_len_kv)
         ctx.init_types_and_pointers()
         gemm_helper = GenericGemmHelper(ctx)
         softmax_helper = GenericSoftmaxHelper(ctx)
@@ -270,7 +267,7 @@ def build_flash_attn_func_module_primary(
         store_helper = GenericStoreHelper(ctx)
 
         ctx.init_sequence_indices()
-        ctx.init_lds_view()
+        ctx.init_lds_view(SharedStorage)
         ctx.init_thread_mapping()
         ctx.init_block_mapping()
         ctx.init_sequence_lengths(CuSeqQ, CuSeqKv)
@@ -525,11 +522,6 @@ def build_flash_attn_func_module_primary(
         seq_len_kv: fx.Int32,
         stream: fx.Stream = fx.Stream(None),
     ):
-        allocator.finalized = False
-        ctx = CompilationContext.get_current()
-        with ir.InsertionPoint(ctx.gpu_module_body):
-            allocator.finalize()
-
         bs_idx = fx.Index(batch_size)
         sl_idx = fx.Index(seq_len)
         num_q_tiles = (sl_idx + traits.BLOCK_M - 1) // traits.BLOCK_M

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -25,7 +25,6 @@ from flydsl.expr import arith, const_expr, gpu, range_constexpr, rocdl
 from flydsl.expr.typing import T
 from flydsl.expr.typing import Vector as Vec
 from flydsl.expr.utils.arith import _to_raw as as_mlir_value
-from flydsl.utils.smem_allocator import SmemPtr
 from kernels.common import buffer_ops
 from kernels.common.kernels_common import dtype_to_elem_type
 
@@ -2050,14 +2049,12 @@ def _make_dualwave_swp_fp8_traits(
 class GenericFlashAttnContext:
     """Runtime setup state for the generic flash-attention kernel."""
 
-    def __init__(self, traits, K, V, seq_len, seq_len_kv, allocator, lds_kv_offset):
+    def __init__(self, traits, K, V, seq_len, seq_len_kv):
         self.traits = traits
         self.K = K
         self.V = V
         self.seq_len = seq_len
         self.seq_len_kv = seq_len_kv
-        self.allocator = allocator
-        self.lds_kv_offset = lds_kv_offset
 
     def init_types_and_pointers(self):
         traits = self.traits
@@ -2081,14 +2078,10 @@ class GenericFlashAttnContext:
         self.seq_len_v = fx.Index(self.seq_len)
         self.seq_len_kv_v = fx.Index(self.seq_len_kv)
 
-    def init_lds_view(self):
-        self.base_ptr = self.allocator.get_base()
-        self.lds_kv = SmemPtr(
-            self.base_ptr,
-            self.lds_kv_offset,
-            self.elem_type,
-            shape=(self.traits.LDS_KV_TOTAL_SIZE,),
-        ).get()
+    def init_lds_view(self, shared_storage):
+        lds = fx.SharedAllocator().allocate(shared_storage).peek()
+        self.lds_kv = lds.kv.ptr
+        self.lds_kv_offset = fx.Index(fx.ptrtoint(lds.kv.ptr))
 
     def init_thread_mapping(self):
         traits = self.traits
@@ -2393,7 +2386,7 @@ class GenericKvGmemToLdsLoader:
                     g_idx = self.global_idx(row_idx, col)
                     lds_row = row + row_offset
                     lds_idx = k_base + lds_row * traits.K_STRIDE + self.k_swizzle(lds_row, col)
-                    Vec(self.load_f16xN(ctx.k_ptr, g_idx)).store(lds_kv, [lds_idx])
+                    fx.ptr_store(self.load_f16xN(ctx.k_ptr, g_idx), lds_kv + fx.Int64(lds_idx))
             else:
                 lds_row = row + row_offset
                 lds_idx = k_base + lds_row * traits.K_STRIDE + self.k_swizzle(lds_row, col)
@@ -2401,7 +2394,7 @@ class GenericKvGmemToLdsLoader:
                     vec = self.load_vectorized_k(ctx.k_ptr, pid, self.sigma_kv(lds_row), col)
                 else:
                     vec = self.load_f16xN(ctx.k_ptr, self.global_idx(row_idx, col))
-                Vec(vec).store(lds_kv, [lds_idx])
+                fx.ptr_store(vec, lds_kv + fx.Int64(lds_idx))
 
     def coop_load_k_global(self, tile_start):
         ctx = self.ctx
@@ -2428,24 +2421,24 @@ class GenericKvGmemToLdsLoader:
                 if ctx.load_row_in_batch < fx.Index(traits.BLOCK_N):
                     lds_row = ctx.load_row_in_batch + row_offset
                     lds_idx = k_base + lds_row * traits.K_STRIDE + self.k_swizzle(lds_row, ctx.load_col_base)
-                    Vec(vecs[batch]).store(ctx.lds_kv, [lds_idx])
+                    fx.ptr_store(vecs[batch], ctx.lds_kv + fx.Int64(lds_idx))
             else:
                 lds_row = ctx.load_row_in_batch + row_offset
                 lds_idx = k_base + lds_row * traits.K_STRIDE + self.k_swizzle(lds_row, ctx.load_col_base)
-                Vec(vecs[batch]).store(ctx.lds_kv, [lds_idx])
+                fx.ptr_store(vecs[batch], ctx.lds_kv + fx.Int64(lds_idx))
 
     def _v_store_to_lds(self, v_base, lds_row, vec):
         ctx = self.ctx
         traits = ctx.traits
         if const_expr(traits.USE_HW_TR):
             lds_idx = v_base + lds_row * traits.V_STRIDE + ctx.load_col_base
-            Vec(vec).store(ctx.lds_kv, [lds_idx])
+            fx.ptr_store(vec, ctx.lds_kv + fx.Int64(lds_idx))
         else:
             for _e in range_constexpr(traits.VEC_WIDTH):
                 elem = Vec(vec)[_e]
                 vt_d = ctx.load_col_base + _e
                 vt_idx = v_base + vt_d * traits.VT_STRIDE + lds_row
-                Vec.from_elements([elem], ctx.elem_dtype).store(ctx.lds_kv, [vt_idx])
+                fx.ptr_store(Vec.from_elements([elem], ctx.elem_dtype), ctx.lds_kv + fx.Int64(vt_idx))
 
     def coop_load_v(self, tile_start, buf_id=0):
         """Cooperative V load, storing row-major or transposed per USE_HW_TR."""
@@ -2517,7 +2510,7 @@ class GenericKvGmemToLdsLoader:
                     + ng * fx.Index(traits.VEC_V_D128)
                     + (d % fx.Index(8)) * fx.Index(8)
                 )
-                Vec(vecs[j]).store(ctx.lds_kv, [dst])
+                fx.ptr_store(vecs[j], ctx.lds_kv + fx.Int64(dst))
             return
         for batch in range_constexpr(traits.NUM_BATCHES_KV):
             row_offset = batch * traits.ROWS_PER_BATCH_LOAD
@@ -2567,10 +2560,10 @@ class GenericKvGmemToLdsLoader:
             dh = dl + fx.Index(1)
             lo_01 = rocdl.perm_b32(b, a, ctx.vp_sel_lo)
             v_lo = Vec.from_elements([lo_01], fx.Int32).bitcast(ctx.elem_dtype)
-            v_lo.store(ctx.lds_kv, [v_base + dl * fx.Index(traits.VT_STRIDE) + ctx.vp_row_base])
+            fx.ptr_store(v_lo, ctx.lds_kv + fx.Int64(v_base + dl * fx.Index(traits.VT_STRIDE) + ctx.vp_row_base))
             hi_01 = rocdl.perm_b32(b, a, ctx.vp_sel_hi)
             v_hi = Vec.from_elements([hi_01], fx.Int32).bitcast(ctx.elem_dtype)
-            v_hi.store(ctx.lds_kv, [v_base + dh * fx.Index(traits.VT_STRIDE) + ctx.vp_row_base])
+            fx.ptr_store(v_hi, ctx.lds_kv + fx.Int64(v_base + dh * fx.Index(traits.VT_STRIDE) + ctx.vp_row_base))
 
     def init_dma_nomajor(self):
         # KV_VECTORIZED V: no-major GM->LDS DMA constants (one aligned v8 per lane).
@@ -2578,7 +2571,7 @@ class GenericKvGmemToLdsLoader:
         traits = ctx.traits
         self._v_dma_base_i64 = fx.Int64(buffer_ops.extract_base_index(ctx.V, address_space=1))
         self._v_dma_page_bytes = fx.Int64(traits.PAGE_STRIDE_VEC * 2)
-        self._v_dma_lds_base = buffer_ops.extract_base_index(ctx.lds_kv, address_space=3)
+        self._v_dma_lds_base = ctx.lds_kv_offset
         self._v_dma_sz = fx.Int32(16)
         self._v_dma_z = fx.Int32(0)
         self._v_dma_aux = fx.Int32(1)
@@ -2620,7 +2613,7 @@ class GenericKvGmemToLdsLoader:
         traits = ctx.traits
         self.DMA_BYTES = 4 if traits.ENABLE_GFX942_DMA else 16
         self.DMA_BATCH_BYTES = traits.BLOCK_SIZE * self.DMA_BYTES
-        self.lds_kv_base_idx = buffer_ops.extract_base_index(ctx.lds_kv, address_space=3)
+        self.lds_kv_base_idx = ctx.lds_kv_offset
         self._dma_size = fx.Int32(self.DMA_BYTES)
         self._dma_soff = fx.Int32(0)
         self._dma_off = fx.Int32(0)
@@ -2755,8 +2748,8 @@ class GenericKvLdsToVgprLoader:
         lo = [None] * traits.K_STEPS_QK
         hi = [None] * traits.K_STEPS_QK
         for p in range_constexpr(depth):
-            lo[p] = Vec.load(ctx.mfma_pack_type, ctx.lds_kv, [_idx(p, False)]).ir_value()
-            hi[p] = Vec.load(ctx.mfma_pack_type, ctx.lds_kv, [_idx(p, True)]).ir_value()
+            lo[p] = fx.ptr_load(ctx.lds_kv + fx.Int64(_idx(p, False)), result_type=ctx.mfma_pack_type).ir_value()
+            hi[p] = fx.ptr_load(ctx.lds_kv + fx.Int64(_idx(p, True)), result_type=ctx.mfma_pack_type).ir_value()
         if const_expr(traits.ENABLE_GFX942_VEC_K or traits.ENABLE_GFX942_KV_GPFETCH):
             rocdl.sched_group_barrier(rocdl.mask_dsrd, depth * 2, 0)
         self._k_idx = _idx
@@ -2765,8 +2758,8 @@ class GenericKvLdsToVgprLoader:
 
     def load_k_pack_at(self, ks):
         ctx = self.ctx
-        lo = Vec.load(ctx.mfma_pack_type, ctx.lds_kv, [self._k_idx(ks, False)]).ir_value()
-        hi = Vec.load(ctx.mfma_pack_type, ctx.lds_kv, [self._k_idx(ks, True)]).ir_value()
+        lo = fx.ptr_load(ctx.lds_kv + fx.Int64(self._k_idx(ks, False)), result_type=ctx.mfma_pack_type).ir_value()
+        hi = fx.ptr_load(ctx.lds_kv + fx.Int64(self._k_idx(ks, True)), result_type=ctx.mfma_pack_type).ir_value()
         return lo, hi
 
     def read_v_pack(self, step_idx, v_base):
@@ -2785,8 +2778,8 @@ class GenericKvLdsToVgprLoader:
             )
             lo_off = dc * (traits.D_CHUNK // 8) * traits.VEC_V_LINE + pks * (traits.PV_K_STEP // 8) * traits.VEC_V_D128
             hi_off = lo_off + (traits.K_SUB_N // 8) * traits.VEC_V_D128
-            vl = Vec.load(ctx.mfma_pack_type, ctx.lds_kv, [v_lane_base + fx.Index(lo_off)])
-            vh = Vec.load(ctx.mfma_pack_type, ctx.lds_kv, [v_lane_base + fx.Index(hi_off)])
+            vl = fx.ptr_load(ctx.lds_kv + fx.Int64(v_lane_base + fx.Index(lo_off)), result_type=ctx.mfma_pack_type)
+            vh = fx.ptr_load(ctx.lds_kv + fx.Int64(v_lane_base + fx.Index(hi_off)), result_type=ctx.mfma_pack_type)
             return vl, vh
         if const_expr(traits.USE_HW_TR):
             d_col = fx.Index(dc * traits.D_CHUNK) + ctx.tr_col_half * 16 + ctx.tr_col_sub * 4
@@ -2809,8 +2802,8 @@ class GenericKvLdsToVgprLoader:
         k_col = fx.Index(pks * traits.PV_K_STEP) + ctx.lane_div_32 * 4
         v_lo_idx = v_base + d_pos * traits.VT_STRIDE + k_col
         v_hi_idx = v_lo_idx + fx.Index(traits.K_SUB_N)
-        vl = Vec.load(ctx.v4f16_type, ctx.lds_kv, [v_lo_idx])
-        vh = Vec.load(ctx.v4f16_type, ctx.lds_kv, [v_hi_idx])
+        vl = fx.ptr_load(ctx.lds_kv + fx.Int64(v_lo_idx), result_type=ctx.v4f16_type)
+        vh = fx.ptr_load(ctx.lds_kv + fx.Int64(v_hi_idx), result_type=ctx.v4f16_type)
         return vl, vh
 
 

--- a/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
+++ b/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
@@ -412,7 +412,8 @@ public:
     } else {
       ptr = applySwizzleOnPtr(rewriter, loc, cast<TypedValue<LLVM::LLVMPointerType>>(ptr),
                               flyPtrTy.getSwizzle());
-      Value loaded = LLVM::LoadOp::create(rewriter, loc, loadTy, ptr);
+      unsigned align = flyPtrTy.getAlignment().getAlignment();
+      Value loaded = LLVM::LoadOp::create(rewriter, loc, loadTy, ptr, align);
       rewriter.replaceOp(op, loaded);
       return success();
     }
@@ -458,7 +459,8 @@ public:
     } else {
       ptr = applySwizzleOnPtr(rewriter, loc, cast<TypedValue<LLVM::LLVMPointerType>>(ptr),
                               flyPtrTy.getSwizzle());
-      LLVM::StoreOp::create(rewriter, loc, value, ptr);
+      unsigned align = flyPtrTy.getAlignment().getAlignment();
+      LLVM::StoreOp::create(rewriter, loc, value, ptr, align);
       rewriter.eraseOp(op);
       return success();
     }

--- a/tests/mlir/Conversion/memref_ops.mlir
+++ b/tests/mlir/Conversion/memref_ops.mlir
@@ -16,7 +16,7 @@ func.func @test_memref_load(%mem: !fly.memref<f32, global, 32:1>) -> f32 {
   %idx = fly.make_int_tuple() : () -> !fly.int_tuple<5>
   // CHECK: %[[C5:.*]] = arith.constant 5 : i32
   // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[PTR]][%[[C5]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f32
-  // CHECK: %[[VAL:.*]] = llvm.load %[[GEP]] : !llvm.ptr<1> -> f32
+  // CHECK: %[[VAL:.*]] = llvm.load %[[GEP]] {alignment = 4 : i64} : !llvm.ptr<1> -> f32
   %val = fly.memref.load(%mem, %idx) : (!fly.memref<f32, global, 32:1>, !fly.int_tuple<5>) -> f32
   // CHECK: return %[[VAL]]
   return %val : f32
@@ -28,7 +28,7 @@ func.func @test_memref_store(%mem: !fly.memref<f32, global, 32:1>, %val: f32) {
   %idx = fly.make_int_tuple() : () -> !fly.int_tuple<3>
   // CHECK: %[[C3:.*]] = arith.constant 3 : i32
   // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[PTR]][%[[C3]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f32
-  // CHECK: llvm.store %[[VAL]], %[[GEP]] : f32, !llvm.ptr<1>
+  // CHECK: llvm.store %[[VAL]], %[[GEP]] {alignment = 4 : i64} : f32, !llvm.ptr<1>
   fly.memref.store(%val, %mem, %idx) : (f32, !fly.memref<f32, global, 32:1>, !fly.int_tuple<3>) -> ()
   return
 }
@@ -39,7 +39,7 @@ func.func @test_memref_load_f16_shared(%mem: !fly.memref<f16, shared, (16,32):(1
   %idx = fly.make_int_tuple() : () -> !fly.int_tuple<10>
   // CHECK: %[[C10:.*]] = arith.constant 10 : i32
   // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[PTR]][%[[C10]]] : (!llvm.ptr<3>, i32) -> !llvm.ptr<3>, f16
-  // CHECK: %[[VAL:.*]] = llvm.load %[[GEP]] : !llvm.ptr<3> -> f16
+  // CHECK: %[[VAL:.*]] = llvm.load %[[GEP]] {alignment = 2 : i64} : !llvm.ptr<3> -> f16
   %val = fly.memref.load(%mem, %idx) : (!fly.memref<f16, shared, (16,32):(1,16)>, !fly.int_tuple<10>) -> f16
   // CHECK: return %[[VAL]]
   return %val : f16
@@ -57,7 +57,7 @@ func.func @test_memref_load_f16_shared(%mem: !fly.memref<f16, shared, (16,32):(1
 // CHECK-LABEL: @test_load_vec
 // CHECK-SAME: (%[[PTR:.*]]: !llvm.ptr<5>)
 func.func @test_load_vec(%mem: !fly.memref<f32, register, 4:1>) -> vector<4xf32> {
-  // CHECK: %[[VEC:.*]] = llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: %[[VEC:.*]] = llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   %vec = fly.memref.load_vec(%mem) : (!fly.memref<f32, register, 4:1>) -> vector<4xf32>
   // CHECK: return %[[VEC]]
   return %vec : vector<4xf32>
@@ -84,42 +84,42 @@ func.func @test_load_vec_3d(%mem: !fly.memref<f32, register, (3, 4, 2):(1, 16, 4
   // Chunk 0: offset=0
   // CHECK: %[[C0:.*]] = arith.constant 0 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C0]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<3xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<3xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [0]
   // Chunk 1: offset=16
   // CHECK: %[[C16:.*]] = arith.constant 16 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C16]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<3xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<3xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [3]
   // Chunk 2: offset=32
   // CHECK: %[[C32:.*]] = arith.constant 32 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C32]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<3xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<3xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [6]
   // Chunk 3: offset=48
   // CHECK: %[[C48:.*]] = arith.constant 48 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C48]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<3xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<3xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [9]
   // Chunk 4: offset=4 (second iteration of dim-2)
   // CHECK: %[[C4:.*]] = arith.constant 4 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C4]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<3xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<3xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [12]
   // Chunk 5: offset=20
   // CHECK: %[[C20:.*]] = arith.constant 20 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C20]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<3xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<3xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [15]
   // Chunk 6: offset=36
   // CHECK: %[[C36:.*]] = arith.constant 36 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C36]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<3xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<3xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [18]
   // Chunk 7: offset=52
   // CHECK: %[[C52:.*]] = arith.constant 52 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C52]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<3xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<3xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [21]
   %vec = fly.memref.load_vec(%mem) : (!fly.memref<f32, register, (3, 4, 2):(1, 16, 4)>) -> vector<24xf32>
   return %vec : vector<24xf32>
@@ -132,7 +132,7 @@ func.func @test_store_vec_3d(%mem: !fly.memref<f32, register, (3, 4, 2):(1, 16, 
   // CHECK: %[[C0:.*]] = arith.constant 0 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C0]]]
   // CHECK: vector.extract_strided_slice %[[VEC]] {offsets = [0], sizes = [3]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : vector<3xf32>, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<3xf32>, !llvm.ptr<5>
   // Chunk 4: offset=4 (verify column-major: dim-1 exhausted, dim-2 increments)
   // CHECK: arith.constant 16
   // CHECK: arith.constant 32
@@ -140,7 +140,7 @@ func.func @test_store_vec_3d(%mem: !fly.memref<f32, register, (3, 4, 2):(1, 16, 
   // CHECK: %[[C4:.*]] = arith.constant 4 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C4]]]
   // CHECK: vector.extract_strided_slice %[[VEC]] {offsets = [12], sizes = [3]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : vector<3xf32>, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<3xf32>, !llvm.ptr<5>
   fly.memref.store_vec(%vec, %mem) : (vector<24xf32>, !fly.memref<f32, register, (3, 4, 2):(1, 16, 4)>) -> ()
   return
 }
@@ -158,32 +158,32 @@ func.func @test_load_vec_nested(%mem: !fly.memref<f32, register, ((4,2),3):((1,4
   // Chunk 0: offset=0
   // CHECK: %[[C0:.*]] = arith.constant 0 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C0]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [0]
   // Chunk 1: offset=4
   // CHECK: %[[C4:.*]] = arith.constant 4 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C4]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [4]
   // Chunk 2: offset=16
   // CHECK: %[[C16:.*]] = arith.constant 16 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C16]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [8]
   // Chunk 3: offset=20
   // CHECK: %[[C20:.*]] = arith.constant 20 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C20]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [12]
   // Chunk 4: offset=32
   // CHECK: %[[C32:.*]] = arith.constant 32 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C32]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [16]
   // Chunk 5: offset=36
   // CHECK: %[[C36:.*]] = arith.constant 36 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C36]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [20]
   %vec = fly.memref.load_vec(%mem) : (!fly.memref<f32, register, ((4,2),3):((1,4),16)>) -> vector<24xf32>
   return %vec : vector<24xf32>
@@ -196,14 +196,14 @@ func.func @test_store_vec_nested(%mem: !fly.memref<f32, register, ((4,2),3):((1,
   // CHECK: %[[C0:.*]] = arith.constant 0 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C0]]]
   // CHECK: vector.extract_strided_slice %[[VEC]] {offsets = [0], sizes = [4]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : vector<4xf32>, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<4xf32>, !llvm.ptr<5>
   // Chunk 3: offset=20 (verify column-major: dim-1 first then dim-2)
   // CHECK: arith.constant 4
   // CHECK: arith.constant 16
   // CHECK: %[[C20:.*]] = arith.constant 20 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C20]]]
   // CHECK: vector.extract_strided_slice %[[VEC]] {offsets = [12], sizes = [4]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : vector<4xf32>, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<4xf32>, !llvm.ptr<5>
   fly.memref.store_vec(%vec, %mem) : (vector<24xf32>, !fly.memref<f32, register, ((4,2),3):((1,4),16)>) -> ()
   return
 }
@@ -214,22 +214,22 @@ func.func @test_store_vec_nested(%mem: !fly.memref<f32, register, ((4,2),3):((1,
 func.func @test_load_vec_stride1_dim1(%mem: !fly.memref<f32, register, (2,4,3):(24,1,8)>) -> vector<24xf32> {
   // 6 chunk loads (vecWidth=4, numChunks=6), col-major over restShape (2,3):
   //   (0,0)→offset 0, (1,0)→offset 24, (0,1)→offset 8, (1,1)→offset 32, (0,2)→offset 16, (1,2)→offset 40
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [0]
   // CHECK: arith.constant 24
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [4]
   // CHECK: arith.constant 8
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [8]
   // CHECK: arith.constant 32
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [12]
   // CHECK: arith.constant 16
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [16]
   // CHECK: arith.constant 40
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> vector<4xf32>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> vector<4xf32>
   // CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [20]
   // Permute: shape_cast [24]→[3,2,4], transpose [0,2,1]→[3,4,2], shape_cast→[24]
   // CHECK: vector.shape_cast %{{.*}} : vector<24xf32> to vector<3x2x4xf32>
@@ -249,22 +249,22 @@ func.func @test_store_vec_stride1_dim1(%mem: !fly.memref<f32, register, (2,4,3):
   // 6 chunk stores
   // CHECK: arith.constant 0
   // CHECK: vector.extract_strided_slice %[[PERM]] {offsets = [0], sizes = [4]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : vector<4xf32>, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<4xf32>, !llvm.ptr<5>
   // CHECK: arith.constant 24
   // CHECK: vector.extract_strided_slice %[[PERM]] {offsets = [4], sizes = [4]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : vector<4xf32>, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<4xf32>, !llvm.ptr<5>
   // CHECK: arith.constant 8
   // CHECK: vector.extract_strided_slice %[[PERM]] {offsets = [8], sizes = [4]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : vector<4xf32>, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<4xf32>, !llvm.ptr<5>
   // CHECK: arith.constant 32
   // CHECK: vector.extract_strided_slice %[[PERM]] {offsets = [12], sizes = [4]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : vector<4xf32>, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<4xf32>, !llvm.ptr<5>
   // CHECK: arith.constant 16
   // CHECK: vector.extract_strided_slice %[[PERM]] {offsets = [16], sizes = [4]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : vector<4xf32>, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<4xf32>, !llvm.ptr<5>
   // CHECK: arith.constant 40
   // CHECK: vector.extract_strided_slice %[[PERM]] {offsets = [20], sizes = [4]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : vector<4xf32>, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<4xf32>, !llvm.ptr<5>
   fly.memref.store_vec(%vec, %mem) : (vector<24xf32>, !fly.memref<f32, register, (2,4,3):(24,1,8)>) -> ()
   return
 }
@@ -277,22 +277,22 @@ func.func @test_store_vec_stride1_dim1(%mem: !fly.memref<f32, register, (2,4,3):
 func.func @test_load_vec_scalar(%mem: !fly.memref<f32, register, (2,3):(4,8)>) -> vector<6xf32> {
   // CHECK: %[[C0:.*]] = arith.constant 0 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C0]]]
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> f32
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> f32
   // CHECK: vector.insert %{{.*}}, %{{.*}} [0]
   // CHECK: arith.constant 4
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> f32
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> f32
   // CHECK: vector.insert %{{.*}}, %{{.*}} [1]
   // CHECK: arith.constant 8
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> f32
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> f32
   // CHECK: vector.insert %{{.*}}, %{{.*}} [2]
   // CHECK: arith.constant 12
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> f32
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> f32
   // CHECK: vector.insert %{{.*}}, %{{.*}} [3]
   // CHECK: arith.constant 16
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> f32
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> f32
   // CHECK: vector.insert %{{.*}}, %{{.*}} [4]
   // CHECK: arith.constant 20
-  // CHECK: llvm.load %{{.*}} : !llvm.ptr<5> -> f32
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<5> -> f32
   // CHECK: vector.insert %{{.*}}, %{{.*}} [5]
   %vec = fly.memref.load_vec(%mem) : (!fly.memref<f32, register, (2,3):(4,8)>) -> vector<6xf32>
   return %vec : vector<6xf32>
@@ -304,22 +304,22 @@ func.func @test_store_vec_scalar(%mem: !fly.memref<f32, register, (2,3):(4,8)>, 
   // CHECK: %[[C0:.*]] = arith.constant 0 : i32
   // CHECK: llvm.getelementptr %[[PTR]][%[[C0]]]
   // CHECK: vector.extract %[[VEC]][0]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : f32, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : f32, !llvm.ptr<5>
   // CHECK: arith.constant 4
   // CHECK: vector.extract %[[VEC]][1]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : f32, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : f32, !llvm.ptr<5>
   // CHECK: arith.constant 8
   // CHECK: vector.extract %[[VEC]][2]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : f32, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : f32, !llvm.ptr<5>
   // CHECK: arith.constant 12
   // CHECK: vector.extract %[[VEC]][3]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : f32, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : f32, !llvm.ptr<5>
   // CHECK: arith.constant 16
   // CHECK: vector.extract %[[VEC]][4]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : f32, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : f32, !llvm.ptr<5>
   // CHECK: arith.constant 20
   // CHECK: vector.extract %[[VEC]][5]
-  // CHECK: llvm.store %{{.*}}, %{{.*}} : f32, !llvm.ptr<5>
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : f32, !llvm.ptr<5>
   fly.memref.store_vec(%vec, %mem) : (vector<6xf32>, !fly.memref<f32, register, (2,3):(4,8)>) -> ()
   return
 }


### PR DESCRIPTION
PtrLoadOpLowering / PtrStoreOpLowering created LLVM load/store without an alignment operand, so LLVM assumed the loaded type's natural alignment (e.g. 16B for vector<8xf16>). 

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
