### PR TITLE
[Bugfix][PA] Fix D192 query staging and 64-bit cache offsets

### DIFF
--- a/kernels/attention/pa_decode_tile.py
+++ b/kernels/attention/pa_decode_tile.py
@@ -112,6 +112,7 @@ def compile_pa_decode_tile(
     # as the absmax butterfly width); QCHUNK scales with head_dim instead.
     NQCHUNK = 16
     QCHUNK = head_dim // NQCHUNK  # f16 elements per lane's load chunk (8 for head_dim=128, 4 for head_dim=64)
+    assert QCHUNK % 4 == 0, f"head_dim {head_dim} must provide a whole number of packed FP8 query words"
 
     VHE_CHUNKS = head_dim // (NWARP * MFMA_MNK)  # 2 for head_dim=128, 1 for head_dim=64
 
@@ -211,8 +212,11 @@ def compile_pa_decode_tile(
         _k_load_fp8x16 = _make_flat_loader(key_cache_ptr, FP8, 16, fx.UniversalCopy128b())
         _v_load_fp8x16 = _make_flat_loader(value_cache_ptr, FP8, 16, fx.UniversalCopy128b())
         # Per-lane Q chunk (QCHUNK 16-bit elems) fetched in QLOAD_UNIT-wide
-        # pieces (128b max per buffer load): head_dim=256 needs 2 pieces.
-        QLOAD_UNIT = QCHUNK if QCHUNK < 8 else 8
+        # pieces (128b max per buffer load). Use 64-bit loads when QCHUNK is
+        # not divisible by 8: head_dim=192 gives QCHUNK=12 and therefore needs
+        # three 4-element loads. Rounding it down to one 8-element load leaves
+        # one third of every query row unstaged in LDS.
+        QLOAD_UNIT = 8 if QCHUNK % 8 == 0 else 4
         N_QLOADS = QCHUNK // QLOAD_UNIT
         _q_copy_op = fx.rocdl.BufferCopy128b() if QLOAD_UNIT == 8 else fx.rocdl.BufferCopy64b()
         _q_load_chunk = _make_flat_loader(query_ptr, Q_DTYPE, QLOAD_UNIT, _q_copy_op)
@@ -348,6 +352,9 @@ def compile_pa_decode_tile(
         # token = warp*TOK_CHUNK + a*c16 + lane16 (the softmax mask and P-pack
         # write position below must encode this same formula).
         def _k_ops(phys, a):
+            # Physical page ids fit in i32, but their element offsets do not
+            # once an individual KV cache grows beyond 2 GiB.
+            phys = fx.Int64(phys)
             within_page_tok = (a * c16 + lane16) % block_size
             ops = []
             for qkhe in range_constexpr(QKHE_LOOP):
@@ -536,11 +543,12 @@ def compile_pa_decode_tile(
             head_element = head_group * 16 + lane16
             ops = []
             for sub in range_constexpr(PAGES_PER_CHUNK):
+                phys = fx.Int64(phys_row[sub])
                 for step in range_constexpr(STEPS_PER_PAGE):
                     if const_expr(trans_v):
-                        base = (((phys_row[sub] * n_kv + kv_h) * STEPS_PER_PAGE + step) * head_dim + head_element) * 16
+                        base = (((phys * n_kv + kv_h) * STEPS_PER_PAGE + step) * head_dim + head_element) * 16
                     else:
-                        base = ((phys_row[sub] * n_kv + kv_h) * head_dim + head_element) * block_size + step * 16
+                        base = ((phys * n_kv + kv_h) * head_dim + head_element) * block_size + step * 16
                     w = _v_load16(base)
                     if const_expr(block_size == 16):
                         # help the scheduler overlap the per-page gathered loads (see _k_ops)

--- a/tests/kernels/test_pa_decode_tile.py
+++ b/tests/kernels/test_pa_decode_tile.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Focused correctness coverage for the tile-programming PA decode path."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from flydsl.runtime.device import get_rocm_arch
+from kernels.attention.pa_decode_tile import pa_decode_tile
+
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
+if not torch.cuda.is_available():
+    pytest.skip("requires a ROCm GPU", allow_module_level=True)
+
+ARCH = str(get_rocm_arch()).split(":", 1)[0]
+SUPPORTED_ARCHS = ("gfx942", "gfx950")
+FP8_DTYPE = torch.float8_e4m3fn if ARCH == "gfx950" else torch.float8_e4m3fnuz
+FP8_MAX = float(torch.finfo(FP8_DTYPE).max)
+
+
+def _quantize_per_tensor(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    scale = tensor.float().abs().max() / FP8_MAX
+    scale = scale.clamp_min(torch.finfo(torch.float32).tiny)
+    return (tensor.float() / scale).to(FP8_DTYPE), scale.reshape(1)
+
+
+def _reference(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    context_length: int,
+    query_length: int,
+    key_scale: torch.Tensor,
+    value_scale: torch.Tensor,
+) -> torch.Tensor:
+    num_q_heads = query.shape[1]
+    head_dim = query.shape[2]
+    outputs = []
+    token_positions = torch.arange(context_length, device=query.device)
+    causal_limit = context_length - query_length + torch.arange(query_length, device=query.device)
+    causal_mask = token_positions[None, :] <= causal_limit[:, None]
+
+    for sequence in range(block_tables.shape[0]):
+        pages = block_tables[sequence].long()
+        key = (
+            key_cache[pages].permute(0, 3, 1, 2, 4).reshape(-1, key_cache.shape[1], head_dim)[:context_length].float()
+            * key_scale
+        ).expand(-1, num_q_heads, -1)
+        value = (
+            value_cache[pages]
+            .permute(0, 2, 4, 1, 3)
+            .reshape(-1, value_cache.shape[1], head_dim)[:context_length]
+            .float()
+            * value_scale
+        ).expand(-1, num_q_heads, -1)
+        q = query[sequence * query_length : (sequence + 1) * query_length].float()
+        scores = torch.einsum("qhd,khd->hqk", q, key) * (head_dim**-0.5)
+        scores.masked_fill_(~causal_mask[None, :, :], float("-inf"))
+        probabilities = torch.softmax(scores, dim=-1)
+        outputs.append(torch.einsum("hqk,khd->qhd", probabilities, value).to(query.dtype))
+
+    return torch.cat(outputs)
+
+
+@pytest.mark.skipif(ARCH not in SUPPORTED_ARCHS, reason=f"requires gfx942 or gfx950, got {ARCH}")
+def test_fp8_head_dim_192_matches_torch() -> None:
+    batch = 2
+    query_length = 4
+    num_q_heads = 16
+    num_kv_heads = 1
+    head_dim = 192
+    page_size = 64
+    context_length = 1027
+    pages_per_sequence = math.ceil(context_length / page_size)
+    num_pages = batch * pages_per_sequence
+    generator = torch.Generator(device="cuda").manual_seed(20260821)
+
+    query = torch.empty((batch * query_length, num_q_heads, head_dim), dtype=torch.bfloat16, device="cuda").uniform_(
+        -0.5, 0.5, generator=generator
+    )
+    key_source = torch.empty(
+        (num_pages, num_kv_heads, head_dim // 16, page_size, 16), dtype=torch.bfloat16, device="cuda"
+    ).uniform_(-0.5, 0.5, generator=generator)
+    value_source = torch.empty(
+        (num_pages, num_kv_heads, page_size // 16, head_dim, 16), dtype=torch.bfloat16, device="cuda"
+    ).uniform_(-0.5, 0.5, generator=generator)
+    key, key_scale = _quantize_per_tensor(key_source)
+    value, value_scale = _quantize_per_tensor(value_source)
+    block_tables = torch.arange(num_pages - 1, -1, -1, dtype=torch.int32, device="cuda").reshape(
+        batch, pages_per_sequence
+    )
+    context_lengths = torch.full((batch,), context_length, dtype=torch.int32, device="cuda")
+
+    expected = _reference(
+        query,
+        key,
+        value,
+        block_tables,
+        context_length,
+        query_length,
+        key_scale,
+        value_scale,
+    )
+    actual = torch.full_like(query, float("nan"))
+    pa_decode_tile(
+        output=actual,
+        query=query,
+        key_cache=key,
+        value_cache=value,
+        block_tables=block_tables,
+        context_lengths=context_lengths,
+        key_scale=key_scale,
+        value_scale=value_scale,
+        softmax_scale=head_dim**-0.5,
+        num_partitions=4,
+    )
+    torch.cuda.synchronize()
+
+    assert bool(torch.isfinite(actual).all().item())
+    torch.testing.assert_close(actual, expected, rtol=2.0e-2, atol=2.0e-2)
+
+
+@pytest.mark.large_shape
+@pytest.mark.skipif(ARCH not in SUPPORTED_ARCHS, reason=f"requires gfx942 or gfx950, got {ARCH}")
+def test_fp8_cache_offset_above_2gib() -> None:
+    num_q_heads = 16
+    num_kv_heads = 1
+    head_dim = 192
+    page_size = 64
+    page_bytes = num_kv_heads * head_dim * page_size
+    high_page = math.ceil(2**31 / page_bytes)
+    num_pages = high_page + 1
+    generator = torch.Generator(device="cuda").manual_seed(20260821)
+
+    query = torch.empty((1, num_q_heads, head_dim), dtype=torch.bfloat16, device="cuda").uniform_(
+        -0.5, 0.5, generator=generator
+    )
+    key = torch.empty((num_pages, num_kv_heads, head_dim // 16, page_size, 16), dtype=FP8_DTYPE, device="cuda")
+    value = torch.empty((num_pages, num_kv_heads, page_size // 16, head_dim, 16), dtype=FP8_DTYPE, device="cuda")
+    key[high_page].copy_(
+        torch.empty_like(key[high_page], dtype=torch.bfloat16).uniform_(-0.5, 0.5, generator=generator).to(FP8_DTYPE)
+    )
+    value[high_page].copy_(
+        torch.empty_like(value[high_page], dtype=torch.bfloat16).uniform_(-0.5, 0.5, generator=generator).to(FP8_DTYPE)
+    )
+    block_tables = torch.tensor([[high_page]], dtype=torch.int32, device="cuda")
+    context_lengths = torch.ones(1, dtype=torch.int32, device="cuda")
+    scale = torch.ones(1, dtype=torch.float32, device="cuda")
+    expected = value[high_page, 0, 0, :, 0].float().expand(num_q_heads, -1).to(torch.bfloat16).unsqueeze(0)
+    actual = torch.full_like(query, float("nan"))
+
+    pa_decode_tile(
+        output=actual,
+        query=query,
+        key_cache=key,
+        value_cache=value,
+        block_tables=block_tables,
+        context_lengths=context_lengths,
+        key_scale=scale,
+        value_scale=scale,
+        softmax_scale=head_dim**-0.5,
+        num_partitions=1,
+    )
+    torch.cuda.synchronize()
+
+    assert bool(torch.isfinite(actual).all().item())
+    torch.testing.assert_close(actual, expected, rtol=2.0e-2, atol=2.0e-2)


### PR DESCRIPTION
## Summary
Fix the tile paged-attention path for D192 queries and serving-sized physical KV caches.

## Motivation
For head dimension 192, each lane stages 12 BF16 query elements. The existing load selection staged only the first 8 elements, which produced incorrect attention output. Physical K/V page IDs were also multiplied in 32-bit arithmetic, so element offsets could wrap once a cache crossed the 2 GiB boundary.

## Changes
- Select three 64-bit query loads for the D192 per-lane query chunk.
- Promote physical K and V page IDs to 64-bit before cache-offset arithmetic.
- Add a D192 PyTorch-reference correctness regression.
- Add a selected-page regression whose physical cache offset exceeds 2 GiB.

Existing D64, D128, and D256 behavior is unchanged.

## Performance
This is a correctness-only addressing and staging fix. It does not change the established D64/D128/D256 schedules. D192 uses the required three 64-bit loads instead of an incomplete 128-bit load.

## Testing
- gfx950: `pytest -q tests/kernels/test_pa_decode_tile.py` — 2 passed
- `python -m black --check kernels/attention/pa_decode_tile.py tests/kernels/test_pa_decode_tile.py`
- `python -m ruff check kernels/attention/pa_decode_tile.py tests/kernels/test_pa_decode_tile.py`
- `git diff --check upstream/main...HEAD`

## Dependencies
- No new third-party dependencies.

## Breaking Changes
None.