### PR TITLE
[Docs] Remove Disclaimer section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,8 +399,3 @@ FlyDSL's design is inspired by ideas from several projects:
 ## 📄 License
 
 Apache License 2.0
-
-## Disclaimer
-
-This is an experimental feature/tool and is not part of the official ROCm distribution. It is provided for evaluation and testing purposes only.
-For further usage or inquiries, please initiate a discussion thread with the original authors.


### PR DESCRIPTION
Removes the **Disclaimer** section from the README (the `#disclaimer` anchor at the bottom of the page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)