### PR TITLE
[GEMM] Refine GFX950 A16W16 async load scheduling

### DIFF
--- a/kernels/gemm/gemm_a16w16_gfx950.py
+++ b/kernels/gemm/gemm_a16w16_gfx950.py
@@ -17,15 +17,13 @@ from .gemm_a16w16_gfx950_utils import (
     SPLIT_K_SEMAPHORE_MAX_LEN,
     BlockSwizzle,
     SplitKProtocol,
-    __barrier,
-    buffer_load_lds_inline,
     get_wave_lds_offset,
     make_lds_layout,
     make_transposed_lds_layout,
-    make_wave_lds_ptr,
     run_cached,
     swizzled_col_idx,
     transposed_contiguous_idx,
+    wait_vmcnt_and_barrier,
 )
 
 GEMM_A16W16_DTYPE_FP32 = 1
@@ -264,7 +262,8 @@ def make_gemm_a16w16_gfx950_kernel_name(param: GemmA16W16Gfx950Param):
 
 def async_load_to_lds(
     lds_base,
-    rsrc,
+    src_base,
+    copy_atom,
     lds_layout,
     outer_tile_size,
     outer_bound,
@@ -283,10 +282,9 @@ def async_load_to_lds(
         ldg_x_threads,
         ks_begin,
         block_k,
-        in_data_bytes,
-        async_load_bytes,
     ) = context
-    lds_ptr = make_wave_lds_ptr(lds_base, wave_offset)
+    elem_bytes = src_base.dtype.width // 8
+    lds_ptr = lds_base + fx.Int32(wave_offset) // elem_bytes
     for i in range_constexpr(load_iters):
         global_tid = block_threads * i + tid
         if const_expr(is_k_major):
@@ -316,12 +314,17 @@ def async_load_to_lds(
         global_outer_idx = global_outer_offset + outer_local_idx
         safe_global_outer_idx = (global_outer_idx < outer_bound).select(global_outer_idx, 0)
         if const_expr(is_k_major):
-            global_offset = (global_k_idx * leading_stride + safe_global_outer_idx) * in_data_bytes
+            global_offset = global_k_idx * leading_stride + safe_global_outer_idx
         else:
-            global_offset = (safe_global_outer_idx * leading_stride + global_k_idx) * in_data_bytes
-        buffer_load_lds_inline(rsrc, lds_ptr, global_offset, async_load_bytes)
+            global_offset = safe_global_outer_idx * leading_stride + global_k_idx
+        unit_layout = fx.make_layout(1, 1)
+        src = fx.make_view(src_base + global_offset, unit_layout)
+        dst = fx.make_view(lds_ptr, unit_layout)
+        rocdl.sched_barrier(0)
+        fx.copy_atom_call(copy_atom, src, dst)
+        rocdl.sched_barrier(0)
         if i < load_iters - 1:
-            lds_ptr = lds_ptr + block_threads * async_load_bytes
+            lds_ptr = lds_ptr + block_threads * async_load_vec_size
 
 
 @flyc.jit
@@ -465,9 +468,6 @@ def gemm_a16w16_gfx950_kernel(
     else:
         bias_buf = None
 
-    a_rsrc = fx.rocdl.get_buffer_rsrc(fx.get_iter(a_buf))
-    b_rsrc = fx.rocdl.get_buffer_rsrc(fx.get_iter(b_buf))
-
     if const_expr(is_split_k):
         splitk_protocol.init(
             semaphore,
@@ -487,6 +487,7 @@ def gemm_a16w16_gfx950_kernel(
 
     uni_copy_atom = fx.make_copy_atom(fx.UniversalCopy128b(), elem_dtype)
     buffer_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_dtype)
+    async_g2s_copy_atom = fx.make_copy_atom(fx.rocdl.cdna4.BufferLoadAsyncLDS128b(), 128)
 
     if const_expr(param.a_is_transposed):
         a_s2r_copy_atom = fx.make_copy_atom(fx.rocdl.cdna4.LDSReadTrans16_64b(), elem_dtype)
@@ -562,14 +563,13 @@ def gemm_a16w16_gfx950_kernel(
         ldg_x_threads,
         ks_begin,
         block_k,
-        in_data_bytes,
-        async_load_bytes,
     )
 
     def async_load_a_to_lds(k_tile, stage):
         async_load_to_lds(
             smem_a + stage * block_m * block_k,
-            a_rsrc,
+            fx.get_iter(a_buf),
+            async_g2s_copy_atom,
             a_lds_layout,
             block_m,
             m,
@@ -584,7 +584,8 @@ def gemm_a16w16_gfx950_kernel(
     def async_load_b_to_lds(k_tile, stage):
         async_load_to_lds(
             smem_b + stage * block_n * block_k,
-            b_rsrc,
+            fx.get_iter(b_buf),
+            async_g2s_copy_atom,
             b_lds_layout,
             block_n,
             n,
@@ -647,7 +648,7 @@ def gemm_a16w16_gfx950_kernel(
     for k_tile in range(0, main_loop_end, 1):
         current_stage = k_tile % stages
         write_stage = (current_stage + stages - 1) % stages
-        __barrier((stages - 2) * ldg_wait_count)
+        wait_vmcnt_and_barrier((stages - 2) * ldg_wait_count)
         async_load_b_to_lds(k_tile + (stages - 1), write_stage)
         async_load_a_to_lds(k_tile + (stages - 1), write_stage)
         compute_stage(current_stage, k_tile)
@@ -655,7 +656,7 @@ def gemm_a16w16_gfx950_kernel(
 
     current_stage = main_loop_end % stages
     for s in range_constexpr(0, stages - 1):
-        __barrier((stages - 2 - s) * ldg_wait_count)
+        wait_vmcnt_and_barrier((stages - 2 - s) * ldg_wait_count)
         compute_stage(current_stage, main_loop_end + s)
         current_stage = (current_stage + 1) % stages
 
@@ -790,9 +791,6 @@ def gemm_a16w16_hti_gfx950_kernel(
     else:
         bias_buf = None
 
-    a_rsrc = fx.rocdl.get_buffer_rsrc(fx.get_iter(a_buf))
-    b_rsrc = fx.rocdl.get_buffer_rsrc(fx.get_iter(b_buf))
-
     if const_expr(is_split_k):
         splitk_protocol.init(
             semaphore,
@@ -812,6 +810,7 @@ def gemm_a16w16_hti_gfx950_kernel(
 
     uni_copy_atom = fx.make_copy_atom(fx.UniversalCopy128b(), elem_dtype)
     buffer_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_dtype)
+    async_g2s_copy_atom = fx.make_copy_atom(fx.rocdl.cdna4.BufferLoadAsyncLDS128b(), 128)
 
     if const_expr(param.a_is_transposed):
         a_s2r_copy_atom = fx.make_copy_atom(fx.rocdl.cdna4.LDSReadTrans16_64b(), elem_dtype)
@@ -858,14 +857,13 @@ def gemm_a16w16_hti_gfx950_kernel(
         ldg_x_threads,
         ks_begin,
         block_k,
-        in_data_bytes,
-        async_load_bytes,
     )
 
     def async_load_a_to_lds(m_part, k_tile, stage):
         async_load_to_lds(
             half_a_base(stage, m_part),
-            a_rsrc,
+            fx.get_iter(a_buf),
+            async_g2s_copy_atom,
             a_lds_layout,
             half_block_m,
             m,
@@ -880,7 +878,8 @@ def gemm_a16w16_hti_gfx950_kernel(
     def async_load_b_to_lds(n_part, k_tile, stage):
         async_load_to_lds(
             half_b_base(stage, n_part),
-            b_rsrc,
+            fx.get_iter(b_buf),
+            async_g2s_copy_atom,
             b_lds_layout,
             half_block_n,
             n,
@@ -1030,7 +1029,7 @@ def gemm_a16w16_hti_gfx950_kernel(
     async_load_a_to_lds(0, 1, 1)
     async_load_b_to_lds(1, 1, 1)
     rocdl.sched_barrier(0)
-    __barrier(half_ldg_b_iters + half_ldg_a_iters)
+    wait_vmcnt_and_barrier(half_ldg_b_iters + half_ldg_a_iters)
 
     main_loop_end = k_tiles - 2
     for k_tile in range(0, main_loop_end, 2):
@@ -1054,7 +1053,7 @@ def gemm_a16w16_hti_gfx950_kernel(
         rocdl.s_barrier()
         b0 = load_b_fragment(0, 1)
         async_load_b_to_lds(1, next_k_tile, 0)
-        __barrier(2 * half_ldg_b_iters + half_ldg_a_iters)
+        wait_vmcnt_and_barrier(2 * half_ldg_b_iters + half_ldg_a_iters)
         consume(c11, a1, b1, True)
         rocdl.s_barrier()
         # 1
@@ -1074,14 +1073,14 @@ def gemm_a16w16_hti_gfx950_kernel(
         consume(c10, a1, b0, True)
         rocdl.s_barrier()
         async_load_b_to_lds(1, next_k_tile + 1, 1)
-        __barrier(half_ldg_b_iters + half_ldg_a_iters)
+        wait_vmcnt_and_barrier(half_ldg_b_iters + half_ldg_a_iters)
         consume(c11, a1, b1, True)
         rocdl.s_barrier()
 
     k_tile = main_loop_end
     # 0
     if const_expr(is_split_k):
-        __barrier(0)
+        wait_vmcnt_and_barrier(0)
     b0 = load_b_fragment(0, 0)
     a0 = load_a_fragment(0, 0)
     async_load_a_to_lds(1, k_tile + 1, 1)
@@ -1099,7 +1098,7 @@ def gemm_a16w16_hti_gfx950_kernel(
     b0 = load_b_fragment(0, 1)
     rocdl.s_barrier()
     consume(c11, a1, b1, True)
-    __barrier(0)
+    wait_vmcnt_and_barrier(0)
     # 1
     a0 = load_a_fragment(0, 1)
     rocdl.s_barrier()
@@ -1133,13 +1132,13 @@ def gemm_a16w16_hti_gfx950_kernel(
         store_half_tile_to_global(1, 1)
         splitk_protocol.finish_split(split_k)
     else:
-        __barrier(0)
+        wait_vmcnt_and_barrier(0)
         store_half_tile_to_global(0, 0)
         store_half_tile_to_global(0, 1)
-        __barrier(0)
+        wait_vmcnt_and_barrier(0)
         store_half_tile_to_lds(1, 0, c10)
         store_half_tile_to_lds(1, 1, c11)
-        __barrier(0)
+        wait_vmcnt_and_barrier(0)
         store_half_tile_to_global(1, 0)
         store_half_tile_to_global(1, 1)
 

--- a/kernels/gemm/gemm_a16w16_gfx950_utils.py
+++ b/kernels/gemm/gemm_a16w16_gfx950_utils.py
@@ -23,14 +23,9 @@ GFX950_WAVE_SIZE = 64
 SPLIT_K_SEMAPHORE_MAX_LEN = 256
 
 
-def __barrier(vmcnt=0):
-    llvm.InlineAsmOp(
-        None,
-        [],
-        f"s_waitcnt vmcnt({vmcnt})\n\ts_barrier",
-        "",
-        has_side_effects=True,
-    )
+def wait_vmcnt_and_barrier(vmcnt=0):
+    rocdl.s_waitcnt(vmcnt=vmcnt)
+    rocdl.s_barrier()
 
 
 _compiled_cache_lock = Lock()
@@ -232,7 +227,7 @@ class SplitKProtocol:
                             "v,v",
                             has_side_effects=True,
                         )
-            __barrier(0)
+            wait_vmcnt_and_barrier(0)
             if self.tid == 0:
                 signal_ptr = get_llvm_ptr(
                     self.signal_ptr,
@@ -365,10 +360,6 @@ def get_wave_lds_offset(tid, async_load_bytes):
     )
 
 
-def make_wave_lds_ptr(ptr, wave_offset):
-    return fx.recast_iter(fx.Int8, ptr) + fx.Int32(wave_offset)
-
-
 def swizzled_col_idx(row, col, layout, block_k):
     elem_offset = fx.get_scalar(fx.crd2idx((row, col), layout))
     return elem_offset % block_k
@@ -380,25 +371,3 @@ def transposed_contiguous_idx(idx, k_idx, layout, rows):
     # vector that belongs at that position.
     elem_offset = fx.get_scalar(fx.crd2idx((idx, k_idx), layout))
     return elem_offset % rows
-
-
-def buffer_load_lds_inline(rsrc, lds_ptr, global_offset, DMA_BYTES):
-    buffer_load_asm_dict = {
-        16: "buffer_load_dwordx4",
-        8: "buffer_load_dwordx2",
-        4: "buffer_load_dword",
-    }
-    llvm.InlineAsmOp(
-        None,
-        [
-            llvm.IntToPtrOp(
-                ir.Type.parse("!llvm.ptr<3>"),
-                fx.as_ir_value(fx.ptrtoint(lds_ptr)),
-            ).result,
-            fx.as_ir_value(global_offset),
-            fx.as_ir_value(rsrc),
-        ],
-        f"s_mov_b32 m0, $0\n\t{buffer_load_asm_dict[DMA_BYTES]} $1, $2, 0 offen sc0 lds",
-        "s,v,s",
-        has_side_effects=True,
-    )


### PR DESCRIPTION
## Summary
- Replace inline-assembly G2S loads with `BufferLoadAsyncLDS128b` copy atoms.
- Use ROCDL wait-counter and barrier operations.
- Add scheduling barriers around async LDS copies.
- Remove obsolete async-load helper functions.
