### PR TITLE
[Ext][Coop] Add cooperative warp- and block-scope collectives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ FlyDSL/
 │   ├── system/                    # Cross-cutting compile/system tests
 │   ├── mlir/                      # FileCheck tests driven by scripts/run_tests.sh
 │   └── python/examples/           # AOT compile/cache pytest tests (aot_example.py)
-├── examples/                      # 01-vectorAdd, 02-tiledCopy, 03-tiledMma, 04-preshuffle_gemm
+├── examples/                      # numbered standalone scripts (01-vectorAdd ...)
+│   └── extension/<library>/       # one folder per extension library (extension/coop/)
 ├── scripts/                       # build, test, benchmark, wheel, debug helper scripts
 ├── docs/                          # Sphinx documentation source
 ├── thirdparty/                    # Vendored dlpack and tvm-ffi

--- a/examples/extension/coop/01-warp_collectives.py
+++ b/examples/extension/coop/01-warp_collectives.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Warp-scope ``warp_reduce`` / ``warp_exclusive_scan`` without any shared memory.
+
+The kernel below computes, for every lane, where its element would go if the
+warp compacted its positive elements, and how many the warp keeps in total.
+
+  1. **The width is named rather than inherited.** Left alone, both collectives
+     span a full warp, which is 64 lanes on CDNA and 32 on RDNA — so a kernel
+     that says nothing computes a different thing on each. Asking for 32 pins
+     the group to one size on either, which is what lets this one source run on
+     both. On a wave64 target the block is then half a wave, and the named width
+     is also what keeps the fold off the lanes that were never launched.
+  2. **Every lane gets the answer.** Both collectives are all-to-all, so the
+     result needs no follow-up broadcast.
+"""
+
+import torch
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+
+WIDTH = 32
+
+
+@flyc.kernel
+def warp_compaction_index(A: fx.Tensor, Rank: fx.Tensor, Total: fx.Tensor):
+    tid = fx.thread_idx.x
+    keep = (A[tid] > 0.0).select(1, 0)
+
+    Rank[tid] = fx.coop.warp_exclusive_scan(keep, fx.ReductionOp.ADD, width=WIDTH)
+    Total[tid] = fx.coop.warp_reduce(keep, fx.ReductionOp.ADD, width=WIDTH)
+
+
+@flyc.jit
+def warp_compaction(A: fx.Tensor, Rank: fx.Tensor, Total: fx.Tensor):
+    warp_compaction_index(A, Rank, Total).launch(grid=(1, 1, 1), block=(WIDTH, 1, 1))
+
+
+A = torch.randn(WIDTH, dtype=torch.float32, device="cuda")
+Rank = torch.zeros(WIDTH, dtype=torch.int32, device="cuda")
+Total = torch.zeros(WIDTH, dtype=torch.int32, device="cuda")
+
+warp_compaction(A, Rank, Total)
+torch.cuda.synchronize()
+
+keep = (A.cpu() > 0).to(torch.int32).reshape(-1, WIDTH)
+expected_rank = keep.cumsum(1, dtype=torch.int32) - keep
+expected_total = keep.sum(1, dtype=torch.int32, keepdim=True).expand(-1, WIDTH)
+
+if torch.equal(Rank.cpu().reshape(-1, WIDTH), expected_rank) and torch.equal(
+    Total.cpu().reshape(-1, WIDTH), expected_total
+):
+    print(f"PASS ({WIDTH} lanes, {int(expected_total[0, 0])} kept)")
+else:
+    print("FAIL")
+    raise SystemExit(1)

--- a/examples/extension/coop/02-block_scan.py
+++ b/examples/extension/coop/02-block_scan.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Stream compaction with ``fx.coop.BlockScan``.
+
+Keeping the positive elements of an array, in order and with no holes, is the
+problem an *exclusive* scan exists to solve: a thread that wants to append needs
+to know how many elements every thread in front of it is appending, and that is
+exactly ``exclusive`` over the per-element keep flags.
+
+  1. **Exclusive, not inclusive.** ``inclusive`` would count the thread's own
+     element, which is the slot after the one it wants.
+  2. **A ``Vector`` scans as a run of consecutive elements.** Thread ``t`` owns
+     items ``t * ITEMS .. t * ITEMS + ITEMS - 1`` of the block's sequence, so a
+     single call gives every one of them its own output slot -- the thread-local
+     scan and the block-wide one compose into one result.
+  3. **``BlockScan`` is specialized on what it folds**, which here is the keep
+     flags rather than the elements they belong to.
+"""
+
+import torch
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+
+BLOCK = 256
+ITEMS = 4
+N = BLOCK * ITEMS
+
+
+@flyc.kernel
+def compact_positive(A: fx.Pointer, Out: fx.Tensor):
+    block_scan = fx.coop.BlockScan[fx.Int32, fx.known_block_size()]
+    storage = fx.SharedAllocator().allocate(block_scan.SharedStorage).peek()
+
+    items = (A + fx.thread_idx.x * ITEMS).load(fx.Int32x4)
+    flags = (items > 0).select(1, 0)
+
+    # slots[i] == how many elements before this one are kept == where it goes.
+    slots = block_scan.exclusive(flags, fx.ReductionOp.ADD, storage=storage)
+
+    for i in fx.range_constexpr(ITEMS):
+        if items[i] > 0:
+            Out[slots[i]] = items[i]
+
+
+@flyc.jit
+def compact(A: fx.Pointer, Out: fx.Tensor):
+    compact_positive(A, Out).launch(grid=(1, 1, 1), block=(BLOCK, 1, 1))
+
+
+A = torch.randint(-8, 8, (N,), dtype=torch.int32, device="cuda")
+Out = torch.zeros(N, dtype=torch.int32, device="cuda")
+
+compact(flyc.from_c_void_p(fx.Int32, A.data_ptr()), Out)
+torch.cuda.synchronize()
+
+expected = A.cpu()[A.cpu() > 0]
+if torch.equal(Out.cpu()[: expected.numel()], expected):
+    print(f"PASS ({expected.numel()} of {N} kept)")
+else:
+    print("FAIL")
+    raise SystemExit(1)

--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 FlyDSL Project Contributors
 
 import ctypes
+import enum
 import fcntl
 import hashlib
 import inspect
@@ -466,7 +467,7 @@ def _collect_closure_scalar_vals(func, visited_ids: Optional[Set[int]] = None) -
             val = cell.cell_contents
         except ValueError:
             continue
-        if isinstance(val, (int, float, bool, str, type(None), tuple)):
+        if isinstance(val, (int, float, bool, str, type(None), tuple, enum.Enum)):
             vals.append(f"{name}={val!r}")
         else:
             # Recurse into callable deps (KernelFunction, JitFunction, plain functions)

--- a/python/flydsl/expr/__init__.py
+++ b/python/flydsl/expr/__init__.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
+from typing import TYPE_CHECKING
+
 # isort: skip_file
 from .numeric import *
 from .typing import *
@@ -23,8 +25,13 @@ _BACKEND_MODULES = {
 }
 
 _LIBRARY_MODULES = {
+    "coop": "..extension.coop",
     "random": "..extension.random",
 }
+
+if TYPE_CHECKING:
+    from ..extension import coop as coop
+    from ..extension import random as random
 
 
 # lazy load backend subpackages and extension libraries

--- a/python/flydsl/expr/gpu.py
+++ b/python/flydsl/expr/gpu.py
@@ -38,6 +38,7 @@ from .typing import Array, PointerType, Tuple3D, as_ir_value
 
 __all__ = [
     "thread_idx",
+    "lane_id",
     "block_idx",
     "block_dim",
     "grid_dim",
@@ -63,12 +64,18 @@ def block_id(*args, **kwargs):
 
 
 @dsl_loc_tracing
+def lane_id():
+    """Index of the calling thread within its warp, in ``[0, num_warp_threads())``."""
+    return Int32(gpu.lane_id())
+
+
+@dsl_loc_tracing
 def barrier(*args, **kwargs):
     return gpu.barrier(*args, **kwargs)
 
 
 @dsl_loc_tracing
-@dsl_math_wrap_result
+@dsl_math_wrap_result(preserve_numeric_type=True)
 def shuffle(value, offset, width, mode="xor"):
     """Move ``value`` across lanes of a subgroup (warp) via ``gpu.shuffle``.
 

--- a/python/flydsl/extension/coop/__init__.py
+++ b/python/flydsl/extension/coop/__init__.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Cooperative algorithms over the threads of one kernel launch.
+
+Layout — one subpackage per scope, one module per algorithm::
+
+    coop/
+    ├── _common.py     glue both scopes need
+    ├── universal.py   the portable forms, dispatch turned off
+    ├── warp/
+    │   ├── reduce.py      warp_reduce
+    │   ├── scan.py        warp_inclusive_scan, warp_exclusive_scan, warp_scan,
+    │   │                      warp_scan_with_aggregate
+    │   └── rocdl.py       ROCm overrides for the above
+    └── block/
+        ├── _spec.py       shared [...] specialization machinery
+        ├── reduce.py      BlockReduce
+        └── scan.py        BlockScan
+
+That surface is flat — ``fx.coop.<name>`` — so callers never spell the scope
+out twice (``fx.coop.warp_reduce``, not ``fx.coop.warp.warp_reduce``).
+
+Those names are dispatched: on a target with an override, ``fx.coop.warp_reduce``
+is the target's. ``fx.coop.universal`` is the same surface with dispatch turned
+off — see :mod:`flydsl.extension.coop.universal`.
+"""
+
+from . import block as block
+from . import universal as universal
+from . import warp as warp
+from .block import *
+from .warp import *
+
+__all__ = [
+    # warp scope
+    "warp_reduce",
+    "warp_inclusive_scan",
+    "warp_exclusive_scan",
+    "warp_scan",
+    "warp_scan_with_aggregate",
+    # block scope
+    "BlockReduceAlgorithm",
+    "BlockReduce",
+    "BlockScanAlgorithm",
+    "BlockScan",
+]

--- a/python/flydsl/extension/coop/_common.py
+++ b/python/flydsl/extension/coop/_common.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Helpers shared by every cooperative algorithm, at any scope.
+
+Anything here is target-neutral and never dispatched: it is plain glue that
+warp- and block-scope algorithms both need. Algorithm logic belongs in the
+scope subpackages, not here.
+
+Every algorithm passes *op* straight through to these three, so the shape of a
+custom op is not baked into any signature above this file.
+"""
+
+from ...expr.arith import max as _max
+from ...expr.arith import min as _min
+from ...expr.gpu import num_warp_threads, thread_idx
+from ...expr.typing import ReductionOp, Vector
+
+
+def require_power_of_two(value, what):
+    if not isinstance(value, int) or value < 1 or (value & (value - 1)):
+        raise ValueError(f"{what} must be a power of two, got {value!r}")
+
+
+def resolve_warp_width(width, what):
+    if width is None:
+        width = num_warp_threads()
+    require_power_of_two(width, what)
+    return width
+
+
+def combine(op, lhs, rhs):
+    if op is ReductionOp.ADD:
+        return lhs + rhs
+    if op is ReductionOp.MUL:
+        return lhs * rhs
+    if op is ReductionOp.MAX:
+        return _max(lhs, rhs)
+    if op is ReductionOp.MIN:
+        return _min(lhs, rhs)
+    # TODO: support more binary reduction ops or lambda fns.
+    raise TypeError(f"unsupported ReductionOp, got {op!r}")
+
+
+def _representable_extreme(dtype, lowest):
+    """The lowest or highest value *dtype* can hold.
+
+    Floats use an infinity rather than the finite lowest/highest: a finite bound
+    is itself a legal input, so a lane holding it would be indistinguishable
+    from an empty one, and an infinity is exactly what ``fx.max`` / ``fx.min``
+    leave unchanged against anything else.
+    """
+    if dtype.is_float:
+        return dtype(float("-inf") if lowest else float("inf"))
+    if dtype.signed:
+        half = 1 << (dtype.width - 1)
+        return dtype(-half if lowest else half - 1)
+    return dtype(0 if lowest else (1 << dtype.width) - 1)
+
+
+def identity(op, dtype):
+    """The value that leaves *op* unchanged: ``identity(op, t) ⊕ x == x``.
+
+    An exclusive scan needs it for the first thread, which has nothing in front
+    of it.
+    """
+    if op is ReductionOp.ADD:
+        return dtype(0)
+    if op is ReductionOp.MUL:
+        return dtype(1)
+    if op is ReductionOp.MAX:
+        return _representable_extreme(dtype, lowest=True)
+    if op is ReductionOp.MIN:
+        return _representable_extreme(dtype, lowest=False)
+    # TODO: support more binary reduction ops
+    raise TypeError(f"unsupported ReductionOp, got {op!r}")
+
+
+def seed(value, op, init):
+    """Fold *init* into a scan result; ``None`` leaves it alone.
+
+    A scan puts :func:`identity` in front of the first thread, and
+    ``init ⊕ identity == init``, so seeding the inclusive and the exclusive
+    form is the same one operation applied to both.
+    """
+    return value if init is None else combine(op, init, value)
+
+
+def thread_partial(value, op):
+    """Fold a per-thread ``Vector`` down to one scalar; pass a scalar through."""
+    return value.reduce(op) if isinstance(value, Vector) else value
+
+
+def linear_thread_id(block_size):
+    """Linear thread index within the block, matching ``gpu.thread_id`` ordering."""
+    tid = thread_idx.x
+    if block_size is None:
+        return tid
+    dim_x, dim_y, dim_z = block_size
+    if dim_y > 1 or dim_z > 1:
+        tid = tid + thread_idx.y * dim_x + thread_idx.z * (dim_x * dim_y)
+    return tid

--- a/python/flydsl/extension/coop/_common.py
+++ b/python/flydsl/extension/coop/_common.py
@@ -23,9 +23,12 @@ def require_power_of_two(value, what):
 
 
 def resolve_warp_width(width, what):
+    warp_threads = num_warp_threads()
     if width is None:
-        width = num_warp_threads()
+        return warp_threads
     require_power_of_two(width, what)
+    if width > warp_threads:
+        raise ValueError(f"{what} must not exceed the target's {warp_threads}-lane warp, got {width}")
     return width
 
 

--- a/python/flydsl/extension/coop/block/__init__.py
+++ b/python/flydsl/extension/coop/block/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Block-scope cooperative algorithms."""
+
+from .reduce import *
+from .scan import *
+
+__all__ = [
+    # reduce
+    "BlockReduceAlgorithm",
+    "BlockReduce",
+    # scan
+    "BlockScanAlgorithm",
+    "BlockScan",
+]

--- a/python/flydsl/extension/coop/block/_spec.py
+++ b/python/flydsl/extension/coop/block/_spec.py
@@ -63,8 +63,8 @@ class BlockAlgorithmMeta(type):
             raise TypeError(f"expected a {cls._algorithms.__name__}, got {algorithm!r}")
         block_size = _block_shape(block_size)
         block_threads = block_size[0] * block_size[1] * block_size[2]
-        # A power-of-two product forces every dimension to be one too, so the
-        # dimensions need no separate check.
+        # A power-of-two product forces every dimension to be a power of two
+        # too, so the dimensions need no separate check.
         require_power_of_two(block_threads, "block_dim_x * block_dim_y * block_dim_z")
         # A block narrower than the wave leaves the wave's remaining lanes
         # unlaunched, and a cross-lane read of one of those is undefined — so

--- a/python/flydsl/extension/coop/block/_spec.py
+++ b/python/flydsl/extension/coop/block/_spec.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Shared specialization machinery for the block-scope collectives.
+
+Every block algorithm is specialized the same way and validates the same things,
+so the parsing lives here once and each algorithm supplies only what differs:
+its policy enum, its default policy, and the shared storage each policy needs.
+"""
+
+from ....compiler.backends import current_target
+from ....expr.gpu import num_warp_threads
+from .._common import require_power_of_two
+
+# Specializations are cached across algorithms, keyed by the root class as well
+# as the parameters, so two algorithms cannot collide on an identical key.
+_CACHE = {}
+
+
+def _block_shape(block_size):
+    """Normalize a block size to ``(x, y, z)``; a bare int means ``(x, 1, 1)``."""
+    dims = tuple(block_size) if isinstance(block_size, (tuple, list)) else (block_size, 1, 1)
+    if len(dims) != 3:
+        raise TypeError(f"block_size must be an int or a 3-tuple, got {block_size!r}")
+    for name, dim in zip(("block_dim_x", "block_dim_y", "block_dim_z"), dims):
+        if not isinstance(dim, int) or dim < 1:
+            raise TypeError(f"{name} must be a positive Python int, got {dim!r}")
+    return dims
+
+
+class BlockAlgorithmMeta(type):
+    """Gives a block collective its ``[...]`` specialization syntax.
+
+    The parameters are ``[dtype, block_size, algorithm]``, of which only the
+    first two are required. *block_size* is either the x extent on its own —
+    the y and z extents are then ``1`` — or the full ``(x, y, z)``, which is
+    what :func:`~flydsl.expr.gpu.known_block_size` hands back.
+
+    A concrete metaclass sets ``_algorithms`` and ``_shared_storage``, and
+    implements :meth:`_default_algorithm_for`.
+    """
+
+    _algorithms = None
+    _shared_storage = None
+
+    def _default_algorithm_for(cls, target):
+        """The policy to use when the caller does not name one."""
+        raise NotImplementedError(f"{cls.__name__} must implement _default_algorithm_for")
+
+    def __getitem__(cls, params):
+        if cls.block_threads is not None:
+            raise TypeError(f"{cls.__name__} is already specialized")
+
+        if not isinstance(params, tuple):
+            params = (params,)
+        if not 2 <= len(params) <= 3:
+            raise TypeError(f"{cls.__name__}[dtype, block_size, algorithm=...]")
+
+        dtype, block_size = params[0], params[1]
+        algorithm = params[2] if len(params) > 2 else cls._default_algorithm_for(current_target())
+
+        if not isinstance(algorithm, cls._algorithms):
+            raise TypeError(f"expected a {cls._algorithms.__name__}, got {algorithm!r}")
+        block_size = _block_shape(block_size)
+        block_threads = block_size[0] * block_size[1] * block_size[2]
+        # A power-of-two product forces every dimension to be one too, so the
+        # dimensions need no separate check.
+        require_power_of_two(block_threads, "block_dim_x * block_dim_y * block_dim_z")
+        # A block narrower than the wave leaves the wave's remaining lanes
+        # unlaunched, and a cross-lane read of one of those is undefined — so
+        # the logical warp narrows to the block.
+        warp_threads = min(num_warp_threads(), block_threads)
+
+        key = (cls, dtype, block_size, algorithm, warp_threads)
+        cached = _CACHE.get(key)
+        if cached is not None:
+            return cached
+
+        make_storage = cls._shared_storage.get(algorithm)
+        if make_storage is None:
+            raise NotImplementedError(f"{cls._algorithms.__name__}.{algorithm.name} is not implemented yet")
+
+        specialized = type(
+            f"{cls.__name__}[{getattr(dtype, '__name__', dtype)}, {block_threads}, {algorithm.name}]",
+            (cls,),
+            {
+                "dtype": dtype,
+                "block_size": block_size,
+                "block_threads": block_threads,
+                "algorithm": algorithm,
+                "warp_threads": warp_threads,
+                "num_warps": block_threads // warp_threads,
+                "SharedStorage": make_storage(dtype, block_threads, warp_threads),
+            },
+        )
+        _CACHE[key] = specialized
+        return specialized

--- a/python/flydsl/extension/coop/block/reduce.py
+++ b/python/flydsl/extension/coop/block/reduce.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Block-wide reduction."""
+
+import enum
+
+from ....compiler import jit
+from ....expr.gpu import barrier
+from ....expr.primitive import const_expr, range_constexpr
+from ....expr.struct import Struct
+from ....expr.typing import Array
+from .. import warp as _dispatched_warp
+from .._common import combine, linear_thread_id, thread_partial
+from ._spec import BlockAlgorithmMeta
+
+__all__ = [
+    "BlockReduceAlgorithm",
+    "BlockReduce",
+]
+
+
+class BlockReduceAlgorithm(enum.Enum):
+    """How a block folds its per-thread partials into one value.
+
+    Every policy implemented so far needs a commutative *op*, whatever its name suggests. The block
+    layer itself folds in order — a raking lane walks its segment by ascending index, and the
+    per-warp totals are combined lowest warp first — but the warp-scope reduction underneath does
+    not, so the requirement belongs to the collective rather than to any one policy.
+
+    So no member below is currently distinguished by accepting a non-commutative *op*, and none can
+    be while every :class:`~flydsl.expr.typing.ReductionOp` on offer is commutative.
+
+    ``RAKING``
+        Stage every thread's partial in shared memory, then let a single warp walk ("rake")
+        equal-length segments of it. ``block_threads`` slots of shared memory, but the cross-lane
+        work collapses to one warp. Named for the variant that honours operand order, which this
+        one does not yet.
+    ``RAKING_COMMUTATIVE_ONLY``
+        *Planned, not implemented.* Raking that spends the freedom to reorder: the first warp keeps
+        its partial in registers rather than staging it, and the rake strides by the warp width
+        instead of walking a contiguous segment, which is bank-conflict-free where a contiguous
+        walk is not. That access pattern is what it would add — the relaxed ordering it is named
+        for is already in force above.
+    ``WARP_REDUCTIONS``
+        Reduce inside each warp with shuffles, then fold the per-warp aggregates through shared
+        memory. Only ``num_warps`` slots of shared memory and one barrier.
+    ``WARP_REDUCTIONS_NONDETERMINISTIC``
+        *Planned, not implemented.* Warp reductions whose combining order may vary between runs,
+        which makes floating-point results irreproducible.
+    """
+
+    RAKING = "raking"
+    RAKING_COMMUTATIVE_ONLY = "raking_commutative_only"  # planned, not implemented
+    WARP_REDUCTIONS = "warp_reductions"
+    WARP_REDUCTIONS_NONDETERMINISTIC = "warp_reductions_nondeterministic"  # planned, not implemented
+
+
+# ── policy implementations ─────────────────────────────────────────────────
+# One function per BlockReduceAlgorithm, each paired with the shared storage it
+# needs in _SHARED_STORAGE below.
+
+
+@jit
+def _reduce_warp_reductions(partial, tid, slots, op, warp_reduce, warp_threads, num_warps):
+    """Reduce within each warp, then fold the per-warp aggregates through shared memory."""
+    aggregate = warp_reduce(partial, op, width=warp_threads)
+    if const_expr(num_warps == 1):
+        total = aggregate
+    else:
+        lane = tid % warp_threads
+        warp_id = tid // warp_threads
+        if lane == 0:
+            slots[warp_id] = aggregate
+        barrier()
+        # Every thread folds the same num_warps values, so the result is valid
+        # block-wide and no second barrier is needed to broadcast it.
+        total = slots[0]
+        for i in range_constexpr(1, num_warps):
+            total = combine(op, total, slots[i])
+    return total
+
+
+@jit
+def _reduce_raking(partial, tid, slots, result, op, warp_reduce, warp_threads, segment_length):
+    """Stage every thread's partial in shared memory, then rake it with a single warp."""
+    if const_expr(segment_length == 1):
+        # One segment per raking lane means the block is already one warp, so
+        # staging it would only be a round trip out to shared memory and back into the
+        # same cross-lane fold. This is the warp reduction, unchanged.
+        total = warp_reduce(partial, op, width=warp_threads)
+    else:
+        slots[tid] = partial
+        barrier()
+        if tid < warp_threads:
+            base = tid * segment_length
+            raked = slots[base]
+            for i in range_constexpr(1, segment_length):
+                raked = combine(op, raked, slots[base + i])
+            raked = warp_reduce(raked, op, width=warp_threads)
+            if tid == 0:
+                result[0] = raked
+        barrier()
+        total = result[0]
+    return total
+
+
+def _storage_warp_reductions(dtype, block_threads, warp_threads):
+    return Struct["slots" : Array[dtype, block_threads // warp_threads]]
+
+
+def _storage_raking(dtype, block_threads, warp_threads):
+    # A single-warp block never reaches the raking grid — see _reduce_raking —
+    # so reserving a slot per thread for it would just be shared memory nothing writes.
+    slots = block_threads if block_threads > warp_threads else 1
+    return Struct["slots" : Array[dtype, slots], "result" : Array[dtype, 1]]
+
+
+# Registry of the implemented policies. An unlisted member of the enum names a
+# strategy this library has not implemented yet.
+_SHARED_STORAGE = {
+    BlockReduceAlgorithm.WARP_REDUCTIONS: _storage_warp_reductions,
+    BlockReduceAlgorithm.RAKING: _storage_raking,
+}
+
+
+class _BlockReduceMeta(BlockAlgorithmMeta):
+    """Gives ``BlockReduce`` its ``[...]`` specialization and call syntax."""
+
+    _algorithms = BlockReduceAlgorithm
+    _shared_storage = _SHARED_STORAGE
+
+    def _default_algorithm_for(cls, target):
+        """``WARP_REDUCTIONS`` everywhere so far, and this is where that is decided.
+
+        Measured on both a wave64 and a wave32 target, it comes out ahead of
+        ``RAKING`` at every block width — fewer shared memory accesses, half the
+        barriers, and a gap that widens with the warp count. A target that
+        inverts that gets its branch here.
+        """
+        return BlockReduceAlgorithm.WARP_REDUCTIONS
+
+    def __call__(cls, value, op, *, storage):
+        if cls.block_threads is None:
+            raise TypeError("specialize first, e.g. BlockReduce[fx.Float32, 256]")
+
+        partial = thread_partial(value, op)
+        tid = linear_thread_id(cls.block_size)
+        if cls.algorithm is BlockReduceAlgorithm.WARP_REDUCTIONS:
+            return _reduce_warp_reductions(
+                partial,
+                tid,
+                storage.slots,
+                op,
+                cls.warp_ops.warp_reduce,
+                cls.warp_threads,
+                cls.num_warps,
+            )
+        return _reduce_raking(
+            partial,
+            tid,
+            storage.slots,
+            storage.result,
+            op,
+            cls.warp_ops.warp_reduce,
+            cls.warp_threads,
+            cls.num_warps,
+        )
+
+
+class BlockReduce(metaclass=_BlockReduceMeta):
+    """Block-wide reduction.
+
+    Specialize it, allocate its shared storage, then call it::
+
+        block_reduce = fx.coop.BlockReduce[fx.Float32, 256]
+        storage = fx.SharedAllocator().allocate(block_reduce.SharedStorage).peek()
+        total = block_reduce(value, fx.ReductionOp.ADD, storage=storage)
+
+    The parameters are ``[dtype, block_size, algorithm]``. *block_size* is either the x extent on
+    its own or the full ``(x, y, z)``, and must be a power of two in total.
+
+    Where the kernel declares its own block size — the usual case, either through
+    ``known_block_size`` or inferred from a static launch — passing
+    :func:`~flydsl.expr.gpu.known_block_size` straight through is the way to keep the two in step
+    without repeating the dimensions::
+
+        block_reduce = fx.coop.BlockReduce[fx.Float32, fx.known_block_size()]
+
+    ``value`` is either one scalar per thread or a ``Vector`` of several per-thread items. The
+    result is valid in every thread of the block, not only in one of them.
+
+    *op* must be commutative under every algorithm implemented so far, and associative under all of
+    them; :class:`BlockReduceAlgorithm` says where that comes from and why no policy is currently
+    free of it. Nothing depends on the distinction while every
+    :class:`~flydsl.expr.typing.ReductionOp` is commutative.
+
+    Reusing *storage* for a second collective call needs a :func:`~flydsl.expr.gpu.barrier` in
+    between, since this one leaves the block unsynchronized after its last read.
+    """
+
+    dtype = None
+    block_size = None
+    block_threads = None
+    algorithm = None
+    warp_threads = None
+    num_warps = None
+    SharedStorage = None
+
+    # Where the warp-scope fold underneath comes from. The default is the
+    # dispatched namespace, so a block reduction picks up whatever override the
+    # target supplies. :mod:`flydsl.extension.coop.universal` subclasses this and
+    # points it at the portable implementations instead.
+    warp_ops = _dispatched_warp

--- a/python/flydsl/extension/coop/block/reduce.py
+++ b/python/flydsl/extension/coop/block/reduce.py
@@ -75,6 +75,11 @@ def _reduce_warp_reductions(partial, tid, slots, op, warp_reduce, warp_threads, 
         barrier()
         # Every thread folds the same num_warps values, so the result is valid
         # block-wide and no second barrier is needed to broadcast it.
+
+        # TODO: that fold is linear in num_warps and every thread walks it —
+        # num_warps - 1 combines each, so 15 at a 1024-thread wave64 block.
+        # Reducing *slots* in one warp instead would make it logarithmic, at the
+        # cost of the second barrier this shape is currently free of.
         total = slots[0]
         for i in range_constexpr(1, num_warps):
             total = combine(op, total, slots[i])
@@ -189,6 +194,10 @@ class BlockReduce(metaclass=_BlockReduceMeta):
 
     ``value`` is either one scalar per thread or a ``Vector`` of several per-thread items. The
     result is valid in every thread of the block, not only in one of them.
+
+    Every thread of the block has to reach this call, and reach it together. It synchronizes the
+    block and reads across lanes, so a call made under a condition that is not uniform block-wide
+    hangs on the barrier or folds in lanes with no defined value.
 
     *op* must be commutative under every algorithm implemented so far, and associative under all of
     them; :class:`BlockReduceAlgorithm` says where that comes from and why no policy is currently

--- a/python/flydsl/extension/coop/block/scan.py
+++ b/python/flydsl/extension/coop/block/scan.py
@@ -67,6 +67,12 @@ def _prefix_warp_scans(partial, tid, slots, op, warp_scan_with_aggregate, warp_t
         barrier()
         # Highest warp first, so the operands stay in block order: a thread in
         # warp w ends up with slots[0] ⊕ ... ⊕ slots[w-1] ⊕ its own warp prefix.
+
+        # TODO: this and the aggregate below are linear in num_warps, and every
+        # thread walks both — 2 * (num_warps - 1) folds each, so 30 at a
+        # 1024-thread wave64 block. Scanning *slots* in one warp instead would
+        # make it logarithmic: warp 0 scans the num_warps totals, and each
+        # thread then reads the single entry in front of its own warp.
         for i in range_constexpr(num_warps - 2, -1, -1):
             prefix = (warp_id > i).select(combine(op, slots[i], prefix), prefix)
         # Same slots, folded unconditionally: that is the whole block.
@@ -111,9 +117,9 @@ class BlockScan(metaclass=_BlockScanMeta):
 
     Specialize it, allocate its shared storage, then ask for the form you want::
 
-        block_scan = fx.coop.BlockScan[fx.Float32, 256] storage =
-        fx.SharedAllocator().allocate(block_scan.SharedStorage).peek() running =
-        block_scan.inclusive(value, fx.ReductionOp.ADD, storage=storage)
+        block_scan = fx.coop.BlockScan[fx.Float32, 256]
+        storage = fx.SharedAllocator().allocate(block_scan.SharedStorage).peek()
+        running = block_scan.inclusive(value, fx.ReductionOp.ADD, storage=storage)
 
     The parameters are ``[dtype, block_size, algorithm]``, exactly as for
     :class:`~flydsl.extension.coop.BlockReduce` — *block_size* is either the x extent or the full
@@ -130,11 +136,11 @@ class BlockScan(metaclass=_BlockScanMeta):
     block_aggregate)`` instead. The aggregate is the fold of every thread's input, valid in all of
     them. It reuses what the scan already staged in shared memory, so it adds ``num_warps - 1``
     folds and no traffic at all — and nothing whatsoever when a caller ignores it. It is what lets a
-    kernel carry a running total across tiles::
+    kernel carry a running total across tiles.
 
-        for tile, (running,) in range(0, n_tiles, init=[fx.Float32(0)]):
-            out, total = block_scan.exclusive_with_aggregate(x, op, storage=s, init=running) yield
-            [running + total]
+    Every thread of the block has to reach the call, and reach it together, exactly as for
+    :class:`~flydsl.extension.coop.BlockReduce`: it synchronizes the block and reads across lanes,
+    and the specialization's *block_size* has to be the size the kernel is actually launched with.
 
     Threads are ordered by their linear id, and *op* has to be associative but not commutative:
     every fold on the way, the warp-scope scan included, keeps its operands in that order. That is

--- a/python/flydsl/extension/coop/block/scan.py
+++ b/python/flydsl/extension/coop/block/scan.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Block-wide prefix scan."""
+
+import enum
+
+from ....compiler import jit
+from ....expr.gpu import barrier
+from ....expr.primitive import const_expr, range_constexpr
+from ....expr.struct import Struct
+from ....expr.typing import Array, Vector
+from .. import warp as _dispatched_warp
+from .._common import combine, linear_thread_id, seed
+from ._spec import BlockAlgorithmMeta
+
+__all__ = [
+    "BlockScanAlgorithm",
+    "BlockScan",
+]
+
+
+class BlockScanAlgorithm(enum.Enum):
+    """How a block turns per-thread values into a block-wide running fold.
+
+    ``WARP_SCANS``
+        Scan inside each warp with shuffles, then fold the per-warp aggregates that precede each
+        warp back in. Only ``num_warps`` slots of shared memory and one barrier.
+    ``RAKING``
+        *Planned, not implemented.* Stage every thread's value in shared memory, then let a single
+        warp walk ("rake") equal-length segments of it: an upsweep to get the segment totals, a scan
+        of those, and a downsweep to push the prefixes back out. ``block_threads`` slots of shared
+        memory and three barriers, but the cross-lane work collapses to one warp.
+    ``RAKING_MEMOIZE``
+        *Planned, not implemented.* Raking that keeps the upsweep's intermediate values in registers
+        instead of re-reading them during the downsweep: fewer shared memory reads at the cost of
+        ``segment_length`` live registers in the raking warp.
+    """
+
+    RAKING = "raking"  # planned, not implemented
+    RAKING_MEMOIZE = "raking_memoize"  # planned, not implemented
+    WARP_SCANS = "warp_scans"
+
+
+# ── policy implementations ─────────────────────────────────────────────────
+# Each one answers the same question — what precedes this thread — and is paired
+# with the shared storage it needs in _SHARED_STORAGE below. Everything else the
+# scan produces follows from that exclusive prefix by one `combine`, so the
+# inclusive and exclusive forms do not need separate policies.
+
+
+@jit
+def _prefix_warp_scans(partial, tid, slots, op, warp_scan_with_aggregate, warp_threads, num_warps):
+    """Scan within each warp, then fold in the aggregates of the warps in front.
+
+    Returns the thread's exclusive prefix together with the block's own
+    aggregate. The aggregate is free: with more than one warp every thread can
+    already read every warp's total out of *slots*, and with a single warp the
+    scan's top lane already holds it.
+    """
+    inclusive, prefix, aggregate = warp_scan_with_aggregate(partial, op, width=warp_threads)
+    if const_expr(num_warps > 1):
+        lane = tid % warp_threads
+        warp_id = tid // warp_threads
+        if lane == warp_threads - 1:
+            slots[warp_id] = inclusive
+        barrier()
+        # Highest warp first, so the operands stay in block order: a thread in
+        # warp w ends up with slots[0] ⊕ ... ⊕ slots[w-1] ⊕ its own warp prefix.
+        for i in range_constexpr(num_warps - 2, -1, -1):
+            prefix = (warp_id > i).select(combine(op, slots[i], prefix), prefix)
+        # Same slots, folded unconditionally: that is the whole block.
+        aggregate = slots[0]
+        for i in range_constexpr(1, num_warps):
+            aggregate = combine(op, aggregate, slots[i])
+    return prefix, aggregate
+
+
+def _storage_warp_scans(dtype, block_threads, warp_threads):
+    return Struct["slots" : Array[dtype, block_threads // warp_threads]]
+
+
+# Registry of the implemented policies. An unlisted member of the enum names a
+# strategy this library has not implemented yet.
+_SHARED_STORAGE = {
+    BlockScanAlgorithm.WARP_SCANS: _storage_warp_scans,
+}
+
+
+class _BlockScanMeta(BlockAlgorithmMeta):
+    """Gives ``BlockScan`` its ``[...]`` specialization syntax."""
+
+    _algorithms = BlockScanAlgorithm
+    _shared_storage = _SHARED_STORAGE
+
+    def _default_algorithm_for(cls, target):
+        """``WARP_SCANS`` on every target, being the only policy implemented.
+
+        The other two members of the enum are declared but have no entry in
+        ``_SHARED_STORAGE``, so there is nothing yet for a target to choose
+        between. Whichever lands first gets its branch here.
+        """
+        return BlockScanAlgorithm.WARP_SCANS
+
+    def __call__(cls, *args, **kwargs):
+        raise TypeError("a scan has two forms; call .inclusive(...) or .exclusive(...)")
+
+
+class BlockScan(metaclass=_BlockScanMeta):
+    """Block-wide prefix scan.
+
+    Specialize it, allocate its shared storage, then ask for the form you want::
+
+        block_scan = fx.coop.BlockScan[fx.Float32, 256] storage =
+        fx.SharedAllocator().allocate(block_scan.SharedStorage).peek() running =
+        block_scan.inclusive(value, fx.ReductionOp.ADD, storage=storage)
+
+    The parameters are ``[dtype, block_size, algorithm]``, exactly as for
+    :class:`~flydsl.extension.coop.BlockReduce` — *block_size* is either the x extent or the full
+    ``(x, y, z)`` — except that ``algorithm`` defaults to ``BlockScanAlgorithm.WARP_SCANS``.
+
+    ``value`` is either one scalar per thread or a ``Vector`` of several per-thread items. A
+    ``Vector`` scans as if its items sat consecutively in the block's sequence — thread ``t`` owns
+    items ``t * n .. t * n + n - 1`` — and the result is a ``Vector`` of the same length.
+
+    Passing ``init=`` folds a value in ahead of the whole block, so the first thread's exclusive
+    result is ``init`` rather than :func:`~flydsl.extension.coop._common.identity`.
+
+    :meth:`inclusive_with_aggregate` and :meth:`exclusive_with_aggregate` return ``(result,
+    block_aggregate)`` instead. The aggregate is the fold of every thread's input, valid in all of
+    them. It reuses what the scan already staged in shared memory, so it adds ``num_warps - 1``
+    folds and no traffic at all — and nothing whatsoever when a caller ignores it. It is what lets a
+    kernel carry a running total across tiles::
+
+        for tile, (running,) in range(0, n_tiles, init=[fx.Float32(0)]):
+            out, total = block_scan.exclusive_with_aggregate(x, op, storage=s, init=running) yield
+            [running + total]
+
+    Threads are ordered by their linear id, and *op* has to be associative but not commutative:
+    every fold on the way, the warp-scope scan included, keeps its operands in that order. That is
+    the opposite of :class:`~flydsl.extension.coop.BlockReduce`, whose implemented policies all
+    need a commutative *op* today — see :class:`BlockReduceAlgorithm` for why.
+
+    Reusing *storage* for a second collective call needs a :func:`~flydsl.expr.gpu.barrier` in
+    between, since this one leaves the block unsynchronized after its last read.
+    """
+
+    dtype = None
+    block_size = None
+    block_threads = None
+    algorithm = None
+    warp_threads = None
+    num_warps = None
+    SharedStorage = None
+
+    # Where the warp-scope scan underneath comes from; see
+    # :class:`~flydsl.extension.coop.BlockReduce` for what overriding it buys.
+    warp_ops = _dispatched_warp
+
+    @classmethod
+    def inclusive(cls, value, op, *, storage, init=None):
+        """Fold everything up to and including this thread's own value."""
+        return cls._scan(value, op, storage, inclusive=True, init=init)[0]
+
+    @classmethod
+    def exclusive(cls, value, op, *, storage, init=None):
+        """Fold everything strictly in front of this thread's own value.
+
+        The first thread has nothing in front of it and gets *init*, or
+        :func:`~flydsl.extension.coop._common.identity` when none is given.
+        """
+        return cls._scan(value, op, storage, inclusive=False, init=init)[0]
+
+    @classmethod
+    def inclusive_with_aggregate(cls, value, op, *, storage, init=None):
+        """:meth:`inclusive`, plus the block aggregate every thread can read.
+
+        The aggregate covers the input alone: *init* seeds the scan but is not
+        folded into it.
+        """
+        return cls._scan(value, op, storage, inclusive=True, init=init)
+
+    @classmethod
+    def exclusive_with_aggregate(cls, value, op, *, storage, init=None):
+        """:meth:`exclusive`, plus the block aggregate every thread can read."""
+        return cls._scan(value, op, storage, inclusive=False, init=init)
+
+    @classmethod
+    def _scan(cls, value, op, storage, *, inclusive, init=None):
+        """The one implementation; returns ``(result, block_aggregate)``."""
+        if cls.block_threads is None:
+            raise TypeError("specialize first, e.g. BlockScan[fx.Float32, 256]")
+
+        if not isinstance(value, Vector):
+            prefix, aggregate = cls._block_prefix(value, op, storage)
+            prefix = seed(prefix, op, init)
+            return (combine(op, prefix, value) if inclusive else prefix), aggregate
+
+        # Scan the thread's own items first: its aggregate is then a single
+        # value the block-wide scan can treat exactly like a scalar input.
+        items = list(value)
+        running = items[0]
+        scanned = [running]
+        for item in items[1:]:
+            running = combine(op, running, item)
+            scanned.append(running)
+
+        prefix, aggregate = cls._block_prefix(running, op, storage)
+        prefix = seed(prefix, op, init)
+        # The exclusive form is the inclusive one shifted a slot to the right,
+        # with the block prefix moving into the hole at the front.
+        heads = scanned if inclusive else scanned[:-1]
+        out = [combine(op, prefix, head) for head in heads]
+        return Vector.from_elements(out if inclusive else [prefix, *out]), aggregate
+
+    @classmethod
+    def _block_prefix(cls, partial, op, storage):
+        """``(prefix, aggregate)``: what precedes this thread, and the block's total."""
+        tid = linear_thread_id(cls.block_size)
+        return _prefix_warp_scans(
+            partial,
+            tid,
+            storage.slots,
+            op,
+            cls.warp_ops.warp_scan_with_aggregate,
+            cls.warp_threads,
+            cls.num_warps,
+        )

--- a/python/flydsl/extension/coop/universal.py
+++ b/python/flydsl/extension/coop/universal.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""The portable implementations, under the public names, never displaced.
+
+``fx.coop.warp_reduce`` resolves through ``extension/_dispatch.py``: on the ROCm
+backend it is the DPP sequence in ``warp/rocdl.py``, not the shuffle butterfly in
+``warp/reduce.py``. ``fx.coop.universal.warp_reduce`` is that butterfly, and stays
+it on every target.
+
+The names, the signatures and the results are the same either way — a target
+override is only ever a faster route to the same answer — so ``universal`` is not
+a second API to learn. It is the same one with dispatch turned off, which two
+callers want:
+
+- **A kernel that measured it.** An override is faster on the shapes it was
+  tuned for, not on every shape; a caller that found the portable form better on
+  its own can say so, rather than being stuck with whatever the target picked.
+- **A test.** Running both and comparing them against each other is what catches
+  an override that is wrong in a way a host reference would not show, and it is
+  the only way to reach the portable code at all once an override exists for the
+  target being tested.
+"""
+
+from types import SimpleNamespace
+
+from .block import reduce as _block_reduce
+from .block import scan as _block_scan
+from .warp import reduce as _warp_reduce
+from .warp import scan as _warp_scan
+
+__all__ = [
+    # warp scope
+    "warp_reduce",
+    "warp_inclusive_scan",
+    "warp_exclusive_scan",
+    "warp_scan",
+    "warp_scan_with_aggregate",
+    # block scope
+    "BlockReduceAlgorithm",
+    "BlockReduce",
+    "BlockScanAlgorithm",
+    "BlockScan",
+]
+
+
+warp_reduce = _warp_reduce.warp_reduce
+warp_inclusive_scan = _warp_scan.warp_inclusive_scan
+warp_exclusive_scan = _warp_scan.warp_exclusive_scan
+warp_scan = _warp_scan.warp_scan
+warp_scan_with_aggregate = _warp_scan.warp_scan_with_aggregate
+
+
+# What the block classes below fold through, in place of the dispatched warp
+# namespace. Only the two names block scope actually reaches for are here, so a
+# warp primitive that gains a block-scope caller has to be added deliberately.
+_UNIVERSAL_WARP = SimpleNamespace(
+    warp_reduce=warp_reduce,
+    warp_scan_with_aggregate=warp_scan_with_aggregate,
+)
+
+
+# The policy enums describe what an algorithm does, not how it is compiled, so
+# they are the dispatched ones rather than copies: a caller must be able to pass
+# ``fx.coop.BlockReduceAlgorithm.RAKING`` to either spelling of ``BlockReduce``.
+BlockReduceAlgorithm = _block_reduce.BlockReduceAlgorithm
+BlockScanAlgorithm = _block_scan.BlockScanAlgorithm
+
+
+class BlockReduce(_block_reduce.BlockReduce):
+    """:class:`~flydsl.extension.coop.BlockReduce`, folding through portable warps."""
+
+    warp_ops = _UNIVERSAL_WARP
+
+
+class BlockScan(_block_scan.BlockScan):
+    """:class:`~flydsl.extension.coop.BlockScan`, folding through portable warps."""
+
+    warp_ops = _UNIVERSAL_WARP

--- a/python/flydsl/extension/coop/warp/__init__.py
+++ b/python/flydsl/extension/coop/warp/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Warp-scope cooperative algorithms."""
+
+from ..._dispatch import Dispatcher
+from .reduce import *
+from .scan import *
+
+__all__ = [
+    "warp_reduce",
+    "warp_inclusive_scan",
+    "warp_exclusive_scan",
+    "warp_scan",
+    "warp_scan_with_aggregate",
+]
+
+_dispatch = Dispatcher(__name__, targets={"rocm": "rocdl"})
+__getattr__ = _dispatch.load_target
+
+_dispatch.dispatch_all(globals(), __all__)

--- a/python/flydsl/extension/coop/warp/reduce.py
+++ b/python/flydsl/extension/coop/warp/reduce.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Warp-wide reduction — the portable form."""
+
+from ....expr.gpu import shuffle_xor
+from .._common import combine, resolve_warp_width
+
+__all__ = ["warp_reduce"]
+
+
+def warp_reduce(value, op, *, width=None):
+    """Reduce *value* across *width* lanes; every participating lane gets the result.
+
+    *width* defaults to the target's warp size; a narrower power-of-two width
+    reduces independent groups of lanes side by side.
+
+    *op* must be commutative, as well as associative. A butterfly folds each
+    lane's own partial on the left and its XOR partner's on the right, and at
+    step ``k`` a lane's own half is the lower one only where its bit ``k`` is
+    clear. Lane 0 therefore folds the group in lane order at every width, and
+    every other lane folds some permutation of it, so the lanes agree on one
+    result only if reordering does not change it.
+
+    Every :class:`~flydsl.expr.typing.ReductionOp` this library accepts today
+    is commutative, so nothing currently depends on the distinction — see
+    :func:`~flydsl.extension.coop._common.combine`, which is where a
+    non-commutative *op* would first become expressible.
+    """
+    width = resolve_warp_width(width, "warp_reduce width")
+    offset = 1
+    while offset < width:
+        value = combine(op, value, shuffle_xor(value, offset, width))
+        offset <<= 1
+    return value

--- a/python/flydsl/extension/coop/warp/rocdl.py
+++ b/python/flydsl/extension/coop/warp/rocdl.py
@@ -60,7 +60,15 @@ def _swizzle_broadcast(width):
 
 
 def _dpp(value, ctrl, row_mask, old):
-    """One DPP move of *value*, with *old* wherever the move reaches nothing."""
+    """One DPP move of *value*, with *old* wherever the move reaches nothing.
+
+    ``bound_ctrl`` is off, which is what puts *old* there: the hardware's own
+    out-of-range fill writes zero, and zero is the identity of ``ADD`` alone.
+    Every caller passes the identity of the *op* it is folding with, so the
+    lanes a move does not reach drop out of that fold whatever the op is. Turning
+    ``bound_ctrl`` on to save the operand would silently break ``MUL``, ``MAX``
+    and ``MIN``.
+    """
     dtype = value.dtype
     moved = update_dpp(
         dtype.ir_type,
@@ -82,7 +90,7 @@ def _swizzle(value, offset):
     return moved if dtype is Int32 else moved.bitcast(dtype)
 
 
-def _dpp_applies(value, width):
+def _dpp_applies(value):
     """Whether the sequences below cover this call, or the portable ones have to.
 
     - **gfx9.** Every control used here -- ``row_bcast``, ``wave_shr``,
@@ -90,10 +98,8 @@ def _dpp_applies(value, width):
     - **A 32-bit scalar.** ``update_dpp`` and ``ds_swizzle`` both move one
       32-bit lane value; a narrower type would have to be packed and a wider
       one split.
-    - **A group no wider than the wave.** gfx9 is wave64 throughout, so this
-      only rejects a caller that asked for something meaningless.
     """
-    if width > 64 or not current_target().arch.startswith("gfx9"):
+    if not current_target().arch.startswith("gfx9"):
         return False
     return isinstance(value, Numeric) and value.dtype.width == 32
 
@@ -171,7 +177,7 @@ def warp_reduce(value, op, *, width=None):
     :func:`~flydsl.extension.coop.warp.reduce.warp_reduce`.
     """
     width = resolve_warp_width(width, "warp_reduce width")
-    if not _dpp_applies(value, width):
+    if not _dpp_applies(value):
         return _portable_warp_reduce(value, op, width=width)
     if width == 64:
         return _wave64_reduce(value, op)
@@ -184,10 +190,11 @@ def warp_reduce(value, op, *, width=None):
 def _inclusive_scan(value, op, width):
     """The raw inclusive scan: ``log2(width)`` rounds, all of them DPP moves."""
     neutral = identity(op, value.dtype)
-    # Within a 16-lane row ``row_shr:k`` is exactly the round's shift, and
-    # ``bound_ctrl`` supplies identity at the row's start for free. A group
-    # narrower than a row shares that row with its neighbours, so it is the one
-    # case that has to mask the reads crossing into them itself.
+    # Within a 16-lane row ``row_shr:k`` is exactly the round's shift, and the
+    # lanes at the row's start read nothing, so ``_dpp`` hands them the identity
+    # and they fold away for free. A group narrower than a row shares that row
+    # with its neighbours, so it is the one case that has to mask the reads
+    # crossing into them itself.
     in_group = lane_id() % width if width < 16 else None
 
     acc = value
@@ -214,10 +221,10 @@ def _shift_up(inclusive, op, width):
     """Turn an inclusive scan into the exclusive one by moving it up a lane.
 
     ``row_shr:1`` covers a group inside a row and ``wave_shr:1`` one spanning
-    rows; either way ``bound_ctrl`` puts identity in front of the lane it
-    shifted in from nowhere. That lane is the group's first only when the group
-    starts where the row (or the wave) does, so the two widths that sit inside
-    a larger unit -- under 16 lanes, or 32 -- name their own first lane.
+    rows; either way the lane that shifted in from nowhere reads nothing, so
+    ``_dpp`` gives it the identity. That lane is the group's first only when the
+    group starts where the row (or the wave) does, so the two widths that sit
+    inside a larger unit -- under 16 lanes, or 32 -- name their own first lane.
     """
     neutral = identity(op, inclusive.dtype)
     ctrl = _ROW_SHR[1] if width <= 16 else _WAVE_SHR1
@@ -247,7 +254,7 @@ def warp_inclusive_scan(value, op, *, width=None, init=None):
     :func:`~flydsl.extension.coop.warp.scan.warp_inclusive_scan`.
     """
     width = resolve_warp_width(width, "warp_inclusive_scan width")
-    if not _dpp_applies(value, width):
+    if not _dpp_applies(value):
         return _universal_scan.warp_inclusive_scan(value, op, width=width, init=init)
     return seed(_inclusive_scan(value, op, width), op, init)
 
@@ -259,7 +266,7 @@ def warp_exclusive_scan(value, op, *, width=None, init=None):
     :func:`~flydsl.extension.coop.warp.scan.warp_exclusive_scan`.
     """
     width = resolve_warp_width(width, "warp_exclusive_scan width")
-    if not _dpp_applies(value, width):
+    if not _dpp_applies(value):
         return _universal_scan.warp_exclusive_scan(value, op, width=width, init=init)
     return seed(_shift_up(_inclusive_scan(value, op, width), op, width), op, init)
 
@@ -271,7 +278,7 @@ def warp_scan(value, op, *, width=None, init=None):
     :func:`~flydsl.extension.coop.warp.scan.warp_scan`.
     """
     width = resolve_warp_width(width, "warp_scan width")
-    if not _dpp_applies(value, width):
+    if not _dpp_applies(value):
         return _universal_scan.warp_scan(value, op, width=width, init=init)
     raw = _inclusive_scan(value, op, width)
     return seed(raw, op, init), seed(_shift_up(raw, op, width), op, init)
@@ -284,7 +291,7 @@ def warp_scan_with_aggregate(value, op, *, width=None, init=None):
     :func:`~flydsl.extension.coop.warp.scan.warp_scan_with_aggregate`.
     """
     width = resolve_warp_width(width, "warp_scan_with_aggregate width")
-    if not _dpp_applies(value, width):
+    if not _dpp_applies(value):
         return _universal_scan.warp_scan_with_aggregate(value, op, width=width, init=init)
     raw = _inclusive_scan(value, op, width)
     inclusive = seed(raw, op, init)

--- a/python/flydsl/extension/coop/warp/rocdl.py
+++ b/python/flydsl/extension/coop/warp/rocdl.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""ROCDL overrides for the warp-scope collectives.
+
+Everything here is gfx9-only. ``row_bcast`` and ``wave_shr`` are CDNA DPP
+controls that RDNA dropped in favour of ``row_share`` / ``permlanex16``, which
+is a different sequence rather than a different constant -- and one with much
+less to gain, since LLVM's own rewrite already reaches pure DPP there.
+"""
+
+from ....compiler.backends import current_target
+from ....expr.gpu import lane_id
+from ....expr.numeric import Int32, Numeric
+from ....expr.rocdl import ds_swizzle, readlane, update_dpp
+from .._common import combine, identity, resolve_warp_width, seed
+from . import scan as _universal_scan
+from .reduce import warp_reduce as _portable_warp_reduce
+
+__all__ = [
+    "warp_reduce",
+    "warp_inclusive_scan",
+    "warp_exclusive_scan",
+    "warp_scan",
+    "warp_scan_with_aggregate",
+]
+
+
+# DPP controls, spelled as the ISA encodes them.
+_ROW_SHR = {1: 0x111, 2: 0x112, 4: 0x114, 8: 0x118}
+_WAVE_SHR1 = 0x138
+_ROW_BCAST15 = 0x142
+_ROW_BCAST31 = 0x143
+_ALL_ROWS = 0xF
+_ALL_BANKS = 0xF
+
+# What a butterfly step of each distance costs. Only the first two and the
+# last are the XOR they stand for: ``quad_perm[1,0,3,2]`` and
+# ``quad_perm[2,3,0,1]`` are XOR by 1 and 2 outright, and rotating a 16-lane
+# row by 8 is XOR by 8 outright. ``row_half_mirror`` (lane ``i`` reads ``7 - i``
+# within each group of 8) is not XOR by 4 -- but by the time a butterfly takes
+# that step every quad already holds one value, so reading *any* lane of the
+# neighbouring quad reads the right one, and the mirror does that.
+_BUTTERFLY_DPP = {1: 0xB1, 2: 0x4E, 4: 0x141, 8: 0x128}
+
+# XOR by 16 crosses the 16-lane rows DPP is built around, and gfx9 has no
+# control that does. ``ds_swizzle_b32`` in its 32-lane mode does: a lane reads
+# ``((lane & and_mask) | or_mask) ^ xor_mask``, and the offset packs the three
+# as ``xor_mask << 10 | or_mask << 5 | and_mask``.
+_SWIZZLE_XOR16 = (16 << 10) | 0x1F
+
+
+def _swizzle_broadcast(width):
+    """Offset that hands every lane of a *width*-lane group its last lane.
+
+    ``and_mask`` keeps the bits above the group, ``or_mask`` sets every bit
+    inside it, so the source lane is the group's base plus ``width - 1``.
+    """
+    return ((width - 1) << 5) | (0x1F & ~(width - 1))
+
+
+def _dpp(value, ctrl, row_mask, old):
+    """One DPP move of *value*, with *old* wherever the move reaches nothing."""
+    dtype = value.dtype
+    moved = update_dpp(
+        dtype.ir_type,
+        old.ir_value(),
+        value.ir_value(),
+        ctrl,
+        row_mask,
+        _ALL_BANKS,
+        False,
+    )
+    return dtype(moved)
+
+
+def _swizzle(value, offset):
+    """One ``ds_swizzle_b32``, which speaks 32-bit integers and nothing else."""
+    dtype = value.dtype
+    raw = value if dtype is Int32 else value.bitcast(Int32)
+    moved = Int32(ds_swizzle(Int32.ir_type, raw.ir_value(), Int32(offset).ir_value()))
+    return moved if dtype is Int32 else moved.bitcast(dtype)
+
+
+def _dpp_applies(value, width):
+    """Whether the sequences below cover this call, or the portable ones have to.
+
+    - **gfx9.** Every control used here -- ``row_bcast``, ``wave_shr``,
+      ``row_ror`` -- is CDNA-only.
+    - **A 32-bit scalar.** ``update_dpp`` and ``ds_swizzle`` both move one
+      32-bit lane value; a narrower type would have to be packed and a wider
+      one split.
+    - **A group no wider than the wave.** gfx9 is wave64 throughout, so this
+      only rejects a caller that asked for something meaningless.
+    """
+    if width > 64 or not current_target().arch.startswith("gfx9"):
+        return False
+    return isinstance(value, Numeric) and value.dtype.width == 32
+
+
+# -- reduce -----------------------------------------------------------------
+
+
+def _wave64_reduce(value, op):
+    """Fold a full 64-lane wave with DPP, then broadcast out of an SGPR.
+
+    Requires a commutative *op*, and in a different way from the portable
+    butterfly: ``row_shr`` brings in the value from *below*, and it is folded
+    in as ``combine(op, acc, moved)`` -- the accumulator on the left. So the
+    total lane 63 accumulates, and that ``readlane`` then broadcasts, is the
+    wave folded in reverse lane order. Every lane agrees on it, unlike the
+    butterfly below; it is simply the mirror image of the lane order a caller
+    would expect. Writing ``combine(op, moved, acc)`` instead would put it back
+    in order at no cost -- the scan further down uses the same DPP sequence
+    that way -- but the two are indistinguishable for the commutative ops this
+    library accepts, so the flip is left for whoever needs it.
+    """
+    neutral = identity(op, value.dtype)
+
+    acc = value
+    for shift in (1, 2, 4, 8):
+        acc = combine(op, acc, _dpp(acc, _ROW_SHR[shift], _ALL_ROWS, neutral))
+    # Each 16-lane row now holds its own running fold, so its last lane -- 15,
+    # 31, 47, 63 -- holds that row's total. ``row_bcast15`` hands each of those
+    # to the row above (rows 1 and 3, hence row_mask 0xa) and ``row_bcast31``
+    # hands lane 31 to the upper half (rows 2 and 3, row_mask 0xc), which
+    # leaves lane 63 holding all four rows.
+    acc = combine(op, acc, _dpp(acc, _ROW_BCAST15, 0xA, neutral))
+    acc = combine(op, acc, _dpp(acc, _ROW_BCAST31, 0xC, neutral))
+
+    return value.dtype(readlane(value.dtype.ir_type, acc, 63))
+
+
+def _butterfly_reduce(value, op, width):
+    """Fold a group narrower than the wave by XOR distance.
+
+    The butterfly is what a narrow group needs anyway -- there is no lane the
+    whole group can read a total out of the way lane 63 serves a full wave --
+    and every one of its steps stays inside the group, so no step leaves a lane
+    without a source and the identity ``_dpp`` takes is never read. It is
+    passed for the other reason ``_dpp`` gives: it is what lets each move fold
+    into the ``combine`` that consumes it.
+
+    Requires a commutative *op*, and needs it harder than the portable
+    butterfly does. There, lane 0 at least folds the group in lane order; here
+    the substitutes noted at ``_BUTTERFLY_DPP`` -- ``row_half_mirror`` for
+    XOR 4, ``row_ror:8`` for XOR 8 -- read *a* lane of the neighbouring group
+    rather than the matching one. Those lanes hold the same values as the
+    matching lane but in a different order, which is exactly the thing
+    commutativity makes invisible, so from width 8 up not even lane 0 folds in
+    lane order. Restoring that would mean a different sequence, not a different
+    operand order.
+    """
+    neutral = identity(op, value.dtype)
+    acc = value
+    offset = 1
+    while offset < width:
+        if offset in _BUTTERFLY_DPP:
+            partner = _dpp(acc, _BUTTERFLY_DPP[offset], _ALL_ROWS, neutral)
+        else:
+            partner = _swizzle(acc, _SWIZZLE_XOR16)
+        acc = combine(op, acc, partner)
+        offset <<= 1
+    return acc
+
+
+def warp_reduce(value, op, *, width=None):
+    """Reduce *value* across *width* lanes; every participating lane gets the result.
+
+    Same contract as the portable implementation this displaces -- see
+    :func:`~flydsl.extension.coop.warp.reduce.warp_reduce`.
+    """
+    width = resolve_warp_width(width, "warp_reduce width")
+    if not _dpp_applies(value, width):
+        return _portable_warp_reduce(value, op, width=width)
+    if width == 64:
+        return _wave64_reduce(value, op)
+    return _butterfly_reduce(value, op, width)
+
+
+# -- scan -------------------------------------------------------------------
+
+
+def _inclusive_scan(value, op, width):
+    """The raw inclusive scan: ``log2(width)`` rounds, all of them DPP moves."""
+    neutral = identity(op, value.dtype)
+    # Within a 16-lane row ``row_shr:k`` is exactly the round's shift, and
+    # ``bound_ctrl`` supplies identity at the row's start for free. A group
+    # narrower than a row shares that row with its neighbours, so it is the one
+    # case that has to mask the reads crossing into them itself.
+    in_group = lane_id() % width if width < 16 else None
+
+    acc = value
+    shift = 1
+    while shift < min(width, 16):
+        moved = _dpp(acc, _ROW_SHR[shift], _ALL_ROWS, neutral)
+        if in_group is not None:
+            moved = (in_group >= shift).select(moved, neutral)
+        acc = combine(op, moved, acc)
+        shift <<= 1
+
+    # Row ``r`` now holds its own prefix, so its last lane holds the row's
+    # total. ``row_bcast15`` hands that to the row above -- masked to rows 1
+    # and 3, whose lanes are the ones missing a row -- and ``row_bcast31``
+    # hands lane 31's running total to the wave's upper half.
+    if width > 16:
+        acc = combine(op, _dpp(acc, _ROW_BCAST15, 0xA, neutral), acc)
+    if width > 32:
+        acc = combine(op, _dpp(acc, _ROW_BCAST31, 0xC, neutral), acc)
+    return acc
+
+
+def _shift_up(inclusive, op, width):
+    """Turn an inclusive scan into the exclusive one by moving it up a lane.
+
+    ``row_shr:1`` covers a group inside a row and ``wave_shr:1`` one spanning
+    rows; either way ``bound_ctrl`` puts identity in front of the lane it
+    shifted in from nowhere. That lane is the group's first only when the group
+    starts where the row (or the wave) does, so the two widths that sit inside
+    a larger unit -- under 16 lanes, or 32 -- name their own first lane.
+    """
+    neutral = identity(op, inclusive.dtype)
+    ctrl = _ROW_SHR[1] if width <= 16 else _WAVE_SHR1
+    shifted = _dpp(inclusive, ctrl, _ALL_ROWS, neutral)
+    if width < 16 or width == 32:
+        at_group_start = (lane_id() % width) == 0
+        shifted = at_group_start.select(neutral, shifted)
+    return shifted
+
+
+def _aggregate(inclusive, width):
+    """Hand every lane of the group what its last lane holds.
+
+    A full wave reads lane 63, which is uniform, so it lifts into an SGPR. A
+    narrower group's last lane differs per group, which is what ``ds_swizzle``
+    in its 32-lane mode names without any address arithmetic.
+    """
+    if width == 64:
+        return inclusive.dtype(readlane(inclusive.dtype.ir_type, inclusive, 63))
+    return _swizzle(inclusive, _swizzle_broadcast(width))
+
+
+def warp_inclusive_scan(value, op, *, width=None, init=None):
+    """Scan *value* across *width* lanes; lane ``k`` gets lanes ``0..k`` folded.
+
+    Same contract as the portable implementation this displaces -- see
+    :func:`~flydsl.extension.coop.warp.scan.warp_inclusive_scan`.
+    """
+    width = resolve_warp_width(width, "warp_inclusive_scan width")
+    if not _dpp_applies(value, width):
+        return _universal_scan.warp_inclusive_scan(value, op, width=width, init=init)
+    return seed(_inclusive_scan(value, op, width), op, init)
+
+
+def warp_exclusive_scan(value, op, *, width=None, init=None):
+    """Scan *value* across *width* lanes; lane ``k`` gets lanes ``0..k-1`` folded.
+
+    Same contract as the portable implementation this displaces -- see
+    :func:`~flydsl.extension.coop.warp.scan.warp_exclusive_scan`.
+    """
+    width = resolve_warp_width(width, "warp_exclusive_scan width")
+    if not _dpp_applies(value, width):
+        return _universal_scan.warp_exclusive_scan(value, op, width=width, init=init)
+    return seed(_shift_up(_inclusive_scan(value, op, width), op, width), op, init)
+
+
+def warp_scan(value, op, *, width=None, init=None):
+    """Return ``(inclusive, exclusive)`` for this lane, sharing one scan.
+
+    Same contract as the portable implementation this displaces -- see
+    :func:`~flydsl.extension.coop.warp.scan.warp_scan`.
+    """
+    width = resolve_warp_width(width, "warp_scan width")
+    if not _dpp_applies(value, width):
+        return _universal_scan.warp_scan(value, op, width=width, init=init)
+    raw = _inclusive_scan(value, op, width)
+    return seed(raw, op, init), seed(_shift_up(raw, op, width), op, init)
+
+
+def warp_scan_with_aggregate(value, op, *, width=None, init=None):
+    """Return ``(inclusive, exclusive, aggregate)``, sharing one scan.
+
+    Same contract as the portable implementation this displaces -- see
+    :func:`~flydsl.extension.coop.warp.scan.warp_scan_with_aggregate`.
+    """
+    width = resolve_warp_width(width, "warp_scan_with_aggregate width")
+    if not _dpp_applies(value, width):
+        return _universal_scan.warp_scan_with_aggregate(value, op, width=width, init=init)
+    raw = _inclusive_scan(value, op, width)
+    inclusive = seed(raw, op, init)
+    exclusive = seed(_shift_up(raw, op, width), op, init)
+    return inclusive, exclusive, _aggregate(raw, width)

--- a/python/flydsl/extension/coop/warp/scan.py
+++ b/python/flydsl/extension/coop/warp/scan.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Warp-wide prefix scan."""
+
+from ....expr.gpu import lane_id, shuffle_idx, shuffle_up
+from .._common import combine, identity, resolve_warp_width, seed
+
+__all__ = [
+    "warp_inclusive_scan",
+    "warp_exclusive_scan",
+    "warp_scan",
+    "warp_scan_with_aggregate",
+]
+
+
+def _shuffle_up(value, offset, width):
+    """Read lane ``k - offset``, together with the flag saying that lane exists."""
+    within_group = lane_id() % width
+    return shuffle_up(value, offset, width), within_group >= offset
+
+
+def _shift_up(inclusive, op, width):
+    """Turn an inclusive scan into the exclusive one by moving it up a lane."""
+    shifted, valid = _shuffle_up(inclusive, 1, width)
+    return valid.select(shifted, identity(op, inclusive.dtype))
+
+
+def _broadcast_last(value, width):
+    """Hand every lane of the group what its highest lane holds.
+
+    After an inclusive scan that lane holds the whole group's fold, so this is
+    what turns a scan into an aggregate — one shuffle rather than a second pass
+    over the data.
+
+    ``shuffle_idx`` takes an *absolute* lane, not one relative to the group, so
+    a group narrower than the warp has to name its own last lane.
+    """
+    group_base = (lane_id() // width) * width
+    return shuffle_idx(value, group_base + (width - 1), width)
+
+
+def _hillis_steele(value, op, width):
+    """The raw inclusive scan: ``log2(width)`` rounds of shuffle-and-fold.
+
+    Each round folds in the lane *offset* below, whose result is kept only
+    where that lane exists.
+    """
+    offset = 1
+    while offset < width:
+        shifted, valid = _shuffle_up(value, offset, width)
+        value = valid.select(combine(op, shifted, value), value)
+        offset <<= 1
+    return value
+
+
+def warp_inclusive_scan(value, op, *, width=None, init=None):
+    """Scan *value* across *width* lanes; lane ``k`` gets lanes ``0..k`` folded.
+
+    *width* defaults to the target's warp size; a narrower power-of-two width
+    scans independent groups of lanes side by side. Passing *init* folds it in
+    ahead of every lane, so lane ``k`` gets ``init`` followed by lanes ``0..k``.
+    """
+    width = resolve_warp_width(width, "warp_inclusive_scan width")
+    return seed(_hillis_steele(value, op, width), op, init)
+
+
+def warp_exclusive_scan(value, op, *, width=None, init=None):
+    """Scan *value* across *width* lanes; lane ``k`` gets lanes ``0..k-1`` folded.
+
+    *width* defaults to the target's warp size, as in
+    :func:`warp_inclusive_scan`. Lane 0 has nothing in front of it and gets
+    *init*, or ``identity(op, ...)`` when no *init* is given.
+    """
+    width = resolve_warp_width(width, "warp_exclusive_scan width")
+    return seed(_shift_up(_hillis_steele(value, op, width), op, width), op, init)
+
+
+def warp_scan(value, op, *, width=None, init=None):
+    """Return ``(inclusive, exclusive)`` for this lane, sharing one scan.
+
+    *width* defaults to the target's warp size, as in :func:`warp_inclusive_scan`.
+    """
+    width = resolve_warp_width(width, "warp_scan width")
+    raw = _hillis_steele(value, op, width)
+    return seed(raw, op, init), seed(_shift_up(raw, op, width), op, init)
+
+
+def warp_scan_with_aggregate(value, op, *, width=None, init=None):
+    """Return ``(inclusive, exclusive, aggregate)``, sharing one scan.
+
+    *width* defaults to the target's warp size, as in :func:`warp_inclusive_scan`.
+    """
+    width = resolve_warp_width(width, "warp_scan_with_aggregate width")
+    raw = _hillis_steele(value, op, width)
+    inclusive = seed(raw, op, init)
+    exclusive = seed(_shift_up(raw, op, width), op, init)
+    return inclusive, exclusive, _broadcast_last(raw, width)

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -45,10 +45,10 @@ if [ "${RUN_TESTS_FULL:-0}" != "1" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 1. All pytest-based tests (kernels + language + unit + system + examples)
+# 1. All pytest-based tests (kernels + language + unit + system + extension + examples)
 # ---------------------------------------------------------------------------
 echo "========================================================================"
-echo "Pytest: kernels + language + unit + system + examples"
+echo "Pytest: kernels + language + unit + system + extension + examples"
 echo "========================================================================"
 
 python3 -m pytest \
@@ -56,6 +56,7 @@ python3 -m pytest \
     tests/language/ \
     tests/unit/ \
     tests/system/ \
+    tests/extension/ \
     tests/python/examples/ \
     "${pytest_args[@]}"
 
@@ -70,9 +71,10 @@ echo "========================================================================"
 # Whitelist from tests/arch_compat.py (single source of truth for arch compat).
 _RDNA_EXAMPLE_WHITELIST=$(python3 -c "from tests.arch_compat import RDNA_COMPATIBLE_EXAMPLES; print(' '.join(RDNA_COMPATIBLE_EXAMPLES))" 2>/dev/null || echo "")
 _gpu_arch=$(python3 -c "from flydsl.runtime.device import get_rocm_arch; print(get_rocm_arch())" 2>/dev/null || echo "unknown")
-for example in "${REPO_ROOT}"/examples/*.py; do
+for example in "${REPO_ROOT}"/examples/*.py "${REPO_ROOT}"/examples/extension/*/*.py; do
     [ -f "${example}" ] || continue
-    name="$(basename "${example}")"
+    # Named by their path under examples/, so nested ones stay unambiguous.
+    name="${example#"${REPO_ROOT}"/examples/}"
     if [[ "${_gpu_arch}" != gfx9* ]] && ! echo "${_RDNA_EXAMPLE_WHITELIST}" | grep -qw "${name}"; then
         echo "  SKIP  ${name}  (not in RDNA whitelist, arch: ${_gpu_arch})"
         continue

--- a/tests/extension/coop/conftest.py
+++ b/tests/extension/coop/conftest.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Pytest configuration for the cooperative-algorithm tests."""
+
+import pytest
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+
+@pytest.fixture(autouse=True)
+def host_default_device():
+    """Keep the default device on the host, whatever the rest of the session set."""
+    if torch is None:
+        yield
+        return
+    with torch.device("cpu"):
+        yield

--- a/tests/extension/coop/coop_common.py
+++ b/tests/extension/coop/coop_common.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Glue shared by the cooperative-algorithm tests."""
+
+from __future__ import annotations
+
+import flydsl.expr as fx
+from flydsl.compiler.backends import current_target
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+
+def _powers_of_two(low, high):
+    return tuple(1 << e for e in range(low.bit_length() - 1, high.bit_length()))
+
+
+# The collectives size themselves off the target's wave, so the axes below have
+# to follow it rather than a constant: 64 on CDNA, 32 on RDNA.
+WARP_SIZE = current_target().warp_size
+
+# Every logical warp width the collectives accept, narrowest first. Each is a
+# power of two strictly inside the wave — a width equal to the wave is spelled
+# ``None`` (the default), and it is last so a test that only wants the plain
+# form can read it off the end.
+WARP_WIDTHS = (*_powers_of_two(2, WARP_SIZE // 2), None)
+
+# A single thread up to the 1024-thread launch limit, which is the whole range
+# the block collectives are defined over. Below a wave they narrow their
+# logical warp to the block rather than refusing it, so the widths under
+# ``WARP_SIZE`` are the ones that exercise that narrowing.
+BLOCK_THREADS = _powers_of_two(1, 1024)
+
+# Just the block widths that fall inside a wave, for the tests that are about
+# the narrowing itself rather than about width in general.
+SUB_WARP_BLOCK_THREADS = _powers_of_two(1, WARP_SIZE // 2)
+
+# The element types the collectives are exercised over, each paired with the
+# name of the torch dtype it maps to. The pair travels together because a test
+# needs the FlyDSL type to specialize the collective and the torch one to build
+# its input; ``torch_dtype`` and ``dtype_id`` below take the name and the pair
+# respectively.
+#
+# int16 stands in for uint16: the runtime has no memref element type for
+# torch.uint16.
+DTYPES = (
+    (fx.Uint8, "torch.uint8"),
+    (fx.Int16, "torch.int16"),
+    (fx.Int32, "torch.int32"),
+    (fx.Int64, "torch.int64"),
+    (fx.Float32, "torch.float32"),
+    (fx.Float64, "torch.float64"),
+)
+
+_TORCH_OF = {
+    "torch.uint8": "uint8",
+    "torch.int16": "int16",
+    "torch.int32": "int32",
+    "torch.int64": "int64",
+    "torch.float32": "float32",
+    "torch.float64": "float64",
+}
+
+
+def torch_dtype(name):
+    """The ``torch`` dtype named by a :data:`DTYPES` entry."""
+    return getattr(torch, _TORCH_OF[name])
+
+
+def dtype_id(entry):
+    """pytest id for a :data:`DTYPES` entry: just the FlyDSL type name."""
+    return entry[0].__name__ if isinstance(entry, tuple) else str(entry)
+
+
+def is_float(name):
+    return torch_dtype(name).is_floating_point
+
+
+def sample(name, n, *, seed=0):
+    """Random input covering the dtype's range.
+
+    Integers are drawn from the whole representable range so that summing them
+    overflows — the wrap-around that :func:`wrap` reproduces on the host.
+    """
+    torch.manual_seed(seed)
+    tdt = torch_dtype(name)
+    if tdt.is_floating_point:
+        return torch.randn(n, dtype=tdt, device="cuda")
+    info = torch.iinfo(tdt)
+    return torch.randint(info.min, info.max, (n,), dtype=tdt, device="cuda")
+
+
+def wrap(total, name):
+    """Fold a widened integer back into *name*'s range, the way the device does.
+
+    ``torch.sum`` and ``torch.cumsum`` promote narrow integers to int64, so the
+    reference has to be brought back down explicitly; the device arithmetic
+    wraps at the type's own width.
+    """
+    tdt = torch_dtype(name)
+    bits = 8 * tdt.itemsize
+    if bits >= 64:
+        # Already the width the device folded at; nothing to fold back.
+        return total.to(tdt)
+    wrapped = total % (1 << bits)
+    if tdt.is_signed:
+        wrapped = torch.where(wrapped >= (1 << (bits - 1)), wrapped - (1 << bits), wrapped)
+    return wrapped.to(tdt)
+
+
+def linear_tid(block_size):
+    """Linear thread id inside *block_size*, ordered as ``gpu.thread_id`` is.
+
+    Mirrors ``coop/_common.py:linear_thread_id``, which is what the collectives
+    themselves index by — a test that ordered its threads differently would
+    compare against the wrong permutation.
+    """
+    dim_x, dim_y, dim_z = block_size
+    tid = fx.thread_idx.x
+    if dim_y > 1:
+        tid = tid + fx.thread_idx.y * fx.Int32(dim_x)
+    if dim_z > 1:
+        tid = tid + fx.thread_idx.z * fx.Int32(dim_x * dim_y)
+    return tid

--- a/tests/extension/coop/test_block_reduce.py
+++ b/tests/extension/coop/test_block_reduce.py
@@ -56,18 +56,16 @@ ALGORITHMS = (
 BLOCK_SHAPES = ((64, 1, 1), (128, 1, 1), (256, 1, 1), (64, 2, 2), (128, 2, 2))
 
 
-def run_block_reduce(values, name, dtype, *, block_size, algorithm, items_per_thread=1, op=None, namespace=None):
+def run_block_reduce(values, name, dtype, *, block_size, algorithm, items_per_thread=1, op=None, universal=False):
     """Reduce *values* with one ``BlockReduce`` call per thread.
 
     Returns the per-thread results on the host: the reduction is valid
     block-wide, so every entry should hold the same total.
 
-    *namespace* is which ``BlockReduce`` to reach for — the dispatched one by
-    default, or ``fx.coop.universal`` for the form that folds through the
-    portable warp reduction.
+    *universal* picks ``fx.coop.universal.BlockReduce``, the form that folds
+    through the portable warp reduction, over the dispatched one.
     """
     op = op if op is not None else fx.ReductionOp.ADD
-    namespace = namespace if namespace is not None else fx.coop
     block_threads = block_size[0] * block_size[1] * block_size[2]
 
     # Decide the per-thread read before tracing: one scalar, or a Vector of
@@ -84,6 +82,7 @@ def run_block_reduce(values, name, dtype, *, block_size, algorithm, items_per_th
 
     @flyc.kernel(known_block_size=list(block_size))
     def kernel(A: fx.Tensor, Out: fx.Tensor):
+        namespace = fx.coop.universal if universal else fx.coop
         block_reduce = namespace.BlockReduce[dtype, block_size, algorithm]
         storage = fx.SharedAllocator().allocate(block_reduce.SharedStorage).peek()
         tid = linear_tid(block_size)
@@ -262,7 +261,7 @@ def test_universal_agrees_with_the_dispatched_reduction(algorithm):
     shared = dict(block_size=(256, 1, 1), algorithm=algorithm)
 
     dispatched = run_block_reduce(values, name, dtype, **shared)
-    universal = run_block_reduce(values, name, dtype, namespace=fx.coop.universal, **shared)
+    universal = run_block_reduce(values, name, dtype, universal=True, **shared)
 
     assert torch.equal(universal, dispatched)
     check_sum(values, universal, name)

--- a/tests/extension/coop/test_block_reduce.py
+++ b/tests/extension/coop/test_block_reduce.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Block-wide reduction.
+
+Covered below: the sum reduction over the dtype list, in both of the
+implemented algorithms. Out of reach for lack of API surface: a partial tile —
+every thread of the block always contributes — an arbitrary callable as the
+reduction op (*op* is a ``ReductionOp``, see ``coop/_common.py``), and vector
+or user-defined element types.
+
+``BlockReduce`` requires a power-of-two thread count (``coop/block/_spec.py``);
+a block that does not fill a wave narrows the logical warp to itself rather
+than being refused, so the widths below run from one thread up.
+``RAKING_COMMUTATIVE_ONLY`` and ``WARP_REDUCTIONS_NONDETERMINISTIC`` are named
+by the enum but not implemented, so the algorithm axis is the two policies that
+are.
+
+The tests at the bottom came from ``test_coop.py`` when the algorithm tests
+were split out by algorithm.
+"""
+
+from __future__ import annotations
+
+import pytest
+from coop_common import (
+    BLOCK_THREADS,
+    DTYPES,
+    SUB_WARP_BLOCK_THREADS,
+    dtype_id,
+    is_float,
+    linear_tid,
+    sample,
+    torch_dtype,
+    wrap,
+)
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+
+ALGORITHMS = (
+    fx.coop.BlockReduceAlgorithm.WARP_REDUCTIONS,
+    fx.coop.BlockReduceAlgorithm.RAKING,
+)
+
+# The legal powers of two on a 64-lane wave, in both a 1-D and a 3-D block
+# shape.
+BLOCK_SHAPES = ((64, 1, 1), (128, 1, 1), (256, 1, 1), (64, 2, 2), (128, 2, 2))
+
+
+def run_block_reduce(values, name, dtype, *, block_size, algorithm, items_per_thread=1, op=None, namespace=None):
+    """Reduce *values* with one ``BlockReduce`` call per thread.
+
+    Returns the per-thread results on the host: the reduction is valid
+    block-wide, so every entry should hold the same total.
+
+    *namespace* is which ``BlockReduce`` to reach for — the dispatched one by
+    default, or ``fx.coop.universal`` for the form that folds through the
+    portable warp reduction.
+    """
+    op = op if op is not None else fx.ReductionOp.ADD
+    namespace = namespace if namespace is not None else fx.coop
+    block_threads = block_size[0] * block_size[1] * block_size[2]
+
+    # Decide the per-thread read before tracing: one scalar, or a Vector of
+    # several per-thread items.
+    if items_per_thread == 1:
+
+        def read(A, tid):
+            return A[tid]
+
+    else:
+
+        def read(A, tid):
+            return fx.Vector.from_elements([A[tid * items_per_thread + i] for i in range(items_per_thread)])
+
+    @flyc.kernel(known_block_size=list(block_size))
+    def kernel(A: fx.Tensor, Out: fx.Tensor):
+        block_reduce = namespace.BlockReduce[dtype, block_size, algorithm]
+        storage = fx.SharedAllocator().allocate(block_reduce.SharedStorage).peek()
+        tid = linear_tid(block_size)
+        Out[tid] = block_reduce(read(A, tid), op, storage=storage)
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Out: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Out).launch(grid=(1, 1, 1), block=block_size, stream=stream)
+
+    out = torch.zeros(block_threads, dtype=torch_dtype(name), device="cuda")
+    launch(values, out, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+    return out.cpu()
+
+
+def check_sum(values, out, name):
+    """Every thread holds the whole-block sum, folded the way the dtype folds."""
+    host = values.cpu()
+    assert torch.equal(out, out[0].expand(out.numel())), "the result must be valid in every thread"
+
+    if is_float(name):
+        tol = dict(rel=1e-12, abs=1e-9) if torch_dtype(name) == torch.float64 else dict(rel=1e-5, abs=1e-3)
+        assert float(out[0]) == pytest.approx(float(host.sum(dtype=torch.float64)), **tol)
+    else:
+        assert out[0] == wrap(host.to(torch.int64).sum(), name)
+
+
+# ── sum reduction ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("entry", DTYPES, ids=dtype_id)
+@pytest.mark.parametrize("items_per_thread", (1, 4))
+@pytest.mark.parametrize("algorithm", ALGORITHMS, ids=lambda a: a.name)
+def test_sum_over_a_full_tile(entry, items_per_thread, algorithm):
+    """A full tile sums to the same value every thread can read."""
+    dtype, name = entry
+    block_size = (128, 1, 1)
+    values = sample(name, 128 * items_per_thread)
+
+    out = run_block_reduce(
+        values, name, dtype, block_size=block_size, algorithm=algorithm, items_per_thread=items_per_thread
+    )
+    check_sum(values, out, name)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("block_size", BLOCK_SHAPES, ids=lambda b: "x".join(map(str, b)))
+@pytest.mark.parametrize("algorithm", ALGORITHMS, ids=lambda a: a.name)
+def test_sum_across_block_shapes(block_size, algorithm):
+    """The block shape axis: the same sum, however the block is shaped."""
+    dtype, name = fx.Int32, "torch.int32"
+    block_threads = block_size[0] * block_size[1] * block_size[2]
+    values = sample(name, block_threads)
+
+    out = run_block_reduce(values, name, dtype, block_size=block_size, algorithm=algorithm)
+    check_sum(values, out, name)
+
+
+# ── from test_coop.py ─────────────────────────────────────────────────────
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("algorithm", ALGORITHMS, ids=lambda a: a.name)
+@pytest.mark.parametrize(
+    "op,reference",
+    (
+        (fx.ReductionOp.ADD, torch.sum if torch else None),
+        (fx.ReductionOp.MAX, torch.max if torch else None),
+        (fx.ReductionOp.MIN, torch.min if torch else None),
+    ),
+    ids=lambda v: getattr(v, "name", ""),
+)
+def test_block_reduce_matches_torch(algorithm, op, reference):
+    """Every thread of the block sees the exact whole-block reduction."""
+    torch.manual_seed(0)
+    values = torch.randn(256, dtype=torch.float32, device="cuda")
+    out = run_block_reduce(values, "torch.float32", fx.Float32, block_size=(256, 1, 1), algorithm=algorithm, op=op)
+
+    expected = reference(values.cpu())
+    assert torch.equal(out, out[0].expand(256)), "result must be valid in every thread"
+    assert float(out[0]) == pytest.approx(float(expected), rel=1e-5)
+
+
+# What these two add over the sum cases above is the *compare/select* combining
+# path — float and integer take different lowerings — so neither is covered by
+# `test_sum_over_a_full_tile[items_per_thread=4]` (``Vector`` input under ADD)
+# or `test_sum_across_block_shapes` (int32 under ADD).
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("algorithm", ALGORITHMS, ids=lambda a: a.name)
+def test_block_reduce_over_vector_items(algorithm):
+    """A per-thread ``Vector`` reduces exactly like the flat block would."""
+    ITEMS = 4
+    BLOCK = 256
+    torch.manual_seed(0)
+    values = torch.randn(BLOCK * ITEMS, dtype=torch.float32, device="cuda")
+    out = run_block_reduce(
+        values,
+        "torch.float32",
+        fx.Float32,
+        block_size=(BLOCK, 1, 1),
+        algorithm=algorithm,
+        items_per_thread=ITEMS,
+        op=fx.ReductionOp.MAX,
+    )
+
+    assert torch.equal(out, out[0].expand(BLOCK))
+    assert float(out[0]) == pytest.approx(float(values.cpu().max()), rel=1e-6)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("algorithm", ALGORITHMS, ids=lambda a: a.name)
+def test_block_reduce_integer_max(algorithm):
+    """Integer max goes through the compare/select path, not the float one."""
+    values = torch.randint(-1000, 1000, (256,), dtype=torch.int32, device="cuda")
+    out = run_block_reduce(
+        values, "torch.int32", fx.Int32, block_size=(256, 1, 1), algorithm=algorithm, op=fx.ReductionOp.MAX
+    )
+
+    assert torch.equal(out, values.cpu().max().expand(256))
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("block_threads", BLOCK_THREADS, ids=lambda n: f"t{n}")
+def test_sum_across_every_legal_block_width(block_threads):
+    """One thread up to the 1024-thread launch limit — the whole legal range.
+
+    What the widths below a wave add is the narrowed logical warp, which folds
+    over the launched lanes alone; what the widths above 256 add is the
+    per-warp fold running over 8 and 16 slots rather than 2 or 4, and a launch
+    at the limit the hardware imposes. Held to one dtype and the default
+    algorithm on purpose: the axis under test is the width, and crossing it
+    with the others would only re-run them.
+    """
+    dtype, name = fx.Int32, "torch.int32"
+    values = sample(name, block_threads)
+
+    out = run_block_reduce(
+        values,
+        name,
+        dtype,
+        block_size=(block_threads, 1, 1),
+        algorithm=fx.coop.BlockReduceAlgorithm.WARP_REDUCTIONS,
+    )
+    check_sum(values, out, name)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("algorithm", ALGORITHMS, ids=lambda a: a.name)
+def test_universal_agrees_with_the_dispatched_reduction(algorithm):
+    """The portable warp fold underneath reaches the same total as the target's.
+
+    A block reduction folds through warp scope, so ``fx.coop.universal`` is the
+    only way to run one over the portable warp reduction at all — and this is
+    the only coverage that path has on a target that overrides it. Integers
+    wrap the same either way, so the two results are equal outright.
+    """
+    dtype, name = fx.Int32, "torch.int32"
+    values = sample(name, 256)
+    shared = dict(block_size=(256, 1, 1), algorithm=algorithm)
+
+    dispatched = run_block_reduce(values, name, dtype, **shared)
+    universal = run_block_reduce(values, name, dtype, namespace=fx.coop.universal, **shared)
+
+    assert torch.equal(universal, dispatched)
+    check_sum(values, universal, name)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+def test_single_warp_block_skips_shared_memory():
+    """A one-warp block reduces entirely in registers."""
+    warp_threads = fx.num_warp_threads()
+    out = run_block_reduce(
+        torch.ones(warp_threads, dtype=torch.float32, device="cuda"),
+        "torch.float32",
+        fx.Float32,
+        block_size=(warp_threads, 1, 1),
+        algorithm=fx.coop.BlockReduceAlgorithm.WARP_REDUCTIONS,
+    )
+    assert torch.equal(out, torch.full((warp_threads,), float(warp_threads)))
+
+
+# ── sub-wave blocks ───────────────────────────────────────────────────────
+
+
+@pytest.mark.l0_backend_agnostic
+@pytest.mark.parametrize("block_threads", SUB_WARP_BLOCK_THREADS, ids=lambda n: f"t{n}")
+@pytest.mark.parametrize("algorithm", ALGORITHMS, ids=lambda a: a.name)
+def test_a_sub_wave_block_narrows_its_logical_warp(block_threads, algorithm):
+    """The warp the collective folds over is the block, not the target's wave.
+
+    This is what keeps every cross-lane read inside the lanes the launch
+    actually started: a wave-wide fold in a block that only fills part of the
+    wave would read lanes that were never launched. Whichever algorithm is
+    named, the block is then a single warp, which is the condition each of
+    them short-circuits on.
+    """
+    block_reduce = fx.coop.BlockReduce[fx.Int32, block_threads, algorithm]
+
+    assert block_reduce.warp_threads == block_threads
+    assert block_reduce.num_warps == 1
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("block_threads", SUB_WARP_BLOCK_THREADS, ids=lambda n: f"t{n}")
+@pytest.mark.parametrize("algorithm", ALGORITHMS, ids=lambda a: a.name)
+def test_sum_in_a_sub_wave_block(block_threads, algorithm):
+    """Both algorithms still sum a block that occupies part of a wave.
+
+    The width sweep above runs one algorithm; this one crosses the sub-wave
+    widths with both, since the short-circuit each takes at a single warp is
+    separate code. The narrowest case is a single thread, where the fold has
+    no cross-lane step left at all.
+    """
+    dtype, name = fx.Int32, "torch.int32"
+    values = sample(name, block_threads)
+
+    out = run_block_reduce(values, name, dtype, block_size=(block_threads, 1, 1), algorithm=algorithm)
+    check_sum(values, out, name)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+def test_multi_dimensional_block():
+    """A 2-D block linearizes its thread id the way gpu.thread_id orders it."""
+    DIM_X, DIM_Y = 64, 2
+    BLOCK = DIM_X * DIM_Y
+    values = torch.ones(BLOCK, dtype=torch.float32, device="cuda")
+    out = run_block_reduce(
+        values,
+        "torch.float32",
+        fx.Float32,
+        block_size=(DIM_X, DIM_Y, 1),
+        algorithm=fx.coop.BlockReduceAlgorithm.WARP_REDUCTIONS,
+    )
+    assert torch.equal(out, torch.full((BLOCK,), float(BLOCK)))
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+def test_block_size_can_come_from_the_traced_launch():
+    """``known_block_size`` feeds the specialization, so the two cannot drift apart."""
+    BLOCK = 128
+
+    @flyc.kernel
+    def kernel(A: fx.Tensor, Out: fx.Tensor):
+        block_reduce = fx.coop.BlockReduce[fx.Float32, fx.known_block_size()]
+        assert block_reduce.block_threads == BLOCK
+        storage = fx.SharedAllocator().allocate(block_reduce.SharedStorage).peek()
+        tid = fx.thread_idx.x
+        Out[tid] = block_reduce(A[tid], fx.ReductionOp.ADD, storage=storage)
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Out: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Out).launch(grid=(1, 1, 1), block=(BLOCK, 1, 1), stream=stream)
+
+    values = torch.ones(BLOCK, dtype=torch.float32, device="cuda")
+    out = torch.zeros(BLOCK, dtype=torch.float32, device="cuda")
+    launch(values, out, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+    assert torch.equal(out.cpu(), torch.full((BLOCK,), float(BLOCK)))
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+def test_dynamic_block_size_has_nothing_to_read():
+    """A dynamic launch width leaves ``known_block_size`` with no answer to give."""
+
+    @flyc.kernel
+    def kernel(A: fx.Tensor, Out: fx.Tensor):
+        block_reduce = fx.coop.BlockReduce[fx.Float32, fx.known_block_size()]
+        storage = fx.SharedAllocator().allocate(block_reduce.SharedStorage).peek()
+        tid = fx.thread_idx.x
+        Out[tid] = block_reduce(A[tid], fx.ReductionOp.ADD, storage=storage)
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Out: fx.Tensor, nthreads: fx.Int32):
+        kernel(A, Out).launch(grid=(1, 1, 1), block=(nthreads, 1, 1))
+
+    values = torch.ones(128, dtype=torch.float32, device="cuda")
+    out = torch.zeros(128, dtype=torch.float32, device="cuda")
+    with pytest.raises(RuntimeError, match="no compile-time block size"):
+        launch(values, out, 128)

--- a/tests/extension/coop/test_block_scan.py
+++ b/tests/extension/coop/test_block_scan.py
@@ -60,16 +60,14 @@ BLOCK_SHAPES = ((64, 1, 1), (128, 1, 1), (256, 1, 1), (64, 2, 2))
 
 
 def run_block_scan(
-    values, name, dtype, *, block_size, inclusive, items_per_thread=1, op=None, init=None, namespace=None
+    values, name, dtype, *, block_size, inclusive, items_per_thread=1, op=None, init=None, universal=False
 ):
     """Scan *values* with one ``BlockScan`` call per thread; return the host result.
 
-    *namespace* is which ``BlockScan`` to reach for — the dispatched one by
-    default, or ``fx.coop.universal`` for the form that folds through the
-    portable warp scan.
+    *universal* picks ``fx.coop.universal.BlockScan``, the form that folds
+    through the portable warp scan, over the dispatched one.
     """
     op = op if op is not None else fx.ReductionOp.ADD
-    namespace = namespace if namespace is not None else fx.coop
 
     # Decide the per-thread read and write before tracing: one scalar, or a
     # Vector of several per-thread items.
@@ -91,6 +89,7 @@ def run_block_scan(
 
     @flyc.kernel(known_block_size=list(block_size))
     def kernel(A: fx.Tensor, Out: fx.Tensor):
+        namespace = fx.coop.universal if universal else fx.coop
         block_scan = namespace.BlockScan[dtype, block_size, namespace.BlockScanAlgorithm.WARP_SCANS]
         storage = fx.SharedAllocator().allocate(block_scan.SharedStorage).peek()
         scan(block_scan, A, Out, linear_tid(block_size), storage)
@@ -313,7 +312,7 @@ def test_universal_agrees_with_the_dispatched_scan(inclusive):
     shared = dict(block_size=(256, 1, 1), inclusive=inclusive)
 
     dispatched = run_block_scan(values, name, dtype, **shared)
-    universal = run_block_scan(values, name, dtype, namespace=fx.coop.universal, **shared)
+    universal = run_block_scan(values, name, dtype, universal=True, **shared)
 
     assert torch.equal(universal, dispatched)
     check_scan(values, universal, name, inclusive=inclusive)

--- a/tests/extension/coop/test_block_scan.py
+++ b/tests/extension/coop/test_block_scan.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Block-wide prefix scan.
+
+Covered below: the sum scan over the dtype list at one and at nine items per
+thread, the block aggregate, and the initial-value form. Out of reach for lack
+of API surface: an arbitrary callable as the scan op (*op* is a
+``ReductionOp``, see ``coop/_common.py``), a callback carrying a running
+prefix across calls, and vector or user-defined element types.
+
+``BlockScan`` needs a power-of-two thread count (``coop/block/_spec.py``); a
+block that does not fill a wave narrows the logical warp to itself rather than
+being refused, so the widths below run from one thread up and
+``items_per_thread`` is unconstrained. int16 stands in for uint16, which the
+runtime cannot hand to a memref.
+
+``RAKING`` and ``RAKING_MEMOIZE`` are named by the enum but not implemented, so
+the algorithm axis collapses to ``WARP_SCANS``.
+
+The tests at the bottom came from ``test_coop.py`` when the algorithm tests
+were split out by algorithm.
+"""
+
+from __future__ import annotations
+
+import pytest
+from coop_common import (
+    BLOCK_THREADS,
+    SUB_WARP_BLOCK_THREADS,
+    WARP_SIZE,
+    dtype_id,
+    is_float,
+    linear_tid,
+    sample,
+    wrap,
+)
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+
+# Integers only: a float scan's result depends on the order the partials are
+# folded in, which is what the algorithm is free to choose.
+SCAN_DTYPES = (
+    (fx.Uint8, "torch.uint8"),
+    (fx.Int16, "torch.int16"),
+    (fx.Int32, "torch.int32"),
+    (fx.Int64, "torch.int64"),
+)
+
+BLOCK_SHAPES = ((64, 1, 1), (128, 1, 1), (256, 1, 1), (64, 2, 2))
+
+
+def run_block_scan(
+    values, name, dtype, *, block_size, inclusive, items_per_thread=1, op=None, init=None, namespace=None
+):
+    """Scan *values* with one ``BlockScan`` call per thread; return the host result.
+
+    *namespace* is which ``BlockScan`` to reach for — the dispatched one by
+    default, or ``fx.coop.universal`` for the form that folds through the
+    portable warp scan.
+    """
+    op = op if op is not None else fx.ReductionOp.ADD
+    namespace = namespace if namespace is not None else fx.coop
+
+    # Decide the per-thread read and write before tracing: one scalar, or a
+    # Vector of several per-thread items.
+    if items_per_thread == 1:
+
+        def scan(block_scan, A, Out, tid, storage):
+            form = block_scan.inclusive if inclusive else block_scan.exclusive
+            Out[tid] = form(A[tid], op, storage=storage, init=init)
+
+    else:
+
+        def scan(block_scan, A, Out, tid, storage):
+            base = tid * items_per_thread
+            items = fx.Vector.from_elements([A[base + i] for i in range(items_per_thread)])
+            form = block_scan.inclusive if inclusive else block_scan.exclusive
+            out = form(items, op, storage=storage, init=init)
+            for i in range(items_per_thread):
+                Out[base + i] = out[i]
+
+    @flyc.kernel(known_block_size=list(block_size))
+    def kernel(A: fx.Tensor, Out: fx.Tensor):
+        block_scan = namespace.BlockScan[dtype, block_size, namespace.BlockScanAlgorithm.WARP_SCANS]
+        storage = fx.SharedAllocator().allocate(block_scan.SharedStorage).peek()
+        scan(block_scan, A, Out, linear_tid(block_size), storage)
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Out: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Out).launch(grid=(1, 1, 1), block=block_size, stream=stream)
+
+    out = torch.zeros_like(values)
+    launch(values, out, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+    return out.cpu()
+
+
+def check_scan(values, out, name, *, inclusive):
+    """Compare against the running fold, wrapped at the dtype's own width."""
+    host = values.cpu()
+    if is_float(name):
+        expected = host.cumsum(0)
+        if not inclusive:
+            expected = expected - host
+        torch.testing.assert_close(out, expected, rtol=1e-5, atol=1e-5)
+        return
+
+    widened = host.to(torch.int64).cumsum(0)
+    if not inclusive:
+        widened = widened - host.to(torch.int64)
+    assert torch.equal(out, wrap(widened, name))
+
+
+# ── sum scan ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("entry", SCAN_DTYPES, ids=dtype_id)
+@pytest.mark.parametrize("items_per_thread", (1, 9))
+@pytest.mark.parametrize("inclusive", (True, False), ids=("inclusive", "exclusive"))
+def test_sum(entry, items_per_thread, inclusive):
+    """Each thread's items fold in as if they sat consecutively in the block."""
+    dtype, name = entry
+    block_size = (128, 1, 1)
+    values = sample(name, 128 * items_per_thread)
+
+    out = run_block_scan(
+        values, name, dtype, block_size=block_size, inclusive=inclusive, items_per_thread=items_per_thread
+    )
+    check_scan(values, out, name, inclusive=inclusive)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("block_size", BLOCK_SHAPES, ids=lambda b: "x".join(map(str, b)))
+@pytest.mark.parametrize("inclusive", (True, False), ids=("inclusive", "exclusive"))
+def test_sum_across_block_shapes(block_size, inclusive):
+    """The block shape axis: the same scan, however the block is shaped."""
+    dtype, name = fx.Int32, "torch.int32"
+    block_threads = block_size[0] * block_size[1] * block_size[2]
+    values = sample(name, block_threads)
+
+    out = run_block_scan(values, name, dtype, block_size=block_size, inclusive=inclusive)
+    check_scan(values, out, name, inclusive=inclusive)
+
+
+# ── block aggregate ───────────────────────────────────────────────────────
+
+# 3 items per thread over a 64-wide block, in a 1-D and a 3-D block shape, plus
+# a block that only fills half a wave. The sub-wave shape is here rather than
+# only under the plain scan because the aggregate is broadcast from the last
+# lane of the logical warp: read at the wave's width instead of the block's, it
+# would come from a lane the launch never started.
+AGGREGATE_SHAPES = ((64, 1, 1), (64, 2, 2), (WARP_SIZE // 2, 1, 1))
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("block_size", AGGREGATE_SHAPES, ids=lambda b: "x".join(map(str, b)))
+@pytest.mark.parametrize("inclusive", (True, False), ids=("inclusive", "exclusive"))
+def test_block_aggregate(block_size, inclusive):
+    """The scan still holds, and every thread reads the whole block's total."""
+    ITEMS = 3
+    dtype, name = fx.Int32, "torch.int32"
+    block_threads = block_size[0] * block_size[1] * block_size[2]
+
+    @flyc.kernel(known_block_size=list(block_size))
+    def kernel(A: fx.Tensor, Out: fx.Tensor, Agg: fx.Tensor):
+        block_scan = fx.coop.BlockScan[dtype, block_size]
+        storage = fx.SharedAllocator().allocate(block_scan.SharedStorage).peek()
+        tid = linear_tid(block_size)
+        base = tid * ITEMS
+        items = fx.Vector.from_elements([A[base + i] for i in range(ITEMS)])
+        form = block_scan.inclusive_with_aggregate if inclusive else block_scan.exclusive_with_aggregate
+        out, aggregate = form(items, fx.ReductionOp.ADD, storage=storage)
+        for i in range(ITEMS):
+            Out[base + i] = out[i]
+        Agg[tid] = aggregate
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Out: fx.Tensor, Agg: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Out, Agg).launch(grid=(1, 1, 1), block=block_size, stream=stream)
+
+    values = sample(name, block_threads * ITEMS)
+    out = torch.zeros_like(values)
+    agg = torch.zeros(block_threads, dtype=torch.int32, device="cuda")
+    launch(values, out, agg, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+
+    check_scan(values, out.cpu(), name, inclusive=inclusive)
+
+    total = values.cpu().to(torch.int64).sum()
+    assert torch.equal(agg.cpu(), wrap(total.expand(block_threads), name))
+
+
+# ── array-based scan with an initial value ────────────────────────────────
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("items_per_thread", (1, 3))
+@pytest.mark.parametrize("inclusive", (True, False), ids=("inclusive", "exclusive"))
+def test_initial_value(items_per_thread, inclusive):
+    """*init* folds in ahead of the block, so thread 0 sees it and nothing else."""
+    INIT = 1
+    name = "torch.int32"
+    block_size = (64, 1, 1)
+    values = sample(name, 64 * items_per_thread)
+
+    out = run_block_scan(
+        values,
+        name,
+        fx.Int32,
+        block_size=block_size,
+        inclusive=inclusive,
+        items_per_thread=items_per_thread,
+        init=fx.Int32(INIT),
+    )
+
+    widened = values.cpu().to(torch.int64).cumsum(0)
+    if not inclusive:
+        widened = widened - values.cpu().to(torch.int64)
+    assert torch.equal(out, wrap(widened + INIT, name))
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+def test_initial_value_stays_out_of_the_aggregate():
+    """*init* seeds the scan but is not part of the aggregate."""
+    INIT = 1
+    BLOCK = 128
+
+    @flyc.kernel(known_block_size=[BLOCK, 1, 1])
+    def kernel(A: fx.Tensor, Out: fx.Tensor, Agg: fx.Tensor):
+        block_scan = fx.coop.BlockScan[fx.Int32, BLOCK]
+        storage = fx.SharedAllocator().allocate(block_scan.SharedStorage).peek()
+        tid = fx.thread_idx.x
+        out, aggregate = block_scan.inclusive_with_aggregate(
+            A[tid], fx.ReductionOp.ADD, storage=storage, init=fx.Int32(INIT)
+        )
+        Out[tid] = out
+        Agg[tid] = aggregate
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Out: fx.Tensor, Agg: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Out, Agg).launch(grid=(1, 1, 1), block=(BLOCK, 1, 1), stream=stream)
+
+    values = torch.ones(BLOCK, dtype=torch.int32, device="cuda")
+    out = torch.zeros_like(values)
+    agg = torch.zeros_like(values)
+    launch(values, out, agg, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+
+    # The scan carries init; the aggregate is the inputs alone.
+    assert torch.equal(out.cpu(), torch.arange(1, BLOCK + 1, dtype=torch.int32) + INIT)
+    assert torch.equal(agg.cpu(), torch.full((BLOCK,), BLOCK, dtype=torch.int32))
+
+
+# ── from test_coop.py ─────────────────────────────────────────────────────
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("block_threads", BLOCK_THREADS, ids=lambda n: f"t{n}")
+def test_scan_across_every_legal_block_width(block_threads):
+    """One thread up to the 1024-thread launch limit — the whole legal range.
+
+    What the widths below a wave add is the narrowed logical warp, which scans
+    over the launched lanes alone; what the widths above 256 add is the
+    per-warp prefix fold running over 8 and 16 slots rather than 2 or 4, and a
+    launch at the limit the hardware imposes. Held to one dtype and the
+    inclusive form on purpose: the axis under test is the width, and crossing
+    it with the others would only re-run them.
+    """
+    dtype, name = fx.Int32, "torch.int32"
+    values = sample(name, block_threads)
+
+    out = run_block_scan(values, name, dtype, block_size=(block_threads, 1, 1), inclusive=True)
+    check_scan(values, out, name, inclusive=True)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("inclusive", (True, False), ids=("inclusive", "exclusive"))
+def test_universal_agrees_with_the_dispatched_scan(inclusive):
+    """The portable warp scan underneath reaches the same prefixes as the target's.
+
+    A block scan folds through warp scope, so ``fx.coop.universal`` is the only
+    way to run one over the portable warp scan at all — and this is the only
+    coverage that path has on a target that overrides it. Integers wrap the
+    same either way, so the two results are equal outright.
+    """
+    dtype, name = fx.Int32, "torch.int32"
+    values = sample(name, 256)
+    shared = dict(block_size=(256, 1, 1), inclusive=inclusive)
+
+    dispatched = run_block_scan(values, name, dtype, **shared)
+    universal = run_block_scan(values, name, dtype, namespace=fx.coop.universal, **shared)
+
+    assert torch.equal(universal, dispatched)
+    check_scan(values, universal, name, inclusive=inclusive)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("inclusive", (True, False), ids=("inclusive", "exclusive"))
+def test_block_scan_matches_torch(inclusive):
+    """Each thread sees the fold of every thread before it, itself included or not."""
+    torch.manual_seed(0)
+    values = torch.randn(256, dtype=torch.float32, device="cuda")
+    out = run_block_scan(values, "torch.float32", fx.Float32, block_size=(256, 1, 1), inclusive=inclusive)
+
+    expected = values.cpu().cumsum(0)
+    if not inclusive:
+        expected = expected - values.cpu()
+    torch.testing.assert_close(out, expected, rtol=1e-5, atol=1e-5)
+
+
+# ADD cannot stand in for MAX here: the point is an identity that is *visible*
+# in the output, and ADD's is 0, which is indistinguishable from a thread that
+# simply summed nothing. MAX's -inf is the only way to tell the two apart.
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("inclusive", (True, False), ids=("inclusive", "exclusive"))
+def test_block_scan_max_starts_from_the_identity(inclusive):
+    """MAX is where the exclusive form's identity shows: thread 0 gets -inf."""
+    torch.manual_seed(0)
+    values = torch.randn(256, dtype=torch.float32, device="cuda")
+    out = run_block_scan(
+        values, "torch.float32", fx.Float32, block_size=(256, 1, 1), inclusive=inclusive, op=fx.ReductionOp.MAX
+    )
+
+    expected = values.cpu().cummax(0).values
+    if not inclusive:
+        expected = torch.cat([torch.full((1,), float("-inf")), expected[:-1]])
+    assert torch.equal(out, expected)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("inclusive", (True, False), ids=("inclusive", "exclusive"))
+def test_block_scan_over_vector_items(inclusive):
+    """A thread's Vector items scan as if they sat consecutively in the block."""
+    ITEMS = 4
+    BLOCK = 64
+    values = torch.ones(BLOCK * ITEMS, dtype=torch.float32, device="cuda")
+    out = run_block_scan(
+        values,
+        "torch.float32",
+        fx.Float32,
+        block_size=(BLOCK, 1, 1),
+        inclusive=inclusive,
+        items_per_thread=ITEMS,
+    )
+
+    expected = torch.arange(1, BLOCK * ITEMS + 1, dtype=torch.float32)
+    if not inclusive:
+        expected = expected - 1
+    assert torch.equal(out, expected)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+def test_block_scan_single_warp_skips_shared_memory():
+    """A one-warp block scans entirely in registers."""
+    warp_threads = fx.num_warp_threads()
+    values = torch.ones(warp_threads, dtype=torch.float32, device="cuda")
+    out = run_block_scan(values, "torch.float32", fx.Float32, block_size=(warp_threads, 1, 1), inclusive=True)
+
+    assert torch.equal(out, torch.arange(1, warp_threads + 1, dtype=torch.float32))
+
+
+@pytest.mark.l0_backend_agnostic
+@pytest.mark.parametrize("block_threads", SUB_WARP_BLOCK_THREADS, ids=lambda n: f"t{n}")
+def test_a_sub_wave_block_narrows_its_logical_warp(block_threads):
+    """The warp the scan folds over is the block, not the target's wave.
+
+    Same contract as the reduction's, and for the same reason: a wave-wide
+    scan in a block that only fills part of the wave would shuffle from lanes
+    the launch never started.
+    """
+    block_scan = fx.coop.BlockScan[fx.Int32, block_threads]
+
+    assert block_scan.warp_threads == block_threads
+    assert block_scan.num_warps == 1
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+def test_block_scan_integer_add():
+    """Integers take the same path; the scan is exact rather than approximate."""
+    values = torch.randint(-1000, 1000, (256,), dtype=torch.int32, device="cuda")
+    out = run_block_scan(values, "torch.int32", fx.Int32, block_size=(256, 1, 1), inclusive=True)
+
+    assert torch.equal(out, values.cpu().cumsum(0, dtype=torch.int32))

--- a/tests/extension/coop/test_block_spec.py
+++ b/tests/extension/coop/test_block_spec.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""The specialization machinery every block collective shares.
+
+``coop/block/_spec.py`` parses ``[dtype, block_size, algorithm]``, resolves the
+default policy, and caches the class it builds. What is checked here is the
+contract an algorithm has to hold up when it plugs into that: the default is
+answered per target and never read off a constant, an algorithm that answers
+nothing is refused rather than defaulted, a policy the enum names but does not
+implement is refused by name, and the cache keeps two targets' answers apart.
+
+None of it reaches a device. A specialization is Python, so these run wherever
+a backend can name its target.
+"""
+
+from __future__ import annotations
+
+import enum
+
+import pytest
+
+import flydsl.expr as fx
+from flydsl.compiler.backends import GPUTarget, current_target
+from flydsl.extension.coop.block._spec import BlockAlgorithmMeta
+
+CDNA = GPUTarget(backend="rocm", arch="gfx942", warp_size=64)
+RDNA = GPUTarget(backend="rocm", arch="gfx1201", warp_size=32)
+
+
+class _Policy(enum.Enum):
+    ALPHA = "alpha"
+    BETA = "beta"
+
+
+def _storage(dtype, block_threads, warp_threads):
+    return fx.Struct["slots" : fx.Array[dtype, 1]]
+
+
+class _PolicyMeta(BlockAlgorithmMeta):
+    """What every algorithm supplies; the answer itself is left to a subclass."""
+
+    _algorithms = _Policy
+    _shared_storage = {_Policy.ALPHA: _storage, _Policy.BETA: _storage}
+
+
+class _PinnedMeta(_PolicyMeta):
+    """An algorithm whose answer happens not to vary — still stated, not assumed."""
+
+    def _default_algorithm_for(cls, target):
+        return _Policy.ALPHA
+
+
+class _ByWaveMeta(_PolicyMeta):
+    """An algorithm whose answer follows the target's wave size."""
+
+    def _default_algorithm_for(cls, target):
+        return _Policy.BETA if target.warp_size == 32 else _Policy.ALPHA
+
+
+class Pinned(metaclass=_PinnedMeta):
+    block_threads = None
+
+
+class ByWave(metaclass=_ByWaveMeta):
+    block_threads = None
+
+
+# ── the hook decides the default ──────────────────────────────────────────
+
+
+@pytest.mark.l1a_compile_no_target_dialect
+def test_an_unspecified_algorithm_comes_from_the_hook():
+    """Leaving the policy out is what asks the hook, and its answer is what sticks."""
+    assert Pinned[fx.Float32, 64].algorithm is _Policy.ALPHA
+    # The same call on an algorithm that answers from the target: this machine's wave.
+    expected = _Policy.BETA if current_target().warp_size == 32 else _Policy.ALPHA
+    assert ByWave[fx.Float32, 64].algorithm is expected
+
+
+@pytest.mark.l1a_compile_no_target_dialect
+def test_an_algorithm_that_does_not_answer_is_refused():
+    """There is no target-independent fallback, so silence is an error, not a default."""
+
+    class _SilentMeta(_PolicyMeta):
+        pass
+
+    class Silent(metaclass=_SilentMeta):
+        block_threads = None
+
+    with pytest.raises(NotImplementedError, match="_default_algorithm_for"):
+        Silent[fx.Float32, 64]
+
+
+@pytest.mark.l1a_compile_no_target_dialect
+def test_the_hook_is_handed_the_target_being_compiled_for():
+    """``__getitem__`` resolves against ``current_target()``, not a cached one."""
+    seen = []
+
+    class _RecordingMeta(_PinnedMeta):
+        def _default_algorithm_for(cls, target):
+            seen.append(target)
+            return _Policy.ALPHA
+
+    class Recording(metaclass=_RecordingMeta):
+        block_threads = None
+
+    Recording[fx.Float32, 64]
+    assert seen == [current_target()]
+
+
+@pytest.mark.l1a_compile_no_target_dialect
+def test_an_override_answers_per_target():
+    """The hook is a pure function of the target, so both answers are reachable."""
+    assert _ByWaveMeta._default_algorithm_for(ByWave, CDNA) is _Policy.ALPHA
+    assert _ByWaveMeta._default_algorithm_for(ByWave, RDNA) is _Policy.BETA
+
+
+@pytest.mark.l1a_compile_no_target_dialect
+def test_a_named_algorithm_bypasses_the_hook():
+    """An explicit policy is the caller's, whatever the target would have picked."""
+
+    class _NeverMeta(_PinnedMeta):
+        def _default_algorithm_for(cls, target):
+            raise AssertionError("the hook must not run when the caller names a policy")
+
+    class Never(metaclass=_NeverMeta):
+        block_threads = None
+
+    assert Never[fx.Float32, 64, _Policy.BETA].algorithm is _Policy.BETA
+
+
+# ── a policy the enum names but does not implement ────────────────────────
+
+
+@pytest.mark.l1a_compile_no_target_dialect
+def test_a_policy_that_is_not_implemented_is_refused_by_name():
+    """The enum names planned variants too, and asking for one says so.
+
+    Only a caller who went looking past the default can reach this — the
+    default is always a policy that is implemented.
+    """
+    with pytest.raises(NotImplementedError, match="BlockScanAlgorithm.RAKING_MEMOIZE is not implemented"):
+        fx.coop.BlockScan[fx.Float32, 64, fx.coop.BlockScanAlgorithm.RAKING_MEMOIZE]
+
+
+# ── the cache keeps the answers apart ─────────────────────────────────────
+
+
+@pytest.mark.l1a_compile_no_target_dialect
+def test_two_defaults_do_not_share_a_cache_entry():
+    """The resolved policy is part of the key, so a per-target default separates.
+
+    This is what makes the hook safe to override: were the default resolved
+    after the key was built, the first target through would pin the class for
+    every later one.
+    """
+    alpha = Pinned[fx.Float32, 64, _Policy.ALPHA]
+    beta = Pinned[fx.Float32, 64, _Policy.BETA]
+    assert alpha is not beta
+    assert alpha is Pinned[fx.Float32, 64]  # the default, resolved to ALPHA
+
+
+@pytest.mark.l1a_compile_no_target_dialect
+def test_an_identical_specialization_is_reused():
+    """Same class, same parameters, same target: the cached specialization."""
+    assert Pinned[fx.Float32, 64] is Pinned[fx.Float32, 64]
+
+
+# ── what the shipped collectives currently choose ─────────────────────────
+
+
+@pytest.mark.l1a_compile_no_target_dialect
+@pytest.mark.parametrize("target", (CDNA, RDNA), ids=lambda t: t.arch)
+def test_the_shipped_defaults_are_target_independent(target):
+    """Neither collective overrides the hook yet, and this is what says so.
+
+    ``BlockReduce`` measured ``WARP_REDUCTIONS`` ahead of ``RAKING`` on both a
+    wave64 and a wave32 target, and ``BlockScan`` has only one policy
+    implemented. A target that inverts either is what would make an override
+    the right change — and would land here first.
+    """
+    assert (
+        type(fx.coop.BlockReduce)._default_algorithm_for(fx.coop.BlockReduce, target)
+        is fx.coop.BlockReduceAlgorithm.WARP_REDUCTIONS
+    )
+    assert (
+        type(fx.coop.BlockScan)._default_algorithm_for(fx.coop.BlockScan, target)
+        is fx.coop.BlockScanAlgorithm.WARP_SCANS
+    )
+
+
+@pytest.mark.l1a_compile_no_target_dialect
+@pytest.mark.parametrize("target", (CDNA, RDNA), ids=lambda t: t.arch)
+def test_the_portable_collectives_inherit_the_same_hook(target):
+    """``fx.coop.universal`` subclasses the dispatched pair, hook included.
+
+    It overrides ``warp_ops`` and nothing else, so a default that started
+    answering per target would reach the portable spelling too — which is what
+    keeps the two from drifting into different policies.
+    """
+    for portable, dispatched in (
+        (fx.coop.universal.BlockReduce, fx.coop.BlockReduce),
+        (fx.coop.universal.BlockScan, fx.coop.BlockScan),
+    ):
+        assert type(portable)._default_algorithm_for(portable, target) is type(dispatched)._default_algorithm_for(
+            dispatched, target
+        )

--- a/tests/extension/coop/test_warp_rocdl.py
+++ b/tests/extension/coop/test_warp_rocdl.py
@@ -64,7 +64,8 @@ def width_id(width):
 requires_dpp = pytest.mark.skipif(not _is_gfx9(), reason="the DPP sequence is gfx9-only")
 
 
-@pytest.mark.l1a_compile_no_target_dialect
+@pytest.mark.l1b_target_dialect
+@pytest.mark.rocm_lower
 def test_rocm_resolves_every_warp_collective_to_the_override():
     """On the ROCm backend the public names are the target's, not the portable ones."""
     from flydsl.extension.coop import warp

--- a/tests/extension/coop/test_warp_rocdl.py
+++ b/tests/extension/coop/test_warp_rocdl.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""The ROCm override for the warp collectives, and the portable form it displaces.
+
+``coop/warp/rocdl.py`` replaces the shuffles behind ``warp_reduce`` and the
+three scan entry points with a DPP sequence on gfx9. Two things have to hold
+for that to be a safe swap, and they are what this file checks:
+
+- **It computes the same thing.** Every case runs through both implementations
+  and compares them against each other, not only against a host reference — a
+  fold that is wrong in the same way in both would still pass a reference check
+  on ones or on a symmetric distribution.
+- **It is actually the code that runs.** A DPP sequence that quietly fell back
+  would still be correct, so the shape of the fold is only observable in the
+  generated ISA: on gfx9 every power-of-two width has to come out of the VALU,
+  with the single ``ds_swizzle_b32`` a 32-lane reduce needs as the one
+  exception. Everything the sequence does not cover — a non-gfx9 target, a
+  value that is not a 32-bit ``Numeric`` — has to reach the portable
+  implementation instead.
+
+The functional coverage of the collectives themselves lives in
+``test_warp_scan.py``; nothing here duplicates it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from coop_common import WARP_WIDTHS
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.backends import current_target
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+
+# The portable forms under the same names the dispatched namespace exposes, so
+# a test can name the collective once and run it through both. That is what
+# ``fx.coop.universal`` is for, and using it here is also what checks it really
+# is the displaced code rather than a second route to the override.
+portable = fx.coop.universal
+
+# ``WARP_WIDTHS`` is every width the DPP sequence takes a different route
+# through: 2 and 4 are ``quad_perm`` alone, 8 brings in ``row_half_mirror``, 16
+# ``row_ror:8``, 32 the one cross-row step, and the full wave the raking
+# ``row_bcast`` ladder.
+CROSS_LANE_LDS = ("ds_swizzle_b32", "ds_bpermute_b32", "ds_permute_b32")
+
+
+def _is_gfx9():
+    return current_target().arch.startswith("gfx9")
+
+
+def width_id(width):
+    return "full" if width is None else f"w{width}"
+
+
+requires_dpp = pytest.mark.skipif(not _is_gfx9(), reason="the DPP sequence is gfx9-only")
+
+
+@pytest.mark.l1a_compile_no_target_dialect
+def test_rocm_resolves_every_warp_collective_to_the_override():
+    """On the ROCm backend the public names are the target's, not the portable ones."""
+    from flydsl.extension.coop import warp
+    from flydsl.extension.coop.warp import rocdl
+
+    assert fx.coop.warp.rocdl is rocdl
+    # The override covers the whole warp-scope surface, so nothing in it is
+    # left resolving to a shuffle by accident.
+    assert set(rocdl.__all__) == set(warp.__all__)
+    # The portable implementations are still reachable, which is what lets the
+    # override fall back to them and this file compare against them.
+    assert portable.warp_reduce is not rocdl.warp_reduce
+    assert portable.warp_inclusive_scan is not rocdl.warp_inclusive_scan
+
+
+# ── the override and the portable form agree ───────────────────────────────
+
+
+def _run_both(values, call, *, block):
+    """Run *call* twice in one kernel: once dispatched, once portable.
+
+    *call* takes the module to reach the collective through, so one line of the
+    test names both the override and the form it displaces.
+    """
+
+    @flyc.kernel(known_block_size=[block, 1, 1])
+    def kernel(A: fx.Tensor, Fast: fx.Tensor, Ref: fx.Tensor):
+        tid = fx.thread_idx.x
+        Fast[tid] = call(fx.coop, A[tid])
+        Ref[tid] = call(portable, A[tid])
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Fast: fx.Tensor, Ref: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Fast, Ref).launch(grid=(1, 1, 1), block=(block, 1, 1), stream=stream)
+
+    fast = torch.zeros_like(values)
+    ref = torch.zeros_like(values)
+    launch(values, fast, ref, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+    return fast.cpu(), ref.cpu()
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("width", WARP_WIDTHS, ids=width_id)
+@pytest.mark.parametrize(
+    "form",
+    ("reduce", "inclusive", "exclusive", "aggregate"),
+)
+def test_every_form_agrees_with_the_portable_one(form, width):
+    """Integers wrap identically, so every one of these is exact on both sides."""
+    warp_threads = fx.num_warp_threads()
+    block = 2 * warp_threads  # two waves, so a fold that overran one would show
+    group = warp_threads if width is None else width
+
+    call = {
+        "reduce": lambda m, v: m.warp_reduce(v, fx.ReductionOp.ADD, width=width),
+        "inclusive": lambda m, v: m.warp_inclusive_scan(v, fx.ReductionOp.ADD, width=width),
+        "exclusive": lambda m, v: m.warp_exclusive_scan(v, fx.ReductionOp.ADD, width=width),
+        "aggregate": lambda m, v: m.warp_scan_with_aggregate(v, fx.ReductionOp.ADD, width=width)[2],
+    }[form]
+
+    torch.manual_seed(0)
+    values = torch.randint(-(2**20), 2**20, (block,), dtype=torch.int32, device="cuda")
+    fast, ref = _run_both(values, call, block=block)
+
+    assert torch.equal(fast, ref)
+
+    # Each group of *group* lanes folds on its own; nothing crosses the boundary.
+    per_group = values.cpu().reshape(-1, group)
+    inclusive = per_group.cumsum(1, dtype=torch.int32)
+    expected = {
+        "reduce": per_group.sum(1, dtype=torch.int32).repeat_interleave(group),
+        "inclusive": inclusive.reshape(-1),
+        "exclusive": (inclusive - per_group).reshape(-1),
+        "aggregate": per_group.sum(1, dtype=torch.int32).repeat_interleave(group),
+    }[form]
+    assert torch.equal(fast, expected)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("op", (fx.ReductionOp.ADD, fx.ReductionOp.MUL), ids=lambda o: o.name)
+def test_float_folds_agree_with_the_portable_form(op):
+    """Floats fold in a different order, so this is a tolerance check, not equality.
+
+    The DPP sequence folds each 16-lane row in lane order and then carries the
+    rows up; the butterfly pairs lanes by XOR distance. Both are valid, and
+    neither is the other's rounding.
+    """
+    warp_threads = fx.num_warp_threads()
+    block = 2 * warp_threads
+    torch.manual_seed(0)
+    if op is fx.ReductionOp.MUL:
+        # Keep the product near 1 so the comparison is about the fold order and
+        # not about a 64-way product overflowing.
+        values = torch.rand(block, dtype=torch.float32, device="cuda") * 0.4 + 0.9
+    else:
+        values = torch.randn(block, dtype=torch.float32, device="cuda")
+
+    fast, ref = _run_both(values, lambda m, v: m.warp_reduce(v, op), block=block)
+
+    torch.testing.assert_close(fast, ref, rtol=1e-5, atol=1e-5)
+    per_warp = values.cpu().reshape(-1, warp_threads).to(torch.float64)
+    expected = (per_warp.sum(1) if op is fx.ReductionOp.ADD else per_warp.prod(1)).to(torch.float32)
+    torch.testing.assert_close(fast, expected.repeat_interleave(warp_threads), rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("width", WARP_WIDTHS, ids=width_id)
+@pytest.mark.parametrize("form", ("reduce", "exclusive"))
+def test_max_keeps_its_identity_inside_the_group(form, width):
+    """MAX is the op whose identity is visible, so it is the one that pins the edges.
+
+    ADD's identity is 0, which a lane that folded nothing also holds, so a
+    boundary the DPP sequence got wrong would not necessarily show. MAX's is
+    ``INT32_MIN``, every input below sits above it, and the exclusive form puts
+    it in the output of each group's first lane.
+    """
+    warp_threads = fx.num_warp_threads()
+    block = 2 * warp_threads
+    group = warp_threads if width is None else width
+    op = fx.ReductionOp.MAX
+
+    call = {
+        "reduce": lambda m, v: m.warp_reduce(v, op, width=width),
+        "exclusive": lambda m, v: m.warp_exclusive_scan(v, op, width=width),
+    }[form]
+
+    torch.manual_seed(0)
+    values = torch.randint(1, 2**20, (block,), dtype=torch.int32, device="cuda")
+    fast, ref = _run_both(values, call, block=block)
+
+    assert torch.equal(fast, ref)
+
+    per_group = values.cpu().reshape(-1, group)
+    if form == "reduce":
+        expected = per_group.amax(1).repeat_interleave(group)
+    else:
+        identity = torch.full((per_group.shape[0], 1), -(2**31), dtype=torch.int32)
+        expected = torch.cat([identity, per_group.cummax(1).values[:, :-1]], dim=1).reshape(-1)
+    assert torch.equal(fast, expected)
+
+
+# ── the override is actually the code that runs ────────────────────────────
+
+
+def _isa(call, torch_dtype, *, tmp_path):
+    """Compile a lone collective and return its final ISA as text."""
+    import os
+    from pathlib import Path
+
+    warp_threads = fx.num_warp_threads()
+
+    @flyc.kernel(known_block_size=[warp_threads, 1, 1])
+    def kernel(A: fx.Tensor, Out: fx.Tensor):
+        tid = fx.thread_idx.x
+        Out[tid] = call(A[tid])
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Out: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Out).launch(grid=(1, 1, 1), block=(warp_threads, 1, 1), stream=stream)
+
+    values = torch.ones(warp_threads, dtype=torch_dtype, device="cuda")
+    out = torch.zeros_like(values)
+
+    previous = {k: os.environ.get(k) for k in ("FLYDSL_DUMP_IR", "FLYDSL_DUMP_DIR", "FLYDSL_RUNTIME_ENABLE_CACHE")}
+    os.environ.update(FLYDSL_DUMP_IR="1", FLYDSL_DUMP_DIR=str(tmp_path), FLYDSL_RUNTIME_ENABLE_CACHE="0")
+    try:
+        launch(values, out, stream=torch.cuda.Stream())
+        torch.cuda.synchronize()
+    finally:
+        for key, value in previous.items():
+            os.environ.pop(key, None) if value is None else os.environ.update({key: value})
+
+    dumped = list(Path(tmp_path).glob("*/*_final_isa.s"))
+    assert dumped, f"no ISA dumped under {tmp_path}"
+    return dumped[0].read_text()
+
+
+def _count(isa, *needles):
+    return sum(line.count(needle) for line in isa.splitlines() for needle in needles)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@requires_dpp
+@pytest.mark.parametrize("width", WARP_WIDTHS, ids=width_id)
+def test_the_fold_stays_out_of_lds(width, tmp_path):
+    """The whole point: the fold is VALU, so the LDS pipe stays free for the kernel.
+
+    The one exception is a 32-lane reduce. Its last butterfly step is XOR by 16,
+    which crosses the 16-lane rows DPP is built around, and gfx9 has no control
+    for that — ``ds_swizzle_b32`` is the cheapest instruction that does it. The
+    scans reach across the same boundary with ``row_bcast:15`` instead, because
+    they only ever carry a value upwards.
+    """
+
+    def call(v):
+        reduced = fx.coop.warp_reduce(v, fx.ReductionOp.ADD, width=width)
+        inclusive, exclusive = fx.coop.warp_scan(v, fx.ReductionOp.ADD, width=width)
+        return reduced + inclusive + exclusive
+
+    isa = _isa(call, torch.float32, tmp_path=tmp_path)
+
+    expected_lds = 1 if width == 32 else 0
+    assert _count(isa, *CROSS_LANE_LDS) == expected_lds, "the DPP sequence did not take"
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@requires_dpp
+def test_a_full_wave_fold_rakes_and_lifts_the_total_into_an_sgpr(tmp_path):
+    """At full width the fold is the ``row_shr`` ladder, not the butterfly.
+
+    A whole wave has one lane holding the total once the ladder has run, so
+    ``v_readlane_b32`` broadcasts it for free out of an SGPR; a narrower group
+    has no such lane and has to butterfly instead.
+    """
+    isa = _isa(lambda v: fx.coop.warp_reduce(v, fx.ReductionOp.ADD), torch.float32, tmp_path=tmp_path)
+
+    assert "row_shr:1" in isa and "row_bcast:15" in isa and "row_bcast:31" in isa
+    assert "v_readlane_b32" in isa
+    assert _count(isa, *CROSS_LANE_LDS) == 0
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@requires_dpp
+def test_universal_is_still_the_shuffles(tmp_path):
+    """``fx.coop.universal`` keeps the LDS fold, which only the ISA can show.
+
+    Every comparison above holds the two implementations against each other by
+    their results, and a ``universal`` that had quietly resolved to the
+    override would agree with itself perfectly. A narrow group is where the
+    difference is unambiguous: LLVM rewrites a whole-wave shuffle fold into DPP
+    on its own, but not one confined to a group, so the shuffles survive into
+    the ISA — where the same width through ``fx.coop`` reaches no LDS at all
+    (``test_the_fold_stays_out_of_lds``).
+    """
+    isa = _isa(lambda v: portable.warp_reduce(v, fx.ReductionOp.ADD, width=8), torch.float32, tmp_path=tmp_path)
+
+    assert _count(isa, *CROSS_LANE_LDS) > 0, "universal did not reach the portable implementation"
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@requires_dpp
+def test_a_dtype_the_sequence_cannot_move_falls_back(tmp_path):
+    """DPP moves 32 bits at a time, so a 16-bit fold has to keep the shuffles."""
+    isa = _isa(lambda v: fx.coop.warp_reduce(v, fx.ReductionOp.ADD), torch.int16, tmp_path=tmp_path)
+
+    assert "row_bcast" not in isa, "the DPP sequence took a dtype it cannot move"
+    assert _count(isa, *CROSS_LANE_LDS) > 0

--- a/tests/extension/coop/test_warp_scan.py
+++ b/tests/extension/coop/test_warp_scan.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Warp-wide prefix scan.
+
+Covered below: the sum scan over the dtype list, the combined
+``(inclusive, exclusive)`` pair, the warp aggregate, and the initial-value
+form. Out of reach for lack of API surface: an arbitrary callable as the scan
+op (*op* is a ``ReductionOp``, see ``coop/_common.py``), vector and
+user-defined element types, and a partial scan — every lane of the logical
+warp always participates.
+
+The width axis is :data:`~coop_common.WARP_WIDTHS`: every width that
+``resolve_warp_width`` accepts (``coop/_common.py``), which is the powers of
+two up to the target's own wave. Each test launches two physical warps, so a
+width that leaked past its group would show up as a scan crossing the
+boundary.
+
+The tests at the bottom came from ``test_coop.py`` when the algorithm tests
+were split out by algorithm. ``warp_reduce`` has no file of its own: what
+covers it is ``test_warp_rocdl.py``, which runs every fold through both the
+dispatched override and the portable form and compares the two.
+"""
+
+from __future__ import annotations
+
+import pytest
+from coop_common import WARP_WIDTHS, dtype_id, sample, wrap
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+
+# int16 stands in for uint16: the runtime has no memref element type for
+# torch.uint16.
+SCAN_DTYPES = (
+    (fx.Uint8, "torch.uint8"),
+    (fx.Int16, "torch.int16"),
+    (fx.Int32, "torch.int32"),
+    (fx.Int64, "torch.int64"),
+)
+
+
+def width_id(width):
+    return "full_warp" if width is None else f"w{width}"
+
+
+def run_warp_scan(values, name, *, width, inclusive, block):
+    """Scan *values* with one ``warp_inclusive/exclusive_scan`` per lane."""
+
+    @flyc.kernel(known_block_size=[block, 1, 1])
+    def kernel(A: fx.Tensor, Out: fx.Tensor):
+        tid = fx.thread_idx.x
+        form = fx.coop.warp_inclusive_scan if inclusive else fx.coop.warp_exclusive_scan
+        Out[tid] = form(A[tid], fx.ReductionOp.ADD, width=width)
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Out: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Out).launch(grid=(1, 1, 1), block=(block, 1, 1), stream=stream)
+
+    out = torch.zeros_like(values)
+    launch(values, out, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+    return out.cpu()
+
+
+def expected_scan(values, name, *, width, inclusive):
+    """The per-group running fold, wrapped at the dtype's own width.
+
+    Nothing crosses a group boundary, so the reference scans each row of a
+    ``(-1, width)`` reshape on its own.
+    """
+    host = values.cpu().to(torch.int64).reshape(-1, width)
+    widened = host.cumsum(1)
+    if not inclusive:
+        widened = widened - host
+    return wrap(widened.reshape(-1), name)
+
+
+# ── sum scan ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("entry", SCAN_DTYPES, ids=dtype_id)
+@pytest.mark.parametrize("width", WARP_WIDTHS, ids=width_id)
+@pytest.mark.parametrize("inclusive", (True, False), ids=("inclusive", "exclusive"))
+def test_sum(entry, width, inclusive):
+    """Each group of *width* lanes scans on its own."""
+    _, name = entry
+    warp_threads = fx.num_warp_threads()
+    group = warp_threads if width is None else width
+    block = 2 * warp_threads
+    values = sample(name, block)
+
+    out = run_warp_scan(values, name, width=width, inclusive=inclusive, block=block)
+    assert torch.equal(out, expected_scan(values, name, width=group, inclusive=inclusive))
+
+
+# ── combined inclusive/exclusive scan ─────────────────────────────────────
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("width", WARP_WIDTHS, ids=width_id)
+def test_combination_scan(width):
+    """Both forms come out of one scan and agree with the two separate ones."""
+    name = "torch.int32"
+    warp_threads = fx.num_warp_threads()
+    group = warp_threads if width is None else width
+    block = 2 * warp_threads
+
+    @flyc.kernel(known_block_size=[block, 1, 1])
+    def kernel(A: fx.Tensor, Inc: fx.Tensor, Exc: fx.Tensor):
+        tid = fx.thread_idx.x
+        inclusive, exclusive = fx.coop.warp_scan(A[tid], fx.ReductionOp.ADD, width=width)
+        Inc[tid] = inclusive
+        Exc[tid] = exclusive
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Inc: fx.Tensor, Exc: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Inc, Exc).launch(grid=(1, 1, 1), block=(block, 1, 1), stream=stream)
+
+    values = sample(name, block)
+    inc = torch.zeros_like(values)
+    exc = torch.zeros_like(values)
+    launch(values, inc, exc, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+
+    assert torch.equal(inc.cpu(), expected_scan(values, name, width=group, inclusive=True))
+    assert torch.equal(exc.cpu(), expected_scan(values, name, width=group, inclusive=False))
+
+
+# ── warp aggregate ────────────────────────────────────────────────────────
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("entry", SCAN_DTYPES, ids=dtype_id)
+@pytest.mark.parametrize("width", WARP_WIDTHS, ids=width_id)
+@pytest.mark.parametrize("inclusive", (True, False), ids=("inclusive", "exclusive"))
+def test_warp_aggregate(entry, width, inclusive):
+    """The scan still holds, and every lane reads its own group's total."""
+    _, name = entry
+    warp_threads = fx.num_warp_threads()
+    group = warp_threads if width is None else width
+    block = 2 * warp_threads
+
+    @flyc.kernel(known_block_size=[block, 1, 1])
+    def kernel(A: fx.Tensor, Out: fx.Tensor, Agg: fx.Tensor):
+        tid = fx.thread_idx.x
+        scanned, exclusive, aggregate = fx.coop.warp_scan_with_aggregate(A[tid], fx.ReductionOp.ADD, width=width)
+        Out[tid] = scanned if inclusive else exclusive
+        Agg[tid] = aggregate
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Out: fx.Tensor, Agg: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Out, Agg).launch(grid=(1, 1, 1), block=(block, 1, 1), stream=stream)
+
+    values = sample(name, block)
+    out = torch.zeros_like(values)
+    agg = torch.zeros_like(values)
+    launch(values, out, agg, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+
+    assert torch.equal(out.cpu(), expected_scan(values, name, width=group, inclusive=inclusive))
+
+    # The aggregate is the group's whole fold, and every lane of the group has it.
+    totals = values.cpu().to(torch.int64).reshape(-1, group).sum(1)
+    assert torch.equal(agg.cpu(), wrap(totals.repeat_interleave(group), name))
+
+
+# ── array-based scan with an initial value ────────────────────────────────
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("width", WARP_WIDTHS, ids=width_id)
+@pytest.mark.parametrize("inclusive", (True, False), ids=("inclusive", "exclusive"))
+def test_initial_value(width, inclusive):
+    """*init* folds in ahead of the group, so lane 0 sees it and nothing else."""
+    INIT = 3
+    name = "torch.int32"
+    warp_threads = fx.num_warp_threads()
+    group = warp_threads if width is None else width
+    block = 2 * warp_threads
+
+    @flyc.kernel(known_block_size=[block, 1, 1])
+    def kernel(A: fx.Tensor, Out: fx.Tensor):
+        tid = fx.thread_idx.x
+        form = fx.coop.warp_inclusive_scan if inclusive else fx.coop.warp_exclusive_scan
+        Out[tid] = form(A[tid], fx.ReductionOp.ADD, width=width, init=fx.Int32(INIT))
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Out: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Out).launch(grid=(1, 1, 1), block=(block, 1, 1), stream=stream)
+
+    values = sample(name, block)
+    out = torch.zeros_like(values)
+    launch(values, out, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+
+    expected = expected_scan(values, name, width=group, inclusive=inclusive).to(torch.int64) + INIT
+    assert torch.equal(out.cpu(), wrap(expected, name))
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+def test_initial_value_stays_out_of_the_aggregate():
+    """*init* seeds the scan but is not part of the aggregate."""
+    INIT = 3
+    warp_threads = fx.num_warp_threads()
+
+    @flyc.kernel(known_block_size=[warp_threads, 1, 1])
+    def kernel(A: fx.Tensor, Out: fx.Tensor, Agg: fx.Tensor):
+        tid = fx.thread_idx.x
+        scanned, _, aggregate = fx.coop.warp_scan_with_aggregate(A[tid], fx.ReductionOp.ADD, init=fx.Int32(INIT))
+        Out[tid] = scanned
+        Agg[tid] = aggregate
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Out: fx.Tensor, Agg: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Out, Agg).launch(grid=(1, 1, 1), block=(warp_threads, 1, 1), stream=stream)
+
+    values = torch.ones(warp_threads, dtype=torch.int32, device="cuda")
+    out = torch.zeros_like(values)
+    agg = torch.zeros_like(values)
+    launch(values, out, agg, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+
+    # The scan carries init; the aggregate is the inputs alone.
+    assert torch.equal(out.cpu(), torch.arange(1, warp_threads + 1, dtype=torch.int32) + INIT)
+    assert torch.equal(agg.cpu(), torch.full((warp_threads,), warp_threads, dtype=torch.int32))
+
+
+# ── from test_coop.py ─────────────────────────────────────────────────────
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+def test_warp_scan_forms_agree():
+    """The warp-scope API on its own, without a block wrapped around it."""
+    WIDTH = 16  # narrower than a warp, so the lane mask has to respect the group
+    warp_threads = fx.num_warp_threads()
+
+    @flyc.kernel(known_block_size=[warp_threads, 1, 1])
+    def kernel(A: fx.Tensor, Inc: fx.Tensor, Exc: fx.Tensor):
+        tid = fx.thread_idx.x
+        inclusive, exclusive = fx.coop.warp_scan(A[tid], fx.ReductionOp.ADD, width=WIDTH)
+        Inc[tid] = inclusive
+        Exc[tid] = exclusive
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Inc: fx.Tensor, Exc: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Inc, Exc).launch(grid=(1, 1, 1), block=(warp_threads, 1, 1), stream=stream)
+
+    values = torch.arange(1, warp_threads + 1, dtype=torch.float32, device="cuda")
+    inc = torch.zeros_like(values)
+    exc = torch.zeros_like(values)
+    launch(values, inc, exc, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+
+    # Each group of WIDTH lanes scans on its own; nothing crosses the boundary.
+    expected = values.cpu().reshape(-1, WIDTH).cumsum(1).reshape(-1)
+    assert torch.equal(inc.cpu(), expected)
+    assert torch.equal(exc.cpu(), expected - values.cpu())
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires GPU")
+def test_warp_width_defaults_to_the_whole_warp():
+    """Leaving *width* out spans exactly one warp, whatever wave size the target has."""
+    warp_threads = fx.num_warp_threads()
+    BLOCK = 2 * warp_threads  # two warps, so a width that overran one would show
+
+    @flyc.kernel(known_block_size=[BLOCK, 1, 1])
+    def kernel(A: fx.Tensor, Total: fx.Tensor, Inc: fx.Tensor):
+        tid = fx.thread_idx.x
+        Total[tid] = fx.coop.warp_reduce(A[tid], fx.ReductionOp.ADD)
+        Inc[tid] = fx.coop.warp_inclusive_scan(A[tid], fx.ReductionOp.ADD)
+
+    @flyc.jit
+    def launch(A: fx.Tensor, Total: fx.Tensor, Inc: fx.Tensor, stream: fx.Stream = fx.Stream(None)):
+        kernel(A, Total, Inc).launch(grid=(1, 1, 1), block=(BLOCK, 1, 1), stream=stream)
+
+    values = torch.arange(1, BLOCK + 1, dtype=torch.int32, device="cuda")
+    total = torch.zeros_like(values)
+    inc = torch.zeros_like(values)
+    launch(values, total, inc, stream=torch.cuda.Stream())
+    torch.cuda.synchronize()
+
+    per_warp = values.cpu().reshape(-1, warp_threads)
+    assert torch.equal(inc.cpu(), per_warp.cumsum(1, dtype=torch.int32).reshape(-1))
+    assert torch.equal(total.cpu(), per_warp.sum(1, dtype=torch.int32).repeat_interleave(warp_threads))

--- a/tests/unit/test_jit_cache_key_completeness.py
+++ b/tests/unit/test_jit_cache_key_completeness.py
@@ -400,3 +400,26 @@ def test_key_computation_leaves_no_in_progress_leak(tmp_path, monkeypatch):
 
     _manager_key(mod.solo, reset=True)
     assert jit_function._keys_in_progress() == set()
+
+
+def test_enum_closures_reach_the_cache_key():
+    """Regression: a captured enum selects code but left no trace in the key.
+
+    An enum member is not a scalar and has no source of its own to hash, so
+    ``_collect_closure_scalar_vals`` used to drop it. Two kernels differing only
+    by ``ReductionOp.ADD`` versus ``ReductionOp.MAX`` then shared a cache entry,
+    and the second one silently ran the first one's code.
+    """
+
+    def vals(op):
+        def traced():
+            return op
+
+        return jit_function._collect_closure_scalar_vals(traced)
+
+    baseline = vals(fx.ReductionOp.ADD)
+    assert baseline == vals(fx.ReductionOp.ADD), "the identity must be stable"
+    assert vals(fx.ReductionOp.MAX) != baseline
+
+    # No address, or the key would differ between processes and never hit.
+    assert not any("0x" in v for v in baseline), baseline


### PR DESCRIPTION
## Motivation

A new fx.coop library of reduction and scan collectives, built on the expr
primitives and layered warp-scope first, block-scope on top.

refs #1016

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
