### PR TITLE
fix(ci): isolate self-hosted runner artifacts

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -292,6 +292,11 @@ jobs:
           ref: ${{ env.GITHUB_COMMIT_SHA }}
           path: flydsl-test
 
+      # download-artifact overlays its destination. Self-hosted workspaces are
+      # persistent, so remove wheels left by an older package version first.
+      - name: Remove stale FlyDSL CI wheels
+        run: rm -rf "${GITHUB_WORKSPACE:?}/flydsl-ci-wheels"
+
       - name: Download FlyDSL CI wheels
         uses: actions/download-artifact@v4
         with:
@@ -300,8 +305,21 @@ jobs:
 
       - name: Verify FlyDSL CI wheels
         run: |
+          shopt -s nullglob
+          pr_wheels=(flydsl-ci-wheels/pr/*.whl)
+          if [ "${#pr_wheels[@]}" -ne 1 ]; then
+            printf 'Expected exactly one PR wheel, found %s:\n' "${#pr_wheels[@]}" >&2
+            printf '  %s\n' "${pr_wheels[@]}" >&2
+            exit 1
+          fi
           (cd flydsl-ci-wheels/pr && sha256sum -c SHA256SUMS)
           if [ -d flydsl-ci-wheels/base ]; then
+            base_wheels=(flydsl-ci-wheels/base/*.whl)
+            if [ "${#base_wheels[@]}" -ne 1 ]; then
+              printf 'Expected exactly one base wheel, found %s:\n' "${#base_wheels[@]}" >&2
+              printf '  %s\n' "${base_wheels[@]}" >&2
+              exit 1
+            fi
             (cd flydsl-ci-wheels/base && sha256sum -c SHA256SUMS)
           else
             echo "::warning title=Baseline wheel unavailable::Exact base benchmark will be skipped."
@@ -375,11 +393,11 @@ jobs:
       - name: Show tests logs
         if: failure()
         run: |
+          log_dir="$(mktemp -d "${RUNNER_TEMP}/flydsl-test-logs.XXXXXX")"
           docker exec flydsl_test bash -c 'cd /tmp && tar czf /tmp/logs.tgz *.log 2>/dev/null || echo "no logs"'
-          docker cp flydsl_test:/tmp/logs.tgz . || true
-          if [ -f logs.tgz ]; then
-            tar -xzf logs.tgz || true
-            cat *.log || true
+          if docker cp flydsl_test:/tmp/logs.tgz "${log_dir}/logs.tgz"; then
+            tar -xzf "${log_dir}/logs.tgz" -C "${log_dir}" || true
+            find "${log_dir}" -maxdepth 1 -type f -name '*.log' -print -exec cat {} \;
           else
             echo "logs.tgz not found; skipping log extraction"
           fi
@@ -526,12 +544,12 @@ jobs:
       - name: Show benchmarks logs
         if: failure()
         run: |
+          log_dir="$(mktemp -d "${RUNNER_TEMP}/flydsl-benchmark-logs.XXXXXX")"
           docker exec flydsl_test bash -c 'cd /tmp && tar czf /tmp/flydsl_bench_logs.tgz flydsl_bench* bench_*.csv 2>/dev/null || echo "no logs"'
-          docker cp flydsl_test:/tmp/flydsl_bench_logs.tgz . || true
-          if [ -f flydsl_bench_logs.tgz ]; then
-            tar -xzf flydsl_bench_logs.tgz || true
-            cat flydsl_bench*/*.log || true
-            cat bench_*.csv || true
+          if docker cp flydsl_test:/tmp/flydsl_bench_logs.tgz "${log_dir}/logs.tgz"; then
+            tar -xzf "${log_dir}/logs.tgz" -C "${log_dir}" || true
+            find "${log_dir}" -type f -name '*.log' -print -exec cat {} \;
+            find "${log_dir}" -maxdepth 1 -type f -name 'bench_*.csv' -print -exec cat {} \;
           else
             echo "flydsl_bench_logs.tgz not found; skipping log extraction"
           fi
@@ -588,6 +606,11 @@ jobs:
           ref: ${{ env.GITHUB_COMMIT_SHA }}
           path: flydsl-test
 
+      # download-artifact overlays its destination. Self-hosted workspaces are
+      # persistent, so remove wheels left by an older package version first.
+      - name: Remove stale FlyDSL CI wheels
+        run: rm -rf "${GITHUB_WORKSPACE:?}/flydsl-ci-wheels"
+
       - name: Download FlyDSL CI wheels
         uses: actions/download-artifact@v4
         with:
@@ -596,8 +619,21 @@ jobs:
 
       - name: Verify FlyDSL CI wheels
         run: |
+          shopt -s nullglob
+          pr_wheels=(flydsl-ci-wheels/pr/*.whl)
+          if [ "${#pr_wheels[@]}" -ne 1 ]; then
+            printf 'Expected exactly one PR wheel, found %s:\n' "${#pr_wheels[@]}" >&2
+            printf '  %s\n' "${pr_wheels[@]}" >&2
+            exit 1
+          fi
           (cd flydsl-ci-wheels/pr && sha256sum -c SHA256SUMS)
           if [ -d flydsl-ci-wheels/base ]; then
+            base_wheels=(flydsl-ci-wheels/base/*.whl)
+            if [ "${#base_wheels[@]}" -ne 1 ]; then
+              printf 'Expected exactly one base wheel, found %s:\n' "${#base_wheels[@]}" >&2
+              printf '  %s\n' "${base_wheels[@]}" >&2
+              exit 1
+            fi
             (cd flydsl-ci-wheels/base && sha256sum -c SHA256SUMS)
           else
             echo "::warning title=Baseline wheel unavailable::Exact base benchmark will be skipped."
@@ -768,11 +804,11 @@ jobs:
       - name: Show test logs
         if: failure()
         run: |
+          log_dir="$(mktemp -d "${RUNNER_TEMP}/flydsl-test-logs.XXXXXX")"
           docker exec flydsl_test bash -c 'cd /tmp && tar czf /tmp/logs.tgz *.log 2>/dev/null || echo "no logs"'
-          docker cp flydsl_test:/tmp/logs.tgz . || true
-          if [ -f logs.tgz ]; then
-            tar -xzf logs.tgz || true
-            cat *.log || true
+          if docker cp flydsl_test:/tmp/logs.tgz "${log_dir}/logs.tgz"; then
+            tar -xzf "${log_dir}/logs.tgz" -C "${log_dir}" || true
+            find "${log_dir}" -maxdepth 1 -type f -name '*.log' -print -exec cat {} \;
           else
             echo "logs.tgz not found; skipping log extraction"
           fi


### PR DESCRIPTION
## Summary

- remove the persistent `flydsl-ci-wheels` directory before each artifact download on single- and multi-GPU self-hosted runners
- require exactly one PR wheel and, when present, exactly one base wheel before installation
- extract failure logs into a fresh runner temp directory so old workspace logs cannot mask the real failure

## Root cause

The failures started after #1044 bumped the package from 0.3.1 to 0.3.2. The uploaded artifact for run [32386362772](https://github.com/ROCm/FlyDSL/actions/runs/32386362772) contains only one 0.3.2 wheel, and the MI325/MI355 jobs consuming that same artifact pass. The Navi job instead sees both 0.3.1 and 0.3.2:

```
Processing /flydsl-ci-wheels/pr/flydsl-0.3.1.dev1-...
Processing /flydsl-ci-wheels/pr/flydsl-0.3.2.dev1-...
ERROR: Cannot install flydsl 0.3.1.dev1 and flydsl 0.3.2.dev1
```

`actions/download-artifact` overlays its destination rather than deleting files that are absent from the new artifact. Because the Navi self-hosted workspace persists between jobs, its old 0.3.1 wheel survived the download and the install wildcard selected both versions.

The later OOM output in those jobs was also stale workspace output: the current container reported `no logs`, after which the workflow globbed old host-side `*.log` files.

Affected examples:

- [run 32366718417](https://github.com/ROCm/FlyDSL/actions/runs/32366718417)
- [run 32386186330](https://github.com/ROCm/FlyDSL/actions/runs/32386186330)
- [run 32386189717](https://github.com/ROCm/FlyDSL/actions/runs/32386189717)
- [run 32386362772](https://github.com/ROCm/FlyDSL/actions/runs/32386362772)

## Verification

- downloaded run 32386362772 artifact and verified it contains exactly one 0.3.2 PR wheel and one base wheel
- reproduced a two-wheel stale bundle and confirmed the new invariant rejects it
- verified all checksums on the clean downloaded artifact
- `actionlint` passes after ignoring the repository custom-runner-label warnings
- PyYAML parse, `bash -n` for every modified shell block, and `git diff --check` pass
