### PR TITLE
[gfx1250][GEMM] Add const-init to the test and support mxscale tile_m=16

### DIFF
--- a/kernels/gemm/gemm_a8w4_mxscale_gfx1250.py
+++ b/kernels/gemm/gemm_a8w4_mxscale_gfx1250.py
@@ -52,7 +52,7 @@ def launch_gemm_a8w4_mxscale(
     K_WS = tile_k // WMMA_K
     PACK_TK = tile_k // 2  # B row bytes per K-tile (FP4 packed 2/byte)
     SC_WORDS = tile_k // 4  # scale i32 words per super-row per K-tile
-    SA_SUPERS = tile_m // 32
+    SA_SUPERS = max(1, tile_m // 32)  # a sub-super tile still stages its whole containing super-row
     SB_SUPERS = tile_n // 32
     warp_tile_m = tile_m // m_warp
     warp_tile_n = tile_n // n_warp
@@ -230,6 +230,8 @@ def launch_gemm_a8w4_mxscale(
 
         def load_sa(buf, wm, ks):
             row = wmb + wm * 16 + lane16
+            if const_expr(tile_m < 32):
+                row = row + blk_m % 32  # sub-super tile: its rows sit mid-super-row
             word = (row // 32) * SC_WORDS + ks * 32 + (row % 32)
             return lds_load_b32(buf, fx.Int64(SA_OFF + word * 4))[0]
 

--- a/tests/kernels/test_gemm_fp8fp4_gfx1250.py
+++ b/tests/kernels/test_gemm_fp8fp4_gfx1250.py
@@ -39,9 +39,29 @@ def _require_gpu():
         pytest.skip(f"requires gfx1250, got {arch}")
 
 
-def _random_fp8_bytes(rows: int, cols: int) -> torch.Tensor:
-    """Finite FP8 E4M3 bytes (avoids the 0x7F/0xFF NaN encodings)."""
-    return torch.randint(0, 126, (rows, cols), dtype=torch.uint8)
+def _const_code(val: float, *, fp4: bool) -> int:
+    """The uint8 code (FP4 E2M1 nibble / FP8 E4M3 byte) that decodes exactly to `val`."""
+    codes = torch.arange(16 if fp4 else 126, dtype=torch.uint8).view(1, -1)
+    vals = gemm_common_utils.mxfp4_to_f32(codes)[0, ::2] if fp4 else gemm_common_utils.fp8_e4m3_to_f32(codes)[0]
+    match = (vals == val).nonzero()
+    if not len(match):
+        raise ValueError(f"{val} is not exactly representable in {'fp4' if fp4 else 'fp8'}")
+    return int(match[0, 0])
+
+
+def _fp8_bytes(rows: int, cols: int, const_val: float | None = None) -> torch.Tensor:
+    """Finite FP8 E4M3 bytes (avoids the 0x7F/0xFF NaN encodings), or a constant fill."""
+    if const_val is None:
+        return torch.randint(0, 126, (rows, cols), dtype=torch.uint8)
+    return torch.full((rows, cols), _const_code(const_val, fp4=False), dtype=torch.uint8)
+
+
+def _fp4_bytes(rows: int, K: int, const_val: float | None = None) -> torch.Tensor:
+    """Packed FP4 E2M1 bytes [rows, K//2], random or a constant fill."""
+    if const_val is None:
+        return gemm_common_utils.random_fp4_packed(rows, K)
+    code = _const_code(const_val, fp4=True)
+    return torch.full((rows, K // 2), code | (code << 4), dtype=torch.uint8)
 
 
 def _with_strided_a(a: torch.Tensor, K: int, lda: int) -> torch.Tensor:
@@ -54,51 +74,46 @@ def _with_strided_a(a: torch.Tensor, K: int, lda: int) -> torch.Tensor:
     return out
 
 
-def _bench_us(launch, output: torch.Tensor, *, warmup: int = 5, iters: int = 20) -> float:
-    """Median per-launch latency (us) via hipGraph capture/replay."""
-    stream = torch.cuda.Stream()
-    stream.wait_stream(torch.cuda.current_stream())
-    with torch.cuda.stream(stream):
-        for _ in range(warmup):
-            launch()
-    torch.cuda.current_stream().wait_stream(stream)
-    torch.cuda.synchronize()
-
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.stream(stream), torch.cuda.graph(graph, stream=stream):
+def _bench_us(launch, output: torch.Tensor, *, warmup: int = 10, iters: int = 100) -> float:
+    """Median per-launch latency (us) from saturated back-to-back throughput."""
+    for _ in range(warmup):
         launch()
     torch.cuda.synchronize()
-    if output.abs().max().item() == 0:
-        raise RuntimeError("hipGraph replay produced an all-zero output")
 
-    starts = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
-    ends = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
-    with torch.cuda.stream(stream):
-        for start, end in zip(starts, ends):
-            start.record()
-            graph.replay()
-            end.record()
+    output.zero_()
+    launch()
     torch.cuda.synchronize()
-    samples = sorted(start.elapsed_time(end) * 1e3 for start, end in zip(starts, ends))
-    return samples[len(samples) // 2]
+    if output.abs().max().item() == 0:
+        raise RuntimeError("the launch produced an all-zero output; it is not running")
+
+    rounds, batch = 10, max(1, iters // 10)
+    samples = []
+    for _ in range(rounds):
+        start, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
+        start.record()
+        for _ in range(batch):
+            launch()
+        end.record()
+        torch.cuda.synchronize()
+        samples.append(start.elapsed_time(end) * 1e3 / batch)
+    return sorted(samples)[len(samples) // 2]
 
 
 def _tflops(M: int, N: int, K: int, us: float) -> float:
     return 2.0 * M * N * K / (us * 1e-6) / 1e12
 
 
-def _assert_case(build_fn, launch_fn, M, N, K, *rest, **kwargs):
-    """Build inputs, compile+run once, and assert against the reference.
-
-    Returns (c_gpu, make_args, compiled) so callers (e.g. the perf CLI) can
-    replay the same compiled kernel without rebuilding it.
-    """
+def _run_and_check(build_fn, launch_fn, M, N, K, *rest, **kwargs):
+    """Build inputs, compile+run once, and compare against the reference."""
     c_gpu, make_args, ref, (rtol, atol) = build_fn(M, N, K, *rest, **kwargs)
     compiled = flyc.compile(launch_fn, *make_args(torch.cuda.current_stream()))
     torch.cuda.synchronize()
-    c_out = c_gpu[:M, :N].float().cpu()
-    torch.testing.assert_close(c_out, ref.float(), rtol=rtol, atol=atol)
-    return c_gpu, make_args, compiled
+    error = None
+    try:
+        torch.testing.assert_close(c_gpu[:M, :N].float(), ref.float(), rtol=rtol, atol=atol)
+    except AssertionError as exc:
+        error = exc
+    return c_gpu, make_args, compiled, error
 
 
 def _preshuffle_scale_32x4(scale: torch.Tensor) -> torch.Tensor:
@@ -152,22 +167,25 @@ def _build_a8w4_case(
     ldc_extra=0,
     cluster_m=1,
     cluster_n=1,
+    const_val=None,
 ):
     torch.manual_seed(0)
-    a = _random_fp8_bytes(M, K)
-    b = gemm_common_utils.random_fp4_packed(N, K)
+    a = _fp8_bytes(M, K, const_val)
+    b = _fp4_bytes(N, K, const_val)
     # f16 output overflows (~65504 max) with the default E8M0 exponent range at this K;
     # pin scales to 1.0 so f16 accumulation stays in range like the other dtypes.
     scale_exp = {"low_exp": 127, "high_exp": 127} if out_dtype == "f16" else {}
     a_scale = gemm_common_utils.random_e8m0(M, K // SCALE_BLOCK_32, **scale_exp)
     b_scale = gemm_common_utils.random_e8m0(N, K // SCALE_BLOCK_32, **scale_exp)
+    a, b = a.cuda(), b.cuda()
+    a_scale, b_scale = a_scale.cuda(), b_scale.cuda()
     ref = _reference_a8w4(a, b, a_scale, b_scale, M, N, K)
 
     lda, ldc = K + lda_extra, N + ldc_extra
-    a_gpu = _with_strided_a(a, K, lda).cuda()
-    b_gpu = gemm_common_utils.preshuffle_b_16x16(b, N, K // 2).cuda()
-    as_gpu = _preshuffle_scale_32x4(a_scale).cuda()
-    bs_gpu = _preshuffle_scale_32x4(b_scale).cuda()
+    a_gpu = _with_strided_a(a, K, lda)
+    b_gpu = gemm_common_utils.preshuffle_b_16x16(b, N, K // 2)
+    as_gpu = _preshuffle_scale_32x4(a_scale)
+    bs_gpu = _preshuffle_scale_32x4(b_scale)
     c_gpu = torch.zeros(M, ldc, dtype=_DT[out_dtype], device="cuda")
     out_is_f16 = 0 if out_dtype == "bf16" else 1
 
@@ -256,18 +274,20 @@ def _build_a8w8_ptpc_case(
     lda_extra=0,
     ldc_extra=0,
     scale_scale=1.0,
+    const_val=None,
 ):
     torch.manual_seed(0)
-    a = _random_fp8_bytes(M, K)
-    b = _random_fp8_bytes(N, K)
+    a = _fp8_bytes(M, K, const_val)
+    b = _fp8_bytes(N, K, const_val)
     sa = (scale_scale * (0.5 + torch.rand(M, dtype=torch.float32))).contiguous()
     sb = (scale_scale * (0.5 + torch.rand(N, dtype=torch.float32))).contiguous()
-    ref = _reference_ptpc(a, b, sa, sb, M, N, K)
+    a, b = a.cuda(), b.cuda()
+    sa_gpu, sb_gpu = sa.cuda().contiguous(), sb.cuda().contiguous()
+    ref = _reference_ptpc(a, b, sa_gpu, sb_gpu, M, N, K)
 
     lda, ldc = K + lda_extra, N + ldc_extra
-    a_gpu = _with_strided_a(a, K, lda).cuda().contiguous()
-    b_gpu = gemm_common_utils.preshuffle_b_16x16(b, N, K).cuda().contiguous()
-    sa_gpu, sb_gpu = sa.cuda().contiguous(), sb.cuda().contiguous()
+    a_gpu = _with_strided_a(a, K, lda).contiguous()
+    b_gpu = gemm_common_utils.preshuffle_b_16x16(b, N, K).contiguous()
     c_gpu = torch.zeros(M, ldc, dtype=_DT[out_dtype], device="cuda")
     out_is_f16 = 1 if out_dtype == "f16" else 0
     peak = float(ref.float().abs().max())
@@ -366,20 +386,23 @@ def _build_a8w8_blockscale_case(
     ldc_extra=0,
     cluster_m=1,
     cluster_n=1,
+    const_val=None,
 ):
     torch.manual_seed(0)
-    a = _random_fp8_bytes(M, K)
-    b = _random_fp8_bytes(N, K)
+    a = _fp8_bytes(M, K, const_val)
+    b = _fp8_bytes(N, K, const_val)
     scale_k = K // SCALE_BLOCK_128
     a_scale = gemm_common_utils.random_e8m0(M, scale_k, low_exp=126, high_exp=129)
     b_scale = gemm_common_utils.random_e8m0(N // SCALE_BLOCK_128, scale_k, low_exp=126, high_exp=129)
+    a, b = a.cuda(), b.cuda()
+    a_scale, b_scale = a_scale.cuda(), b_scale.cuda()
     ref = _reference_blockscale(a, b, a_scale, b_scale, M, N, K)
 
     lda, ldc = K + lda_extra, N + ldc_extra
-    a_gpu = _with_strided_a(a, K, lda).cuda()
-    b_gpu = gemm_common_utils.preshuffle_b_16x16(b, N, K).cuda()
-    as_gpu = a_scale.T.contiguous().cuda()  # [scale_k, M], row stride == M
-    bs_gpu = b_scale.cuda()
+    a_gpu = _with_strided_a(a, K, lda)
+    b_gpu = gemm_common_utils.preshuffle_b_16x16(b, N, K)
+    as_gpu = a_scale.T.contiguous()  # [scale_k, M], row stride == M
+    bs_gpu = b_scale
     c_gpu = torch.zeros(M, ldc, dtype=torch.bfloat16, device="cuda")
 
     def make_args(stream):
@@ -445,6 +468,8 @@ _MODES = {
         build=_build_a8w4_case,
         launch=launch_gemm_a8w4_mxscale,
         supports_out_dtype=True,
+        # A fp8 + B fp4 (2/byte) + E8M0 scales for A and B + C
+        bytes_moved=lambda M, N, K: M * K + N * K // 2 + (M + N) * (K // SCALE_BLOCK_32) + M * N * 2,
         checks=lambda N, K, tile_n, tile_k, num_buffers: [
             (K % SCALE_BLOCK_32 != 0, f"K={K} must be divisible by {SCALE_BLOCK_32}"),
             (N % tile_n != 0, f"N={N} must be divisible by tile_n={tile_n}"),
@@ -457,6 +482,8 @@ _MODES = {
         build=_build_a8w8_ptpc_case,
         launch=launch_gemm_a8w8,
         supports_out_dtype=True,
+        # A + B fp8 + one f32 scale per row/column + C
+        bytes_moved=lambda M, N, K: M * K + N * K + (M + N) * 4 + M * N * 2,
         checks=lambda N, K, tile_n, tile_k, num_buffers: [
             (N % tile_n != 0, f"N={N} must be divisible by tile_n={tile_n} (no silent pad)"),
             (K % tile_k != 0, f"K={K} must be divisible by tile_k={tile_k} (no silent pad)"),
@@ -468,6 +495,8 @@ _MODES = {
         build=_build_a8w8_blockscale_case,
         launch=launch_gemm_a8w8,
         supports_out_dtype=False,
+        # A + B fp8 + 128-blocked E8M0 scales (per A row, per B 128-row block) + C
+        bytes_moved=lambda M, N, K: M * K + N * K + (M + N // SCALE_BLOCK_128) * (K // SCALE_BLOCK_128) + M * N * 2,
         checks=lambda N, K, tile_n, tile_k, num_buffers: [
             (K % SCALE_BLOCK_128 != 0 or N % SCALE_BLOCK_128 != 0, f"N={N}, K={K} must both be divisible by 128"),
             (N % tile_n != 0, f"N={N} must be divisible by tile_n={tile_n}"),
@@ -485,7 +514,11 @@ def _run_case(mode, M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers
     for bad, msg in cfg["checks"](N, K, tile_n, tile_k, num_buffers):
         if bad:
             pytest.skip(msg)
-    _assert_case(cfg["build"], cfg["launch"], M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers, **kwargs)
+    error = _run_and_check(
+        cfg["build"], cfg["launch"], M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers, **kwargs
+    )[3]
+    if error is not None:
+        raise error
 
 
 def _run_smoke(mode, M, **kwargs):
@@ -517,41 +550,80 @@ def _parse_csv_ints(value: str, n: int, name: str) -> list[int]:
     return parts
 
 
+def _parse_init_mode(value: str) -> float | None:
+    """'random' -> None (random fill); 'const,<float>' -> that constant A/B fill value."""
+    if value == "random":
+        return None
+    kind, _, num = value.partition(",")
+    if kind != "const" or not num:
+        raise SystemExit(f"--init-mode expects 'random' or 'const,<float>', got {value!r}")
+    return float(num)
+
+
+def _print_table(headers: list[str], rows: list[list[str]]) -> None:
+    """Fixed-width plain-text table: first column left-aligned, the rest right-aligned."""
+    widths = [max(len(h), *(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
+
+    def line(cells):
+        return "  ".join(c.ljust(w) if i == 0 else c.rjust(w) for i, (c, w) in enumerate(zip(cells, widths)))
+
+    print(line(headers))
+    print("  ".join("-" * w for w in widths))
+    for row in rows:
+        print(line(row))
+
+
 def _main():
     import argparse
+    import itertools
 
     parser = argparse.ArgumentParser(description="Manual correctness/perf run for the gfx1250 GEMM kernels")
     parser.add_argument("-mode", choices=sorted(_MODES), required=True)
-    parser.add_argument("-mnk", required=True, help="M,N,K")
+    parser.add_argument("-mnk", nargs="+", required=True, metavar="M,N,K", help="one or more shapes")
     parser.add_argument("-tiles", required=True, help="tile_m,tile_n,tile_k")
     parser.add_argument("-warps", required=True, help="m_warp,n_warp")
     parser.add_argument("-nb", type=int, required=True, help="num_buffers")
     parser.add_argument("-cluster", default="1,1", help="cluster_m,cluster_n")
     parser.add_argument("-out-dtype", default="bf16", choices=["bf16", "f16"])
     parser.add_argument("-bench", action="store_true", help="also measure perf (warmup=10, iters=100)")
+    parser.add_argument(
+        "--init-mode",
+        nargs="+",
+        default=["random", "const,0.5"],
+        metavar="MODE",
+        help="A/B fill(s) to run: 'random' and/or 'const,<float>' (default: both)",
+    )
     args = parser.parse_args()
 
-    M, N, K = _parse_csv_ints(args.mnk, 3, "mnk")
+    shapes = [_parse_csv_ints(v, 3, "mnk") for v in args.mnk]
     tile_m, tile_n, tile_k = _parse_csv_ints(args.tiles, 3, "tiles")
     m_warp, n_warp = _parse_csv_ints(args.warps, 2, "warps")
     cluster_m, cluster_n = _parse_csv_ints(args.cluster, 2, "cluster")
 
     cfg = _MODES[args.mode]
-    kwargs = {"cluster_m": cluster_m, "cluster_n": cluster_n}
-    if cfg["supports_out_dtype"]:
-        kwargs["out_dtype"] = args.out_dtype
-    c_gpu, make_args, compiled = _assert_case(
-        cfg["build"], cfg["launch"], M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, args.nb, **kwargs
-    )
-    print(f"PASSED correctness: mode={args.mode} M={M} N={N} K={K}")
+    out_dtype = args.out_dtype if cfg["supports_out_dtype"] else "bf16"
 
-    if args.bench:
+    rows = []
+    for (M, N, K), init in itertools.product(shapes, args.init_mode):
+        kwargs = {"cluster_m": cluster_m, "cluster_n": cluster_n, "const_val": _parse_init_mode(init)}
+        if cfg["supports_out_dtype"]:
+            kwargs["out_dtype"] = args.out_dtype
+        c_gpu, make_args, compiled, error = _run_and_check(
+            cfg["build"], cfg["launch"], M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, args.nb, **kwargs
+        )
+        perf = ["-", "-", "-"]
+        if args.bench:
+            us = _bench_us(lambda: compiled(*make_args(torch.cuda.current_stream())), c_gpu, warmup=10, iters=100)
+            moved = cfg["bytes_moved"](M, N, K)
+            perf = [f"{us:.3f}", f"{_tflops(M, N, K, us):.2f}", f"{moved / (us * 1e-6) / 1e12:.3f}"]
+        rows.append([args.mode, str(M), str(N), str(K), out_dtype, init, *perf, "PASS" if error is None else "FAIL"])
+        if error is not None:
+            print(f"\n{M}x{N}x{K} {init}: {error}\n")
 
-        def launch():
-            compiled(*make_args(torch.cuda.current_stream()))
-
-        us = _bench_us(launch, c_gpu, warmup=10, iters=100)
-        print(f"perf: mode={args.mode} M={M} N={N} K={K} {us:.3f}us ({_tflops(M, N, K, us):.2f} TFLOPS)")
+    print(f"\ntiles={tile_m},{tile_n},{tile_k} warps={m_warp},{n_warp} nb={args.nb} cluster={cluster_m},{cluster_n}")
+    _print_table(["mode", "M", "N", "K", "out", "init_mode", "latency us", "TFLOPS", "BW TB/s", "result"], rows)
+    if any(r[-1] == "FAIL" for r in rows):
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Enable small-M (`tile_m=16`) tiles for the gfx1250 a8w4 mxscale GEMM, and let the manual harness run deterministic constant inputs for stable perf comparisons.

## Technical Details

- Kernel: a sub-super tile stages its whole containing 32-row A-scale super and `load_sa` offsets by `blk_m % 32`, so a 16-row tile reads its own half instead of always the upper one.
- Harness: `--init-mode` selects `random` and/or `const,<float>` (default both), `-mnk` takes multiple shapes, and results print as a latency / TFLOPS / BW table with pass/fail per row.

## Test Plan

```bash
python3 -m pytest tests/kernels/test_gemm_fp8fp4_gfx1250.py -q

python3 tests/kernels/test_gemm_fp8fp4_gfx1250.py \
  -mode mxscale_a8w4 -mnk 16,262144,16384 -tiles 16,512,256 -warps 1,4 -nb 4 -cluster 1,4 -bench
```

## Test Result

All tests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
