### PR TITLE
Release: bump version to 0.3.2

### DIFF
--- a/python/flydsl/__init__.py
+++ b/python/flydsl/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 FlyDSL Project Contributors
 # ruff: noqa: I001
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 from .autotune import Config as Config, autotune as autotune
 


### PR DESCRIPTION
Bump `flydsl.__version__` from 0.3.1 to 0.3.2. This is the single source of truth for the package version: `setup.py:_read_version()` parses it for the wheel version and `docs/conf.py` derives `version`/`release` from `flydsl.__version__`.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
