### PR TITLE
[Bugfix] Refuse a batch entry the buffer descriptor cannot address

### DIFF
--- a/kernels/attention/flash_attn_interface.py
+++ b/kernels/attention/flash_attn_interface.py
@@ -819,8 +819,9 @@ def flydsl_flash_attn_func(
             if _entry_bytes >= _MAX_DESCRIPTOR_BYTES:
                 raise NotImplementedError(
                     f"flydsl_flash_attn_func: one batch entry of {_name} is {_entry_bytes} bytes, at or over the "
-                    f"{_MAX_DESCRIPTOR_BYTES} a buffer descriptor can address. Launching would silently write only "
-                    f"{_entry_bytes % _MAX_DESCRIPTOR_BYTES} bytes of the output. Shorten the sequence or use fewer heads."
+                    f"{_MAX_DESCRIPTOR_BYTES} bytes a buffer descriptor can address. Its byte count and its offset "
+                    "are both 32-bit, so the span wraps and the kernel returns a wrong result without reporting "
+                    "anything. Shorten the sequence or use fewer heads."
                 )
     if return_lse and dtype_str == "fp8":
         raise NotImplementedError("flydsl_flash_attn_func: return_lse is not supported for fp8")

--- a/kernels/attention/flash_attn_interface.py
+++ b/kernels/attention/flash_attn_interface.py
@@ -43,6 +43,10 @@ _DTYPE_MAP = {torch.bfloat16: "bf16", torch.float16: "f16", torch.float8_e4m3fn:
 
 # Short varlen/paged cases use the lightweight generic path.
 _VARLEN_LIGHT_MAX_SEQ = 256
+# A buffer descriptor is built per batch entry and carries a 32-bit byte count,
+# addressed by a 32-bit voffset. One entry above this writes only
+# (bytes mod 2**32) of its output and reports nothing.
+_MAX_DESCRIPTOR_BYTES = 2**32
 _DENSE_LIGHT_CU_FALLBACK = 256
 _DENSE_DUALWAVE_MIN_SEQ = 256
 _DENSE_DUALWAVE_LARGE_BATCH = 8
@@ -802,6 +806,22 @@ def flydsl_flash_attn_func(
         raise ValueError(f"flydsl_flash_attn_func: q/k/v must share dtype; got {q.dtype}/{k.dtype}/{v.dtype}")
 
     dtype_str = _dtype_str(q)
+    if q.dim() == 4:
+        # Descriptors span one batch entry, so the bound is per entry, not per tensor.
+        _out_elem = 2 if dtype_str == "fp8" else q.element_size()
+        for _name, _t, _elem in (
+            ("q", q, q.element_size()),
+            ("k", k, k.element_size()),
+            ("v", v, v.element_size()),
+            ("out", q, _out_elem),
+        ):
+            _entry_bytes = (_t.numel() // _t.shape[0]) * _elem
+            if _entry_bytes >= _MAX_DESCRIPTOR_BYTES:
+                raise NotImplementedError(
+                    f"flydsl_flash_attn_func: one batch entry of {_name} is {_entry_bytes} bytes, at or over the "
+                    f"{_MAX_DESCRIPTOR_BYTES} a buffer descriptor can address. Launching would silently write only "
+                    f"{_entry_bytes % _MAX_DESCRIPTOR_BYTES} bytes of the output. Shorten the sequence or use fewer heads."
+                )
     if return_lse and dtype_str == "fp8":
         raise NotImplementedError("flydsl_flash_attn_func: return_lse is not supported for fp8")
     paged_kv = any(x is not None for x in (block_table, seqlen_k))

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -34,6 +34,7 @@ import pytest  # noqa: E402
 
 from flydsl.runtime.device import get_rocm_arch  # noqa: E402
 from kernels.attention.flash_attn_gfx950 import build_flash_attn_dualwave_swp_module  # noqa: E402
+from kernels.attention import flash_attn_interface  # noqa: E402
 from kernels.attention.flash_attn_interface import flydsl_flash_attn_func  # noqa: E402
 from kernels.attention.flash_attn_utils import (  # noqa: E402
     BIAS_MAX_DESCRIPTOR_BYTES,
@@ -4634,3 +4635,26 @@ def test_fp8_lazy_paths_do_not_roll_their_own_correction():
         assert "exp2" not in chunk, f"{name} computes its own correction instead of taking the monotonic one"
         assert "_lazy_correction" in chunk or "rescale_from_tile_max" in chunk, f"{name} has no correction source"
     assert "rescale_from_tile_max" in method("_lazy_correction"), "the shared correction is not the monotonic one"
+
+
+@pytest.mark.parametrize("over", [True, False])
+def test_descriptor_span_guard(monkeypatch, over):
+    """A batch entry the buffer descriptor cannot address must raise, not truncate.
+
+    The descriptor carries a 32-bit byte count and is addressed by a 32-bit
+    voffset, so one entry at or over 2**32 bytes writes only (bytes mod 2**32)
+    and reports nothing -- measured at 0 of 2**31 elements exactly on the bound,
+    and 1/3 of them at 1.5x. Reaching that for real needs 4 GiB of q, so the
+    bound is lowered here the way the fp8 flat-dim tests lower theirs.
+    """
+    B, S, H, D = 1, 256, 8, 128
+    entry_bytes = S * H * D * 2
+    monkeypatch.setattr(flash_attn_interface, "_MAX_DESCRIPTOR_BYTES", entry_bytes if over else entry_bytes * 2)
+    q = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
+    k, v = torch.randn_like(q), torch.randn_like(q)
+    if over:
+        with pytest.raises(NotImplementedError, match="buffer descriptor can address"):
+            flydsl_flash_attn_func(q, k, v, causal=False)
+    else:
+        out = flydsl_flash_attn_func(q, k, v, causal=False)
+        assert torch.isfinite(out).all()

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -34,6 +34,7 @@ import pytest  # noqa: E402
 
 from flydsl.runtime.device import get_rocm_arch  # noqa: E402
 from kernels.attention.flash_attn_gfx950 import build_flash_attn_dualwave_swp_module  # noqa: E402
+from kernels.attention import flash_attn_interface  # noqa: E402
 from kernels.attention.flash_attn_interface import flydsl_flash_attn_func  # noqa: E402
 from kernels.attention.flash_attn_utils import (  # noqa: E402
     BIAS_MAX_DESCRIPTOR_BYTES,
@@ -4532,3 +4533,28 @@ def test_sink_lse_cross_attn_skipped_blocks(Sq, Skv):
     masked_lse = lse[:, :, :n_masked].float()
     assert (masked_lse - sink.view(1, H, 1)).abs().max().item() <= 1e-4, "all-masked rows must carry the sink LSE"
     assert out[:, :n_masked].abs().max().item() == 0.0, "all-masked rows must have zero output"
+
+
+@pytest.mark.parametrize("over", [True, False])
+def test_descriptor_span_guard(monkeypatch, over):
+    """A batch entry the buffer descriptor cannot address must raise, not truncate.
+
+    The descriptor carries a 32-bit byte count and is addressed by a 32-bit
+    voffset, so one entry at or over 2**32 bytes writes only (bytes mod 2**32)
+    and reports nothing -- measured at 0 of 2**31 elements exactly on the bound,
+    and 1/3 of them at 1.5x. Reaching that for real needs 4 GiB of q, so the
+    bound is lowered here the way the fp8 flat-dim tests lower theirs.
+    """
+    B, S, H, D = 1, 256, 8, 128
+    entry_bytes = S * H * D * 2
+    monkeypatch.setattr(
+        flash_attn_interface, "_MAX_DESCRIPTOR_BYTES", entry_bytes if over else entry_bytes * 2
+    )
+    q = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
+    k, v = torch.randn_like(q), torch.randn_like(q)
+    if over:
+        with pytest.raises(NotImplementedError, match="buffer descriptor can address"):
+            flydsl_flash_attn_func(q, k, v, causal=False)
+    else:
+        out = flydsl_flash_attn_func(q, k, v, causal=False)
+        assert torch.isfinite(out).all()

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4542,8 +4542,8 @@ def test_descriptor_span_guard(monkeypatch, over):
     The descriptor carries a 32-bit byte count and is addressed by a 32-bit
     voffset, so one entry at or over 2**32 bytes writes only (bytes mod 2**32)
     and reports nothing -- measured at 0 of 2**31 elements exactly on the bound,
-    and 1/3 of them at 1.5x. Reaching that for real needs 4 GiB of q, so the
-    bound is lowered here the way the fp8 flat-dim tests lower theirs.
+    and 1/3 of them at 1.5x, all of them wrong. Reaching the real bound needs a
+    4 GiB q, so the bound is lowered instead of the tensor being grown.
     """
     B, S, H, D = 1, 256, 8, 128
     entry_bytes = S * H * D * 2

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4644,8 +4644,8 @@ def test_descriptor_span_guard(monkeypatch, over):
     The descriptor carries a 32-bit byte count and is addressed by a 32-bit
     voffset, so one entry at or over 2**32 bytes writes only (bytes mod 2**32)
     and reports nothing -- measured at 0 of 2**31 elements exactly on the bound,
-    and 1/3 of them at 1.5x. Reaching that for real needs 4 GiB of q, so the
-    bound is lowered here the way the fp8 flat-dim tests lower theirs.
+    and 1/3 of them at 1.5x, all of them wrong. Reaching the real bound needs a
+    4 GiB q, so the bound is lowered instead of the tensor being grown.
     """
     B, S, H, D = 1, 256, 8, 128
     entry_bytes = S * H * D * 2

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -33,8 +33,8 @@ if not torch.cuda.is_available():
 import pytest  # noqa: E402
 
 from flydsl.runtime.device import get_rocm_arch  # noqa: E402
-from kernels.attention.flash_attn_gfx950 import build_flash_attn_dualwave_swp_module  # noqa: E402
 from kernels.attention import flash_attn_interface  # noqa: E402
+from kernels.attention.flash_attn_gfx950 import build_flash_attn_dualwave_swp_module  # noqa: E402
 from kernels.attention.flash_attn_interface import flydsl_flash_attn_func  # noqa: E402
 from kernels.attention.flash_attn_utils import (  # noqa: E402
     BIAS_MAX_DESCRIPTOR_BYTES,

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4547,9 +4547,7 @@ def test_descriptor_span_guard(monkeypatch, over):
     """
     B, S, H, D = 1, 256, 8, 128
     entry_bytes = S * H * D * 2
-    monkeypatch.setattr(
-        flash_attn_interface, "_MAX_DESCRIPTOR_BYTES", entry_bytes if over else entry_bytes * 2
-    )
+    monkeypatch.setattr(flash_attn_interface, "_MAX_DESCRIPTOR_BYTES", entry_bytes if over else entry_bytes * 2)
     q = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
     k, v = torch.randn_like(q), torch.randn_like(q)
     if over:


### PR DESCRIPTION
## Summary

Dense attention builds one buffer descriptor per batch entry, sized `seqlen * STRIDE_TOKEN * 2` bytes ([flash_attn_utils.py](https://github.com/ROCm/FlyDSL/blob/main/kernels/attention/flash_attn_utils.py#L2182)). That count is 32-bit, and the voffset addressing it is 32-bit. An entry at or over 2\*\*32 bytes wraps: the kernel writes only `bytes mod 2**32` of its output, raises nothing, and leaves the rest as the allocator handed it over.

## Measurement

MI355X, bf16, B=1 S=32768 D=128, `out` pre-filled with a sentinel so what changed is exactly what the kernel wrote:

With `V` all ones the exact output is 1.0 everywhere, so the written values are checkable too:

| H | descriptor bytes | × 2\*\*32 | elements written | value written |
|---|---|---|---|---|
| 504 | 4,227,858,432 | 0.984 | all | 1.0000 |
| 512 | 4,294,967,296 | **1.000** | **0** | — |
| 520 | 4,362,076,160 | 1.016 | 33,554,432 | **0.035 – 0.070** |
| 768 | 6,442,450,944 | 1.500 | 1,073,741,824 | **0.719 – 0.832** |

Every over-limit row writes `(bytes - 2**32) / 2` elements exactly, **and those elements are wrong**. The bound binds on all four tensors, not just the output: Q and K/V are truncated by the same descriptors, so the softmax runs over a subset of the keys. This is not a partly-filled result, it is a wrong one. That is truncation, not a clamp: `buffer_ops.create_buffer_resource` clamps the static-int path only, and this size arrives as a runtime value.

bf16 was used deliberately — it passes its natural 4-D shape and never touches the fp8 flattening, so nothing about the flat-dim ABI is involved here.

## Change

Check the per-entry byte count for q, k, v and the output before dispatch, and raise `NotImplementedError` naming the count, the limit, and how much would actually have been written.

Lifting the ceiling is a separate job, and a larger one than it first looks. Q and O funnel through a single `global_idx_q`, so those could be rebased per q-block. K and V cannot: every q-block streams the whole entry, so their descriptors would have to be rebuilt per KV tile inside the innermost loop. Host-side splitting does not help either — queries are independent so Q/O could be split along the sequence, but in self-attention K/V are over the bound at the same time and every block needs all of them.

## Scope

The check is on the dense 4-D path, which is where the truncation is. The other two were measured rather than assumed:

- **varlen** writes its full output at 0.75x, 1.0x and 1.5x of the bound (sentinel untouched count 0 in all three), so it does not reach these descriptors the way dense does and a check there would never fire.
- **fp8** cannot get here: its flat dim must stay under 2\*\*31 elements, and its bf16 output is exactly twice that in bytes, so the int32 flat-dim limit binds first.

Paged KV counts blocks in `shape[0]` rather than batch entries, so its K/V spans are per page; its Q/O follow the dense rule and are covered when q is 4-D.

## Testing

- [x] Unit test added — `test_descriptor_span_guard`, both sides of the bound, with `_MAX_DESCRIPTOR_BYTES` lowered so it needs no 4 GiB allocation.
- [x] Full file: **95 passed** cold (3m02s).
- [x] Tested on MI355X (gfx950).
- [x] No new third-party dependencies added

## Breaking Changes

A configuration that used to return a partly-written tensor now raises. Nothing that produced correct output is affected — the bound is exact and verified from both sides.


