### PR TITLE
[gfx1250] Add bf16 gemm

### DIFF
--- a/kernels/gemm/gemm_a8w4_mxscale_gfx1250.py
+++ b/kernels/gemm/gemm_a8w4_mxscale_gfx1250.py
@@ -42,8 +42,11 @@ def launch_gemm_a8w4_mxscale(
     num_buffers: Constexpr[int],
     cluster_m: Constexpr[int],
     cluster_n: Constexpr[int],
+    b_preshuffle: Constexpr[bool] = True,
 ):
-    """A: [M, K] uint8 (FP8 E4M3). B: [N, K//2] uint8, 16x16-preshuffled FP4 (E2M1)."""
+    """A: [M, K] uint8 (FP8 E4M3). B: uint8 packed FP4 (E2M1), 16x16-preshuffled
+    [N//16, 16*K//2] when ``b_preshuffle``, else row-major [N, K//2] staged with a
+    16-byte LDS row pad (costs one LDS stage slot, drops the 16-row global stride)."""
 
     use_cluster = cluster_m > 1 or cluster_n > 1
     WMMA_M = WMMA_N = 16
@@ -63,15 +66,19 @@ def launch_gemm_a8w4_mxscale(
     block = num_waves * WAVE
 
     LDS_PAD_A = 16
+    B_NBLOCK = 16 if b_preshuffle else 1
+    LDS_PAD_B = 0 if b_preshuffle else 16
     A_LDS_ROW = tile_k + LDS_PAD_A
-    B_LDS_ROW = PACK_TK * 16
+    B_INNER = PACK_TK * B_NBLOCK
+    B_OUTER = tile_n // B_NBLOCK
+    B_LDS_ROW = B_INNER + LDS_PAD_B
     STAGE_A = ((tile_m * A_LDS_ROW + 15) // 16) * 16
-    STAGE_B = (((tile_n // 16) * B_LDS_ROW + 15) // 16) * 16
+    STAGE_B = ((B_OUTER * B_LDS_ROW + 15) // 16) * 16
     STAGE_SA = ((SA_SUPERS * tile_k + 15) // 16) * 16
     STAGE_SB = ((SB_SUPERS * tile_k + 15) // 16) * 16
     SA_OFF = STAGE_A + STAGE_B
-    SB_OFF = STAGE_A + STAGE_B + STAGE_SA
-    PITCH = ((STAGE_A + STAGE_B + STAGE_SA + STAGE_SB + 1023) // 1024) * 1024
+    SB_OFF = SA_OFF + STAGE_SA
+    PITCH = ((SB_OFF + STAGE_SB + 1023) // 1024) * 1024
 
     C_STORE_B = ((tile_m * tile_n * 2 + 127) // 128) * 128
     ARENA_B = max(num_buffers * PITCH, C_STORE_B)
@@ -94,7 +101,7 @@ def launch_gemm_a8w4_mxscale(
         k64 = fx.Int64(i32_k)
         lda64 = fx.Int64(i32_lda)
         ldc64 = fx.Int64(i32_ldc)
-        Kp16 = (k64 // 2) * 16
+        b_block_stride = (k64 // 2) * B_NBLOCK
 
         tid = fx.Int32(fx.thread_idx.x)
         bid_x, bid_y, _ = fx.block_idx
@@ -148,7 +155,7 @@ def launch_gemm_a8w4_mxscale(
 
         W_A, W_B, W_SA, W_SB = 0, 1, 2 % num_waves, 3 % num_waves
         a_off0 = blk_m64 * lda64
-        b_off0 = (blk_n64 // 16) * Kp16
+        b_off0 = (blk_n64 // B_NBLOCK) * b_block_stride
         sa_off0 = (blk_m64 // 32) * k64
         sb_off0 = (blk_n64 // 32) * k64
 
@@ -166,9 +173,17 @@ def launch_gemm_a8w4_mxscale(
             "workgroup_mask",
             a_mask,
         )
-        gB = _gv(gB_base, b_off0, (tile_n // 16, PACK_TK * 16), (PACK_TK * 16, 1))
+        gB = _gv(gB_base, b_off0, (B_OUTER, B_INNER), (B_INNER, 1))
         atomB = fx.atom_set_value(
-            fx.rocdl.make_tdm_atom(gB, [None, None], strides=[Kp16, None], num_warps=1, early_timeout=True),
+            fx.rocdl.make_tdm_atom(
+                gB,
+                [None, None],
+                strides=[b_block_stride, None],
+                num_warps=1,
+                pad_interval=B_INNER if LDS_PAD_B else 0,
+                pad_amount=LDS_PAD_B,
+                early_timeout=True,
+            ),
             "workgroup_mask",
             b_mask,
         )
@@ -189,8 +204,8 @@ def launch_gemm_a8w4_mxscale(
                 W_B,
                 atomB,
                 gB,
-                _lv(fx.add_offset(pa, STAGE_A), (tile_n // 16, PACK_TK * 16), (B_LDS_ROW, 1)),
-                kt64 * fx.Int64(PACK_TK * 16),
+                _lv(fx.add_offset(pa, STAGE_A), (B_OUTER, B_INNER), (B_LDS_ROW, 1)),
+                kt64 * fx.Int64(B_INNER),
             )
             _wcopy(
                 W_SA,
@@ -222,10 +237,14 @@ def launch_gemm_a8w4_mxscale(
             return v01.shuffle(v23, list(range(16)))
 
         def load_b(buf, wn, ks):
-            nbl = wnb // 16 + wn
-            b0 = fx.Int64(STAGE_A + nbl * B_LDS_ROW + ks * 1024 + kgrp * 256 + lane16 * 16)
+            n_base = wnb + wn * 16
+            n_group = (n_base + lane16) // B_NBLOCK
+            n_lane = lane16 % B_NBLOCK
+            b0 = fx.Int64(
+                STAGE_A + n_group * B_LDS_ROW + ks * (WMMA_K // 2) * B_NBLOCK + kgrp * 16 * B_NBLOCK + n_lane * 16
+            )
             v0 = Vec(lds_load_b128(buf, b0))
-            v1 = Vec(lds_load_b128(buf, b0 + 512))
+            v1 = Vec(lds_load_b128(buf, b0 + 32 * B_NBLOCK))
             return v0.shuffle(v1, list(range(8)))
 
         def load_sa(buf, wm, ks):
@@ -266,12 +285,19 @@ def launch_gemm_a8w4_mxscale(
 
         DS_A, DS_B = 4, 2
         _BS_DS = wmma_n_rep * DS_B + wmma_n_rep + wmma_m_rep
+        KS_DS = wmma_m_rep * DS_A + _BS_DS  # ds_reads for one whole WMMA K-step
 
         def _load_b_scales(buf, ks):
             wt = [_rmem(8, load_b(buf, wn, ks)) for wn in range_constexpr(wmma_n_rep)]
             sb_k = [load_sb(buf, wn, ks) for wn in range_constexpr(wmma_n_rep)]
             sa_k = [load_sa(buf, wm, ks) for wm in range_constexpr(wmma_m_rep)]
             return wt, sb_k, sa_k
+
+        def _load_ks(buf, ks):
+            """Every A/B/scale fragment for one WMMA K-step."""
+            wt, sb_k, sa_k = _load_b_scales(buf, ks)
+            act = [_rmem(16, load_a(buf, wm, ks)) for wm in range_constexpr(wmma_m_rep)]
+            return act, wt, sb_k, sa_k
 
         def _kstep(buf, ks, wt, sb_k, sa_k, nxt_ks, prefetch_kt=None):
             act_f = [_rmem(16, load_a(buf, wm, ks)) for wm in _FRONT]
@@ -290,7 +316,27 @@ def launch_gemm_a8w4_mxscale(
                 _mma_rows(_BACK, act_b, wt, sa_k, sb_k)
             return _load_b_scales(buf, nxt_ks) if const_expr(nxt_ks is not None) else None
 
-        def compute_ktile(buf, prefetch_kt):
+        def _compute_ktile_flat(buf, prefetch_kt):
+            """Single M-row: keep the next K-step's reads in flight across the WMMAs."""
+            cur = _load_ks(buf, 0)
+            for ks in range_constexpr(K_WS):
+                nxt = _load_ks(buf, ks + 1) if const_expr(ks + 1 < K_WS) else None
+                rocdl.s_wait_dscnt(KS_DS if const_expr(nxt is not None) else 0)
+                _mma_rows(_FRONT, cur[0], cur[1], cur[3], cur[2])
+                if const_expr(ks == 0 and prefetch_kt is not None):
+                    rocdl.sched_barrier(0)
+                    issue(prefetch_kt % num_buffers, prefetch_kt)
+                    rocdl.sched_barrier(0)
+                if const_expr(nxt is not None):
+                    cur = nxt
+            rocdl.sched_dsrd(KS_DS)
+            for _ks in range_constexpr(K_WS):
+                if const_expr(_ks < K_WS - 1):
+                    rocdl.sched_dsrd(KS_DS)
+                rocdl.sched_mfma(n_acc)
+            rocdl.sched_barrier(0)
+
+        def _compute_ktile_split(buf, prefetch_kt):
             prev = _load_b_scales(buf, 0)
             for ks in range_constexpr(K_WS):
                 nxt_ks = ks + 1 if const_expr(ks + 1 < K_WS) else None
@@ -305,6 +351,8 @@ def launch_gemm_a8w4_mxscale(
                 if const_expr(_ks < K_WS - 1):
                     rocdl.sched_dsrd(_BS_DS)
             rocdl.sched_barrier(0)
+
+        compute_ktile = _compute_ktile_flat if const_expr(len(_BACK) == 0) else _compute_ktile_split
 
         if const_expr(use_cluster):
             cluster.cluster_barrier()

--- a/kernels/gemm/gemm_bf16_gfx1250.py
+++ b/kernels/gemm/gemm_bf16_gfx1250.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Dense BF16/FP16 GEMM (C = A x B^T) for gfx1250: TDM staging + 16x16x32 WMMA."""
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import const_expr, range_constexpr, rocdl
+from flydsl.expr.rocdl import cluster, tdm_ops
+from flydsl.expr.typing import Constexpr, T
+from flydsl.expr.typing import Vector as Vec
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import check_smem_capacity
+from kernels.common.gfx1250_cluster import compute_mcast_masks
+
+from .gemm_common_gfx1250 import (
+    make_lds_copy_ops,
+    pipeline_fence,
+    workgroup_barrier,
+)
+
+
+@flyc.jit
+def launch_gemm_bf16(
+    arg_c: fx.Pointer,
+    arg_a: fx.Pointer,
+    arg_b: fx.Pointer,
+    i32_m: fx.Int32,
+    stream: fx.Stream,
+    N: fx.Int32,
+    K: fx.Int32,
+    i32_lda: fx.Int32,
+    i32_ldb: fx.Int32,
+    i32_ldc: fx.Int32,
+    tile_m: Constexpr[int],
+    tile_n: Constexpr[int],
+    tile_k: Constexpr[int],
+    m_warp: Constexpr[int],
+    n_warp: Constexpr[int],
+    num_buffers: Constexpr[int],
+    is_f16: Constexpr[int] = 0,
+    cluster_m: Constexpr[int] = 1,
+    cluster_n: Constexpr[int] = 1,
+):
+    """Requires N % tile_n == 0 and K % tile_k == 0; M is clamped per tile."""
+    WMMA_M = WMMA_N = 16
+    WMMA_K = 32
+    WAVE = 32
+    EB = 2  # bytes per element
+    KB = tile_k * EB  # K-tile row bytes
+    KSB = WMMA_K * EB  # bytes consumed by one WMMA K-step
+    K_WS = tile_k // WMMA_K
+    warp_tile_m = tile_m // m_warp
+    warp_tile_n = tile_n // n_warp
+    wmma_m_rep = warp_tile_m // WMMA_M
+    wmma_n_rep = warp_tile_n // WMMA_N
+    n_acc = wmma_m_rep * wmma_n_rep
+    num_waves = m_warp * n_warp
+    block = num_waves * WAVE
+    use_cluster = cluster_m > 1 or cluster_n > 1
+
+    if tile_k % WMMA_K or warp_tile_m % WMMA_M or warp_tile_n % WMMA_N:
+        raise ValueError(f"tile ({tile_m},{tile_n},{tile_k}) / warps ({m_warp},{n_warp}) not WMMA-aligned")
+    if K_WS < 2:
+        raise ValueError(f"tile_k={tile_k} needs at least 2 WMMA K-steps to hide the LDS reads")
+
+    LDS_PAD = 16  # keeps consecutive rows 4 dwords apart -> conflict-free b128 reads
+    LDS_ROW = KB + LDS_PAD
+    STAGE_A = ((tile_m * LDS_ROW + 15) // 16) * 16
+    STAGE_B = ((tile_n * LDS_ROW + 15) // 16) * 16
+    PITCH = ((STAGE_A + STAGE_B + 1023) // 1024) * 1024
+    elem_cls = fx.Float16 if is_f16 else fx.BFloat16
+    C_STORE_B = ((tile_m * tile_n * EB + 127) // 128) * 128
+    ARENA_B = max(num_buffers * PITCH, C_STORE_B)
+    check_smem_capacity(ARENA_B, str(get_hip_arch()))
+
+    @flyc.kernel(known_block_size=[block, 1, 1])
+    def kernel_gemm_bf16(
+        arg_c: fx.Pointer,
+        arg_a: fx.Pointer,
+        arg_b: fx.Pointer,
+        i32_m: fx.Int32,
+        i32_k: fx.Int32,
+        i32_lda: fx.Int32,
+        i32_ldb: fx.Int32,
+        i32_ldc: fx.Int32,
+    ):
+        K_TILES = i32_k // tile_k
+        lda_b = fx.Int64(i32_lda) * EB  # global row strides in bytes
+        ldb_b = fx.Int64(i32_ldb) * EB
+        ldc64 = fx.Int64(i32_ldc)
+
+        tid = fx.Int32(fx.thread_idx.x)
+        bid_x, bid_y, _ = fx.block_idx
+        wave = rocdl.readfirstlane(T.i32, tid // WAVE)
+        lane = tid % WAVE
+        lane16 = lane % 16
+        kgrp = lane // 16
+        wave_m = wave // n_warp
+        wave_n = wave % n_warp
+        if const_expr(use_cluster):
+            local_x, local_y = cluster.compute_cluster_position()
+            a_mask, b_mask = compute_mcast_masks(local_x, local_y, cluster_m, cluster_n)
+        else:
+            a_mask, b_mask = 0, 0
+        blk_m = bid_x * tile_m
+        blk_n = bid_y * tile_n
+        mn_oob = i32_m - blk_m  # valid M rows (A / C)
+
+        arena = fx.SharedAllocator(static=False)
+        arena.allocate(ARENA_B)
+        base_ptr = arena.base_ptr
+
+        def _bidx(p):
+            return fx.Int64(fx.ptrtoint(p))
+
+        def _buf_ptr(s):
+            return fx.add_offset(base_ptr, s * PITCH)
+
+        def _gv(base, off, shape, stride):
+            return fx.Tensor(fx.make_view(fx.add_offset(base, off), fx.make_layout(shape, stride)))
+
+        def _lv(ptr, shape, stride):
+            return fx.Tensor(fx.make_view(ptr, fx.make_layout(shape, stride)))
+
+        def _tdm(gt, outer, stride, mask):  # single-warp row-tile atom, dim0 clamped
+            atom = fx.rocdl.make_tdm_atom(
+                gt,
+                [outer, None],
+                strides=[stride, None],
+                num_warps=1,
+                pad_interval=KB,
+                pad_amount=LDS_PAD,
+                early_timeout=True,
+            )
+            return fx.atom_set_value(atom, "workgroup_mask", mask)
+
+        gA_base = fx.recast_iter(fx.Int8, arg_a)
+        gB_base = fx.recast_iter(fx.Int8, arg_b)
+        gC_base = fx.recast_iter(fx.PointerType.get(elem_cls.ir_type, arg_c.address_space), arg_c)
+
+        W_A, W_B = 0, 1 % num_waves
+        gA = _gv(gA_base, fx.Int64(blk_m) * lda_b, (tile_m, KB), (KB, 1))
+        atomA = _tdm(gA, mn_oob, lda_b, a_mask)
+        gB = _gv(gB_base, fx.Int64(blk_n) * ldb_b, (tile_n, KB), (KB, 1))
+        atomB = _tdm(gB, None, ldb_b, b_mask)
+
+        def _wcopy(w, atom, gt, lv, imm_offset):
+            if wave == w:
+                fx.copy(atom, gt, lv, imm_offset=imm_offset)
+
+        def issue(s, kt):
+            pa = _buf_ptr(s)
+            koff = fx.Int64(kt) * fx.Int64(KB)
+            _wcopy(W_A, atomA, gA, _lv(pa, (tile_m, KB), (LDS_ROW, 1)), koff)
+            _wcopy(W_B, atomB, gB, _lv(fx.add_offset(pa, STAGE_A), (tile_n, KB), (LDS_ROW, 1)), koff)
+
+        wmb = wave_m * warp_tile_m
+        wnb = wave_n * warp_tile_n
+        lds_load_b128, _ = make_lds_copy_ops(128)
+
+        def _frag(buf, b0):
+            """One 16-element operand fragment: two 16-byte chunks 32 bytes apart."""
+            v0 = Vec(lds_load_b128(buf, b0))
+            v1 = Vec(lds_load_b128(buf, b0 + 32))
+            return v0.shuffle(v1, list(range(8)))
+
+        def load_a(buf, wm, ks):
+            row = wmb + wm * WMMA_M + lane16
+            return _frag(buf, fx.Int64(row * LDS_ROW + ks * KSB + kgrp * 16))
+
+        def load_b(buf, wn, ks):
+            col = wnb + wn * WMMA_N + lane16
+            return _frag(buf, fx.Int64(STAGE_A + col * LDS_ROW + ks * KSB + kgrp * 16))
+
+        wmma_atom = fx.make_mma_atom(fx.rocdl.WMMA(WMMA_M, WMMA_N, WMMA_K, elem_cls, fx.Float32))
+        c_frags = [fx.make_rmem_tensor(8, fx.Float32) for _ in range_constexpr(n_acc)]
+        for cf in c_frags:
+            cf.store(Vec.filled(8, 0.0, fx.Float32))
+
+        def _rmem(n, v):
+            t = fx.make_rmem_tensor(n, fx.Int32)
+            t.store(v)
+            return t
+
+        DS_A = DS_B = 2  # ds_read_b128 per fragment
+        KS_DS = wmma_m_rep * DS_A + wmma_n_rep * DS_B  # ds_reads for one WMMA K-step
+
+        def _load_ks(buf, ks):
+            """All A/B fragments for one WMMA K-step."""
+            act = [_rmem(8, load_a(buf, wm, ks)) for wm in range_constexpr(wmma_m_rep)]
+            wt = [_rmem(8, load_b(buf, wn, ks)) for wn in range_constexpr(wmma_n_rep)]
+            return act, wt
+
+        def _mma_ks(state):
+            act, wt = state
+            for wm in range_constexpr(wmma_m_rep):
+                for wn_raw in range_constexpr(wmma_n_rep):
+                    wn = (wmma_n_rep - 1 - wn_raw) if (wm % 2 == 1) else wn_raw
+                    idx = wm * wmma_n_rep + wn
+                    # B is the instruction's A operand: the accumulator's fast dim is N.
+                    fx.gemm(wmma_atom, c_frags[idx], wt[wn], act[wm], c_frags[idx])
+
+        def compute_ktile(buf, prefetch_kt):
+            cur = _load_ks(buf, 0)
+            for ks in range_constexpr(K_WS):
+                nxt = _load_ks(buf, ks + 1) if const_expr(ks + 1 < K_WS) else None
+                rocdl.s_wait_dscnt(KS_DS if const_expr(nxt is not None) else 0)
+                _mma_ks(cur)
+                if const_expr(ks == 0 and prefetch_kt is not None):
+                    rocdl.sched_barrier(0)
+                    issue(prefetch_kt % num_buffers, prefetch_kt)
+                    rocdl.sched_barrier(0)
+                if const_expr(nxt is not None):
+                    cur = nxt
+            rocdl.sched_dsrd(KS_DS)  # prologue group
+            for _ks in range_constexpr(K_WS):
+                if const_expr(_ks < K_WS - 1):
+                    rocdl.sched_dsrd(KS_DS)
+                rocdl.sched_mfma(n_acc)
+            rocdl.sched_barrier(0)
+
+        if const_expr(use_cluster):
+            cluster.cluster_barrier()
+        for i in range_constexpr(num_buffers - 1):
+            issue(i, i)
+        n_steady = K_TILES - (num_buffers - 1)
+        for kt in range(n_steady):
+            buf = _bidx(_buf_ptr(kt % num_buffers))
+            pipeline_fence(outstanding=(num_buffers - 2), use_cluster=False)
+            compute_ktile(buf, kt + (num_buffers - 1))
+            if const_expr(use_cluster) and kt % num_buffers == num_buffers - 1:
+                cluster.cluster_barrier()
+        for j in range_constexpr(num_buffers - 1):
+            kt = n_steady + j
+            buf = _bidx(_buf_ptr(kt % num_buffers))
+            pipeline_fence(outstanding=(num_buffers - 2 - j), use_cluster=False)
+            compute_ktile(buf, None)
+
+        accs = [c_frags[idx].load() for idx in range_constexpr(n_acc)]
+        pipeline_fence(outstanding=0, use_cluster=use_cluster)
+        for wm in range_constexpr(wmma_m_rep):
+            row_rel = wmb + wm * WMMA_M + lane16
+            for wn in range_constexpr(wmma_n_rep):
+                col_rel = wnb + wn * WMMA_N + kgrp * 8
+                h = accs[wm * wmma_n_rep + wn].to(elem_cls)
+                fx.ptr_store(h.bitcast(fx.Int8), base_ptr + (row_rel * tile_n + col_rel) * EB)
+        workgroup_barrier(use_cluster=False)
+        gtC = _gv(gC_base, fx.Int64(blk_m) * ldc64 + fx.Int64(blk_n), (tile_m, tile_n), (tile_n, 1))
+        atomC = fx.rocdl.make_tdm_atom(
+            gtC,
+            [mn_oob, None],
+            strides=[ldc64, None],
+            num_warps=num_waves,
+            early_timeout=False,
+        )
+        fx.copy(atomC, _lv(fx.recast_iter(elem_cls, base_ptr), (tile_m, tile_n), (tile_n, 1)), gtC)
+        tdm_ops.tensor_wait(0)
+
+    gx = (i32_m + (tile_m - 1)) // tile_m
+    gy = N // tile_n
+    if use_cluster:
+        gx = ((gx + (cluster_m - 1)) // cluster_m) * cluster_m
+    cluster_arg = (cluster_m, cluster_n, 1) if use_cluster else None
+    kernel_gemm_bf16(
+        arg_c,
+        arg_a,
+        arg_b,
+        i32_m,
+        K,
+        i32_lda,
+        i32_ldb,
+        i32_ldc,
+        value_attrs={"rocdl.cluster_dims": f"{cluster_m},{cluster_n},1" if use_cluster else None},
+    ).launch(grid=(gx, gy, 1), block=(block, 1, 1), stream=stream, cluster=cluster_arg)
+
+
+launch_gemm_bf16.compile_hints["llvm_options"] = {
+    "amdgpu-expert-scheduling-mode": True,
+}

--- a/tests/kernels/test_gemm_bf16_gfx1250.py
+++ b/tests/kernels/test_gemm_bf16_gfx1250.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Dense BF16/FP16 GEMM (C = A x B^T) tests for gfx1250."""
+
+import math
+import os
+import sys
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
+import flydsl.compiler as flyc  # noqa: E402,I001
+import flydsl.expr as fx  # noqa: E402
+
+from flydsl.runtime.device import get_rocm_arch  # noqa: E402
+from kernels.gemm.gemm_bf16_gfx1250 import launch_gemm_bf16  # noqa: E402
+
+_DT = {"bf16": torch.bfloat16, "f16": torch.float16}
+
+
+def _require_gfx1250():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA/ROCm not available")
+    arch = str(get_rocm_arch())
+    if arch != "gfx1250":
+        pytest.skip(f"requires gfx1250, got {arch}")
+
+
+def _bytes_moved(M, N, K, eb=2):
+    return (M * K + N * K + M * N) * eb
+
+
+def _tflops(M, N, K, us):
+    return 2.0 * M * N * K / (us * 1e-6) / 1e12
+
+
+def _err_stats(c, ref):
+    """(max abs error, relative Frobenius error) against the f32 reference."""
+    d = (c.float() - ref).abs()
+    return float(d.max()), float(d.norm() / ref.norm().clamp_min(1e-12))
+
+
+def _build_case(
+    M,
+    N,
+    K,
+    tile_m,
+    tile_n,
+    tile_k,
+    m_warp,
+    n_warp,
+    num_buffers,
+    dtype="bf16",
+    *,
+    cluster_m=1,
+    cluster_n=1,
+):
+    """Inputs, a make_args(stream) thunk, the f32 reference, and tolerances."""
+    if (N // tile_n) % cluster_n:
+        raise ValueError(f"cluster_n={cluster_n} needs N/tile_n={N // tile_n} to be a multiple of it")
+    torch.manual_seed(0)
+    dt = _DT[dtype]
+    a = torch.randn(M, K, dtype=torch.float32, device="cuda").to(dt)
+    b = torch.randn(N, K, dtype=torch.float32, device="cuda").to(dt)
+    c = torch.zeros(M, N, dtype=dt, device="cuda")
+    ref = torch.matmul(a.float(), b.float().T)
+
+    def make_args(stream):
+        return (
+            flyc.from_c_void_p(fx.Uint8, c.data_ptr()),
+            flyc.from_c_void_p(fx.Uint8, a.data_ptr()),
+            flyc.from_c_void_p(fx.Uint8, b.data_ptr()),
+            M,
+            stream,
+            N,
+            K,
+            K,  # lda
+            K,  # ldb
+            N,  # ldc
+            tile_m,
+            tile_n,
+            tile_k,
+            m_warp,
+            n_warp,
+            num_buffers,
+            1 if dtype == "f16" else 0,
+            cluster_m,
+            cluster_n,
+        )
+
+    # bf16/f16 inputs with f32 accumulation: error grows with sqrt(K).
+    tol = (2e-2, 2e-2 * math.sqrt(K))
+    return c, make_args, ref, tol
+
+
+def _bench_us(launch, *, warmup=10, iters=100):
+    """Median per-launch latency (us) from saturated back-to-back throughput."""
+    for _ in range(warmup):
+        launch()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(5):
+        start, end = torch.cuda.Event(True), torch.cuda.Event(True)
+        start.record()
+        for _ in range(iters):
+            launch()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end) * 1e3 / iters)
+    times.sort()
+    return times[len(times) // 2]
+
+
+def _run_case(M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers, dtype="bf16", **kw):
+    _require_gfx1250()
+    c, make_args, ref, (rtol, atol) = _build_case(
+        M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers, dtype, **kw
+    )
+    compiled = flyc.compile(launch_gemm_bf16, *make_args(torch.cuda.current_stream()))
+    torch.cuda.synchronize()
+    max_err, rel_err = _err_stats(c, ref)
+    print(
+        f"  {M}x{N}x{K} {dtype} cluster={kw.get('cluster_m', 1)},{kw.get('cluster_n', 1)}: "
+        f"max_err={max_err:.4g} rel_err={rel_err:.3g}"
+    )
+    torch.testing.assert_close(c.float(), ref, rtol=rtol, atol=atol)
+    return c, make_args, compiled
+
+
+# (M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers)
+_CASES = [
+    (8, 256, 512, 16, 128, 128, 1, 2, 2),  # skinny M: exercises the per-tile M clamp
+    (16, 256, 1024, 16, 128, 128, 1, 2, 4),  # MAB-shaped tile: 4 accs/wave, 4-deep ring
+    (64, 64, 256, 64, 64, 64, 1, 1, 2),  # single wave issues both TDMs
+    (128, 128, 512, 128, 128, 128, 2, 2, 2),
+    (129, 512, 1024, 128, 128, 128, 2, 2, 2),  # ragged M
+    (256, 256, 512, 128, 256, 128, 2, 4, 2),
+]
+
+
+@pytest.mark.parametrize("M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers", _CASES)
+def test_gemm_bf16(M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers):
+    _run_case(M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers)
+
+
+@pytest.mark.parametrize("dtype", ["bf16", "f16"])
+def test_gemm_dtypes(dtype):
+    _run_case(128, 128, 512, 128, 128, 128, 2, 2, 2, dtype=dtype)
+
+
+# A multicasts along N, B along M. Kept small on purpose: a single 16-wide
+# cluster dim is known to wedge the queue on gfx1250.
+@pytest.mark.parametrize("cluster_m, cluster_n", [(2, 1), (1, 2), (2, 2)])
+def test_gemm_cluster(cluster_m, cluster_n):
+    # 4 M-tiles x 4 N-tiles so every cluster shape has real peers to span.
+    _run_case(64, 512, 512, 16, 128, 128, 1, 2, 2, cluster_m=cluster_m, cluster_n=cluster_n)
+
+
+def _parse_csv_ints(value, n, name):
+    parts = [int(x) for x in value.split(",")]
+    if len(parts) != n:
+        raise SystemExit(f"-{name} needs {n} comma-separated ints, got {value!r}")
+    return parts
+
+
+def _print_table(headers, rows):
+    widths = [max(len(h), *(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
+
+    def line(cells):
+        return "  ".join(c.ljust(w) if i == 0 else c.rjust(w) for i, (c, w) in enumerate(zip(cells, widths)))
+
+    print(line(headers))
+    print("  ".join("-" * w for w in widths))
+    for row in rows:
+        print(line(row))
+
+
+def _main():
+    import argparse
+    import itertools
+
+    parser = argparse.ArgumentParser(description="Manual correctness/perf run for the gfx1250 bf16 GEMM")
+    parser.add_argument("-mnk", nargs="+", required=True, metavar="M,N,K", help="one or more shapes")
+    parser.add_argument("-tiles", required=True, help="tile_m,tile_n,tile_k")
+    parser.add_argument("-warps", required=True, help="m_warp,n_warp")
+    parser.add_argument("-nb", type=int, required=True, help="num_buffers")
+    parser.add_argument("-dtype", default="bf16", choices=["bf16", "f16"], nargs="+")
+    parser.add_argument("-cluster", default="1,1", help="cluster_m,cluster_n (1,1 disables clustering)")
+    parser.add_argument("-bench", action="store_true", help="also measure perf (warmup=10, iters=100)")
+    args = parser.parse_args()
+
+    shapes = [_parse_csv_ints(v, 3, "mnk") for v in args.mnk]
+    tiles = _parse_csv_ints(args.tiles, 3, "tiles")
+    warps = _parse_csv_ints(args.warps, 2, "warps")
+    cluster = _parse_csv_ints(args.cluster, 2, "cluster")
+    dtypes = args.dtype if isinstance(args.dtype, list) else [args.dtype]
+
+    rows = []
+    for (M, N, K), dtype in itertools.product(shapes, dtypes):
+        c, make_args, ref, (rtol, atol) = _build_case(
+            M,
+            N,
+            K,
+            *tiles,
+            *warps,
+            args.nb,
+            dtype,
+            cluster_m=cluster[0],
+            cluster_n=cluster[1],
+        )
+        compiled = flyc.compile(launch_gemm_bf16, *make_args(torch.cuda.current_stream()))
+        torch.cuda.synchronize()
+        max_err, rel_err = _err_stats(c, ref)
+        ok = torch.allclose(c.float(), ref, rtol=rtol, atol=atol)
+        perf = ["-", "-", "-"]
+        if args.bench:
+            us = _bench_us(lambda: compiled(*make_args(torch.cuda.current_stream())))
+            moved = _bytes_moved(M, N, K)
+            perf = [f"{us:.3f}", f"{_tflops(M, N, K, us):.2f}", f"{moved / (us * 1e-6) / 1e12:.3f}"]
+        rows.append(
+            [str(M), str(N), str(K), dtype, *perf, f"{max_err:.4g}", f"{rel_err:.3g}", "PASS" if ok else "FAIL"]
+        )
+
+    print(
+        f"\ntiles={tiles[0]},{tiles[1]},{tiles[2]} warps={warps[0]},{warps[1]} "
+        f"nb={args.nb} cluster={cluster[0]},{cluster[1]}"
+    )
+    _print_table(["M", "N", "K", "dtype", "latency us", "TFLOPS", "BW TB/s", "max_err", "rel_err", "result"], rows)
+    if any(r[-1] == "FAIL" for r in rows):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    _main()

--- a/tests/kernels/test_gemm_fp8fp4_gfx1250.py
+++ b/tests/kernels/test_gemm_fp8fp4_gfx1250.py
@@ -52,16 +52,16 @@ def _const_code(val: float, *, fp4: bool) -> int:
 def _fp8_bytes(rows: int, cols: int, const_val: float | None = None) -> torch.Tensor:
     """Finite FP8 E4M3 bytes (avoids the 0x7F/0xFF NaN encodings), or a constant fill."""
     if const_val is None:
-        return torch.randint(0, 126, (rows, cols), dtype=torch.uint8)
-    return torch.full((rows, cols), _const_code(const_val, fp4=False), dtype=torch.uint8)
+        return torch.randint(0, 126, (rows, cols), dtype=torch.uint8, device="cuda")
+    return torch.full((rows, cols), _const_code(const_val, fp4=False), dtype=torch.uint8, device="cuda")
 
 
 def _fp4_bytes(rows: int, K: int, const_val: float | None = None) -> torch.Tensor:
     """Packed FP4 E2M1 bytes [rows, K//2], random or a constant fill."""
     if const_val is None:
-        return gemm_common_utils.random_fp4_packed(rows, K)
+        return gemm_common_utils.random_fp4_packed(rows, K, device="cuda")
     code = _const_code(const_val, fp4=True)
-    return torch.full((rows, K // 2), code | (code << 4), dtype=torch.uint8)
+    return torch.full((rows, K // 2), code | (code << 4), dtype=torch.uint8, device="cuda")
 
 
 def _with_strided_a(a: torch.Tensor, K: int, lda: int) -> torch.Tensor:
@@ -168,6 +168,7 @@ def _build_a8w4_case(
     cluster_m=1,
     cluster_n=1,
     const_val=None,
+    b_preshuffle=True,
 ):
     torch.manual_seed(0)
     a = _fp8_bytes(M, K, const_val)
@@ -175,15 +176,13 @@ def _build_a8w4_case(
     # f16 output overflows (~65504 max) with the default E8M0 exponent range at this K;
     # pin scales to 1.0 so f16 accumulation stays in range like the other dtypes.
     scale_exp = {"low_exp": 127, "high_exp": 127} if out_dtype == "f16" else {}
-    a_scale = gemm_common_utils.random_e8m0(M, K // SCALE_BLOCK_32, **scale_exp)
-    b_scale = gemm_common_utils.random_e8m0(N, K // SCALE_BLOCK_32, **scale_exp)
-    a, b = a.cuda(), b.cuda()
-    a_scale, b_scale = a_scale.cuda(), b_scale.cuda()
+    a_scale = gemm_common_utils.random_e8m0(M, K // SCALE_BLOCK_32, device="cuda", **scale_exp)
+    b_scale = gemm_common_utils.random_e8m0(N, K // SCALE_BLOCK_32, device="cuda", **scale_exp)
     ref = _reference_a8w4(a, b, a_scale, b_scale, M, N, K)
 
     lda, ldc = K + lda_extra, N + ldc_extra
     a_gpu = _with_strided_a(a, K, lda)
-    b_gpu = gemm_common_utils.preshuffle_b_16x16(b, N, K // 2)
+    b_gpu = gemm_common_utils.preshuffle_b_16x16(b, N, K // 2) if b_preshuffle else b
     as_gpu = _preshuffle_scale_32x4(a_scale)
     bs_gpu = _preshuffle_scale_32x4(b_scale)
     c_gpu = torch.zeros(M, ldc, dtype=_DT[out_dtype], device="cuda")
@@ -211,6 +210,7 @@ def _build_a8w4_case(
             num_buffers,
             cluster_m,
             cluster_n,
+            b_preshuffle,
         )
 
     return c_gpu, make_args, ref, _a8w4_tolerances(a_scale, b_scale, K)
@@ -279,10 +279,8 @@ def _build_a8w8_ptpc_case(
     torch.manual_seed(0)
     a = _fp8_bytes(M, K, const_val)
     b = _fp8_bytes(N, K, const_val)
-    sa = (scale_scale * (0.5 + torch.rand(M, dtype=torch.float32))).contiguous()
-    sb = (scale_scale * (0.5 + torch.rand(N, dtype=torch.float32))).contiguous()
-    a, b = a.cuda(), b.cuda()
-    sa_gpu, sb_gpu = sa.cuda().contiguous(), sb.cuda().contiguous()
+    sa_gpu = (scale_scale * (0.5 + torch.rand(M, dtype=torch.float32, device="cuda"))).contiguous()
+    sb_gpu = (scale_scale * (0.5 + torch.rand(N, dtype=torch.float32, device="cuda"))).contiguous()
     ref = _reference_ptpc(a, b, sa_gpu, sb_gpu, M, N, K)
 
     lda, ldc = K + lda_extra, N + ldc_extra
@@ -392,10 +390,8 @@ def _build_a8w8_blockscale_case(
     a = _fp8_bytes(M, K, const_val)
     b = _fp8_bytes(N, K, const_val)
     scale_k = K // SCALE_BLOCK_128
-    a_scale = gemm_common_utils.random_e8m0(M, scale_k, low_exp=126, high_exp=129)
-    b_scale = gemm_common_utils.random_e8m0(N // SCALE_BLOCK_128, scale_k, low_exp=126, high_exp=129)
-    a, b = a.cuda(), b.cuda()
-    a_scale, b_scale = a_scale.cuda(), b_scale.cuda()
+    a_scale = gemm_common_utils.random_e8m0(M, scale_k, low_exp=126, high_exp=129, device="cuda")
+    b_scale = gemm_common_utils.random_e8m0(N // SCALE_BLOCK_128, scale_k, low_exp=126, high_exp=129, device="cuda")
     ref = _reference_blockscale(a, b, a_scale, b_scale, M, N, K)
 
     lda, ldc = K + lda_extra, N + ldc_extra
@@ -582,10 +578,16 @@ def _main():
     parser.add_argument("-mnk", nargs="+", required=True, metavar="M,N,K", help="one or more shapes")
     parser.add_argument("-tiles", required=True, help="tile_m,tile_n,tile_k")
     parser.add_argument("-warps", required=True, help="m_warp,n_warp")
-    parser.add_argument("-nb", type=int, required=True, help="num_buffers")
+    parser.add_argument("-nb", "-n", type=int, required=True, help="num_buffers")
     parser.add_argument("-cluster", default="1,1", help="cluster_m,cluster_n")
     parser.add_argument("-out-dtype", default="bf16", choices=["bf16", "f16"])
     parser.add_argument("-bench", action="store_true", help="also measure perf (warmup=10, iters=100)")
+    parser.add_argument(
+        "-no-b-preshuffle",
+        dest="b_preshuffle",
+        action="store_false",
+        help="disable the 16x16 B preshuffle for mxscale_a8w4 (default: enabled)",
+    )
     parser.add_argument(
         "--init-mode",
         nargs="+",
@@ -606,6 +608,8 @@ def _main():
     rows = []
     for (M, N, K), init in itertools.product(shapes, args.init_mode):
         kwargs = {"cluster_m": cluster_m, "cluster_n": cluster_n, "const_val": _parse_init_mode(init)}
+        if args.mode == "mxscale_a8w4":
+            kwargs["b_preshuffle"] = args.b_preshuffle
         if cfg["supports_out_dtype"]:
             kwargs["out_dtype"] = args.out_dtype
         c_gpu, make_args, compiled, error = _run_and_check(
@@ -620,7 +624,13 @@ def _main():
         if error is not None:
             print(f"\n{M}x{N}x{K} {init}: {error}\n")
 
-    print(f"\ntiles={tile_m},{tile_n},{tile_k} warps={m_warp},{n_warp} nb={args.nb} cluster={cluster_m},{cluster_n}")
+    b_layout = ""
+    if args.mode == "mxscale_a8w4":
+        b_layout = f" b_layout={'preshuffle' if args.b_preshuffle else 'row-major+pad'}"
+    print(
+        f"\ntiles={tile_m},{tile_n},{tile_k} warps={m_warp},{n_warp} nb={args.nb} "
+        f"cluster={cluster_m},{cluster_n}{b_layout}"
+    )
     _print_table(["mode", "M", "N", "K", "out", "init_mode", "latency us", "TFLOPS", "BW TB/s", "result"], rows)
     if any(r[-1] == "FAIL" for r in rows):
         raise SystemExit(1)


### PR DESCRIPTION
## Motivation

Add bf16 gemm.

## Technical Details

Add bf16 gemm.

## Test Plan

```
python3 tests/kernels/test_gemm_bf16_gfx1250.py -mnk 16,65536,16384 -tiles 16,256,128 -warps 1,4 -nb 4 -cluster 1,4 -bench
```

## Test Result

```bash
tiles=16,256,128 warps=1,4 nb=4 cluster=1,4
M       N      K  dtype  latency us  TFLOPS  BW TB/s  max_err  rel_err  result
--  -----  -----  -----  ----------  ------  -------  -------  -------  ------
16  65536  16384   bf16     109.635  313.40   19.612    1.931  0.00166    PASS
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
