### PR TITLE
[Fix] Restore the fastmath flag on flash-attention maxnumf

### DIFF
--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -386,7 +386,7 @@ def _lane_pair_reduce(v, reducer, fm_fast):
 
 
 def _score_pair_max(v_s, neg_inf, fm_fast):
-    reducer = lambda a, b, _fm: fx.maxnumf(a, b, fastmath=_fm)  # noqa: E731
+    reducer = lambda a, b, fm: fx.maxnumf(a, b, fastmath=fm)  # noqa: E731
     return _lane_pair_reduce(_reduce_score_pair(v_s, neg_inf, reducer, fm_fast), reducer, fm_fast)
 
 

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -386,7 +386,7 @@ def _lane_pair_reduce(v, reducer, fm_fast):
 
 
 def _score_pair_max(v_s, neg_inf, fm_fast):
-    reducer = lambda a, b, _fm: fx.maxnumf(a, b)  # noqa: E731
+    reducer = lambda a, b, _fm: fx.maxnumf(a, b, fastmath=_fm)  # noqa: E731
     return _lane_pair_reduce(_reduce_score_pair(v_s, neg_inf, reducer, fm_fast), reducer, fm_fast)
 
 
@@ -460,7 +460,7 @@ def _safe_l_inv(l_row, zero_f):
 
 
 def _rescale_from_tile_max(m_row, m_tile_max, fm_fast):
-    row_max = fx.maxnumf(m_row, m_tile_max)
+    row_max = fx.maxnumf(m_row, m_tile_max, fastmath=fm_fast)
     rescale = rocdl.exp2(T.f32, as_mlir_value(m_row - row_max))
     return row_max, rescale
 
@@ -2980,19 +2980,19 @@ class GenericSoftmaxHelper:
         if const_expr(os.getenv("FLYDSL_FLASH_ATTN_FUNC_TREE_REDUCE", "0") == "1"):
 
             def _max_pair(a, b):
-                return fx.maxnumf(a, b)
+                return fx.maxnumf(a, b, fastmath=ctx.fm_fast)
 
             local_max = _tree_reduce(list(s_raw_lo) + list(s_raw_hi), _max_pair)
         else:
             local_max = s_raw_lo[0]
             for r in range_constexpr(15):
-                local_max = fx.maxnumf(local_max, s_raw_lo[r + 1])
+                local_max = fx.maxnumf(local_max, s_raw_lo[r + 1], fastmath=ctx.fm_fast)
             for r in range_constexpr(16):
-                local_max = fx.maxnumf(local_max, s_raw_hi[r])
-        row_max = fx.maxnumf(local_max, self.reduction_peer(local_max))
-        m_new_raw = fx.maxnumf(m_running, row_max)
+                local_max = fx.maxnumf(local_max, s_raw_hi[r], fastmath=ctx.fm_fast)
+        row_max = fx.maxnumf(local_max, self.reduction_peer(local_max), fastmath=ctx.fm_fast)
+        m_new_raw = fx.maxnumf(m_running, row_max, fastmath=ctx.fm_fast)
         if const_expr(traits.CAUSAL):
-            m_new_raw = fx.maxnumf(m_new_raw, ctx.c_neg_floor)
+            m_new_raw = fx.maxnumf(m_new_raw, ctx.c_neg_floor, fastmath=ctx.fm_fast)
 
         diff_m_scaled = (m_running - m_new_raw) * ctx.c_sm_scale_log2e
         corr = self._exp2(diff_m_scaled)
@@ -3772,7 +3772,7 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         return _score_pair_max(v_s, self.c_neg_inf, self.fm_fast)
 
     def floor_masked_max(self, row_max):
-        return fx.maxnumf(row_max, self.c_neg_floor)
+        return fx.maxnumf(row_max, self.c_neg_floor, fastmath=self.fm_fast)
 
     def rescale_from_tile_max(self, m_row, m_tile_max):
         return _rescale_from_tile_max(m_row, m_tile_max, self.fm_fast)
@@ -3803,7 +3803,7 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         _scale_o_accs(v_o, scale_scalar, self.traits, self.fm_fast)
 
     def rescale_o(self, v_o, m_row, l_row, m_tile_max, v_p):
-        m_new = fx.maxnumf(m_row, m_tile_max)
+        m_new = fx.maxnumf(m_row, m_tile_max, fastmath=self.fm_fast)
         corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_new))
         self.scale_o(v_o, corr)
         v_o = _anchor_v_o(self.traits, v_o)
@@ -3818,7 +3818,7 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         return v_o, m_new, l_row, v_p
 
     def fold_sink(self, v_o, m_row, l_row, sink_log2):
-        m_new = fx.maxnumf(m_row, sink_log2)
+        m_new = fx.maxnumf(m_row, sink_log2, fastmath=self.fm_fast)
         corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_new))
         self.scale_o(v_o, corr)
         sink_w = rocdl.exp2(T.f32, as_mlir_value(sink_log2 - m_new))
@@ -5101,10 +5101,10 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
         return _score_pair_max(v_s, self.c_neg_inf, self.fm_fast)
 
     def max2(self, a, b):
-        return fx.maxnumf(a, b)
+        return fx.maxnumf(a, b, fastmath=self.fm_fast)
 
     def floor_masked_max(self, row_max):
-        return fx.maxnumf(row_max, self.c_neg_floor)
+        return fx.maxnumf(row_max, self.c_neg_floor, fastmath=self.fm_fast)
 
     def sub_m(self, v_s, row_max):
         return _scale_sub_score_pair(v_s, row_max, self.c_logit_scale, self.c_zero_f, self.fm_fast)
@@ -5149,7 +5149,7 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
         return _safe_l_inv(l_row, self.c_zero_f)
 
     def rescale_from_tile_max(self, m_row, m_tile_max):
-        row_max = fx.maxnumf(m_row, m_tile_max)
+        row_max = fx.maxnumf(m_row, m_tile_max, fastmath=self.fm_fast)
         diff_scaled = (m_row - row_max) * self.c_logit_scale
         rescale = rocdl.exp2(T.f32, as_mlir_value(diff_scaled))
         return row_max, rescale


### PR DESCRIPTION
## Summary

#930 moved the attention kernels from `arith.MaxNumFOp(..., fastmath=fm_fast)` to the `fx.maxnumf` free function. `fx.maxnumf` forwards to the raw MLIR builder without going through `resolve_fastmath`, so with no explicit argument the op is emitted as `fastmath<none>` and the ambient hint never reaches it. Fourteen call sites in `flash_attn_utils.py` lost the flag that way. Restoring it is worth **10.3–11.1%** at long sequences on today's `main`, and changes no output.

## Root cause

The ambient mechanism #930 introduced sets a tracing-wide default:

```python
# compiler/kernel_function.py
with tracing_context(fastmath=effective_fastmath_hint(CompilationContext.get_compile_hints()), ...):
```

DSL operators pick it up through `expr/utils/arith.py`:

```python
def resolve_fastmath(explicit):
    """Pick the effective fastmath: explicit arg wins over ambient context."""
    return explicit if explicit is not None else current_fastmath()
```

`fx.maxnumf` does not:

```python
# expr/arith.py
from .._mlir.dialects import arith          # raw MLIR builder

def maxnumf(a, b, **kwargs):
    result = arith.maxnumf(as_ir_value(a), as_ir_value(b), **kwargs)
```

No `fastmath=` argument, no `resolve_fastmath`. `fx.maximumf` and `fx.minimumf` right below it at least carry an explicit `fastmath=None` parameter. So the conversion `arith.MaxNumFOp(a, b, fastmath=fm_fast)` → `fx.maxnumf(a, b)` silently dropped the flag at every site it touched.

## Evidence

Bisect over upstream, MI355X, B=2 H=32 D=128 bf16 non-causal, stock kwargs, cache cold, TFLOP/s:

| commit | date | PR | S=61,380 | S=180,180 | S=239,580 |
|---|---|---|---|---|---|
| `f6d0a41` | 8/14 | #991 | 1256.0 | 1182.8 | 1183.6 |
| `47009a3` | 8/14 | #1004 | 1260.5 | 1188.6 | 1183.4 |
| `daee90e` | 8/17 | **#930** | 1254.1 | **1077.0** | **1060.9** |
| `96af91b` | 8/17 | #1014 | 1251.8 | 1074.9 | 1060.6 |

A step of −10.4% lands exactly on #930, and applying the flag back to that commit alone restores 1188.2 / 1183.1 — the pre-#930 level to within 0.4%.

## Result

Two rounds each, alternating, cache cold. On today's `main`, where the XCD remap is off:

| S | main | this PR | change |
|---|---|---|---|
| 61,380 | 1250.0 / 1248.0 | 1258.1 / 1258.7 | +0.8% |
| 180,180 | 1078.8 / 1074.1 | 1186.5 / 1188.0 | **+10.3%** |
| 239,580 | 1054.4 / 1051.9 | 1170.7 / 1170.1 | **+11.1%** |

**The gain depends on #1009.** That PR restores the XCD workgroup remap for bf16, which #950 disabled. With the remap on, the kernel is no longer memory-starved and most of this cost is hidden:

| S | #1009 alone | #1009 + this PR | change |
|---|---|---|---|
| 61,380 | 1278.6 / 1279.0 | 1281.4 / 1282.6 | +0.3% |
| 180,180 | 1276.5 / 1275.9 | 1285.5 / 1284.9 | +0.7% |
| 239,580 | 1266.4 / 1266.1 | 1285.9 / 1285.2 | +1.5% |

So: **+11% if this lands first, +1.5% if #1009 does.** The two regressions were masking each other, which is also why #1009 alone stops 1.4% short of the pre-regression figure. Together they reach 1285.5, against 1286.8 measured at `cf1db2f` (7/31) before either regression — the gap closes to 0.1%.

Output is bit-identical: normal, K scaled 4x and 16x, and a planted NaN all give `ndiff=0/67108864` with matching NaN masks, and rel L2 identical to seven digits.

## Scope

Fourteen sites in `flash_attn_utils.py`: the module-level `_score_pair_max` / `_rescale_from_tile_max` helpers, `GenericSoftmaxHelper.online_softmax_stats`, and the bf16 and fp8 dualwave softmax helpers.

Two sites are left alone — `DualwaveSplitKCombineHelper.reduce_m_max` and its sink fold. That class has no fastmath in scope at all, and inventing one for it belongs in a change that can measure the split-K path.

## Follow-up, not in this PR

This fixes the call sites; the DSL-level hole is still there. `fx.maxnumf` and `fx.minnumf` should resolve the ambient fastmath the way the operators do, which would cover the other 30 unflagged `maxnumf` calls across `pa_metadata.py`, `mla_fwd_decode_m16x8_fp8_fp8.py` and the moe kernels in one place and stop the next DSL-ification from repeating this.

That change needs care this one does not: it would move those ops from `fastmath<none>` to whatever their launcher's ambient is, which is `fast` for the attention launchers and deliberately `contract` for pa — #930 pinned pa to `contract` precisely because `reassoc` reorders fp accumulation and costs fp8 accuracy. `fast` also implies `nnan`, and `maxnumf` is the operation whose contract is to return the non-NaN operand. On the bf16 dense path that turns out to be safe (the NaN case above is bit-identical), but fp8 dense, MLA and moe would each need the same check.

## Testing

```bash
FLYDSL_RUNTIME_ENABLE_CACHE=0 python3 -m pytest tests/kernels/test_flash_attn_fwd.py -q
```

- [x] Existing tests pass — **87 passed** cold (2m39s), against a FlyDSL built from this branch's base. No new test: the change is bit-identical and shows up only in throughput, so a unit test would either assert nothing or assert a timing. The durable guard is the DSL-level fix above.
- [x] Performance benchmarks run — tables above, two rounds per configuration, aiter measured in the same process as a control (stable at 1250–1256 throughout).
- [x] Tested on MI355X (gfx950).

## Dependencies

- [x] No new third-party dependencies added

## Breaking Changes

None. Verified bit-identical on four input distributions including NaN.
