### PR TITLE
[Fix] Fix alignment reported by ptr.load/ptr.store lowering

### DIFF
--- a/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
+++ b/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
@@ -15,6 +15,9 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/bit.h"
+
+#include <numeric>
 
 #include "flydsl/Conversion/FlyToROCDL/FlyToROCDL.h"
 #include "flydsl/Dialect/Fly/IR/FlyDialect.h"
@@ -56,6 +59,23 @@ unsigned mapAttrToLLVMAddressSpace(Attribute attr) {
   if (isTargetAddressSpace<BufferDescAddressAttr>(attr))
     return 8;
   return 0; // default to generic address space
+}
+
+/// Byte alignment that still holds after `applySwizzleOnPtr`.
+///
+/// The swizzle XORs address bits at and above `base`, so only the low `base`
+/// bits of the address survive; whatever the pointer type promises above that
+/// no longer holds. `llvm::Align` additionally requires a power of two, which
+/// the divisibility arithmetic behind `AlignAttr` does not guarantee, so what
+/// is left is the greatest power-of-two divisor.
+static unsigned getLLVMAlignment(fly::PointerType ptrTy) {
+  int32_t align = ptrTy.getAlignment().getAlignment();
+  if (align <= 0)
+    return 0;
+  auto swizzle = ptrTy.getSwizzle();
+  if (!swizzle.isTrivialSwizzle())
+    align = std::gcd(align, int32_t{1} << swizzle.getBase());
+  return 1u << llvm::countr_zero(static_cast<unsigned>(align));
 }
 
 // Create a freshly named LDS global of `[nbytes x i8]` in `addrSpace`, inserted
@@ -412,7 +432,7 @@ public:
     } else {
       ptr = applySwizzleOnPtr(rewriter, loc, cast<TypedValue<LLVM::LLVMPointerType>>(ptr),
                               flyPtrTy.getSwizzle());
-      unsigned align = flyPtrTy.getAlignment().getAlignment();
+      unsigned align = getLLVMAlignment(flyPtrTy);
       Value loaded = LLVM::LoadOp::create(rewriter, loc, loadTy, ptr, align);
       rewriter.replaceOp(op, loaded);
       return success();
@@ -459,7 +479,7 @@ public:
     } else {
       ptr = applySwizzleOnPtr(rewriter, loc, cast<TypedValue<LLVM::LLVMPointerType>>(ptr),
                               flyPtrTy.getSwizzle());
-      unsigned align = flyPtrTy.getAlignment().getAlignment();
+      unsigned align = getLLVMAlignment(flyPtrTy);
       LLVM::StoreOp::create(rewriter, loc, value, ptr, align);
       rewriter.eraseOp(op);
       return success();

--- a/tests/mlir/Conversion/ptr_alignment.mlir
+++ b/tests/mlir/Conversion/ptr_alignment.mlir
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 FlyDSL Project Contributors
+// RUN: %fly-opt %s --fly-rewrite-func-signature --fly-canonicalize --fly-layout-lowering --convert-fly-to-rocdl | FileCheck %s
+
+// Alignment carried into llvm.load/llvm.store by ptr.load/ptr.store lowering.
+
+// -----
+
+// A trivially swizzled pointer keeps the alignment its type promises.
+
+// CHECK-LABEL: @test_align_no_swizzle
+func.func @test_align_no_swizzle(%p: !fly.ptr<f16, shared, align<16>>) -> vector<4xf16> {
+  // CHECK: llvm.load %{{.*}} {alignment = 16 : i64} : !llvm.ptr<3> -> vector<4xf16>
+  %v = fly.ptr.load(%p) : (!fly.ptr<f16, shared, align<16>>) -> vector<4xf16>
+  return %v : vector<4xf16>
+}
+
+// -----
+
+// A swizzle XORs address bits at and above `base`, so only the low `base` bits
+// survive: align<16> under S<_,3,_> may only be reported as 8 bytes.
+
+// CHECK-LABEL: @test_align_swizzle_weakens
+func.func @test_align_swizzle_weakens(%p: !fly.ptr<f16, shared, align<16>, S<3,3,3>>) -> vector<4xf16> {
+  // CHECK: llvm.load %{{.*}} {alignment = 8 : i64} : !llvm.ptr<3> -> vector<4xf16>
+  %v = fly.ptr.load(%p) : (!fly.ptr<f16, shared, align<16>, S<3,3,3>>) -> vector<4xf16>
+  return %v : vector<4xf16>
+}
+
+// -----
+
+// CHECK-LABEL: @test_align_swizzle_weakens_store
+func.func @test_align_swizzle_weakens_store(%p: !fly.ptr<f16, shared, align<16>, S<3,3,3>>, %v: vector<4xf16>) {
+  // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 8 : i64} : vector<4xf16>, !llvm.ptr<3>
+  fly.ptr.store(%v, %p) : (vector<4xf16>, !fly.ptr<f16, shared, align<16>, S<3,3,3>>) -> ()
+  return
+}
+
+// -----
+
+// AlignAttr arithmetic can produce a non-power-of-two byte count, which
+// llvm::Align rejects; the lowering must weaken it to its greatest
+// power-of-two divisor.
+
+// CHECK-LABEL: @test_align_non_power_of_two
+func.func @test_align_non_power_of_two(%mem: !fly.memref<f32, global, 32:1, align<12>>) -> f32 {
+  %idx = fly.make_int_tuple() : () -> !fly.int_tuple<3>
+  // CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<1> -> f32
+  %val = fly.memref.load(%mem, %idx) : (!fly.memref<f32, global, 32:1, align<12>>, !fly.int_tuple<3>) -> f32
+  return %val : f32
+}


### PR DESCRIPTION
PtrLoadOpLowering / PtrStoreOpLowering read the alignment straight off the fly pointer type and attached it to the LLVM load/store built on top of the *swizzled* pointer. Two problems:

- `applySwizzleOnPtr` XORs address bits at and above `base`, so only the low `base` bits of the address survive. An `align<16>` pointer under `S<3,3,3>` only holds 8-byte alignment afterwards, but 16 was still reported. The dialect already models this weakening for the value domain (`divisibilityApplySwizzle`); the byte-domain pointer path did not.

- `AlignAttr` stores `(bitWidth * divisibility + 7) / 8`, and the gcd-based divisibility arithmetic can retain odd factors, so the byte count is not necessarily a power of two. Nothing rejected such a value: the Python binding only checks it is a multiple of the element size, `AlignAttr` has no verifier, and `llvm.load`'s verifier accepts it too. It reached `llvm::Align`, which asserts on non-power-of-two, i.e. an `!fly.memref<f32, global, 32:1, align<12>>` load crashed mlir-translate.

Both are handled in one helper: weaken by the swizzle base, then round down to a power of two.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
