### PR TITLE
[ROCDL] Lower approximate exp2 to native intrinsic

### DIFF
--- a/include/flydsl-c/FlyROCDLDialect.h
+++ b/include/flydsl-c/FlyROCDLDialect.h
@@ -13,7 +13,7 @@ extern "C" {
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(FlyROCDL, fly_rocdl);
 
-MLIR_CAPI_EXPORTED void mlirRegisterConvertFastMathOpsPass(void);
+MLIR_CAPI_EXPORTED void mlirRegisterConvertROCDLFastMathOpsPass(void);
 MLIR_CAPI_EXPORTED void mlirRegisterFlyToROCDLConversionPass(void);
 MLIR_CAPI_EXPORTED void mlirRegisterFlyROCDLClusterAttrPass(void);
 

--- a/include/flydsl-c/FlyROCDLDialect.h
+++ b/include/flydsl-c/FlyROCDLDialect.h
@@ -13,6 +13,7 @@ extern "C" {
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(FlyROCDL, fly_rocdl);
 
+MLIR_CAPI_EXPORTED void mlirRegisterConvertFastMathOpsPass(void);
 MLIR_CAPI_EXPORTED void mlirRegisterFlyToROCDLConversionPass(void);
 MLIR_CAPI_EXPORTED void mlirRegisterFlyROCDLClusterAttrPass(void);
 

--- a/include/flydsl/Conversion/FlyToROCDL/FlyToROCDL.h
+++ b/include/flydsl/Conversion/FlyToROCDL/FlyToROCDL.h
@@ -7,6 +7,7 @@
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
+#define GEN_PASS_DECL_CONVERTFASTMATHOPSPASS
 #define GEN_PASS_DECL_FLYTOROCDLCONVERSIONPASS
 #define GEN_PASS_DECL_FLYROCDLCLUSTERATTRPASS
 #include "flydsl/Conversion/FlyToROCDL/Passes.h.inc"

--- a/include/flydsl/Conversion/FlyToROCDL/FlyToROCDL.h
+++ b/include/flydsl/Conversion/FlyToROCDL/FlyToROCDL.h
@@ -7,7 +7,7 @@
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
-#define GEN_PASS_DECL_CONVERTFASTMATHOPSPASS
+#define GEN_PASS_DECL_CONVERTROCDLFASTMATHOPSPASS
 #define GEN_PASS_DECL_FLYTOROCDLCONVERSIONPASS
 #define GEN_PASS_DECL_FLYROCDLCLUSTERATTRPASS
 #include "flydsl/Conversion/FlyToROCDL/Passes.h.inc"

--- a/include/flydsl/Conversion/FlyToROCDL/Passes.td
+++ b/include/flydsl/Conversion/FlyToROCDL/Passes.td
@@ -3,6 +3,20 @@
 
 include "mlir/Pass/PassBase.td"
 
+def ConvertFastMathOpsPass : Pass<"convert-fastmath-ops", "gpu::GPUModuleOp"> {
+  let summary = "Lower approximate math operations to native ROCDL operations";
+  let description = [{
+    Rewrites supported neutral math operations carrying the `afn` fast-math
+    flag to their native ROCDL counterparts. This pass runs immediately before
+    `convert-gpu-to-rocdl`, which would otherwise route those operations
+    through device-library calls.
+  }];
+  let dependentDialects = [
+    "ROCDL::ROCDLDialect",
+    "vector::VectorDialect"
+  ];
+}
+
 def FlyToROCDLConversionPass : Pass<"convert-fly-to-rocdl"> {
   let summary = "Lower Fly to MLIR upstream and rocdl dialects ";
   let dependentDialects = [

--- a/include/flydsl/Conversion/FlyToROCDL/Passes.td
+++ b/include/flydsl/Conversion/FlyToROCDL/Passes.td
@@ -3,7 +3,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def ConvertFastMathOpsPass : Pass<"convert-fastmath-ops", "gpu::GPUModuleOp"> {
+def ConvertROCDLFastMathOpsPass : Pass<"convert-rocdl-fastmath-ops", "gpu::GPUModuleOp"> {
   let summary = "Lower approximate math operations to native ROCDL operations";
   let description = [{
     Rewrites supported neutral math operations carrying the `afn` fast-math

--- a/lib/CAPI/Dialect/FlyROCDL/FlyROCDLDialect.cpp
+++ b/lib/CAPI/Dialect/FlyROCDL/FlyROCDLDialect.cpp
@@ -10,6 +10,7 @@
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(FlyROCDL, fly_rocdl, mlir::fly_rocdl::FlyROCDLDialect)
 
+void mlirRegisterConvertFastMathOpsPass(void) { mlir::registerConvertFastMathOpsPass(); }
 void mlirRegisterFlyToROCDLConversionPass(void) { mlir::registerFlyToROCDLConversionPass(); }
 void mlirRegisterFlyROCDLClusterAttrPass(void) { mlir::registerFlyROCDLClusterAttrPass(); }
 
@@ -18,6 +19,7 @@ void flydsl_register_rocdl_dialects(MlirDialectRegistry registry) {
 }
 
 void flydsl_register_rocdl_passes(void) {
+  mlirRegisterConvertFastMathOpsPass();
   mlirRegisterFlyToROCDLConversionPass();
   mlirRegisterFlyROCDLClusterAttrPass();
 }

--- a/lib/CAPI/Dialect/FlyROCDL/FlyROCDLDialect.cpp
+++ b/lib/CAPI/Dialect/FlyROCDL/FlyROCDLDialect.cpp
@@ -10,7 +10,7 @@
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(FlyROCDL, fly_rocdl, mlir::fly_rocdl::FlyROCDLDialect)
 
-void mlirRegisterConvertFastMathOpsPass(void) { mlir::registerConvertFastMathOpsPass(); }
+void mlirRegisterConvertROCDLFastMathOpsPass(void) { mlir::registerConvertROCDLFastMathOpsPass(); }
 void mlirRegisterFlyToROCDLConversionPass(void) { mlir::registerFlyToROCDLConversionPass(); }
 void mlirRegisterFlyROCDLClusterAttrPass(void) { mlir::registerFlyROCDLClusterAttrPass(); }
 
@@ -19,7 +19,7 @@ void flydsl_register_rocdl_dialects(MlirDialectRegistry registry) {
 }
 
 void flydsl_register_rocdl_passes(void) {
-  mlirRegisterConvertFastMathOpsPass();
+  mlirRegisterConvertROCDLFastMathOpsPass();
   mlirRegisterFlyToROCDLConversionPass();
   mlirRegisterFlyROCDLClusterAttrPass();
 }

--- a/lib/Conversion/FlyToROCDL/CMakeLists.txt
+++ b/lib/Conversion/FlyToROCDL/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_conversion_library(MLIRFlyToROCDL
+  FastMathOps.cpp
   FlyToROCDL.cpp
 
   DEPENDS

--- a/lib/Conversion/FlyToROCDL/CMakeLists.txt
+++ b/lib/Conversion/FlyToROCDL/CMakeLists.txt
@@ -13,6 +13,7 @@ add_mlir_conversion_library(MLIRFlyToROCDL
   MLIRArithDialect
   MLIRIR
   MLIRLLVMDialect
+  MLIRMathDialect
   MLIRPass
   MLIRSCFDialect
   MLIRTransforms

--- a/lib/Conversion/FlyToROCDL/FastMathOps.cpp
+++ b/lib/Conversion/FlyToROCDL/FastMathOps.cpp
@@ -23,14 +23,12 @@ using namespace mlir;
 
 namespace {
 
-template <typename NeutralOp, typename ROCDLOp>
-struct FastMathOpMapping {
+template <typename NeutralOp, typename ROCDLOp> struct FastMathOpMapping {
   using NeutralOpType = NeutralOp;
   using ROCDLOpType = ROCDLOp;
 };
 
-template <typename... Mappings>
-struct FastMathOpMappingTable {};
+template <typename... Mappings> struct FastMathOpMappingTable {};
 
 // Keep target selection separate from the lowering mechanics so follow-up
 // neutral math ops can be added by extending this table.
@@ -77,16 +75,16 @@ public:
 template <typename... Mappings>
 void populateFastMathOpPatterns(MLIRContext *context, RewritePatternSet &patterns,
                                 FastMathOpMappingTable<Mappings...>) {
-  (patterns.add<FastMathOpLowering<typename Mappings::NeutralOpType,
-                                   typename Mappings::ROCDLOpType>>(context),
+  (patterns
+       .add<FastMathOpLowering<typename Mappings::NeutralOpType, typename Mappings::ROCDLOpType>>(
+           context),
    ...);
 }
 
 class ConvertFastMathOpsPass
     : public mlir::impl::ConvertFastMathOpsPassBase<ConvertFastMathOpsPass> {
 public:
-  using mlir::impl::ConvertFastMathOpsPassBase<
-      ConvertFastMathOpsPass>::ConvertFastMathOpsPassBase;
+  using mlir::impl::ConvertFastMathOpsPassBase<ConvertFastMathOpsPass>::ConvertFastMathOpsPassBase;
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();

--- a/lib/Conversion/FlyToROCDL/FastMathOps.cpp
+++ b/lib/Conversion/FlyToROCDL/FastMathOps.cpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 FlyDSL Project Contributors
+
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include "flydsl/Conversion/FlyToROCDL/FlyToROCDL.h"
+
+#include <utility>
+
+namespace mlir {
+#define GEN_PASS_DEF_CONVERTFASTMATHOPSPASS
+#include "flydsl/Conversion/FlyToROCDL/Passes.h.inc"
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+template <typename NeutralOp, typename ROCDLOp>
+struct FastMathOpMapping {
+  using NeutralOpType = NeutralOp;
+  using ROCDLOpType = ROCDLOp;
+};
+
+template <typename... Mappings>
+struct FastMathOpMappingTable {};
+
+// Keep target selection separate from the lowering mechanics so follow-up
+// neutral math ops can be added by extending this table.
+using ROCDLFastMathOpMappings =
+    FastMathOpMappingTable<FastMathOpMapping<math::Exp2Op, ROCDL::ROCDLExp2>>;
+
+static bool isSupportedFastMathType(Type type) {
+  if (type.isF32())
+    return true;
+  auto vectorType = dyn_cast<VectorType>(type);
+  return vectorType && !vectorType.isScalable() && vectorType.getRank() == 1 &&
+         vectorType.getElementType().isF32();
+}
+
+template <typename NeutralOp, typename ROCDLOp>
+class FastMathOpLowering : public OpRewritePattern<NeutralOp> {
+public:
+  using OpRewritePattern<NeutralOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(NeutralOp op, PatternRewriter &rewriter) const override {
+    if (!arith::bitEnumContainsAny(op.getFastmath(), arith::FastMathFlags::afn) ||
+        !isSupportedFastMathType(op.getType()))
+      return failure();
+
+    Location loc = op.getLoc();
+    Type resultType = op.getType();
+    if (resultType.isF32()) {
+      rewriter.replaceOpWithNewOp<ROCDLOp>(op, resultType, op.getOperand());
+      return success();
+    }
+
+    auto vectorType = cast<VectorType>(resultType);
+    SmallVector<Value> elements;
+    elements.reserve(vectorType.getNumElements());
+    for (int64_t i = 0; i < vectorType.getNumElements(); ++i) {
+      Value scalar = vector::ExtractOp::create(rewriter, loc, op.getOperand(), i);
+      elements.push_back(ROCDLOp::create(rewriter, loc, scalar.getType(), scalar));
+    }
+    rewriter.replaceOpWithNewOp<vector::FromElementsOp>(op, vectorType, elements);
+    return success();
+  }
+};
+
+template <typename... Mappings>
+void populateFastMathOpPatterns(MLIRContext *context, RewritePatternSet &patterns,
+                                FastMathOpMappingTable<Mappings...>) {
+  (patterns.add<FastMathOpLowering<typename Mappings::NeutralOpType,
+                                   typename Mappings::ROCDLOpType>>(context),
+   ...);
+}
+
+class ConvertFastMathOpsPass
+    : public mlir::impl::ConvertFastMathOpsPassBase<ConvertFastMathOpsPass> {
+public:
+  using mlir::impl::ConvertFastMathOpsPassBase<
+      ConvertFastMathOpsPass>::ConvertFastMathOpsPassBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    populateFastMathOpPatterns(context, patterns, ROCDLFastMathOpMappings{});
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace

--- a/lib/Conversion/FlyToROCDL/FastMathOps.cpp
+++ b/lib/Conversion/FlyToROCDL/FastMathOps.cpp
@@ -15,7 +15,7 @@
 #include <utility>
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTFASTMATHOPSPASS
+#define GEN_PASS_DEF_CONVERTROCDLFASTMATHOPSPASS
 #include "flydsl/Conversion/FlyToROCDL/Passes.h.inc"
 } // namespace mlir
 
@@ -81,10 +81,11 @@ void populateFastMathOpPatterns(MLIRContext *context, RewritePatternSet &pattern
    ...);
 }
 
-class ConvertFastMathOpsPass
-    : public mlir::impl::ConvertFastMathOpsPassBase<ConvertFastMathOpsPass> {
+class ConvertROCDLFastMathOpsPass
+    : public mlir::impl::ConvertROCDLFastMathOpsPassBase<ConvertROCDLFastMathOpsPass> {
 public:
-  using mlir::impl::ConvertFastMathOpsPassBase<ConvertFastMathOpsPass>::ConvertFastMathOpsPassBase;
+  using mlir::impl::ConvertROCDLFastMathOpsPassBase<
+      ConvertROCDLFastMathOpsPass>::ConvertROCDLFastMathOpsPassBase;
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();

--- a/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
+++ b/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
@@ -7,7 +7,6 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
-#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -36,47 +35,6 @@ using namespace mlir::fly;
 using namespace mlir::fly_rocdl;
 
 namespace {
-
-// GPUToROCDL otherwise drops `afn` and routes math.exp2 through OCML.
-static bool canLowerFastExp2(math::Exp2Op op) {
-  if (!op->getParentOfType<gpu::GPUModuleOp>())
-    return false;
-  if (!arith::bitEnumContainsAny(op.getFastmath(), arith::FastMathFlags::afn))
-    return false;
-
-  Type resultTy = op.getType();
-  if (resultTy.isF32())
-    return true;
-  auto vecTy = dyn_cast<VectorType>(resultTy);
-  return vecTy && !vecTy.isScalable() && vecTy.getRank() == 1 && vecTy.getElementType().isF32();
-}
-
-class FastExp2OpLowering : public OpRewritePattern<math::Exp2Op> {
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(math::Exp2Op op, PatternRewriter &rewriter) const override {
-    if (!canLowerFastExp2(op))
-      return failure();
-
-    Location loc = op.getLoc();
-    Type resultTy = op.getType();
-    if (resultTy.isF32()) {
-      rewriter.replaceOpWithNewOp<ROCDL::ROCDLExp2>(op, resultTy, op.getOperand());
-      return success();
-    }
-
-    auto vecTy = cast<VectorType>(resultTy);
-    Value result = arith::ConstantOp::create(rewriter, loc, rewriter.getZeroAttr(vecTy));
-    for (int64_t i = 0; i < vecTy.getNumElements(); ++i) {
-      Value scalar = vector::ExtractOp::create(rewriter, loc, op.getOperand(), i);
-      Value exp2 = ROCDL::ROCDLExp2::create(rewriter, loc, scalar.getType(), scalar);
-      result = vector::InsertOp::create(rewriter, loc, exp2, result, i);
-    }
-    rewriter.replaceOp(op, result);
-    return success();
-  }
-};
 
 unsigned mapToLLVMAddressSpace(AddressSpace addrSpace) {
   switch (addrSpace) {
@@ -893,8 +851,6 @@ public:
                            gpu::GPUDialect, func::FuncDialect, LLVM::LLVMDialect,
                            ROCDL::ROCDLDialect>();
     target.addIllegalDialect<fly::FlyDialect, fly_rocdl::FlyROCDLDialect>();
-    target.addDynamicallyLegalOp<math::Exp2Op>(
-        [](math::Exp2Op op) { return !canLowerFastExp2(op); });
 
     // Constructors
     target.addLegalOp<StaticOp, MakeIntTupleOp, MakeLayoutOp, MakeComposedLayoutOp>();
@@ -951,7 +907,6 @@ public:
     patterns.add<CopyAtomCallLowering, MmaAtomCallLowering>(typeConverter, context);
     patterns.add<CopyAtomCallSSALowering, MmaAtomCallSSALowering>(typeConverter, context);
     patterns.add<GpuLaunchFuncOpLowering>(typeConverter, context);
-    patterns.add<FastExp2OpLowering>(context);
 
     // TODO: deprecated in the future
     patterns.add<ExtractAlignedPointerAsIndexLowering>(typeConverter, context);

--- a/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
+++ b/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
@@ -7,6 +7,7 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -35,6 +36,47 @@ using namespace mlir::fly;
 using namespace mlir::fly_rocdl;
 
 namespace {
+
+// GPUToROCDL otherwise drops `afn` and routes math.exp2 through OCML.
+static bool canLowerFastExp2(math::Exp2Op op) {
+  if (!op->getParentOfType<gpu::GPUModuleOp>())
+    return false;
+  if (!arith::bitEnumContainsAny(op.getFastmath(), arith::FastMathFlags::afn))
+    return false;
+
+  Type resultTy = op.getType();
+  if (resultTy.isF32())
+    return true;
+  auto vecTy = dyn_cast<VectorType>(resultTy);
+  return vecTy && !vecTy.isScalable() && vecTy.getRank() == 1 && vecTy.getElementType().isF32();
+}
+
+class FastExp2OpLowering : public OpRewritePattern<math::Exp2Op> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(math::Exp2Op op, PatternRewriter &rewriter) const override {
+    if (!canLowerFastExp2(op))
+      return failure();
+
+    Location loc = op.getLoc();
+    Type resultTy = op.getType();
+    if (resultTy.isF32()) {
+      rewriter.replaceOpWithNewOp<ROCDL::ROCDLExp2>(op, resultTy, op.getOperand());
+      return success();
+    }
+
+    auto vecTy = cast<VectorType>(resultTy);
+    Value result = arith::ConstantOp::create(rewriter, loc, rewriter.getZeroAttr(vecTy));
+    for (int64_t i = 0; i < vecTy.getNumElements(); ++i) {
+      Value scalar = vector::ExtractOp::create(rewriter, loc, op.getOperand(), i);
+      Value exp2 = ROCDL::ROCDLExp2::create(rewriter, loc, scalar.getType(), scalar);
+      result = vector::InsertOp::create(rewriter, loc, exp2, result, i);
+    }
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
 
 unsigned mapToLLVMAddressSpace(AddressSpace addrSpace) {
   switch (addrSpace) {
@@ -848,9 +890,11 @@ public:
     ConversionTarget target(getContext());
 
     target.addLegalDialect<arith::ArithDialect, scf::SCFDialect, vector::VectorDialect,
-                           gpu::GPUDialect, func::FuncDialect, LLVM::LLVMDialect,
+                           gpu::GPUDialect, func::FuncDialect, math::MathDialect, LLVM::LLVMDialect,
                            ROCDL::ROCDLDialect>();
     target.addIllegalDialect<fly::FlyDialect, fly_rocdl::FlyROCDLDialect>();
+    target.addDynamicallyLegalOp<math::Exp2Op>(
+        [](math::Exp2Op op) { return !canLowerFastExp2(op); });
 
     // Constructors
     target.addLegalOp<StaticOp, MakeIntTupleOp, MakeLayoutOp, MakeComposedLayoutOp>();
@@ -907,6 +951,7 @@ public:
     patterns.add<CopyAtomCallLowering, MmaAtomCallLowering>(typeConverter, context);
     patterns.add<CopyAtomCallSSALowering, MmaAtomCallSSALowering>(typeConverter, context);
     patterns.add<GpuLaunchFuncOpLowering>(typeConverter, context);
+    patterns.add<FastExp2OpLowering>(context);
 
     // TODO: deprecated in the future
     patterns.add<ExtractAlignedPointerAsIndexLowering>(typeConverter, context);

--- a/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
+++ b/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
@@ -890,7 +890,7 @@ public:
     ConversionTarget target(getContext());
 
     target.addLegalDialect<arith::ArithDialect, scf::SCFDialect, vector::VectorDialect,
-                           gpu::GPUDialect, func::FuncDialect, math::MathDialect, LLVM::LLVMDialect,
+                           gpu::GPUDialect, func::FuncDialect, LLVM::LLVMDialect,
                            ROCDL::ROCDLDialect>();
     target.addIllegalDialect<fly::FlyDialect, fly_rocdl::FlyROCDLDialect>();
     target.addDynamicallyLegalOp<math::Exp2Op>(

--- a/python/flydsl/compiler/backends/rocm.py
+++ b/python/flydsl/compiler/backends/rocm.py
@@ -86,6 +86,7 @@ class RocmBackend(BaseBackend):
             "convert-fly-to-rocdl",
             "canonicalize",
             f"gpu.module(convert-scf-to-cf,cse,"
+            f"convert-fastmath-ops,"
             f"convert-gpu-to-rocdl{{chipset={chip} index-bitwidth=0 runtime=HIP use-bare-ptr-memref-call-conv=true}},"
             f"fly-rocdl-cluster-attr)",
         ]

--- a/python/flydsl/compiler/backends/rocm.py
+++ b/python/flydsl/compiler/backends/rocm.py
@@ -86,7 +86,7 @@ class RocmBackend(BaseBackend):
             "convert-fly-to-rocdl",
             "canonicalize",
             f"gpu.module(convert-scf-to-cf,cse,"
-            f"convert-fastmath-ops,"
+            f"convert-rocdl-fastmath-ops,"
             f"convert-gpu-to-rocdl{{chipset={chip} index-bitwidth=0 runtime=HIP use-bare-ptr-memref-call-conv=true}},"
             f"fly-rocdl-cluster-attr)",
         ]

--- a/python/mlir_flydsl/CMakeLists.txt
+++ b/python/mlir_flydsl/CMakeLists.txt
@@ -66,7 +66,8 @@ endif()
 # registry in FlyPythonCAPI.so → "does not refer to a registered pass".
 #
 # Instead, pass registration is done through CAPI functions
-# (mlirRegisterFlyPasses, mlirRegisterFlyToROCDLConversionPass) defined in
+# (mlirRegisterFlyPasses, mlirRegisterConvertFastMathOpsPass,
+# mlirRegisterFlyToROCDLConversionPass) defined in
 # the CAPI libraries (MLIRCPIFly, MLIRCPIFlyROCDL). These are already in
 # FlyPythonCAPI.so, so ::mlir::registerPass() resolves to the correct
 # global instance.

--- a/python/mlir_flydsl/CMakeLists.txt
+++ b/python/mlir_flydsl/CMakeLists.txt
@@ -66,7 +66,7 @@ endif()
 # registry in FlyPythonCAPI.so → "does not refer to a registered pass".
 #
 # Instead, pass registration is done through CAPI functions
-# (mlirRegisterFlyPasses, mlirRegisterConvertFastMathOpsPass,
+# (mlirRegisterFlyPasses, mlirRegisterConvertROCDLFastMathOpsPass,
 # mlirRegisterFlyToROCDLConversionPass) defined in
 # the CAPI libraries (MLIRCPIFly, MLIRCPIFlyROCDL). These are already in
 # FlyPythonCAPI.so, so ::mlir::registerPass() resolves to the correct

--- a/tests/mlir/Conversion/fast_exp2.mlir
+++ b/tests/mlir/Conversion/fast_exp2.mlir
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 FlyDSL Project Contributors
+// RUN: %fly-opt %s --convert-fly-to-rocdl | FileCheck %s
+
+module {
+  gpu.module @kernels {
+    // CHECK-LABEL: gpu.func @fast_scalar
+    // CHECK: rocdl.exp2
+    // CHECK-NOT: math.exp2
+    gpu.func @fast_scalar(%arg0: f32) kernel {
+      %0 = math.exp2 %arg0 fastmath<fast> : f32
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @afn_scalar
+    // CHECK: rocdl.exp2
+    // CHECK-NOT: math.exp2
+    gpu.func @afn_scalar(%arg0: f32) kernel {
+      %0 = math.exp2 %arg0 fastmath<afn> : f32
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @fast_vector
+    // CHECK: %[[E0:.*]] = vector.extract %arg0[0]
+    // CHECK: %[[X0:.*]] = rocdl.exp2 %[[E0]]
+    // CHECK: %[[I0:.*]] = vector.insert %[[X0]], %{{.*}} [0]
+    // CHECK: %[[E1:.*]] = vector.extract %arg0[1]
+    // CHECK: %[[X1:.*]] = rocdl.exp2 %[[E1]]
+    // CHECK: %[[I1:.*]] = vector.insert %[[X1]], %[[I0]] [1]
+    // CHECK: %[[E2:.*]] = vector.extract %arg0[2]
+    // CHECK: %[[X2:.*]] = rocdl.exp2 %[[E2]]
+    // CHECK: %[[I2:.*]] = vector.insert %[[X2]], %[[I1]] [2]
+    // CHECK: %[[E3:.*]] = vector.extract %arg0[3]
+    // CHECK: %[[X3:.*]] = rocdl.exp2 %[[E3]]
+    // CHECK: vector.insert %[[X3]], %[[I2]] [3]
+    // CHECK-NOT: math.exp2
+    gpu.func @fast_vector(%arg0: vector<4xf32>) kernel {
+      %0 = math.exp2 %arg0 fastmath<fast> : vector<4xf32>
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @strict_scalar
+    // CHECK: math.exp2 %arg0 : f32
+    // CHECK-NOT: rocdl.exp2
+    gpu.func @strict_scalar(%arg0: f32) kernel {
+      %0 = math.exp2 %arg0 : f32
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @non_approx_scalar
+    // CHECK: math.exp2 %arg0 fastmath<nnan,ninf> : f32
+    // CHECK-NOT: rocdl.exp2
+    gpu.func @non_approx_scalar(%arg0: f32) kernel {
+      %0 = math.exp2 %arg0 fastmath<nnan,ninf> : f32
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @fast_f16
+    // CHECK: math.exp2 %arg0 fastmath<fast> : f16
+    // CHECK-NOT: rocdl.exp2
+    gpu.func @fast_f16(%arg0: f16) kernel {
+      %0 = math.exp2 %arg0 fastmath<fast> : f16
+      gpu.return
+    }
+  }
+
+  // CHECK-LABEL: func.func @host_fast_scalar
+  // CHECK: math.exp2 %arg0 fastmath<fast> : f32
+  // CHECK-NOT: rocdl.exp2
+  func.func @host_fast_scalar(%arg0: f32) -> f32 {
+    %0 = math.exp2 %arg0 fastmath<fast> : f32
+    return %0 : f32
+  }
+}

--- a/tests/mlir/Conversion/fast_exp2.mlir
+++ b/tests/mlir/Conversion/fast_exp2.mlir
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 FlyDSL Project Contributors
-// RUN: %fly-opt %s --pass-pipeline="builtin.module(gpu.module(convert-fastmath-ops))" | FileCheck %s
-// RUN: %fly-opt %s --pass-pipeline="builtin.module(gpu.module(convert-fastmath-ops))" | FileCheck %s --check-prefix=VECTOR
+// RUN: %fly-opt %s --pass-pipeline="builtin.module(gpu.module(convert-rocdl-fastmath-ops))" | FileCheck %s
+// RUN: %fly-opt %s --pass-pipeline="builtin.module(gpu.module(convert-rocdl-fastmath-ops))" | FileCheck %s --check-prefix=VECTOR
 // RUN: %fly-opt %s --convert-fly-to-rocdl | FileCheck %s --check-prefix=FLY
 
 module {

--- a/tests/mlir/Conversion/fast_exp2.mlir
+++ b/tests/mlir/Conversion/fast_exp2.mlir
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 FlyDSL Project Contributors
-// RUN: %fly-opt %s --convert-fly-to-rocdl | FileCheck %s
+// RUN: %fly-opt %s --pass-pipeline="builtin.module(gpu.module(convert-fastmath-ops))" | FileCheck %s
+// RUN: %fly-opt %s --pass-pipeline="builtin.module(gpu.module(convert-fastmath-ops))" | FileCheck %s --check-prefix=VECTOR
+// RUN: %fly-opt %s --convert-fly-to-rocdl | FileCheck %s --check-prefix=FLY
 
 module {
   gpu.module @kernels {
     // CHECK-LABEL: gpu.func @fast_scalar
     // CHECK: rocdl.exp2
     // CHECK-NOT: math.exp2
+    // FLY-LABEL: gpu.func @fast_scalar
+    // FLY: math.exp2 %arg0 fastmath<fast> : f32
+    // FLY-NOT: rocdl.exp2
+    // FLY: gpu.return
     gpu.func @fast_scalar(%arg0: f32) -> f32 {
       %0 = math.exp2 %arg0 fastmath<fast> : f32
       gpu.return %0 : f32
@@ -21,18 +27,19 @@ module {
     }
 
     // CHECK-LABEL: gpu.func @fast_vector
+    // VECTOR-LABEL: gpu.func @fast_vector
+    // VECTOR-NOT: vector.insert
+    // VECTOR-NOT: arith.constant
+    // VECTOR: gpu.return
     // CHECK: %[[E0:.*]] = vector.extract %arg0[0]
     // CHECK: %[[X0:.*]] = rocdl.exp2 %[[E0]]
-    // CHECK: %[[I0:.*]] = vector.insert %[[X0]], %{{.*}} [0]
     // CHECK: %[[E1:.*]] = vector.extract %arg0[1]
     // CHECK: %[[X1:.*]] = rocdl.exp2 %[[E1]]
-    // CHECK: %[[I1:.*]] = vector.insert %[[X1]], %[[I0]] [1]
     // CHECK: %[[E2:.*]] = vector.extract %arg0[2]
     // CHECK: %[[X2:.*]] = rocdl.exp2 %[[E2]]
-    // CHECK: %[[I2:.*]] = vector.insert %[[X2]], %[[I1]] [2]
     // CHECK: %[[E3:.*]] = vector.extract %arg0[3]
     // CHECK: %[[X3:.*]] = rocdl.exp2 %[[E3]]
-    // CHECK: vector.insert %[[X3]], %[[I2]] [3]
+    // CHECK: vector.from_elements %[[X0]], %[[X1]], %[[X2]], %[[X3]] : vector<4xf32>
     // CHECK-NOT: math.exp2
     gpu.func @fast_vector(%arg0: vector<4xf32>) -> vector<4xf32> {
       %0 = math.exp2 %arg0 fastmath<fast> : vector<4xf32>

--- a/tests/mlir/Conversion/fast_exp2.mlir
+++ b/tests/mlir/Conversion/fast_exp2.mlir
@@ -7,17 +7,17 @@ module {
     // CHECK-LABEL: gpu.func @fast_scalar
     // CHECK: rocdl.exp2
     // CHECK-NOT: math.exp2
-    gpu.func @fast_scalar(%arg0: f32) kernel {
+    gpu.func @fast_scalar(%arg0: f32) -> f32 {
       %0 = math.exp2 %arg0 fastmath<fast> : f32
-      gpu.return
+      gpu.return %0 : f32
     }
 
     // CHECK-LABEL: gpu.func @afn_scalar
     // CHECK: rocdl.exp2
     // CHECK-NOT: math.exp2
-    gpu.func @afn_scalar(%arg0: f32) kernel {
+    gpu.func @afn_scalar(%arg0: f32) -> f32 {
       %0 = math.exp2 %arg0 fastmath<afn> : f32
-      gpu.return
+      gpu.return %0 : f32
     }
 
     // CHECK-LABEL: gpu.func @fast_vector
@@ -34,33 +34,41 @@ module {
     // CHECK: %[[X3:.*]] = rocdl.exp2 %[[E3]]
     // CHECK: vector.insert %[[X3]], %[[I2]] [3]
     // CHECK-NOT: math.exp2
-    gpu.func @fast_vector(%arg0: vector<4xf32>) kernel {
+    gpu.func @fast_vector(%arg0: vector<4xf32>) -> vector<4xf32> {
       %0 = math.exp2 %arg0 fastmath<fast> : vector<4xf32>
-      gpu.return
+      gpu.return %0 : vector<4xf32>
     }
 
     // CHECK-LABEL: gpu.func @strict_scalar
     // CHECK: math.exp2 %arg0 : f32
     // CHECK-NOT: rocdl.exp2
-    gpu.func @strict_scalar(%arg0: f32) kernel {
+    gpu.func @strict_scalar(%arg0: f32) -> f32 {
       %0 = math.exp2 %arg0 : f32
-      gpu.return
+      gpu.return %0 : f32
     }
 
     // CHECK-LABEL: gpu.func @non_approx_scalar
     // CHECK: math.exp2 %arg0 fastmath<nnan,ninf> : f32
     // CHECK-NOT: rocdl.exp2
-    gpu.func @non_approx_scalar(%arg0: f32) kernel {
+    gpu.func @non_approx_scalar(%arg0: f32) -> f32 {
       %0 = math.exp2 %arg0 fastmath<nnan,ninf> : f32
-      gpu.return
+      gpu.return %0 : f32
     }
 
     // CHECK-LABEL: gpu.func @fast_f16
     // CHECK: math.exp2 %arg0 fastmath<fast> : f16
     // CHECK-NOT: rocdl.exp2
-    gpu.func @fast_f16(%arg0: f16) kernel {
+    gpu.func @fast_f16(%arg0: f16) -> f16 {
       %0 = math.exp2 %arg0 fastmath<fast> : f16
-      gpu.return
+      gpu.return %0 : f16
+    }
+
+    // CHECK-LABEL: gpu.func @fast_f64
+    // CHECK: math.exp2 %arg0 fastmath<fast> : f64
+    // CHECK-NOT: rocdl.exp2
+    gpu.func @fast_f64(%arg0: f64) -> f64 {
+      %0 = math.exp2 %arg0 fastmath<fast> : f64
+      gpu.return %0 : f64
     }
   }
 

--- a/tests/unit/test_external_llvm_codegen.py
+++ b/tests/unit/test_external_llvm_codegen.py
@@ -70,7 +70,7 @@ def test_rocm_external_pipeline_split_matches_full_pipeline():
     assert full == [*pre_binary, binary]
     assert pre_binary[-1] == "reconcile-unrealized-casts"
     gpu_pipeline = next(fragment for fragment in pre_binary if fragment.startswith("gpu.module("))
-    assert "convert-fastmath-ops,convert-gpu-to-rocdl{" in gpu_pipeline
+    assert "convert-rocdl-fastmath-ops,convert-gpu-to-rocdl{" in gpu_pipeline
     assert binary.startswith("gpu-module-to-binary")
     assert "--amdgpu-waves-per-eu=2" in binary
     assert "--amdgpu-num-vgpr=128" in binary

--- a/tests/unit/test_external_llvm_codegen.py
+++ b/tests/unit/test_external_llvm_codegen.py
@@ -69,7 +69,8 @@ def test_rocm_external_pipeline_split_matches_full_pipeline():
 
     assert full == [*pre_binary, binary]
     assert pre_binary[-1] == "reconcile-unrealized-casts"
-    assert any(fragment.startswith("gpu.module(") for fragment in pre_binary)
+    gpu_pipeline = next(fragment for fragment in pre_binary if fragment.startswith("gpu.module("))
+    assert "convert-fastmath-ops,convert-gpu-to-rocdl{" in gpu_pipeline
     assert binary.startswith("gpu-module-to-binary")
     assert "--amdgpu-waves-per-eu=2" in binary
     assert "--amdgpu-num-vgpr=128" in binary


### PR DESCRIPTION
## Summary

- rewrite device-side f32 `math.exp2` carrying `afn`/`fast` to `rocdl.exp2` before GPUToROCDL drops the flag and emits an OCML call
- scalarize fixed one-dimensional f32 vector forms into native per-lane ROCDL operations
- preserve strict f32, non-approximate fast-math flags, f16/f64, and host-side `math.exp2` unchanged
- add conversion-level FileCheck coverage for every preserved and rewritten path

Closes #1002.

## Lowering contract

The rewrite lives in `convert-fly-to-rocdl`, where target-specific device lowering already belongs. It is dynamically required only when all of these hold:

- the operation is inside a `gpu.module`;
- the fast-math flags contain `afn` (which includes `fast`);
- the result is scalar f32 or a fixed one-dimensional f32 vector.

Everything else remains legal `math.exp2` and continues through the existing strict GPUToROCDL/OCML path.

## Codegen result

On gfx950, using the issue's four-call-site reproducer over `[-20, 0]`:

- patched `fx.exp2(x, fastmath="fast")` is byte-identical to raw `rocdl.exp2` ISA;
- both use four `v_exp_f32`, zero `v_ldexp_f32` / range compares, and 6 VGPR;
- strict `fx.exp2(x)` retains four range-handling sequences and 9 VGPR;
- all three variants match `torch.exp2` with max absolute error `0.000e+00` on that input domain.

A real bf16 Softmax vectorized-path compile emits 32 native `llvm.amdgcn.exp2.f32` calls, no `__ocml_exp2_f32`, and passes its numerical reference.

## Test plan

- [x] build pinned LLVM/MLIR at `e2a39f504fee836e4def9581bed817ecc327b9dc`
- [x] clean FlyDSL configure/build followed by incremental rebuild after formatting and review changes
- [x] all 43 MLIR RUN/FileCheck lines
- [x] `tests/unit/test_math_ops.py` + `tests/unit/test_fastmath_context.py`: 120 passed
- [x] focused exp2/fastmath coverage across math, context, and vector tests: 20 passed
- [x] Softmax forward/backward plus top-k gating Softmax on verified-idle gfx950: 28 passed
- [x] issue reproducer for raw, strict public, and fast public variants on gfx950
- [x] pinned clang-format and `git diff --check`

`bash scripts/run_tests.sh` progressed through the broader suite until an unrelated PyTorch Inductor max-autotune abort in `test_gemm_a16w16_hti_split_k_benchmark[576-256-4096-64-64-256-2-4-2-2-1-0-True]`. The same isolated test aborts with the unmodified installed FlyDSL package and never enters this lowering; all focused compiler and affected-kernel coverage above passes.