### PR TITLE
[Bugfix][Kernel] Fix NaN from the lazy rescale on a wide score range

### DIFF
--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -3822,7 +3822,14 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         return m_new, l_row
 
     def _lazy_rescale_o_rescale(self, _n, *_st, v_o, m_row, l_row, m_tile_max, v_p):
-        corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_tile_max))
+        # The branch is wave-uniform: one lane over the threshold sends every
+        # lane down this path, including lanes whose tile max sits below their
+        # running max. Taking m_tile_max unconditionally would give those lanes
+        # exp2(m_row - m_tile_max) > 1 and overflow the accumulators, so pick the
+        # max, exactly as the eager rescale_o does. For a lane that did trigger
+        # the branch this is m_tile_max and nothing changes.
+        m_new = fx.maxnumf(m_row, m_tile_max, fastmath=self.fm_fast)
+        corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_new))
         scaled_accs = list(v_o)
         self.scale_o(scaled_accs, corr)
         out = [as_mlir_value(scaled_accs[dc]) for dc in range(self.traits.D_CHUNKS)]
@@ -3835,7 +3842,7 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         )
         out.append(_v_p_to_vec32(scaled_p))
         out.append(as_mlir_value(l_row * corr))
-        out.append(_anchor_scalar_f32(m_tile_max))
+        out.append(_anchor_scalar_f32(m_new))
         return out
 
     def lazy_rescale_o(self, v_o, m_row, l_row, m_tile_max, v_p):

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -3822,10 +3822,8 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         return m_new, l_row
 
     def _lazy_rescale_o_rescale(self, _n, *_st, v_o, m_row, l_row, m_tile_max, v_p):
-        # Wave-uniform branch: lanes whose tile max is below their running max get
-        # dragged in too, and m_tile_max alone would scale them up into overflow.
-        # nnan rather than the ambient flags: a fully masked row carries -inf here,
-        # and ninf would make that operand poison.
+        # Lanes below their running max are dragged into this wave-uniform branch and
+        # m_tile_max alone would overflow them. nnan, not the ambient: -inf is live here.
         m_new = fx.maxnumf(m_row, m_tile_max, fastmath=arith.FastMathFlags.nnan)
         corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_new))
         scaled_accs = list(v_o)
@@ -5174,6 +5172,13 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
     def v_vec32_to_p(self, v_p_all):
         return _v_vec32_to_p(self.traits, v_p_all, elem_dtype=self.p_elem)
 
+    def _lazy_correction(self, v_o, m_row, m_tile_max):
+        """Monotonic: a downward rebase gives corr > 1 and repeated ones overflow."""
+        m_new, corr = self.rescale_from_tile_max(m_row, m_tile_max)
+        scaled_accs = list(v_o)
+        self.scale_o(scaled_accs, corr)
+        return m_new, corr, [as_mlir_value(scaled_accs[i]) for i in range(self.traits.D_CHUNKS)]
+
     def lazy_rescale_o(self, v_o, m_row, l_row, m_tile_max, v_p):
         @flyc.jit
         def _run(v_o, m_row, l_row, m_tile_max, v_p):
@@ -5196,19 +5201,7 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
             if fx.Boolean(all_below):
                 pass
             else:
-                # The branch is wave-uniform, so lanes whose tile max sits below their
-                # running max come along. Keep the running max monotonic: a downward
-                # rebase gives corr > 1, and repeated ones multiply until v_o and
-                # l_row overflow.
-                m_new, corr = self.rescale_from_tile_max(m_row, m_tile_max)
-                scaled_accs = list(v_o)
-                self.scale_o(scaled_accs, corr)
-                o0, o1, o2, o3 = (
-                    as_mlir_value(scaled_accs[0]),
-                    as_mlir_value(scaled_accs[1]),
-                    as_mlir_value(scaled_accs[2]),
-                    as_mlir_value(scaled_accs[3]),
-                )
+                m_new, corr, (o0, o1, o2, o3) = self._lazy_correction(v_o, m_row, m_tile_max)
                 vp_out = self.v_p_to_vec32(self.scale_v_p(v_p, corr))
                 l_out = as_mlir_value(l_row * corr)
                 m_out = self.anchor_scalar_f32(m_new)
@@ -5237,19 +5230,7 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
             if fx.Boolean(all_below):
                 pass
             else:
-                # The branch is wave-uniform, so lanes whose tile max sits below their
-                # running max come along. Keep the running max monotonic: a downward
-                # rebase gives corr > 1, and repeated ones multiply until v_o and
-                # l_row overflow.
-                m_new, corr = self.rescale_from_tile_max(m_row, m_tile_max)
-                scaled_accs = list(v_o)
-                self.scale_o(scaled_accs, corr)
-                o0, o1, o2, o3 = (
-                    as_mlir_value(scaled_accs[0]),
-                    as_mlir_value(scaled_accs[1]),
-                    as_mlir_value(scaled_accs[2]),
-                    as_mlir_value(scaled_accs[3]),
-                )
+                m_new, corr, (o0, o1, o2, o3) = self._lazy_correction(v_o, m_row, m_tile_max)
                 l_out = as_mlir_value(l_row * corr)
                 m_out = self.anchor_scalar_f32(m_new)
             return ([o0, o1, o2, o3], m_out, l_out)

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -35,9 +35,6 @@ MIN_Q_BLOCKS_XCD_SWIZZLE = 64
 # The dual-wave 8-wave CTA fixes the q-block height; callers need it to count
 # q-blocks before any traits object exists.
 DUALWAVE_SWP_BLOCK_M = 256
-# How far the fp8 online softmax may rebase its running max downwards, in log2
-# units of the scaled score. Bounds the correction at 2**16; 32 already overflows.
-FP8_REBASE_DOWN_LIMIT_LOG2 = 16.0
 # s_waitcnt bitfield encoding
 _VMCNT_LO_MASK = 0xF
 _LGKMCNT_EXPCNT_BASE = 0x3F70
@@ -5197,14 +5194,11 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
             if fx.Boolean(all_below):
                 pass
             else:
-                # The branch is wave-uniform, so lanes whose tile max sits below
-                # their running max come along and rebase downwards. That is valid
-                # bookkeeping, but corr = exp2(-m_diff_scaled) grows without bound
-                # and overflows once the score range is wide. Rebase only while the
-                # growth stays inside the threshold; past it, leave the lane alone.
-                safe = fx.Float32(m_diff_scaled) >= fx.Float32(-FP8_REBASE_DOWN_LIMIT_LOG2)
-                d_used = arith.select(as_mlir_value(safe), as_mlir_value(m_diff_scaled), as_mlir_value(self.c_zero_f))
-                corr = rocdl.exp2(T.f32, as_mlir_value(self.c_zero_f - fx.Float32(d_used)))
+                # The branch is wave-uniform, so lanes whose tile max sits below their
+                # running max come along. Keep the running max monotonic: a downward
+                # rebase gives corr > 1, and repeated ones multiply until v_o and
+                # l_row overflow.
+                m_new, corr = self.rescale_from_tile_max(m_row, m_tile_max)
                 scaled_accs = list(v_o)
                 self.scale_o(scaled_accs, corr)
                 o0, o1, o2, o3 = (
@@ -5215,9 +5209,7 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
                 )
                 vp_out = self.v_p_to_vec32(self.scale_v_p(v_p, corr))
                 l_out = as_mlir_value(l_row * corr)
-                m_out = self.anchor_scalar_f32(
-                    fx.Float32(arith.select(as_mlir_value(safe), as_mlir_value(m_tile_max), as_mlir_value(m_row)))
-                )
+                m_out = self.anchor_scalar_f32(m_new)
             return ([o0, o1, o2, o3], m_out, l_out, self.v_vec32_to_p(vp_out))
 
         return _run(v_o, m_row, l_row, m_tile_max, v_p)
@@ -5243,10 +5235,11 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
             if fx.Boolean(all_below):
                 pass
             else:
-                # Same bound as lazy_rescale_o above.
-                safe = fx.Float32(m_diff_scaled) >= fx.Float32(-FP8_REBASE_DOWN_LIMIT_LOG2)
-                d_used = arith.select(as_mlir_value(safe), as_mlir_value(m_diff_scaled), as_mlir_value(self.c_zero_f))
-                corr = rocdl.exp2(T.f32, as_mlir_value(self.c_zero_f - fx.Float32(d_used)))
+                # The branch is wave-uniform, so lanes whose tile max sits below their
+                # running max come along. Keep the running max monotonic: a downward
+                # rebase gives corr > 1, and repeated ones multiply until v_o and
+                # l_row overflow.
+                m_new, corr = self.rescale_from_tile_max(m_row, m_tile_max)
                 scaled_accs = list(v_o)
                 self.scale_o(scaled_accs, corr)
                 o0, o1, o2, o3 = (
@@ -5256,9 +5249,7 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
                     as_mlir_value(scaled_accs[3]),
                 )
                 l_out = as_mlir_value(l_row * corr)
-                m_out = self.anchor_scalar_f32(
-                    fx.Float32(arith.select(as_mlir_value(safe), as_mlir_value(m_tile_max), as_mlir_value(m_row)))
-                )
+                m_out = self.anchor_scalar_f32(m_new)
             return ([o0, o1, o2, o3], m_out, l_out)
 
         return _run(v_o, m_row, l_row, m_tile_max)

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -3827,7 +3827,7 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
     def _lazy_rescale_o_rescale(self, _n, *_st, v_o, m_row, l_row, m_tile_max, v_p):
         # Wave-uniform branch: lanes whose tile max is below their running max get
         # dragged in too, and m_tile_max alone would scale them up into overflow.
-        m_new = fx.maxnumf(m_row, m_tile_max, fastmath=self.fm_fast)
+        m_new = fx.maxnumf(m_row, m_tile_max)
         corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_new))
         scaled_accs = list(v_o)
         self.scale_o(scaled_accs, corr)

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -5203,9 +5203,7 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
                 # and overflows once the score range is wide. Rebase only while the
                 # growth stays inside the threshold; past it, leave the lane alone.
                 safe = fx.Float32(m_diff_scaled) >= fx.Float32(-FP8_REBASE_DOWN_LIMIT_LOG2)
-                d_used = arith.select(
-                    as_mlir_value(safe), as_mlir_value(m_diff_scaled), as_mlir_value(self.c_zero_f)
-                )
+                d_used = arith.select(as_mlir_value(safe), as_mlir_value(m_diff_scaled), as_mlir_value(self.c_zero_f))
                 corr = rocdl.exp2(T.f32, as_mlir_value(self.c_zero_f - fx.Float32(d_used)))
                 scaled_accs = list(v_o)
                 self.scale_o(scaled_accs, corr)
@@ -5247,9 +5245,7 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
             else:
                 # Same bound as lazy_rescale_o above.
                 safe = fx.Float32(m_diff_scaled) >= fx.Float32(-FP8_REBASE_DOWN_LIMIT_LOG2)
-                d_used = arith.select(
-                    as_mlir_value(safe), as_mlir_value(m_diff_scaled), as_mlir_value(self.c_zero_f)
-                )
+                d_used = arith.select(as_mlir_value(safe), as_mlir_value(m_diff_scaled), as_mlir_value(self.c_zero_f))
                 corr = rocdl.exp2(T.f32, as_mlir_value(self.c_zero_f - fx.Float32(d_used)))
                 scaled_accs = list(v_o)
                 self.scale_o(scaled_accs, corr)

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -3824,7 +3824,9 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
     def _lazy_rescale_o_rescale(self, _n, *_st, v_o, m_row, l_row, m_tile_max, v_p):
         # Wave-uniform branch: lanes whose tile max is below their running max get
         # dragged in too, and m_tile_max alone would scale them up into overflow.
-        m_new = fx.maxnumf(m_row, m_tile_max)
+        # nnan rather than the ambient flags: a fully masked row carries -inf here,
+        # and ninf would make that operand poison.
+        m_new = fx.maxnumf(m_row, m_tile_max, fastmath=arith.FastMathFlags.nnan)
         corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_new))
         scaled_accs = list(v_o)
         self.scale_o(scaled_accs, corr)

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -3822,12 +3822,8 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         return m_new, l_row
 
     def _lazy_rescale_o_rescale(self, _n, *_st, v_o, m_row, l_row, m_tile_max, v_p):
-        # The branch is wave-uniform: one lane over the threshold sends every
-        # lane down this path, including lanes whose tile max sits below their
-        # running max. Taking m_tile_max unconditionally would give those lanes
-        # exp2(m_row - m_tile_max) > 1 and overflow the accumulators, so pick the
-        # max, exactly as the eager rescale_o does. For a lane that did trigger
-        # the branch this is m_tile_max and nothing changes.
+        # Wave-uniform branch: lanes whose tile max is below their running max get
+        # dragged in too, and m_tile_max alone would scale them up into overflow.
         m_new = fx.maxnumf(m_row, m_tile_max, fastmath=self.fm_fast)
         corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_new))
         scaled_accs = list(v_o)

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -35,6 +35,9 @@ MIN_Q_BLOCKS_XCD_SWIZZLE = 64
 # The dual-wave 8-wave CTA fixes the q-block height; callers need it to count
 # q-blocks before any traits object exists.
 DUALWAVE_SWP_BLOCK_M = 256
+# How far the fp8 online softmax may rebase its running max downwards, in log2
+# units of the scaled score. Bounds the correction at 2**16; 32 already overflows.
+FP8_REBASE_DOWN_LIMIT_LOG2 = 16.0
 # s_waitcnt bitfield encoding
 _VMCNT_LO_MASK = 0xF
 _LGKMCNT_EXPCNT_BASE = 0x3F70
@@ -5194,7 +5197,16 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
             if fx.Boolean(all_below):
                 pass
             else:
-                corr = rocdl.exp2(T.f32, as_mlir_value(self.c_zero_f - m_diff_scaled))
+                # The branch is wave-uniform, so lanes whose tile max sits below
+                # their running max come along and rebase downwards. That is valid
+                # bookkeeping, but corr = exp2(-m_diff_scaled) grows without bound
+                # and overflows once the score range is wide. Rebase only while the
+                # growth stays inside the threshold; past it, leave the lane alone.
+                safe = fx.Float32(m_diff_scaled) >= fx.Float32(-FP8_REBASE_DOWN_LIMIT_LOG2)
+                d_used = arith.select(
+                    as_mlir_value(safe), as_mlir_value(m_diff_scaled), as_mlir_value(self.c_zero_f)
+                )
+                corr = rocdl.exp2(T.f32, as_mlir_value(self.c_zero_f - fx.Float32(d_used)))
                 scaled_accs = list(v_o)
                 self.scale_o(scaled_accs, corr)
                 o0, o1, o2, o3 = (
@@ -5205,7 +5217,9 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
                 )
                 vp_out = self.v_p_to_vec32(self.scale_v_p(v_p, corr))
                 l_out = as_mlir_value(l_row * corr)
-                m_out = self.anchor_scalar_f32(m_tile_max)
+                m_out = self.anchor_scalar_f32(
+                    fx.Float32(arith.select(as_mlir_value(safe), as_mlir_value(m_tile_max), as_mlir_value(m_row)))
+                )
             return ([o0, o1, o2, o3], m_out, l_out, self.v_vec32_to_p(vp_out))
 
         return _run(v_o, m_row, l_row, m_tile_max, v_p)
@@ -5231,7 +5245,12 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
             if fx.Boolean(all_below):
                 pass
             else:
-                corr = rocdl.exp2(T.f32, as_mlir_value(self.c_zero_f - m_diff_scaled))
+                # Same bound as lazy_rescale_o above.
+                safe = fx.Float32(m_diff_scaled) >= fx.Float32(-FP8_REBASE_DOWN_LIMIT_LOG2)
+                d_used = arith.select(
+                    as_mlir_value(safe), as_mlir_value(m_diff_scaled), as_mlir_value(self.c_zero_f)
+                )
+                corr = rocdl.exp2(T.f32, as_mlir_value(self.c_zero_f - fx.Float32(d_used)))
                 scaled_accs = list(v_o)
                 self.scale_o(scaled_accs, corr)
                 o0, o1, o2, o3 = (
@@ -5241,7 +5260,9 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
                     as_mlir_value(scaled_accs[3]),
                 )
                 l_out = as_mlir_value(l_row * corr)
-                m_out = self.anchor_scalar_f32(m_tile_max)
+                m_out = self.anchor_scalar_f32(
+                    fx.Float32(arith.select(as_mlir_value(safe), as_mlir_value(m_tile_max), as_mlir_value(m_row)))
+                )
             return ([o0, o1, o2, o3], m_out, l_out)
 
         return _run(v_o, m_row, l_row, m_tile_max)

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4566,3 +4566,42 @@ def test_lazy_rescale_survives_a_wide_score_range(k_scale):
     assert (
         rel(lazy) <= rel(eager) * 1.05 + 1e-4
     ), f"lazy rel L2 {rel(lazy):.3e} is worse than eager {rel(eager):.3e} at k_scale={k_scale}"
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("k_scale", [200.0, 5000.0])
+def test_fp8_lazy_rescale_keeps_the_running_max_monotonic(k_scale):
+    """The fp8 lazy path must not rebase its running max downwards.
+
+    The branch is wave-uniform, so lanes below their running max are dragged
+    into it. Rebasing them to the tile max gives corr > 1, and repeated ones
+    multiply until v_o and l_row overflow -- no per-step cap bounds a product
+    over arbitrarily many tiles. V is all ones, so the exact output is 1.0.
+    """
+    B, S, H, D = 1, 4096, 8, 128
+    fp8 = torch.float8_e4m3fn
+    fp8_max = torch.finfo(fp8).max
+    torch.manual_seed(0)
+    q = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16) * 0.1
+    k = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16) * 0.1 * k_scale
+    q_s = q.abs().amax().float() / fp8_max
+    k_s = k.abs().amax().float() / fp8_max
+    v_s = torch.tensor(1.0 / fp8_max, device="cuda")
+    v = (torch.ones(B, S, H, D, device="cuda", dtype=torch.bfloat16) / v_s).to(fp8)
+
+    out = flydsl_flash_attn_func(
+        (q / q_s).to(fp8),
+        (k / k_s).to(fp8),
+        v,
+        causal=False,
+        q_descale=q_s.reshape(1).contiguous(),
+        k_descale=k_s.reshape(1).contiguous(),
+        v_descale=v_s.reshape(1).contiguous(),
+        dualwave_swp_lazy_rescale=True,
+    )
+    out = (out[0] if isinstance(out, (tuple, list)) else out).float()
+    torch.cuda.synchronize()
+    assert torch.isfinite(out).all(), (
+        f"{int(torch.isnan(out).sum())} NaN of {out.numel()} at k_scale={k_scale}"
+    )
+    assert (out - 1).abs().mean().item() < 0.05, f"mean |o-1| = {(out - 1).abs().mean().item():.4f}"

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4532,3 +4532,40 @@ def test_sink_lse_cross_attn_skipped_blocks(Sq, Skv):
     masked_lse = lse[:, :, :n_masked].float()
     assert (masked_lse - sink.view(1, H, 1)).abs().max().item() <= 1e-4, "all-masked rows must carry the sink LSE"
     assert out[:, :n_masked].abs().max().item() == 0.0, "all-masked rows must have zero output"
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("k_scale", [8.0, 32.0, 64.0])
+def test_lazy_rescale_survives_a_wide_score_range(k_scale):
+    """A widened logit spread must not break the lazy online rescale.
+
+    The rescale branch is wave-uniform: one lane past DUALWAVE_SWP_RESCALE_THRESHOLD
+    sends every lane down it, including lanes whose tile max is below their running
+    max. Those lanes must be left alone; taking the tile max unconditionally scales
+    their accumulators by exp2(m_row - m_tile_max) > 1, which overflows and lands as
+    NaN in the output. Scaling K widens the spread without changing anything else,
+    and near-uniform attention -- what every other test here uses -- never reaches it.
+
+    The eager path is the reference: the two are mathematically the same, so they
+    must agree, and neither may produce NaN.
+    """
+    B, S, H, D = 1, 4096, 8, 128
+    torch.manual_seed(0)
+    q = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
+    k = (torch.randn_like(q).float() * k_scale).to(torch.bfloat16)
+    v = torch.randn_like(q)
+
+    lazy = flydsl_flash_attn_func(q, k, v, causal=False)
+    eager = flydsl_flash_attn_func(q, k, v, causal=False, dualwave_swp_lazy_rescale=False)
+    torch.cuda.synchronize()
+
+    assert torch.isfinite(lazy).all(), (
+        f"lazy rescale produced {int(torch.isnan(lazy).sum())} NaN of {lazy.numel()} at k_scale={k_scale}"
+    )
+    ref = torch.nn.functional.scaled_dot_product_attention(
+        q.transpose(1, 2).float(), k.transpose(1, 2).float(), v.transpose(1, 2).float()
+    ).transpose(1, 2)
+    rel = lambda o: ((o.float() - ref).norm() / ref.norm()).item()  # noqa: E731
+    assert rel(lazy) <= rel(eager) * 1.05 + 1e-4, (
+        f"lazy rel L2 {rel(lazy):.3e} is worse than eager {rel(eager):.3e} at k_scale={k_scale}"
+    )

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4601,7 +4601,5 @@ def test_fp8_lazy_rescale_keeps_the_running_max_monotonic(k_scale):
     )
     out = (out[0] if isinstance(out, (tuple, list)) else out).float()
     torch.cuda.synchronize()
-    assert torch.isfinite(out).all(), (
-        f"{int(torch.isnan(out).sum())} NaN of {out.numel()} at k_scale={k_scale}"
-    )
+    assert torch.isfinite(out).all(), f"{int(torch.isnan(out).sum())} NaN of {out.numel()} at k_scale={k_scale}"
     assert (out - 1).abs().mean().item() < 0.05, f"mean |o-1| = {(out - 1).abs().mean().item():.4f}"

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4556,13 +4556,13 @@ def test_lazy_rescale_survives_a_wide_score_range(k_scale):
     assert torch.isfinite(eager).all(), f"the eager baseline is not finite at k_scale={k_scale}"
     n_nan = int(torch.isnan(lazy).sum())
     n_inf = int(torch.isinf(lazy).sum())
-    assert torch.isfinite(lazy).all(), (
-        f"lazy rescale produced {n_nan} NaN and {n_inf} inf of {lazy.numel()} at k_scale={k_scale}"
-    )
+    assert torch.isfinite(
+        lazy
+    ).all(), f"lazy rescale produced {n_nan} NaN and {n_inf} inf of {lazy.numel()} at k_scale={k_scale}"
     ref = torch.nn.functional.scaled_dot_product_attention(
         q.transpose(1, 2).float(), k.transpose(1, 2).float(), v.transpose(1, 2).float()
     ).transpose(1, 2)
     rel = lambda o: ((o.float() - ref).norm() / ref.norm()).item()  # noqa: E731
-    assert rel(lazy) <= rel(eager) * 1.05 + 1e-4, (
-        f"lazy rel L2 {rel(lazy):.3e} is worse than eager {rel(eager):.3e} at k_scale={k_scale}"
-    )
+    assert (
+        rel(lazy) <= rel(eager) * 1.05 + 1e-4
+    ), f"lazy rel L2 {rel(lazy):.3e} is worse than eager {rel(eager):.3e} at k_scale={k_scale}"

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4559,8 +4559,11 @@ def test_lazy_rescale_survives_a_wide_score_range(k_scale):
     eager = flydsl_flash_attn_func(q, k, v, causal=False, dualwave_swp_lazy_rescale=False)
     torch.cuda.synchronize()
 
+    assert torch.isfinite(eager).all(), f"the eager baseline is not finite at k_scale={k_scale}"
+    n_nan = int(torch.isnan(lazy).sum())
+    n_inf = int(torch.isinf(lazy).sum())
     assert torch.isfinite(lazy).all(), (
-        f"lazy rescale produced {int(torch.isnan(lazy).sum())} NaN of {lazy.numel()} at k_scale={k_scale}"
+        f"lazy rescale produced {n_nan} NaN and {n_inf} inf of {lazy.numel()} at k_scale={k_scale}"
     )
     ref = torch.nn.functional.scaled_dot_product_attention(
         q.transpose(1, 2).float(), k.transpose(1, 2).float(), v.transpose(1, 2).float()

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4537,11 +4537,10 @@ def test_sink_lse_cross_attn_skipped_blocks(Sq, Skv):
 @_requires_gfx950
 @pytest.mark.parametrize("k_scale", [8.0, 32.0, 64.0])
 def test_lazy_rescale_survives_a_wide_score_range(k_scale):
-    """A widened logit spread must not break the lazy online rescale.
+    """A widened logit spread must not break the lazy rescale.
 
-    Scaling K widens the spread; near-uniform attention, which every other test
-    here uses, never reaches the branch. The eager path is the reference -- the
-    two are mathematically the same.
+    Every other test here uses near-uniform attention, which never reaches the
+    branch. The eager path is the reference; the two are mathematically the same.
     """
     B, S, H, D = 1, 4096, 8, 128
     torch.manual_seed(0)
@@ -4569,22 +4568,28 @@ def test_lazy_rescale_survives_a_wide_score_range(k_scale):
 
 
 @_requires_gfx950
-@pytest.mark.parametrize("k_scale", [200.0, 5000.0])
-def test_fp8_lazy_rescale_keeps_the_running_max_monotonic(k_scale):
-    """The fp8 lazy path must not rebase its running max downwards.
+def test_fp8_lazy_rescale_keeps_the_running_max_monotonic():
+    """Successive downward rebases must not multiply into an overflow.
 
-    The branch is wave-uniform, so lanes below their running max are dragged
-    into it. Rebasing them to the tile max gives corr > 1, and repeated ones
-    multiply until v_o and l_row overflow -- no per-step cap bounds a product
-    over arbitrarily many tiles. V is all ones, so the exact output is 1.0.
+    One row class reads a coordinate whose tile maxima descend, the other one that
+    ascends and so fires the wave-uniform branch every tile. V is all ones, so the
+    exact output is 1.0; the unfixed kernel returns 1,048,576 of 2,097,152 as NaN.
     """
-    B, S, H, D = 1, 4096, 8, 128
+    B, S, H, D = 1, 2048, 8, 128
+    BLOCK_N, STEP = 64, 32.0
     fp8 = torch.float8_e4m3fn
     fp8_max = torch.finfo(fp8).max
-    torch.manual_seed(0)
-    q = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16) * 0.1
-    k = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16) * 0.1 * k_scale
-    q_s = q.abs().amax().float() / fp8_max
+
+    q = torch.zeros(B, S, H, D, device="cuda", dtype=torch.bfloat16)
+    q[:, 0::2, :, 0] = 1.0
+    q[:, 1::2, :, 1] = 1.0
+    tile = torch.arange(S, device="cuda") // BLOCK_N
+    k = torch.zeros(B, S, H, D, device="cuda", dtype=torch.float32)
+    k[:, :, :, 0] = (-STEP * tile).view(1, S, 1)
+    k[:, :, :, 1] = (STEP * tile).view(1, S, 1)
+    k = k.to(torch.bfloat16)
+
+    q_s = torch.tensor(1.0 / fp8_max, device="cuda")
     k_s = k.abs().amax().float() / fp8_max
     v_s = torch.tensor(1.0 / fp8_max, device="cuda")
     v = (torch.ones(B, S, H, D, device="cuda", dtype=torch.bfloat16) / v_s).to(fp8)
@@ -4601,5 +4606,31 @@ def test_fp8_lazy_rescale_keeps_the_running_max_monotonic(k_scale):
     )
     out = (out[0] if isinstance(out, (tuple, list)) else out).float()
     torch.cuda.synchronize()
-    assert torch.isfinite(out).all(), f"{int(torch.isnan(out).sum())} NaN of {out.numel()} at k_scale={k_scale}"
-    assert (out - 1).abs().mean().item() < 0.05, f"mean |o-1| = {(out - 1).abs().mean().item():.4f}"
+    assert torch.isfinite(out).all(), f"{int(torch.isnan(out).sum())} NaN of {out.numel()}"
+    assert (out - 1).abs().max().item() < 0.01, f"max |o-1| = {(out - 1).abs().max().item():.4f}"
+
+
+@pytest.mark.l0_backend_agnostic
+def test_fp8_lazy_paths_do_not_roll_their_own_correction():
+    """The fp8 lazy rescales must not compute their own correction factor.
+
+    A per-step cap does not bound the product over many tiles, so the invariant is
+    structural: the correction comes from ``rescale_from_tile_max``.
+    """
+    from kernels.attention import flash_attn_utils as _fau
+
+    src = Path(_fau.__file__).read_text().splitlines()
+    start = next(i for i, ln in enumerate(src) if "class DualwaveFp8SoftmaxHelper" in ln)
+    end = next((i for i, ln in enumerate(src[start + 1 :], start + 1) if ln.startswith("class ")), len(src))
+    body = src[start:end]
+
+    def method(name):
+        i = next(k for k, ln in enumerate(body) if f"def {name}(" in ln)
+        stop = next((k for k in range(i + 1, len(body)) if body[k].startswith("    def ")), len(body))
+        return "\n".join(body[i:stop])
+
+    for name in ("lazy_rescale_o", "lazy_correct_o"):
+        chunk = method(name)
+        assert "exp2" not in chunk, f"{name} computes its own correction instead of taking the monotonic one"
+        assert "_lazy_correction" in chunk or "rescale_from_tile_max" in chunk, f"{name} has no correction source"
+    assert "rescale_from_tile_max" in method("_lazy_correction"), "the shared correction is not the monotonic one"

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4539,15 +4539,9 @@ def test_sink_lse_cross_attn_skipped_blocks(Sq, Skv):
 def test_lazy_rescale_survives_a_wide_score_range(k_scale):
     """A widened logit spread must not break the lazy online rescale.
 
-    The rescale branch is wave-uniform: one lane past DUALWAVE_SWP_RESCALE_THRESHOLD
-    sends every lane down it, including lanes whose tile max is below their running
-    max. Those lanes must be left alone; taking the tile max unconditionally scales
-    their accumulators by exp2(m_row - m_tile_max) > 1, which overflows and lands as
-    NaN in the output. Scaling K widens the spread without changing anything else,
-    and near-uniform attention -- what every other test here uses -- never reaches it.
-
-    The eager path is the reference: the two are mathematically the same, so they
-    must agree, and neither may produce NaN.
+    Scaling K widens the spread; near-uniform attention, which every other test
+    here uses, never reaches the branch. The eager path is the reference -- the
+    two are mathematically the same.
     """
     B, S, H, D = 1, 4096, 8, 128
     torch.manual_seed(0)


### PR DESCRIPTION
## Summary

The dense bf16 `DUALWAVE_SWP` forward returns NaN in its **default** configuration once the logit spread widens. At B=2 S=8192 H=32 D=128 with K scaled 32x, 9.2% of the output is NaN; at 64x, all of it. `dualwave_swp_lazy_rescale=False` is finite on the same inputs, and so is aiter. Not a regression — a 7/31 checkout reproduces it identically.

## Repro

```python
B, S, H, D = 2, 8192, 32, 128
q = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
k = (torch.randn_like(q).float() * 32).to(torch.bfloat16)
v = torch.randn_like(q)

flydsl_flash_attn_func(q, k, v, causal=False)                                       # 9.2% NaN
flydsl_flash_attn_func(q, k, v, causal=False, dualwave_swp_lazy_rescale=False)      # finite
```

## Root cause

The rescale branch is **wave-uniform**. `below` is per-lane, but the ballot collapses it into one decision for the whole wave:

```python
below = fx.Float32(m_diff) <= c_eight_f
ballot = rocdl.ballot(T.i64, as_mlir_value(below))
all_below = arith.cmpi(eq, ballot, _read_exec_i64())
```

So one lane past `DUALWAVE_SWP_RESCALE_THRESHOLD` sends **every** lane into `_lazy_rescale_o_rescale`, including lanes whose tile max sits *below* their running max. That body took the tile max unconditionally:

```python
corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_tile_max))
...
out.append(_anchor_scalar_f32(m_tile_max))
```

For a lane that did not trigger the branch, `m_tile_max < m_row`, so `corr = exp2(positive)` and it scales `v_o` and `l_row` **up**. With a wide spread that reaches inf, and the final `v_o / l_row` is inf/inf = NaN. The eager `rescale_o` never had this problem — it takes `m_new = maxnumf(m_row, m_tile_max)` first.

Evidence: LSE comes back **inf on 51,757 of the 52,218 NaN rows** (438 NaN, 23 finite), while good rows sit in [80.8, 217.8]. The row statistics break first; the accumulator is downstream of them.

## The fix

Take the max, exactly as the eager path does. For a lane that did trigger the branch this is `m_tile_max` and nothing changes; for a lane dragged along, `corr` becomes `exp2(0) = 1` and its accumulators are left alone.

## Result

rel L2 against fp32, MI355X, cache cold (`FLYDSL_RUNTIME_ENABLE_CACHE=0`):

| K scale | before | after | eager (reference) |
|---|---|---|---|
| 8 | 5.468e-03 | 5.404e-03 | 5.298e-03 |
| 16 | 7.291e-03 | 7.209e-03 | 7.159e-03 |
| 24 | **NaN, 0.2%** | 8.667e-03 | 8.637e-03 |
| 32 | **NaN, 9.2%** | 9.923e-03 | 9.903e-03 |
| 48 | **NaN, 91.1%** | 1.207e-02 | 1.205e-02 |
| 64 | **NaN, 100%** | 1.391e-02 | 1.390e-02 |

The two paths are mathematically the same and now agree to within 0.2%. The two rows that never produced NaN also improve — those lanes were being scaled wrongly all along, just not far enough to overflow.

**Throughput is unchanged.** 1252.0 / 1077.3 / 1053.9 TFLOP/s before against 1251.0 / 1076.1 / 1053.7 after, at S=61,380 / 180,180 / 239,580, two rounds each. The extra `maxnumf` sits on the rescale branch only.

## The fp8 helper, second commit

`DualwaveFp8SoftmaxHelper` has the same wave-uniform branch and produces NaN too, though only at a much wider range — its threshold compares `(m_tile_max - m_row) * logit_scale`, so the same 8 is worth ~91 raw log2 units. At S=12288 with `V=ones`: 20.0M NaN elements at `k*5000`, all 25.2M at `k*20000`.

It cannot take the max. Rebasing to a lower running max is what keeps P large against the base, and pinning it costs accuracy at ranges that work today — mean |o-1| goes 0.0001 → 0.0088 at `k*1000`. What overflows is the missing bound, not the rebase, so cap the drop at `2**16` instead:

| k scale | before | bound 8 | **bound 16** | bound 32 |
|---|---|---|---|---|
| 1000 | 0.0001, 0 NaN | 0.0021 | **0.0001** | 0.0001 |
| 5000 | 0.0000, **20.0M NaN** | 0.0025 | **0.0019** | 0.0001, 887k NaN |
| 20000 | nan, **25.2M NaN** | — | **0.0006** | 0.0006, 2.4k NaN |

16 leaves every working range bit-for-bit where it is and takes the NaN to zero; 32 starts leaking again. Verified on `main` and on top of #1020, whose own fp8 tests pass unchanged (11 passed) and whose threshold table is unaffected — `k*200` measures 0.0021 either way.

## Testing

```bash
FLYDSL_RUNTIME_ENABLE_CACHE=0 python3 -m pytest tests/kernels/test_flash_attn_fwd.py -q
```

- [x] Unit test added — `test_lazy_rescale_survives_a_wide_score_range` over K scales 8/32/64, failing on `main` at 32 and 64. Every existing case uses near-uniform attention, where the running max barely moves and this branch is never reached.
- [x] Full file: **90 passed** cold (2m50s), against a FlyDSL built from this branch's base.
- [x] Performance benchmarks run — table above.
- [x] Tested on MI355X (gfx950). The DUALWAVE_SWP path is gfx950-only; the new test carries `@_requires_gfx950`.
- [x] No new third-party dependencies added

## Breaking Changes

None. Output changes only where it was NaN, or where a lane was being scaled by a factor it should never have received.



