### PR TITLE
[Build] Restore symlink to mlir target after build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -130,6 +130,16 @@ echo "Building with -j${PARALLEL_JOBS}..."
 cmake --build . -j"${PARALLEL_JOBS}"
 
 # ---------------------------------------------------------------------------
+# Restore the generated bindings link used by editable installs. That was removed
+# before the build due to CopyFlyPythonSources
+# ---------------------------------------------------------------------------
+if [ ! -e "${_EDITABLE_MLIR_LINK}" ]; then
+  _EDITABLE_MLIR_TARGET="../../${BUILD_DIR#"${REPO_ROOT}/"}/python_packages/flydsl/_mlir"
+  ln -s "${_EDITABLE_MLIR_TARGET}" "${_EDITABLE_MLIR_LINK}"
+  echo "Restored editable-install symlink: ${_EDITABLE_MLIR_LINK} -> ${_EDITABLE_MLIR_TARGET}"
+fi
+
+# ---------------------------------------------------------------------------
 # Done
 # ---------------------------------------------------------------------------
 PYTHON_PKG_DIR="${BUILD_DIR}/python_packages"


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Restore relative symlink after incremental build. We removed the symlink so that python can correctly resolve the `_mlir` package. This can be circumvented by `PYTHONPATH` or rerunning `pip install -e .` everytime we build from source, so it's not a hard blocker. Happy to close this if it's considered trivial.


<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Tested locally, and python correctly resolves the mlir target.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
