### PR TITLE
[Perf] avoid hashing when cache not enabled

### DIFF
--- a/python/flydsl/compiler/jit_function.py
+++ b/python/flydsl/compiler/jit_function.py
@@ -1236,22 +1236,23 @@ class JitFunction:
         warn_invalid_annotations(self._sig, context="@jit")
 
     def _ensure_cache_manager(self, owner_cls=None):
+        run_only = env.runtime.run_only
+        if not (env.runtime.enable_cache or run_only):
+            self._manager_owner_cls = owner_cls
+            self.manager_key = None
+            self.cache_manager = None
+            return
+
         if self.manager_key is not None and self._manager_owner_cls is owner_cls:
             return
         self._manager_owner_cls = owner_cls
         self.manager_key = _jit_function_cache_key(self.func, owner_cls=owner_cls)
 
-        run_only = env.runtime.run_only
         if run_only and env.debug.dump_ir:
             raise ValueError(
                 "FLYDSL_RUNTIME_RUN_ONLY=1 is incompatible with FLYDSL_DUMP_IR=1: "
                 "run-only mode skips the MLIR pass pipeline that would produce IR dumps."
             )
-
-        need_cache = env.runtime.enable_cache or run_only
-        if not need_cache:
-            self.cache_manager = None
-            return
 
         cache_root = env.runtime.cache_dir
         if not cache_root:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Currently the JIT hashes the kernel even if caching is disabled. This PR improves cache-disabled compilation by skipping the expensive hashing in `_jit_function_cache_key` when cache is not used. Compiliation time improved from approximately 232ms to 73ms on local compile-only benchmark.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
