### PR TITLE
[Fix] Restore the fx.maxnumf contract, and keep ninf off the score reductions

### DIFF
--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -28,6 +28,11 @@ from flydsl.expr.utils.arith import _to_raw as as_mlir_value
 from kernels.common import buffer_ops
 from kernels.common.kernels_common import dtype_to_elem_type
 
+# Softmax scores are finite or the -inf mask sentinel, never NaN, so nnan lets
+# maxnum lower to a bare v_max and fuse to v_max3. ninf must NOT be set here:
+# -inf is load-bearing, and an infinite operand under ninf is poison.
+_MAX_FASTMATH = arith.FastMathFlags.nnan
+
 _LOG2E = host_math.log2(host_math.e)
 # gfx950 (MI350/MI355X): 8 XCDs, each with a private ~4 MB L2.
 NUM_XCD_GFX950 = 8
@@ -388,7 +393,7 @@ def _lane_pair_reduce(v, reducer, fm_fast):
 
 
 def _score_pair_max(v_s, neg_inf, fm_fast):
-    reducer = lambda a, b, _fm: fx.maxnumf(a, b)  # noqa: E731
+    reducer = lambda a, b, _fm: fx.maxnumf(a, b, fastmath=_MAX_FASTMATH)  # noqa: E731
     return _lane_pair_reduce(_reduce_score_pair(v_s, neg_inf, reducer, fm_fast), reducer, fm_fast)
 
 
@@ -462,7 +467,7 @@ def _safe_l_inv(l_row, zero_f):
 
 
 def _rescale_from_tile_max(m_row, m_tile_max, fm_fast):
-    row_max = fx.maxnumf(m_row, m_tile_max)
+    row_max = fx.maxnumf(m_row, m_tile_max, fastmath=_MAX_FASTMATH)
     rescale = rocdl.exp2(T.f32, as_mlir_value(m_row - row_max))
     return row_max, rescale
 
@@ -2976,19 +2981,19 @@ class GenericSoftmaxHelper:
         if const_expr(os.getenv("FLYDSL_FLASH_ATTN_FUNC_TREE_REDUCE", "0") == "1"):
 
             def _max_pair(a, b):
-                return fx.maxnumf(a, b)
+                return fx.maxnumf(a, b, fastmath=_MAX_FASTMATH)
 
             local_max = _tree_reduce(list(s_raw_lo) + list(s_raw_hi), _max_pair)
         else:
             local_max = s_raw_lo[0]
             for r in range_constexpr(15):
-                local_max = fx.maxnumf(local_max, s_raw_lo[r + 1])
+                local_max = fx.maxnumf(local_max, s_raw_lo[r + 1], fastmath=_MAX_FASTMATH)
             for r in range_constexpr(16):
-                local_max = fx.maxnumf(local_max, s_raw_hi[r])
-        row_max = fx.maxnumf(local_max, self.reduction_peer(local_max))
-        m_new_raw = fx.maxnumf(m_running, row_max)
+                local_max = fx.maxnumf(local_max, s_raw_hi[r], fastmath=_MAX_FASTMATH)
+        row_max = fx.maxnumf(local_max, self.reduction_peer(local_max), fastmath=_MAX_FASTMATH)
+        m_new_raw = fx.maxnumf(m_running, row_max, fastmath=_MAX_FASTMATH)
         if const_expr(traits.CAUSAL):
-            m_new_raw = fx.maxnumf(m_new_raw, ctx.c_neg_floor)
+            m_new_raw = fx.maxnumf(m_new_raw, ctx.c_neg_floor, fastmath=_MAX_FASTMATH)
 
         diff_m_scaled = (m_running - m_new_raw) * ctx.c_sm_scale_log2e
         corr = self._exp2(diff_m_scaled)
@@ -3768,7 +3773,7 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         return _score_pair_max(v_s, self.c_neg_inf, self.fm_fast)
 
     def floor_masked_max(self, row_max):
-        return fx.maxnumf(row_max, self.c_neg_floor)
+        return fx.maxnumf(row_max, self.c_neg_floor, fastmath=_MAX_FASTMATH)
 
     def rescale_from_tile_max(self, m_row, m_tile_max):
         return _rescale_from_tile_max(m_row, m_tile_max, self.fm_fast)
@@ -3799,7 +3804,7 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         _scale_o_accs(v_o, scale_scalar, self.traits, self.fm_fast)
 
     def rescale_o(self, v_o, m_row, l_row, m_tile_max, v_p):
-        m_new = fx.maxnumf(m_row, m_tile_max)
+        m_new = fx.maxnumf(m_row, m_tile_max, fastmath=_MAX_FASTMATH)
         corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_new))
         self.scale_o(v_o, corr)
         v_o = _anchor_v_o(self.traits, v_o)
@@ -3814,7 +3819,7 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         return v_o, m_new, l_row, v_p
 
     def fold_sink(self, v_o, m_row, l_row, sink_log2):
-        m_new = fx.maxnumf(m_row, sink_log2)
+        m_new = fx.maxnumf(m_row, sink_log2, fastmath=_MAX_FASTMATH)
         corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_new))
         self.scale_o(v_o, corr)
         sink_w = rocdl.exp2(T.f32, as_mlir_value(sink_log2 - m_new))
@@ -5097,10 +5102,10 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
         return _score_pair_max(v_s, self.c_neg_inf, self.fm_fast)
 
     def max2(self, a, b):
-        return fx.maxnumf(a, b)
+        return fx.maxnumf(a, b, fastmath=_MAX_FASTMATH)
 
     def floor_masked_max(self, row_max):
-        return fx.maxnumf(row_max, self.c_neg_floor)
+        return fx.maxnumf(row_max, self.c_neg_floor, fastmath=_MAX_FASTMATH)
 
     def sub_m(self, v_s, row_max):
         return _scale_sub_score_pair(v_s, row_max, self.c_logit_scale, self.c_zero_f, self.fm_fast)
@@ -5145,7 +5150,7 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
         return _safe_l_inv(l_row, self.c_zero_f)
 
     def rescale_from_tile_max(self, m_row, m_tile_max):
-        row_max = fx.maxnumf(m_row, m_tile_max)
+        row_max = fx.maxnumf(m_row, m_tile_max, fastmath=_MAX_FASTMATH)
         diff_scaled = (m_row - row_max) * self.c_logit_scale
         rescale = rocdl.exp2(T.f32, as_mlir_value(diff_scaled))
         return row_max, rescale
@@ -5459,7 +5464,7 @@ class DualwaveSplitKCombineHelper(DualwaveSplitKCombineContext):
     def reduce_m_max(self, m_s):
         m_max = m_s[0]
         for i in range_constexpr(self.traits.NUM_KV_SPLITS - 1):
-            m_max = fx.maxnumf(m_max, m_s[i + 1])
+            m_max = fx.maxnumf(m_max, m_s[i + 1], fastmath=_MAX_FASTMATH)
         return m_max
 
     def fold_sink(self, m_max, bias_log2e):
@@ -5475,7 +5480,7 @@ class DualwaveSplitKCombineHelper(DualwaveSplitKCombineContext):
         )
 
         sink_log2 = sink_f32 * fx.Float32(bias_log2e)
-        m_new = fx.maxnumf(m_max, sink_log2)
+        m_new = fx.maxnumf(m_max, sink_log2, fastmath=_MAX_FASTMATH)
         sink_w = rocdl.exp2(T.f32, as_mlir_value(sink_log2 - m_new))
         return m_new, sink_w
 

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -28,6 +28,11 @@ from flydsl.expr.utils.arith import _to_raw as as_mlir_value
 from kernels.common import buffer_ops
 from kernels.common.kernels_common import dtype_to_elem_type
 
+# Softmax scores are finite or the -inf mask sentinel, never NaN, so nnan lets
+# maxnum lower to a bare v_max and fuse to v_max3. ninf must NOT be set here:
+# -inf is load-bearing, and an infinite operand under ninf is poison.
+_MAX_FASTMATH = arith.FastMathFlags.nnan
+
 _LOG2E = host_math.log2(host_math.e)
 # gfx950 (MI350/MI355X): 8 XCDs, each with a private ~4 MB L2.
 NUM_XCD_GFX950 = 8
@@ -389,7 +394,7 @@ def _lane_pair_reduce(v, reducer, fm_fast):
 
 
 def _score_pair_max(v_s, neg_inf, fm_fast):
-    reducer = lambda a, b, _fm: fx.maxnumf(a, b)  # noqa: E731
+    reducer = lambda a, b, _fm: fx.maxnumf(a, b, fastmath=_MAX_FASTMATH)  # noqa: E731
     return _lane_pair_reduce(_reduce_score_pair(v_s, neg_inf, reducer, fm_fast), reducer, fm_fast)
 
 
@@ -463,7 +468,7 @@ def _safe_l_inv(l_row, zero_f):
 
 
 def _rescale_from_tile_max(m_row, m_tile_max, fm_fast):
-    row_max = fx.maxnumf(m_row, m_tile_max)
+    row_max = fx.maxnumf(m_row, m_tile_max, fastmath=_MAX_FASTMATH)
     rescale = rocdl.exp2(T.f32, as_mlir_value(m_row - row_max))
     return row_max, rescale
 
@@ -2972,19 +2977,19 @@ class GenericSoftmaxHelper:
         if const_expr(os.getenv("FLYDSL_FLASH_ATTN_FUNC_TREE_REDUCE", "0") == "1"):
 
             def _max_pair(a, b):
-                return fx.maxnumf(a, b)
+                return fx.maxnumf(a, b, fastmath=_MAX_FASTMATH)
 
             local_max = _tree_reduce(list(s_raw_lo) + list(s_raw_hi), _max_pair)
         else:
             local_max = s_raw_lo[0]
             for r in range_constexpr(15):
-                local_max = fx.maxnumf(local_max, s_raw_lo[r + 1])
+                local_max = fx.maxnumf(local_max, s_raw_lo[r + 1], fastmath=_MAX_FASTMATH)
             for r in range_constexpr(16):
-                local_max = fx.maxnumf(local_max, s_raw_hi[r])
-        row_max = fx.maxnumf(local_max, self.reduction_peer(local_max))
-        m_new_raw = fx.maxnumf(m_running, row_max)
+                local_max = fx.maxnumf(local_max, s_raw_hi[r], fastmath=_MAX_FASTMATH)
+        row_max = fx.maxnumf(local_max, self.reduction_peer(local_max), fastmath=_MAX_FASTMATH)
+        m_new_raw = fx.maxnumf(m_running, row_max, fastmath=_MAX_FASTMATH)
         if const_expr(traits.CAUSAL):
-            m_new_raw = fx.maxnumf(m_new_raw, ctx.c_neg_floor)
+            m_new_raw = fx.maxnumf(m_new_raw, ctx.c_neg_floor, fastmath=_MAX_FASTMATH)
 
         diff_m_scaled = (m_running - m_new_raw) * ctx.c_sm_scale_log2e
         corr = self._exp2(diff_m_scaled)
@@ -3764,7 +3769,7 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         return _score_pair_max(v_s, self.c_neg_inf, self.fm_fast)
 
     def floor_masked_max(self, row_max):
-        return fx.maxnumf(row_max, self.c_neg_floor)
+        return fx.maxnumf(row_max, self.c_neg_floor, fastmath=_MAX_FASTMATH)
 
     def rescale_from_tile_max(self, m_row, m_tile_max):
         return _rescale_from_tile_max(m_row, m_tile_max, self.fm_fast)
@@ -3795,7 +3800,7 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         _scale_o_accs(v_o, scale_scalar, self.traits, self.fm_fast)
 
     def rescale_o(self, v_o, m_row, l_row, m_tile_max, v_p):
-        m_new = fx.maxnumf(m_row, m_tile_max)
+        m_new = fx.maxnumf(m_row, m_tile_max, fastmath=_MAX_FASTMATH)
         corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_new))
         self.scale_o(v_o, corr)
         v_o = _anchor_v_o(self.traits, v_o)
@@ -3810,7 +3815,7 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
         return v_o, m_new, l_row, v_p
 
     def fold_sink(self, v_o, m_row, l_row, sink_log2):
-        m_new = fx.maxnumf(m_row, sink_log2)
+        m_new = fx.maxnumf(m_row, sink_log2, fastmath=_MAX_FASTMATH)
         corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_new))
         self.scale_o(v_o, corr)
         sink_w = rocdl.exp2(T.f32, as_mlir_value(sink_log2 - m_new))
@@ -3819,8 +3824,8 @@ class DualwaveSoftmaxHelper(DualwaveKernelContext):
 
     def _lazy_rescale_o_rescale(self, _n, *_st, v_o, m_row, l_row, m_tile_max, v_p):
         # Lanes below their running max are dragged into this wave-uniform branch and
-        # m_tile_max alone would overflow them. nnan, not the ambient: -inf is live here.
-        m_new = fx.maxnumf(m_row, m_tile_max, fastmath=arith.FastMathFlags.nnan)
+        # m_tile_max alone would overflow them.
+        m_new = fx.maxnumf(m_row, m_tile_max, fastmath=_MAX_FASTMATH)
         corr = rocdl.exp2(T.f32, as_mlir_value(m_row - m_new))
         scaled_accs = list(v_o)
         self.scale_o(scaled_accs, corr)
@@ -5096,10 +5101,10 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
         return _score_pair_max(v_s, self.c_neg_inf, self.fm_fast)
 
     def max2(self, a, b):
-        return fx.maxnumf(a, b)
+        return fx.maxnumf(a, b, fastmath=_MAX_FASTMATH)
 
     def floor_masked_max(self, row_max):
-        return fx.maxnumf(row_max, self.c_neg_floor)
+        return fx.maxnumf(row_max, self.c_neg_floor, fastmath=_MAX_FASTMATH)
 
     def sub_m(self, v_s, row_max):
         return _scale_sub_score_pair(v_s, row_max, self.c_logit_scale, self.c_zero_f, self.fm_fast)
@@ -5144,7 +5149,7 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
         return _safe_l_inv(l_row, self.c_zero_f)
 
     def rescale_from_tile_max(self, m_row, m_tile_max):
-        row_max = fx.maxnumf(m_row, m_tile_max)
+        row_max = fx.maxnumf(m_row, m_tile_max, fastmath=_MAX_FASTMATH)
         diff_scaled = (m_row - row_max) * self.c_logit_scale
         rescale = rocdl.exp2(T.f32, as_mlir_value(diff_scaled))
         return row_max, rescale
@@ -5449,7 +5454,7 @@ class DualwaveSplitKCombineHelper(DualwaveSplitKCombineContext):
     def reduce_m_max(self, m_s):
         m_max = m_s[0]
         for i in range_constexpr(self.traits.NUM_KV_SPLITS - 1):
-            m_max = fx.maxnumf(m_max, m_s[i + 1])
+            m_max = fx.maxnumf(m_max, m_s[i + 1], fastmath=_MAX_FASTMATH)
         return m_max
 
     def fold_sink(self, m_max, bias_log2e):
@@ -5465,7 +5470,7 @@ class DualwaveSplitKCombineHelper(DualwaveSplitKCombineContext):
         )
 
         sink_log2 = sink_f32 * fx.Float32(bias_log2e)
-        m_new = fx.maxnumf(m_max, sink_log2)
+        m_new = fx.maxnumf(m_max, sink_log2, fastmath=_MAX_FASTMATH)
         sink_w = rocdl.exp2(T.f32, as_mlir_value(sink_log2 - m_new))
         return m_new, sink_w
 

--- a/kernels/attention/swa_gfx950.py
+++ b/kernels/attention/swa_gfx950.py
@@ -12,8 +12,7 @@ from flydsl.expr import arith, const_expr, range_constexpr, rocdl
 from flydsl.expr.typing import T
 from flydsl.expr.typing import Vector as Vec
 from flydsl.expr.utils.arith import _to_raw as _raw
-from flydsl.expr.utils.arith import current_fastmath
-from kernels.attention.flash_attn_utils import _reduction_pair
+from kernels.attention.flash_attn_utils import _MAX_FASTMATH, _reduction_pair
 
 MFMA_MASK = 0x08
 VALU_MASK = 0x02
@@ -105,8 +104,9 @@ def build_gqa_attn(
             return i32(rocdl.readfirstlane(T.i32, _raw(i32(x))))
 
         def fmax(a, b):
-            # fx.maxnumf takes fastmath explicitly instead of reading the ambient
-            return fx.maxnumf(a, b, fastmath=current_fastmath())
+            # nnan, not the ambient flags: this masks with -inf, which ninf would
+            # turn into poison. Same invariant as the dense score reductions.
+            return fx.maxnumf(a, b, fastmath=_MAX_FASTMATH)
 
         def bcast16(scalar):
             return Vec.from_elements([f32(scalar)], f32).broadcast_to(16)

--- a/python/flydsl/expr/arith.py
+++ b/python/flydsl/expr/arith.py
@@ -290,10 +290,22 @@ def ceildiv(lhs, rhs, **kwargs):
 
 
 @dsl_loc_tracing
-@dsl_math_wrap_result
 def maxnumf(a, b, *, fastmath=None, **kwargs):
-    """Floating-point maximum, returning the non-NaN operand when one input is NaN (libm ``fmax``)."""
-    return arith.maxnumf(as_ir_value(a), as_ir_value(b), fastmath=fastmath, **kwargs)
+    """Floating-point maximum, returning the non-NaN operand when one input is NaN (libm ``fmax``).
+
+    Wrapped by hand rather than by ``dsl_math_wrap_result``: this is a stable API
+    that returns the DSL type of ``a``, including a generic vector dtype and a
+    logical shape the flat wrapper would not preserve.
+    """
+    from .numeric import Numeric
+    from .typing import Vector
+
+    result = arith.maxnumf(as_ir_value(a), as_ir_value(b), fastmath=resolve_fastmath(fastmath), **kwargs)
+    if isinstance(a, Vector):
+        return Vector(result, a.shape, a.dtype)
+    if isinstance(a, Numeric):
+        return Numeric.from_ir_type(result.type)(result)
+    return result
 
 
 @dsl_loc_tracing

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4640,7 +4640,6 @@ def test_fp8_lazy_paths_do_not_roll_their_own_correction():
 def test_score_max_flag_excludes_ninf():
     """-inf is load-bearing in the score reductions; ninf would make it poison."""
     from flydsl.expr import arith as _arith
-
     from kernels.attention import flash_attn_utils as _fau
 
     flag = _fau._MAX_FASTMATH

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4538,7 +4538,6 @@ def test_sink_lse_cross_attn_skipped_blocks(Sq, Skv):
 def test_score_max_flag_excludes_ninf():
     """-inf is load-bearing in the score reductions; ninf would make it poison."""
     from flydsl.expr import arith as _arith
-
     from kernels.attention import flash_attn_utils as _fau
 
     flag = _fau._MAX_FASTMATH

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4634,3 +4634,18 @@ def test_fp8_lazy_paths_do_not_roll_their_own_correction():
         assert "exp2" not in chunk, f"{name} computes its own correction instead of taking the monotonic one"
         assert "_lazy_correction" in chunk or "rescale_from_tile_max" in chunk, f"{name} has no correction source"
     assert "rescale_from_tile_max" in method("_lazy_correction"), "the shared correction is not the monotonic one"
+
+
+@pytest.mark.l0_backend_agnostic
+def test_score_max_flag_excludes_ninf():
+    """-inf is load-bearing in the score reductions; ninf would make it poison."""
+    from flydsl.expr import arith as _arith
+
+    from kernels.attention import flash_attn_utils as _fau
+
+    flag = _fau._MAX_FASTMATH
+    assert flag & _arith.FastMathFlags.nnan, "nnan is what makes maxnum lower to a bare v_max"
+    assert not (flag & _arith.FastMathFlags.ninf), "ninf must not be set"
+    src = Path(_fau.__file__).read_text()
+    bare = [ln for ln in src.splitlines() if "fx.maxnumf(" in ln and "fastmath=" not in ln]
+    assert not bare, f"these would inherit the ambient flags, ninf included: {bare}"

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -4532,3 +4532,18 @@ def test_sink_lse_cross_attn_skipped_blocks(Sq, Skv):
     masked_lse = lse[:, :, :n_masked].float()
     assert (masked_lse - sink.view(1, H, 1)).abs().max().item() <= 1e-4, "all-masked rows must carry the sink LSE"
     assert out[:, :n_masked].abs().max().item() == 0.0, "all-masked rows must have zero output"
+
+
+@pytest.mark.l0_backend_agnostic
+def test_score_max_flag_excludes_ninf():
+    """-inf is load-bearing in the score reductions; ninf would make it poison."""
+    from flydsl.expr import arith as _arith
+
+    from kernels.attention import flash_attn_utils as _fau
+
+    flag = _fau._MAX_FASTMATH
+    assert flag & _arith.FastMathFlags.nnan, "nnan is what makes maxnum lower to a bare v_max"
+    assert not (flag & _arith.FastMathFlags.ninf), "ninf must not be set"
+    src = Path(_fau.__file__).read_text()
+    bare = [ln for ln in src.splitlines() if "fx.maxnumf(" in ln and "fastmath=" not in ln]
+    assert not bare, f"these would inherit the ambient flags, ninf included: {bare}"

--- a/tests/unit/test_fastmath_context.py
+++ b/tests/unit/test_fastmath_context.py
@@ -340,3 +340,49 @@ def test_minmax_unflagged_outside_block(op_name):
 
     ir_text = _build(build, [ir.F32Type.get, ir.F32Type.get])
     assert f"arith.{op_name}" in ir_text and "fastmath" not in ir_text
+
+
+@pytest.mark.l0_backend_agnostic
+def test_maxnumf_keeps_its_result_contract():
+    """``fx.maxnumf`` is a stable API that returns the DSL type of ``a``.
+
+    The generic flat wrapper drops a keyword binding to a raw value, flattens a
+    logical shape, and pins a generic vector dtype to a concrete one, so this
+    one stays hand-wrapped.
+    """
+    from flydsl.expr.numeric import Float
+    from flydsl.expr.typing import Vector
+
+    def build_scalar(a, b):
+        fa, fb = Float32(a), Float32(b)
+        assert isinstance(fx.maxnumf(fa, fb), Float32), "positional scalar"
+        assert isinstance(fx.maxnumf(a=fa, b=fb), Float32), "keyword scalar"
+
+    def build_vector(a, b):
+        va, vb = Vector(a, (2, 2), Float32), Vector(b, (2, 2), Float32)
+        assert fx.maxnumf(a=va, b=vb).shape == (2, 2), "keyword vector keeps its logical shape"
+        ga, gb = Vector(a, (4,), Float), Vector(b, (4,), Float)
+        assert fx.maxnumf(ga, gb).dtype is Float, "generic vector dtype is preserved"
+
+    _build(build_scalar, [ir.F32Type.get, ir.F32Type.get])
+    _vec = lambda: ir.VectorType.get([4], ir.F32Type.get())  # noqa: E731
+    _build(build_vector, [_vec, _vec])
+
+
+@pytest.mark.l0_backend_agnostic
+def test_maxnumf_can_carry_nnan_without_ninf():
+    """The score reductions need nnan but must not get ninf.
+
+    Their scores are finite or the -inf mask sentinel, and an infinite operand
+    under ninf is poison, so an ambient ``fast`` must not reach them.
+    """
+
+    def build(a, b):
+        fa, fb = Float32(a), Float32(b)
+        with fx.fastmath(fx.FastMathFlags.fast):
+            fx.maxnumf(fa, fb, fastmath=fx.FastMathFlags.nnan)
+
+    ir_text = _build(build, [ir.F32Type.get, ir.F32Type.get])
+    assert "arith.maxnumf" in ir_text
+    assert "fastmath<nnan>" in ir_text, ir_text
+    assert "ninf" not in ir_text, ir_text


### PR DESCRIPTION
Follow-ups to #1035, both from @jhinpan's post-merge review.

## 1. `fx.maxnumf` result contract

`fx.maxnumf` is in the stable catalog and documented to return the DSL type of `a`. The bare `@dsl_math_wrap_result` it moved to does not do that:

| call | before #1035 | on main |
|---|---|---|
| `maxnumf(a=x, b=x)`, `Float32` | `Float32` | raw `ArithValue` |
| keyword `Vector` shape `(2, 2)` | `(2, 2)` | flat `(4,)` |
| positional `Vector(..., dtype=Float)` | `Float` | `Float32` |

`exemplar="a"` fixes the first two but not the third, and `preserve_numeric_type=True` changes generic-scalar behaviour, so this hand-wraps it again and resolves the ambient inside — exact parity plus the flag. Three regressions added for keyword scalar, keyword vector and generic vector dtype; they fail on main.

## 2. `ninf` on the score reductions

The 16 `maxnumf` sites in `flash_attn_utils.py` inherit the ambient `fast`, which carries `ninf`. But `_score_pair_max` is seeded with literal `-inf` and masked scores are `-inf`, and an infinite operand under `ninf` is poison. `pa_decode_tile.py` already records the invariant:

> `nnan` lets maxnum lower to a bare v_max […] (ninf must NOT be set: -inf is load-bearing.)

So they carry `nnan` explicitly now. `swa_gfx950.py` masks with `-inf` too and was reaching for the ambient through a `current_fastmath()` workaround whose comment no longer held; it uses the same flag.

**The speed was in `nnan`.** Two rounds, cache cold, B=2 H=32 D=128 bf16:

| S | main (ambient `fast`) | this PR (`nnan`) |
|---|---|---|
| 61,380 | 1210.3 / 1212.6 | 1213.5 / 1213.4 |
| 180,180 | 1208.3 / 1207.0 | 1207.2 / 1206.7 |

Within noise, so #1035's recovery is untouched.

## Testing

- [x] `test_fastmath_context.py` — 25 passed, no GPU. Includes an IR guard that the reduction flag emits `fastmath<nnan>` with no `ninf`.
- [x] `test_flash_attn_fwd.py` — 94 passed. Includes a check that the flag excludes `ninf` and that no bare `fx.maxnumf` is left in that module.
- [x] `test_swa_gfx950.py` — 5 passed.
- [x] Benchmarks — table above.
- [x] No new third-party dependencies added

## Breaking Changes

None. The contract change restores the pre-#1035 behaviour.