### PR TITLE
[CI] Bypass runner git-cache in promote checkout

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        env:
+          # Keep checkout independent of runner-local git-cache rewrites.
+          # If that cache is unavailable, checkout fails before promotion starts.
+          GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
+          GIT_CONFIG_NOSYSTEM: "1"
         with:
           sparse-checkout: |
             scripts/install_awscli.sh


### PR DESCRIPTION
## Problem

The scheduled `promote / promote` job failed at **Checkout code** with:

```
unable to access 'http://git-cache.git-cache.svc.cluster.local/ROCm/FlyDSL/':
Failed to connect to git-cache.git-cache.svc.cluster.local port 80
```

(run [32324744356](https://github.com/ROCm/FlyDSL/actions/runs/32324744356/job/96311232888))

The self-hosted runners inject a global git config that rewrites GitHub URLs to an internal `git-cache` proxy. When that proxy is unavailable, `actions/checkout` fails before the job can start.

## Fix

Every other workflow's checkout step already neutralizes this rewrite by pointing `GIT_CONFIG_GLOBAL` at an empty temp file and setting `GIT_CONFIG_NOSYSTEM=1` (see `flydsl.yaml`, `test-whl.yaml`). `promote.yaml` was the only one missing it — this applies the same block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)