### PR TITLE
[Test] Print when aiter is missing instead of collecting nothing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,26 @@ def pytest_addoption(parser):
     )
 
 
+_AITER_ERROR = None
+try:
+    import aiter as _aiter
+except Exception as _exc:  # a version-mismatched aiter raises ImportError from inside itself
+    _aiter = None
+    _AITER_ERROR = _exc
+
+
+def pytest_report_header(config):
+    """Say whether aiter imported.
+
+    Nineteen suites skip themselves at module level when it does not, and
+    pytest_sessionfinish below rewrites the resulting exit code 5 to 0, so a run
+    that collected nothing is indistinguishable from a run that passed.
+    """
+    if _aiter is not None:
+        return f"aiter: {getattr(_aiter, '__version__', 'unknown version')}"
+    return f"aiter: NOT IMPORTABLE ({_AITER_ERROR}) -- the suites that need it will collect nothing"
+
+
 def pytest_configure(config):
     """Apply FlyDSL env overrides from CLI options.
 
@@ -123,6 +143,10 @@ def pytest_configure(config):
         os.environ["FLYDSL_COMPILE_BACKEND"] = backend
     if arch:
         os.environ["ARCH"] = arch
+
+    # Opt-in for CI, where a silently empty run is worse than a red one.
+    if _aiter is None and os.environ.get("FLYDSL_REQUIRE_AITER", "") not in ("", "0", "false", "False"):
+        pytest.exit(f"FLYDSL_REQUIRE_AITER is set but aiter is not importable: {_AITER_ERROR}", returncode=1)
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/kernels/test_mla_decode.py
+++ b/tests/kernels/test_mla_decode.py
@@ -36,15 +36,18 @@ try:
     from aiter.ops.attention import (  # noqa: E402  # pyright: ignore[reportMissingImports]
         get_mla_metadata_info_v1,
         get_mla_metadata_v1,
-        hk_mla_decode_fwd,
         mla_decode_stage1_asm_fwd,
         mla_reduce_v1,
     )
 except ImportError as _e:
-    # aiter is installed but its attention API drifted (e.g. hk_mla_decode_fwd
-    # was renamed). Skip this module cleanly instead of aborting collection for
-    # the whole suite.
     pytest.skip(f"aiter.ops.attention API mismatch ({_e})", allow_module_level=True)
+
+# Benchmark-only, and gone from aiter since mid-2026. Missing it must not take
+# the correctness tests down with it.
+try:
+    from aiter.ops.attention import hk_mla_decode_fwd  # pyright: ignore[reportMissingImports]
+except ImportError:
+    hk_mla_decode_fwd = None
 
 from kernels.attention.mla_fwd_decode import flydsl_mla_fwd_decode  # noqa: E402
 from tests.test_common import checkAllclose, run_perftest  # noqa: E402
@@ -413,7 +416,7 @@ def run_single(
     )
     assert cos_diff < 3e-2, f"cos_diff={cos_diff} exceeds threshold"
 
-    if bench_aiter:
+    if bench_aiter and hk_mla_decode_fwd is not None:
         aiter_hk_out = torch.empty_like(out_asm).fill_(-1)
         aiter_hk_logits = torch.empty_like(logits)
         aiter_hk_lse = torch.empty_like(attn_lse)

--- a/tests/kernels/test_pa.py
+++ b/tests/kernels/test_pa.py
@@ -20,7 +20,7 @@ try:
     import aiter
     from aiter import dtypes, per_tensor_quant, pertoken_quant
     from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
-except Exception as exc:
+except ImportError as exc:
     pytest.skip(f"aiter is not available: {exc}", allow_module_level=True)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary

Nineteen suites skip themselves at module level when `aiter` will not import, and `pytest_sessionfinish` rewrites the resulting exit code 5 to 0. A run that collected none of `test_pa.py`'s 2305 cases is therefore indistinguishable from a run that passed them.

That is the state on the box this was found on: `import aiter` raises `ImportError: cannot import name 'fly_values' from 'flydsl.compiler.protocol'`, and `test_pa.py` and `test_mla_decode.py` collect zero tests and exit 0. Nothing in the output says so.

## Changes

- `pytest_report_header` reports aiter's version, or the import error and the fact that the suites needing it will collect nothing. One line, every run.
- `FLYDSL_REQUIRE_AITER=1` turns that into `pytest.exit(..., returncode=1)`. Off by default, so local runs without aiter behave as they do now; CI can set it.
- `test_pa.py`'s module guard narrows from `except Exception` to `except ImportError`. Anything else raised while importing aiter is a real failure, not a skip.
- `test_mla_decode.py` no longer imports `hk_mla_decode_fwd` at module level. It is used in one opt-in benchmark path, and its removal from aiter was taking all six correctness tests down with it.

## What the silence was hiding

Forcing the suites to run — through a shim for the old aiter, and against `ROCm/aiter` main for the new — turned up three things, none of which was visible before.

**1. `test_pa.py::test_sliding_window_accuracy[...fp8]` fails on all 8 parameterisations with the aiter this image ships** (`rocm/vllm-dev:torch2.11_v0.22.0_20260610`, gluon file dated 2026-06-10). Differences reach **5.4e+29**. Two distinct faults:

- The reduce reads partition slots the first stage never wrote. The test allocates `exp_sums` / `max_logits` / `temporary_output` with `torch.empty`, so uninitialised memory lands in the output. Zeroing them drops the worst difference from 5.4e+29 to 1.2e-01.
- Even zeroed, 93 of the 128 sequences are still wrong against the torch reference (tolerance 0.06). Every wrong sequence is one the window actually clips: sequences with `context_length <= sliding_window` are all correct, and of the 106 clipped ones, 93 fail.

**This is already fixed in `ROCm/aiter` main.** Same test, same box, aiter at `243bebb`: **8 passed**, worst difference 0.042 against the 0.06 tolerance. So it is not a FlyDSL bug and needs no change here — but the repo has no aiter floor in `pyproject.toml`, `setup.py` or any requirements file, so nothing stops an image that is two months stale from testing nothing and reporting success.

**2. `test_mla_decode.py` cannot run on either version, for two different reasons.** With the 2026-06-10 aiter it fails: `aiter::mla_reduce_v1()` takes 8 arguments, the test passes 9. With aiter main it skipped, because `hk_mla_decode_fwd` no longer exists anywhere in aiter — main's own `aiter/mla.py:911` still calls it, so that reference is dangling upstream too. Main's `mla_reduce_v1` does take the 9 arguments the test passes, so the test is written against something close to current aiter.

**3. With the benchmark import made optional, the MLA suite runs against aiter main and 4 of its 6 cases fail:**

| case | result |
|---|---|
| `test_mla_decode[1-63]` | FAILED — `cos_diff=0.365` against a 0.03 threshold |
| `test_mla_decode[1-64]` | FAILED |
| `test_mla_decode[1-128]` | FAILED |
| `test_mla_decode[4-2048]` | FAILED |
| `test_mla_decode[33-2333]` | passed |
| `test_mla_decode[32-8192]` | passed |

Batch size, not context length, separates them: 1 and 4 fail, 32 and 33 pass. `mla_reduce_v1` gained a `num_kv_splits` parameter in current aiter, and small batches are where the split count per sequence is largest, so the likeliest reading is split-metadata drift rather than a kernel defect — the kernel is right at 32 and 33 batches. **This needs an owner**; it is not addressed here.

Point 3 means this PR can turn a green CI red on an environment with current aiter. That is the intended effect: those four cases were never passing, they were being skipped.

## Testing

```
$ pytest tests/kernels/test_pa.py -q
aiter: NOT IMPORTABLE (cannot import name 'fly_values' from 'flydsl.compiler.protocol') -- the suites that need it will collect nothing
1 skipped

$ FLYDSL_REQUIRE_AITER=1 pytest tests/kernels/test_pa.py -q; echo $?
Exit: FLYDSL_REQUIRE_AITER is set but aiter is not importable: cannot import name 'fly_values' ...
1
```

With a working aiter the header reads `aiter: <version>` and collection is unchanged: `test_pa.py` collects 2305 and `test_mla_decode.py` collects 6.

- [x] No new third-party dependencies added

## Breaking Changes

None by default. `FLYDSL_REQUIRE_AITER` is opt-in. A CI job that sets it will fail on an environment that was already testing nothing.
