### PR TITLE
[Kernel][PA] Support BF16 vectorized KV with asymmetric K/V head dim

### DIFF
--- a/kernels/attention/pa_decode_fp8.py
+++ b/kernels/attention/pa_decode_fp8.py
@@ -296,11 +296,83 @@ def pa_decode_ps_launch(
     """
     num_query_heads = query.shape[1]
     num_kv_heads = key_cache.shape[1]
-    trans_v = len(value_cache.shape) == 5
-    query_input_dtype = _get_query_input_dtype(query)
-
+    batch_size = context_lengths.shape[0]
+    if query.shape[0] % batch_size != 0:
+        raise ValueError(f"query.shape[0] ({query.shape[0]}) must be divisible by " f"batch_size ({batch_size})")
+    if num_query_heads % num_kv_heads != 0:
+        raise ValueError(f"num_query_heads ({num_query_heads}) must be divisible by " f"num_kv_heads ({num_kv_heads})")
+    query_length = query.shape[0] // batch_size
+    query_group_size = num_query_heads // num_kv_heads
+    head_size = query.shape[-1]
+    value_head_size = output.shape[-1]
+    block_size = key_cache.shape[-2]
     dev = query.device
     is_graph_capturing = _is_current_stream_capturing()
+    s = stream or torch.cuda.current_stream()
+
+    if max_context_partition_num <= 0:
+        raise ValueError("max_context_partition_num must be positive.")
+
+    # Small physical pages use the standalone tile kernel. Dispatch before the
+    # FP8 metadata/SW setup so BF16 KV stays unscaled and asymmetric V uses the
+    # tile wrapper's value-sized workspace allocation and validation.
+    if block_size in _PA_DECODE_PS_SMALL_BLOCK_SIZES and sliding_window == 0:
+        if block_tables is None:
+            raise ValueError(
+                f"pa_decode_ps_launch: block_size={block_size} requires `block_tables` "
+                "(per-sequence physical block index table)."
+            )
+
+        tile_key_scale = key_scale
+        tile_value_scale = value_scale
+        if key_cache.dtype != torch.bfloat16:
+            tile_key_scale = _prepare_scale_tensor(
+                "key_scale",
+                key_scale,
+                device=dev,
+                is_graph_capturing=is_graph_capturing,
+            )
+            tile_value_scale = _prepare_scale_tensor(
+                "value_scale",
+                value_scale,
+                device=dev,
+                is_graph_capturing=is_graph_capturing,
+            )
+            if tile_key_scale.ndim > 1:
+                num_blocks = key_cache.shape[0]
+                tile_key_scale = tile_key_scale.reshape(num_blocks, num_kv_heads, block_size)
+                tile_value_scale = tile_value_scale.reshape(num_blocks, num_kv_heads, block_size)
+
+        pa_decode_tile(
+            output,
+            query,
+            key_cache,
+            value_cache,
+            block_tables,
+            context_lengths,
+            tile_key_scale,
+            tile_value_scale,
+            softmax_scale=softmax_scale,
+            stream=s,
+            num_partitions=max_context_partition_num,
+            pmax=max_logits,
+            psum=exp_sums,
+            pout=temporary_output,
+        )
+        return "ps_small_block"
+
+    is_bf16_kv = key_cache.dtype == torch.bfloat16
+    is_asymmetric = value_head_size != head_size
+    if is_bf16_kv or is_asymmetric:
+        unsupported_path = "sliding-window" if sliding_window > 0 else "page-1024 metadata"
+        raise ValueError(
+            "BF16 KV and asymmetric value dimensions currently require "
+            "block_size 16 or 64 with sliding_window=0; "
+            f"the {unsupported_path} path is not supported."
+        )
+
+    trans_v = len(value_cache.shape) == 5
+    query_input_dtype = _get_query_input_dtype(query)
 
     key_scale = _prepare_scale_tensor(
         "key_scale",
@@ -319,28 +391,16 @@ def pa_decode_ps_launch(
     # token), which enables the per-token K/V path in the metadata kernel.
     per_token_kv = key_scale.ndim > 1
 
-    query_length = query.shape[0] // context_lengths.shape[0]
-    query_group_size = num_query_heads // num_kv_heads
-    batch_size = context_lengths.shape[0]
-    head_size = query.shape[-1]
-
     # Strides for key_scale/value_scale
     stride_ks_block = key_scale.stride(0) if per_token_kv else 0
     stride_ks_head = key_scale.stride(1) if per_token_kv else 0
 
-    s = stream or torch.cuda.current_stream()
-
-    if max_context_partition_num <= 0:
-        raise ValueError("max_context_partition_num must be positive for sliding-window decode.")
     if is_graph_capturing and (exp_sums is None or max_logits is None or temporary_output is None):
         raise ValueError(
             "CUDA graph capture requires preallocated `exp_sums`, `max_logits`, "
             "and `temporary_output` for the sliding-window path."
         )
-    # ── small-block (block_size 16/64) → tile kernel ──
-    # Key cache shape is [num_blocks, num_kv_heads, head_size // 16, block_size, 16].
-    block_size = key_cache.shape[-2]
-    if block_size in _PA_DECODE_PS_SMALL_BLOCK_SIZES or sliding_window > 0:
+    if sliding_window > 0:
         eqgs = query_length * query_group_size
         if exp_sums is None:
             exp_sums = torch.zeros(
@@ -453,48 +513,6 @@ def pa_decode_ps_launch(
             s,
         )
         return "ps_sw_partitioned"
-
-    if block_size in _PA_DECODE_PS_SMALL_BLOCK_SIZES:
-        if block_tables is None:
-            raise ValueError(
-                f"pa_decode_ps_launch: block_size={block_size} requires `block_tables` "
-                "(per-sequence physical block index table)."
-            )
-        if is_graph_capturing:
-            # Buffer sizes must be fixed ahead of capture and stay identical
-            # across every replay, so require the caller to have preallocated
-            # exp_sums/max_logits/temporary_output, exactly as the other PS
-            # paths already require.
-            if exp_sums is None or max_logits is None or temporary_output is None:
-                raise ValueError(
-                    "CUDA graph capture requires preallocated `exp_sums`, `max_logits`, "
-                    "and `temporary_output` for the tile-backed small-block PS path."
-                )
-        # pa_decode_tile requires an exact [num_blocks, num_kv_heads,
-        # block_size] per-token scale shape; callers here may pass an extra
-        # trailing singleton dim (e.g. from a pertoken-quant helper), which
-        # reshape away without changing the strides.
-        if per_token_kv:
-            num_blocks = key_cache.shape[0]
-            key_scale = key_scale.reshape(num_blocks, num_kv_heads, block_size)
-            value_scale = value_scale.reshape(num_blocks, num_kv_heads, block_size)
-        pa_decode_tile(
-            output,
-            query,
-            key_cache,
-            value_cache,
-            block_tables,
-            context_lengths,
-            key_scale,
-            value_scale,
-            softmax_scale=softmax_scale,
-            stream=s,
-            num_partitions=max_context_partition_num,
-            pmax=max_logits,
-            psum=exp_sums,
-            pout=temporary_output,
-        )
-        return "ps_small_block"
 
     if metadata is None:
         if is_graph_capturing:

--- a/kernels/attention/pa_decode_tile.py
+++ b/kernels/attention/pa_decode_tile.py
@@ -187,9 +187,9 @@ def compile_pa_decode_tile(
     def pa_decode_tile_kernel(
         output_ptr: fx.Tensor,  # [num_seqs*query_length, num_q_heads, v_head_dim]  (written directly when NP==1)
         # per-partition partial outputs (combined by the reduce kernel when NP>1):
-        pmax_ptr: fx.Tensor,  # [num_seqs*query_length, num_kv_heads, num_partitions, query_group_size]   row max
-        psum_ptr: fx.Tensor,  # [num_seqs*query_length, num_kv_heads, num_partitions, query_group_size]   row sum
-        pout_ptr: fx.Tensor,  # [num_seqs*query_length, num_kv_heads, num_partitions, query_group_size, v_head_dim] Q_DTYPE, normalized O_p/l_p
+        pmax_ptr: fx.Tensor,  # [num_seqs, num_kv_heads, num_partitions, total_rows] row max
+        psum_ptr: fx.Tensor,  # [num_seqs, num_kv_heads, num_partitions, total_rows] row sum
+        pout_ptr: fx.Tensor,  # [num_seqs, num_kv_heads, num_partitions, total_rows, v_head_dim] normalized O_p/l_p
         query_ptr: fx.Tensor,  # [num_seqs*query_length, num_q_heads, head_dim] -- row = seq*query_length + qi (MTP position)
         key_cache_ptr: fx.Tensor,  # fp8 vector-16 or bf16 vector-8, see module docstring
         value_cache_ptr: fx.Tensor,  # fp8 vector-16 or bf16 vector-8, see module docstring
@@ -1185,6 +1185,9 @@ def pa_decode_tile(
     assert (
         value_cache.dtype == key_cache.dtype
     ), f"key/value cache dtype mismatch: {key_cache.dtype} vs {value_cache.dtype}"
+    assert num_q_heads % num_kv_heads == 0, (
+        f"num_q_heads ({num_q_heads}) must be divisible by " f"num_kv_heads ({num_kv_heads})"
+    )
     assert block_tables.dtype == torch.int32, f"block_tables must be int32, got {block_tables.dtype}"
     assert context_lengths.dtype == torch.int32, f"context_lengths must be int32, got {context_lengths.dtype}"
     query_group_size = num_q_heads // num_kv_heads

--- a/kernels/attention/pa_decode_tile.py
+++ b/kernels/attention/pa_decode_tile.py
@@ -1,25 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
-"""Readable tile-programming reference for paged-attention fp8 decode.
+"""Readable tile-programming reference for paged-attention decode.
 
-K/V are fp8 e4m3 (FNUZ on gfx942, OCP on gfx950) fed straight into
-``mfma_f32_16x16x32_fp8_fp8``; Q (bf16/f16) and the softmax probabilities P are
-quantized to fp8 too. Scales fold out of the matmuls (q/key scale into the QK
-score, value scale + 1/FP8_MAX into the epilogue); softmax max/sum stay f32.
+K/V may be fp8 e4m3 (FNUZ on gfx942, OCP on gfx950), or BF16 on gfx942/gfx950
+in an 8-element vectorized-5D cache layout. The FP8 path uses
+``mfma_f32_16x16x32_fp8_fp8`` with quantized Q/P. The BF16 path keeps Q, K, P,
+and V as BF16 MFMA operands and uses ``mfma_f32_16x16x16bf16_1k``. Both paths
+keep the online-softmax max/sum and MFMA accumulation in f32.
 ``key_scale``/``value_scale`` are either a ``[1]`` per-tensor scalar or a
 ``[num_blocks, num_kv_heads, block_size]`` per-token tensor (chosen by rank).
 
-``block_size`` (16/64) and ``head_dim`` (multiple of 64) are compile-time
-constants. Layouts are logical, not production's preshuffle.
+``block_size`` (16/64), Q/K ``head_dim``, and ``v_head_dim`` (both multiples
+of 64) are compile-time constants. Layouts are logical, not production's
+preshuffle.
 
 * ``query``        [num_seqs, num_q_heads, head_dim]  f16/bf16 (head_dim contiguous)
-* ``key_cache``    [num_blocks, num_kv_heads, head_dim//16, block_size, 16]  fp8
-* ``value_cache``  [num_blocks, num_kv_heads, block_size//16, head_dim, 16] (trans_v)
-                   or [num_blocks, num_kv_heads, head_dim, block_size] (plain), by rank
+* ``key_cache``    [num_blocks, num_kv_heads, head_dim//16, block_size, 16] fp8
+                   or [num_blocks, num_kv_heads, head_dim//8, block_size, 8] bf16
+* ``value_cache``  [num_blocks, num_kv_heads, block_size//16, v_head_dim, 16] fp8
+                   or [num_blocks, num_kv_heads, block_size//8, v_head_dim, 8] bf16
+                   (fp8 also supports [num_blocks, num_kv_heads, v_head_dim, block_size])
 * ``block_tables`` [num_seqs, max_blocks_per_seq]  int32
 * ``context_lengths`` [num_seqs]  int32
-* ``output``       [num_seqs, num_q_heads, head_dim]  same dtype as query
+* ``output``       [num_seqs, num_q_heads, v_head_dim]  same dtype as query
 
 One CTA (4 waves) per (seq, kv_head) runs a flash-style online softmax over
 256-token blocks; the 4 waves split tokens for Q·Kᵀ and head-dim for P·V, with
@@ -47,15 +51,18 @@ from kernels.common.utils import (
 )
 
 MFMA_MNK = 16  # M = N = 16 for the MMA atom; also query rows handled per CTA (padded to 16)
-MFMA_K = 32  # fp8 MFMA contracts K = 32 per instruction (mfma_f32_16x16x32_fp8_fp8)
+FP8_MFMA_K = 32
+BF16_MFMA_K = 16
 WAVE = 64
 LOG2E = 1.4426950408889634
+BF16_KV_SUPPORTED_ARCHS = ("gfx942", "gfx950")
 
 
 @functools.lru_cache(maxsize=None)
 def compile_pa_decode_tile(
     *,
     head_dim: int,
+    v_head_dim: int | None = None,
     query_group_size: int,
     block_size: int,
     num_partitions: int = 1,
@@ -64,19 +71,25 @@ def compile_pa_decode_tile(
     per_token_kv: bool = False,
     query_length: int = 1,
     trans_v: bool = True,
+    bf16_kv: bool = False,
 ):
     """Build the tile-programming PA-decode kernel + launch wrapper.
 
-    ``block_size``, ``head_dim``, and ``query_dtype`` are compile-time
-    constants (lru_cache keys). ``query_length`` (MTP) and ``query_group_size``
-    flatten into ``TOTAL_ROWS = query_length * query_group_size``, tiled into
+    ``block_size``, Q/K ``head_dim``, ``v_head_dim``, and ``query_dtype`` are
+    compile-time constants (lru_cache keys). ``query_length`` (MTP) and
+    ``query_group_size`` flatten into
+    ``TOTAL_ROWS = query_length * query_group_size``, tiled into
     ``M_TILES = ceil(TOTAL_ROWS / 16)`` independent 16-row MFMA tiles; each
     extra M-tile duplicates loop-carried state, so VGPR/LDS/occupancy scale
     roughly linearly with ``M_TILES``.
     """
-    is_gfx950 = "gfx95" in get_rocm_arch()
+    arch = str(get_rocm_arch()).split(":", 1)[0]
+    is_gfx950 = "gfx95" in arch
     FP8 = fx.Float8E4M3FN if is_gfx950 else fx.Float8E4M3FNUZ
     FP8_MAX = 448.0 if is_gfx950 else 240.0  # max representable magnitude of the format above
+
+    if v_head_dim is None:
+        v_head_dim = head_dim
 
     assert head_dim % MFMA_MNK == 0, f"head_dim {head_dim} must be a multiple of {MFMA_MNK}"
     assert block_size in (16, 64), f"pa_decode_tile only supports block_size in (16, 64), got {block_size}"
@@ -85,20 +98,25 @@ def compile_pa_decode_tile(
         "bf16",
     ), f"pa_decode_tile only supports query_dtype in ('f16', 'bf16'), got {query_dtype}"
     Q_DTYPE = fx.BFloat16 if query_dtype == "bf16" else fx.Float16
+    if bf16_kv:
+        if arch not in BF16_KV_SUPPORTED_ARCHS:
+            raise ValueError("BF16 vectorized-5D PA decode requires gfx942 or gfx950; " f"got {arch}")
+        assert query_dtype == "bf16", "BF16 KV MFMA requires a BF16 query"
 
     assert head_dim % 64 == 0, f"pa_decode_tile only supports head_dim that's a multiple of 64, got {head_dim}"
+    assert v_head_dim % 64 == 0, "pa_decode_tile only supports v_head_dim that's a multiple of 64, " f"got {v_head_dim}"
     assert query_length >= 1, f"query_length must be >= 1, got {query_length}"
     # Flattened query-row axis (MTP outer, GQA head inner), tiled into 16-row M-tiles.
     TOTAL_ROWS = query_length * query_group_size
     M_TILES = cdiv(TOTAL_ROWS, MFMA_MNK)
     ROWS_PADDED = M_TILES * MFMA_MNK
-    # PV layout: V=A, P=B -> output [head-dim (row), query-row (col=lane16)],
-    # generalized over head_dim via the VHE_CHUNKS loop.
+    # PV layout: V=A, P=B -> output [V-head-dim (row), query-row (col=lane16)],
+    # generalized over v_head_dim via the VHE_CHUNKS loop.
     NWARP = 4  # 4 waves / CTA
     TOK_PER_WARP = 64  # tokens each warp owns per compute block (matches production KV_COMPUTE_BLOCK)
     TILE_TOK = NWARP * TOK_PER_WARP  # 256 tokens / compute block
     PAGES_PER_CHUNK = TOK_PER_WARP // block_size  # pages spanned by one 64-token warp-chunk: 1 (bs=64) or 4 (bs=16)
-    assert head_dim % (NWARP * MFMA_MNK) == 0, "head_dim must split across the 4 warps for PV"
+    assert v_head_dim % (NWARP * MFMA_MNK) == 0, "v_head_dim must split across the 4 warps for PV"
 
     # head_dim splits into 16-element chunks (QK_CHUNK_ELEMS, one dwordx4 load);
     # RGROUP_QUARTERS of them make a 64-element fetch group, QKHE_LOOP groups total.
@@ -106,7 +124,9 @@ def compile_pa_decode_tile(
     QK_CHUNK_ELEMS = 16
     QKHE_LOOP = head_dim // (RGROUP_QUARTERS * QK_CHUNK_ELEMS)
     assert QKHE_LOOP >= 1, f"head_dim {head_dim} must be at least {RGROUP_QUARTERS * QK_CHUNK_ELEMS}"
-    N_SUBCHUNKS = QKHE_LOOP * (QK_CHUNK_ELEMS // 8)
+    MFMA_K = BF16_MFMA_K if bf16_kv else FP8_MFMA_K
+    MFMA_VALUES_PER_LANE = 4 if bf16_kv else 8
+    N_SUBCHUNKS = QKHE_LOOP * (QK_CHUNK_ELEMS // MFMA_VALUES_PER_LANE)
 
     # Q-quant chunk width: NQCHUNK stays fixed at 16 (tied to `lane16`'s role
     # as the absmax butterfly width); QCHUNK scales with head_dim instead.
@@ -114,7 +134,7 @@ def compile_pa_decode_tile(
     QCHUNK = head_dim // NQCHUNK  # f16 elements per lane's load chunk (8 for head_dim=128, 4 for head_dim=64)
     assert QCHUNK % 4 == 0, f"head_dim {head_dim} must provide a whole number of packed FP8 query words"
 
-    VHE_CHUNKS = head_dim // (NWARP * MFMA_MNK)  # 2 for head_dim=128, 1 for head_dim=64
+    VHE_CHUNKS = v_head_dim // (NWARP * MFMA_MNK)
 
     if softmax_scale is None:
         softmax_scale = 1.0 / (head_dim**0.5)
@@ -123,18 +143,20 @@ def compile_pa_decode_tile(
     BLOCK_THREADS = NWARP * WAVE  # 256
 
     # ── LDS layout (shared across the 4 warps) ──
-    # sQ: fp8[ROWS_PADDED,head_dim] staged+quantized query. sP: fp8[16,TILE_TOK]
-    # quantized probs. sQscale: f32[ROWS_PADDED]. sLmax/sLsum: cross-warp scratch.
+    # sQ/sP use BF16 for the BF16-MFMA path and FP8 for the FP8 path.
+    # sQscale is used only by FP8 query quantization. sLmax/sLsum are
+    # cross-warp softmax scratch.
     # sVPage: V page-index broadcast. sKScale/sVScale/sVScaleMax: per-token K/V
     # scale staging. No sO/sM/sL/sCorr: PV output is register-resident/loop-carried
     # and stored straight to global (V=A/P=B swap).
     f32 = 4
-    sQ_bytes = ROWS_PADDED * head_dim * 1  # fp8
+    QP_ELEM_BYTES = 2 if bf16_kv else 1
+    sQ_bytes = ROWS_PADDED * head_dim * QP_ELEM_BYTES
     sP_off = sQ_bytes
     # +16B row padding breaks a 32-bank LDS conflict on the P-pack writes while
     # keeping the row 16B-aligned for PV's ds_read_b128.
-    SP_ROW_BYTES = TILE_TOK + 16
-    sP_bytes = MFMA_MNK * SP_ROW_BYTES  # fp8, padded rows
+    SP_ROW_BYTES = TILE_TOK * QP_ELEM_BYTES + 16
+    sP_bytes = MFMA_MNK * SP_ROW_BYTES
     sQscale_off = sP_off + sP_bytes
     NWARP_PAD = NWARP + 1  # coprime with 32 banks -> no LDS bank conflict on the cross-warp scratch
     # Phase-split slices sLmax per M-tile so all pass-1 writes share one barrier.
@@ -163,14 +185,14 @@ def compile_pa_decode_tile(
 
     @flyc.kernel(known_block_size=(BLOCK_THREADS, 1, 1))
     def pa_decode_tile_kernel(
-        output_ptr: fx.Tensor,  # [num_seqs*query_length, num_q_heads, head_dim]  (written directly when NP==1)
+        output_ptr: fx.Tensor,  # [num_seqs*query_length, num_q_heads, v_head_dim]  (written directly when NP==1)
         # per-partition partial outputs (combined by the reduce kernel when NP>1):
         pmax_ptr: fx.Tensor,  # [num_seqs*query_length, num_kv_heads, num_partitions, query_group_size]   row max
         psum_ptr: fx.Tensor,  # [num_seqs*query_length, num_kv_heads, num_partitions, query_group_size]   row sum
-        pout_ptr: fx.Tensor,  # [num_seqs*query_length, num_kv_heads, num_partitions, query_group_size, head_dim] Q_DTYPE, normalized O_p/l_p
+        pout_ptr: fx.Tensor,  # [num_seqs*query_length, num_kv_heads, num_partitions, query_group_size, v_head_dim] Q_DTYPE, normalized O_p/l_p
         query_ptr: fx.Tensor,  # [num_seqs*query_length, num_q_heads, head_dim] -- row = seq*query_length + qi (MTP position)
-        key_cache_ptr: fx.Tensor,  # [num_blocks, num_kv_heads, head_dim//16, block_size, 16] (blocked, see module docstring)
-        value_cache_ptr: fx.Tensor,  # [num_blocks, num_kv_heads, block_size//16, head_dim, 16] (blocked, see module docstring)
+        key_cache_ptr: fx.Tensor,  # fp8 vector-16 or bf16 vector-8, see module docstring
+        value_cache_ptr: fx.Tensor,  # fp8 vector-16 or bf16 vector-8, see module docstring
         block_tables_ptr: fx.Tensor,  # [num_seqs, max_blocks_per_seq]
         context_lengths_ptr: fx.Tensor,  # [num_seqs]
         key_scale_ptr: fx.Tensor,  # [1] per-tensor OR [num_blocks, num_kv_heads, block_size] per-token
@@ -211,6 +233,8 @@ def compile_pa_decode_tile(
 
         _k_load_fp8x16 = _make_flat_loader(key_cache_ptr, FP8, 16, fx.UniversalCopy128b())
         _v_load_fp8x16 = _make_flat_loader(value_cache_ptr, FP8, 16, fx.UniversalCopy128b())
+        _k_load_bf16x8 = _make_flat_loader(key_cache_ptr, fx.BFloat16, 8, fx.UniversalCopy128b())
+        _v_load_bf16x8 = _make_flat_loader(value_cache_ptr, fx.BFloat16, 8, fx.UniversalCopy128b())
         # Per-lane Q chunk (QCHUNK 16-bit elems) fetched in QLOAD_UNIT-wide
         # pieces (128b max per buffer load). Use 64-bit loads when QCHUNK is
         # not divisible by 8: head_dim=192 gives QCHUNK=12 and therefore needs
@@ -228,6 +252,26 @@ def compile_pa_decode_tile(
         def _v_load16(byte_off):
             return _v_load_fp8x16(byte_off).bitcast(fx.Int64)
 
+        def _k_load_bf16x8_words(elem_off):
+            return _k_load_bf16x8(elem_off).bitcast(fx.Int64)
+
+        def _v_load_bf16x8_words(elem_off):
+            return _v_load_bf16x8(elem_off).bitcast(fx.Int64)
+
+        def _bf16_mfma_operand(word):
+            # K16 BF16 MFMA consumes four i16 lanes per thread. Keep the
+            # 64-bit load packed through the loop-carried state and expose the
+            # required vector<4xi16> only at the instruction boundary.
+            return fx.Vector.from_elements([word], dtype=fx.Int64).bitcast(fx.Int16)
+
+        def _mfma(a, b, acc):
+            if const_expr(bf16_kv):
+                return fx.rocdl.mfma_f32_16x16x16bf16_1k(
+                    T.f32x4,
+                    [_bf16_mfma_operand(a), _bf16_mfma_operand(b), acc, 0, 0, 0],
+                )
+            return fx.rocdl.mfma_f32_16x16x32_fp8_fp8(T.f32x4, [a, b, acc, 0, 0, 0])
+
         context_len = fx.Int32(_ctxlen_load(seq)[0])
         # Bound block_tables to its real extent: the last (partial) 256-token tile
         # can index a page past ceil(context/block_size); the bounded resource
@@ -241,7 +285,7 @@ def compile_pa_decode_tile(
         vs_rsrc = buffer_ops.create_buffer_resource(value_scale_ptr, max_size=True)
         # Per-tensor: a single global scale, read once. Per-token: read
         # per-token instead (see _kv_scale_ops/_stage_kv_scale_to_lds below).
-        if const_expr(not per_token_kv):
+        if const_expr(not per_token_kv and not bf16_kv):
             key_scale = fx.Int32(
                 buffer_ops.buffer_load(ks_rsrc, arith.constant(0, type=T.i32), vec_width=1, is_scalar=True)
             ).bitcast(fx.Float32)
@@ -359,12 +403,19 @@ def compile_pa_decode_tile(
             ops = []
             for qkhe in range_constexpr(QKHE_LOOP):
                 he_idx = qkhe * RGROUP_QUARTERS + rgroup
-                base = (((phys * n_kv + kv_h) * QCHUNK + he_idx) * block_size + within_page_tok) * QK_CHUNK_ELEMS
-                w = _k_load16(base)  # head[he_idx*16 : +16] -> k_step 2*qkhe, 2*qkhe+1
+                if const_expr(bf16_kv):
+                    for qkr in range_constexpr(2):
+                        he8_idx = he_idx * 2 + qkr
+                        base = (((phys * n_kv + kv_h) * (head_dim // 8) + he8_idx) * block_size + within_page_tok) * 8
+                        words = _k_load_bf16x8_words(base)
+                        ops.extend([words[0], words[1]])
+                else:
+                    base = (((phys * n_kv + kv_h) * QCHUNK + he_idx) * block_size + within_page_tok) * QK_CHUNK_ELEMS
+                    w = _k_load16(base)  # head[he_idx*16 : +16] -> k_step 2*qkhe, 2*qkhe+1
+                    ops.extend([w[0], w[1]])
                 if const_expr(block_size == 16):
                     # help the scheduler overlap the PAGES_PER_CHUNK gathered loads
                     fx.rocdl.sched_barrier(fx.rocdl.mask_vmem_rd)
-                ops.extend([w[0], w[1]])
             return ops  # N_SUBCHUNKS i64 operands
 
         def _k_ops_flat(tt_i32):
@@ -399,6 +450,9 @@ def compile_pa_decode_tile(
         # below) and v_scale_f is unused (replaced by v_max_scaled).
         if const_expr(per_token_kv):
             scale_qk = fx.Float32(softmax_scale * LOG2E)
+        elif const_expr(bf16_kv):
+            scale_qk = fx.Float32(softmax_scale * LOG2E)
+            v_scale_f = fx.Float32(1.0)
         else:
             scale_qk = fx.Float32(softmax_scale * LOG2E) * fx.Float32(key_scale)
             v_scale_f = fx.Float32(value_scale)
@@ -445,12 +499,12 @@ def compile_pa_decode_tile(
 
         qh_local = warp * 4 + rgroup  # 0..15: this thread's query row within an M-tile
 
-        # Each M-tile quantizes 16 rows of the flattened (MTP position, GQA
-        # head) axis: `flat_idx = m*16 + qh_local`, decomposed as
+        # Each M-tile stages 16 rows of the flattened (MTP position, GQA head)
+        # axis: `flat_idx = m*16 + qh_local`, decomposed as
         # `qi = flat_idx // query_group_size`, `gs_head = flat_idx %
         # query_group_size` (same convention as `_mtp_groups`). No
         # cross-M-tile dependency, so no barriers needed between iterations.
-        def _quant_q_row(m, qi, gs_head, q_row_off):
+        def _stage_q_row(m, qi, gs_head, q_row_off):
             qh0 = kv_h * query_group_size + gs_head
             row_byte0 = ((seq * query_length + qi) * stride_q_row + qh0 * stride_q_head) * 2  # 16-bit float = 2B/elem
             base_elem = (row_byte0 + lane16 * (QCHUNK * 2)) // 2  # byte offset -> element index
@@ -458,49 +512,63 @@ def compile_pa_decode_tile(
             # (a buffer load is 128b max); head_dim=256 splits into 2 pieces.
             q_units = [_q_load_chunk(base_elem + u * QLOAD_UNIT) for u in range_constexpr(N_QLOADS)]
 
-            absmax = fx.absf(q_units[0]).reduce(ReductionOp.MAX).to(fx.Float32)
-            for u in range_constexpr(1, N_QLOADS):
-                absmax = fx.maxnumf(absmax, fx.absf(q_units[u]).reduce(ReductionOp.MAX).to(fx.Float32))
-            for sh in (8, 4, 2, 1):
-                absmax = fx.maxnumf(absmax, dpp_utils.dpp_xor_f32(absmax, sh))
+            if const_expr(bf16_kv):
+                for u in range_constexpr(N_QLOADS):
+                    elem_off = qh_local * head_dim + lane16 * QCHUNK + u * QLOAD_UNIT
+                    _lds_store(q_row_off + elem_off * 2, fx.BFloat16, q_units[u])
+            else:
+                absmax = fx.absf(q_units[0]).reduce(ReductionOp.MAX).to(fx.Float32)
+                for u in range_constexpr(1, N_QLOADS):
+                    absmax = fx.maxnumf(absmax, fx.absf(q_units[u]).reduce(ReductionOp.MAX).to(fx.Float32))
+                for sh in (8, 4, 2, 1):
+                    absmax = fx.maxnumf(absmax, dpp_utils.dpp_xor_f32(absmax, sh))
 
-            q_scale = absmax * fx.Float32(1.0 / FP8_MAX)
-            inv = fx.Float32(rcp_f32(fx.maxnumf(q_scale, fx.Float32(1e-20))))
-            inv_b = fx.Vector.from_elements([inv], dtype=fx.Float32).broadcast_to(QLOAD_UNIT)
+                q_scale = absmax * fx.Float32(1.0 / FP8_MAX)
+                inv = fx.Float32(rcp_f32(fx.maxnumf(q_scale, fx.Float32(1e-20))))
+                inv_b = fx.Vector.from_elements([inv], dtype=fx.Float32).broadcast_to(QLOAD_UNIT)
 
-            for u in range_constexpr(N_QLOADS):
-                q_scaled_unit = q_units[u].to(fx.Float32) * inv_b
-                _st_words(
-                    q_row_off + qh_local * head_dim + lane16 * QCHUNK + u * QLOAD_UNIT,
-                    _f32_to_fp8_words(q_scaled_unit),
-                )
-            if lane16 == 0:
-                # Transposed [qh][m] (not [m][qh]) so the whole M_TILES-wide
-                # row for a fixed qh is contiguous, letting the KV-loop read
-                # it back in one wide load instead of M_TILES separate
-                # narrow ones -- see the read site below.
-                _st1(sQscale_off, qh_local * M_TILES + m, q_scale)
+                for u in range_constexpr(N_QLOADS):
+                    q_scaled_unit = q_units[u].to(fx.Float32) * inv_b
+                    _st_words(
+                        q_row_off + qh_local * head_dim + lane16 * QCHUNK + u * QLOAD_UNIT,
+                        _f32_to_fp8_words(q_scaled_unit),
+                    )
+                if lane16 == 0:
+                    # Transposed [qh][m] (not [m][qh]) so the whole M_TILES-wide
+                    # row for a fixed qh is contiguous, letting the KV-loop read
+                    # it back in one wide load instead of M_TILES separate
+                    # narrow ones -- see the read site below.
+                    _st1(sQscale_off, qh_local * M_TILES + m, q_scale)
 
         for m in range_constexpr(M_TILES):
             flat_idx = m * MFMA_MNK + qh_local
             qi = flat_idx // query_group_size
             gs_head = flat_idx - qi * query_group_size
-            q_row_off = m * MFMA_MNK * head_dim
+            q_row_off = m * MFMA_MNK * head_dim * QP_ELEM_BYTES
             # `flat_idx < TOTAL_ROWS` is statically true for every lane except
             # possibly on the last M-tile (only it can be a partial tile), so
             # skip the runtime branch (and its EXEC-mask overhead) entirely
             # for every other M-tile.
             if const_expr((m + 1) * MFMA_MNK <= TOTAL_ROWS):
-                _quant_q_row(m, qi, gs_head, q_row_off)
+                _stage_q_row(m, qi, gs_head, q_row_off)
             elif flat_idx < TOTAL_ROWS:
-                _quant_q_row(m, qi, gs_head, q_row_off)
+                _stage_q_row(m, qi, gs_head, q_row_off)
             else:
-                _st_words(
-                    q_row_off + qh_local * head_dim + lane16 * QCHUNK,
-                    fx.Vector.filled(QCHUNK // 4, 0, fx.Int32),
-                )
-                if lane16 == 0:
-                    _st1(sQscale_off, qh_local * M_TILES + m, ZERO_F)
+                if const_expr(bf16_kv):
+                    for u in range_constexpr(N_QLOADS):
+                        elem_off = qh_local * head_dim + lane16 * QCHUNK + u * QLOAD_UNIT
+                        _lds_store(
+                            q_row_off + elem_off * 2,
+                            fx.BFloat16,
+                            fx.Vector.filled(QLOAD_UNIT, 0.0, fx.BFloat16),
+                        )
+                else:
+                    _st_words(
+                        q_row_off + qh_local * head_dim + lane16 * QCHUNK,
+                        fx.Vector.filled(QCHUNK // 4, 0, fx.Int32),
+                    )
+                    if lane16 == 0:
+                        _st1(sQscale_off, qh_local * M_TILES + m, ZERO_F)
 
         gpu.barrier()
 
@@ -513,13 +581,17 @@ def compile_pa_decode_tile(
         # permutation as K's `_k_ops`.
         q_ops_all = []
         for m in range_constexpr(M_TILES):
-            q_row_off = m * MFMA_MNK * head_dim
+            q_row_off = m * MFMA_MNK * head_dim * QP_ELEM_BYTES
             for qkhe in range_constexpr(QKHE_LOOP):
                 he_idx = qkhe * RGROUP_QUARTERS + rgroup
-                chunk = _lds_load(q_row_off + lane16 * head_dim + he_idx * QK_CHUNK_ELEMS, fx.Int64, 2)
-                q_ops_all.extend([chunk[0], chunk[1]])
-        # q_ops_all[m*N_SUBCHUNKS+s] for s=0..N_SUBCHUNKS-1, s = qkhe*2+qkr,
-        # = M-tile m's head[he_idx*16+qkr*8 : +8] of qhead=lane16
+                elem_off = lane16 * head_dim + he_idx * QK_CHUNK_ELEMS
+                chunk = _lds_load(
+                    q_row_off + elem_off * QP_ELEM_BYTES,
+                    fx.Int64,
+                    4 if bf16_kv else 2,
+                )
+                for qkr in range_constexpr(4 if bf16_kv else 2):
+                    q_ops_all.append(chunk[qkr])
 
         # QK in NCHUNK chunks of 4 tokens: each chunk yields a f32x4
         # C-fragment, so softmax processes 4 scores at a time (low VGPR peak).
@@ -528,15 +600,15 @@ def compile_pa_decode_tile(
         ]
         # P·V is loop-tiled over head-dim (like production's VHELOOP): each
         # step computes O[:, vh*VHE_SIZE:+VHE_SIZE] instead of materializing
-        # the full [16, head_dim] at once.
-        VHE_SIZE = head_dim // VHE_CHUNKS
+        # the full [16, v_head_dim] at once.
+        VHE_SIZE = v_head_dim // VHE_CHUNKS
         OP_ELEMS = MFMA_MNK * VHE_SIZE // (NWARP * WAVE)  # PV C-fragment elements/lane/chunk (probed = 4)
 
-        # ── raw dwordx4 V load (B operand) ──
-        # One dwordx4 load per (16-token sub-block, head_elem); trans_v only
-        # changes the offset formula. `sub`/`step` walk pages/16-token sub-blocks.
-        NVOPS = TILE_TOK // MFMA_K  # 8 PV k_steps (256 tokens / K=32)
-        STEPS_PER_PAGE = block_size // 16
+        # ── raw V load (B operand) ──
+        # FP8 uses K32 MFMA operands; BF16 uses K16 operands packed as four
+        # i16 values in each i64 word.
+        NVOPS = TILE_TOK // MFMA_K
+        STEPS_PER_PAGE = block_size // (8 if bf16_kv else 16)
 
         def _v_ops(phys_row, vh):
             head_group = ((vh * VHE_SIZE) // 16) + warp
@@ -546,15 +618,22 @@ def compile_pa_decode_tile(
                 phys = fx.Int64(phys_row[sub])
                 for step in range_constexpr(STEPS_PER_PAGE):
                     if const_expr(trans_v):
-                        base = (((phys * n_kv + kv_h) * STEPS_PER_PAGE + step) * head_dim + head_element) * 16
+                        vector_width = 8 if bf16_kv else 16
+                        base = (
+                            ((phys * n_kv + kv_h) * STEPS_PER_PAGE + step) * v_head_dim + head_element
+                        ) * vector_width
                     else:
-                        base = ((phys * n_kv + kv_h) * head_dim + head_element) * block_size + step * 16
-                    w = _v_load16(base)
+                        base = ((phys * n_kv + kv_h) * v_head_dim + head_element) * block_size + step * 16
+                    if const_expr(bf16_kv):
+                        words = _v_load_bf16x8_words(base)
+                        ops.extend([words[0], words[1]])
+                    else:
+                        w = _v_load16(base)
+                        ops.extend([w[0], w[1]])
                     if const_expr(block_size == 16):
                         # help the scheduler overlap the per-page gathered loads (see _k_ops)
                         fx.rocdl.sched_barrier(fx.rocdl.mask_vmem_rd)
-                    ops.extend([w[0], w[1]])
-            if const_expr(head_dim == 64):
+            if const_expr(v_head_dim == 64):
                 fx.rocdl.sched_vmem(len(ops) // 2)
             return ops  # NVOPS i64, the 64-token contiguous run for this head
 
@@ -570,7 +649,7 @@ def compile_pa_decode_tile(
 
         K_SLOT, V_SLOT = 0, 1
         # Per-M-tile loop-carried state after the K/V slots: one output chunk
-        # per VHE_CHUNKS (2 for head_dim=128, 4 for head_dim=256, 1 for 64),
+        # per VHE_CHUNKS (2 for v_head_dim=128, 4 for 256, 1 for 64),
         # then running-max + running-denom.
         STATE_PER_M = VHE_CHUNKS + 2
 
@@ -613,7 +692,7 @@ def compile_pa_decode_tile(
             # q_scale doesn't depend on `m`; read the whole M_TILES-wide row once
             # (contiguous via the transposed [qh][m] sQscale layout).
             q_scale_vec = None
-            if const_expr(M_TILES > 1):
+            if const_expr(M_TILES > 1 and not bf16_kv):
                 q_scale_vec = _lds_load(sQscale_off + lane16 * (M_TILES * f32), fx.Float32, M_TILES)
 
             def _lmax_off_m(m):
@@ -644,12 +723,14 @@ def compile_pa_decode_tile(
                     for a in range_constexpr(NCHUNK):
                         acc = arith.constant_vector(0.0, T.f32x4)
                         for s in range_constexpr(N_SUBCHUNKS):
-                            acc = fx.rocdl.mfma_f32_16x16x32_fp8_fp8(
-                                T.f32x4, [k_cur[a * N_SUBCHUNKS + s], q_ops_all[m * N_SUBCHUNKS + s], acc, 0, 0, 0]
+                            acc = _mfma(
+                                k_cur[a * N_SUBCHUNKS + s],
+                                q_ops_all[m * N_SUBCHUNKS + s],
+                                acc,
                             )
                         frag_Ss.append(fx.Vector(acc))
 
-                    scale = scale_qk * fx.Float32(q_scale_vec[m])
+                    scale = scale_qk if const_expr(bf16_kv) else scale_qk * fx.Float32(q_scale_vec[m])
                     n_valid_tile = (causal_bound[m] - tok0).to(fx.Float32)
                     base_tok_f = fx.Int32(warp * TOK_CHUNK + rgroup * 4).to(fx.Float32)
                     thr = fx.Vector.from_elements([n_valid_tile - base_tok_f], dtype=fx.Float32).broadcast_to(4)
@@ -725,7 +806,7 @@ def compile_pa_decode_tile(
                     safe_max = arith.select(m_new > NEG_INF, m_new, ZERO_F)
                     m_new_b = fx.Vector.from_elements([safe_max], dtype=fx.Float32).broadcast_to(4)
                     ls = fx.Float32(0.0)
-                    words = []
+                    p_chunks = []
                     for a in range_constexpr(NCHUNK):
                         Pa = fx.Vector(exp2_f32_fast(masked_chunks[a] * scale - m_new_b))
                         ls = ls + Pa.reduce(ReductionOp.ADD)
@@ -736,18 +817,29 @@ def compile_pa_decode_tile(
                                 else v_scale_shared[a]
                             )
                             p_scaled = Pa * v_sc * norm_factor_b
+                        elif const_expr(bf16_kv):
+                            p_scaled = Pa
                         else:
                             p_scaled = Pa * fx.Vector.filled(4, FP8_MAX, fx.Float32)
-                        words.append(_f32_to_fp8_words(p_scaled)[0])
+                        if const_expr(bf16_kv):
+                            p_chunks.append(p_scaled.to(fx.BFloat16))
+                        else:
+                            p_chunks.append(_f32_to_fp8_words(p_scaled)[0])
 
-                    p_off0 = sP_off + lane16 * SP_ROW_BYTES + warp * TOK_CHUNK + rgroup * 4
-                    # The NCHUNK P words scatter across the row at stride c16//4
-                    # i32 (the token->fp8-lane interleave the PV ds_read_b128
-                    # expects); one strided store per chunk.
+                    p_off0 = sP_off + lane16 * SP_ROW_BYTES + (warp * TOK_CHUNK + rgroup * 4) * QP_ELEM_BYTES
                     for a in range_constexpr(NCHUNK):
-                        _lds_store(
-                            p_off0 + a * (c16 // 4) * f32, fx.Int32, fx.Vector.from_elements([words[a]], dtype=fx.Int32)
-                        )
+                        if const_expr(bf16_kv):
+                            _lds_store(
+                                p_off0 + a * c16 * QP_ELEM_BYTES,
+                                fx.BFloat16,
+                                p_chunks[a],
+                            )
+                        else:
+                            _lds_store(
+                                p_off0 + a * c16,
+                                fx.Int32,
+                                fx.Vector.from_elements([p_chunks[a]], dtype=fx.Int32),
+                            )
                     for sh in (16, 32):
                         ls = ls + ls.shuffle_xor(sh, WAVE)
                     # PV output is [head-dim, query-row=lane16] after the operand
@@ -760,7 +852,11 @@ def compile_pa_decode_tile(
                     gsum = _ld_lw_row(sLsum_off, lane16).reduce(ReductionOp.ADD)
                     l_new = l_prev * corr_reg + gsum
 
-                    p_ops = _lds_load(sP_off + lane16 * SP_ROW_BYTES + rgroup * 64, fx.Int64, NVOPS)
+                    p_ops = _lds_load(
+                        sP_off + lane16 * SP_ROW_BYTES + rgroup * 64 * QP_ELEM_BYTES,
+                        fx.Int64,
+                        NVOPS,
+                    )
 
                     corr_b = fx.Vector.from_elements([corr_reg], dtype=fx.Float32).broadcast_to(OP_ELEMS)
                     for vh in range_constexpr(VHE_CHUNKS):
@@ -769,7 +865,7 @@ def compile_pa_decode_tile(
                         for s in range_constexpr(NVOPS):
                             # SWAPPED operands (V=A, P=B): output row =
                             # head-dim, output col = query-row=lane16.
-                            acc = fx.rocdl.mfma_f32_16x16x32_fp8_fp8(T.f32x4, [v_vh[s], p_ops[s], acc, 0, 0, 0])
+                            acc = _mfma(v_vh[s], p_ops[s], acc)
                         op = fx.Vector(acc)
                         if const_expr(per_token_kv):
                             op = op * fx.Vector.from_elements([v_max_scaled], dtype=fx.Float32).broadcast_to(OP_ELEMS)
@@ -791,8 +887,10 @@ def compile_pa_decode_tile(
                 for a in range_constexpr(NCHUNK):
                     acc = arith.constant_vector(0.0, T.f32x4)
                     for s in range_constexpr(N_SUBCHUNKS):
-                        acc = fx.rocdl.mfma_f32_16x16x32_fp8_fp8(
-                            T.f32x4, [k_cur[a * N_SUBCHUNKS + s], q_ops_all[s], acc, 0, 0, 0]
+                        acc = _mfma(
+                            k_cur[a * N_SUBCHUNKS + s],
+                            q_ops_all[s],
+                            acc,
                         )
                     frag_Ss.append(fx.Vector(acc))
                 # tt+1 K/V/scale prefetch, issued here to reuse the pass-1 barrier.
@@ -804,7 +902,7 @@ def compile_pa_decode_tile(
                         _stage_kv_scale_to_lds(phys_vec1, _kv_buf_off(tt1))
                 next_state[K_SLOT] = k_next
                 # Softmax: each lane owns one qhead (lane%16); register reduce + shuffle_xor.
-                scale = scale_qk * _ld1(sQscale_off, lane16)  # per-qhead positive score scale
+                scale = scale_qk if const_expr(bf16_kv) else scale_qk * _ld1(sQscale_off, lane16)
                 n_valid_tile = (causal_bound[0] - tok0).to(fx.Float32)
                 base_tok_f = fx.Int32(warp * TOK_CHUNK + rgroup * 4).to(fx.Float32)
                 thr = fx.Vector.from_elements([n_valid_tile - base_tok_f], dtype=fx.Float32).broadcast_to(4)
@@ -858,7 +956,7 @@ def compile_pa_decode_tile(
                 m_new = fx.maxnumf(m_prev, _ld_lw_row(sLmax_off, lane16).reduce(ReductionOp.MAX))
                 m_new_b = fx.Vector.from_elements([m_new], dtype=fx.Float32).broadcast_to(4)
                 ls = fx.Float32(0.0)
-                words = []
+                p_chunks = []
                 zero4_p = fx.Vector.filled(4, 0.0, fx.Float32)
                 for a in range_constexpr(NCHUNK):
                     # re-mask Pa so a fully-masked chunk contributes exactly 0
@@ -872,15 +970,28 @@ def compile_pa_decode_tile(
                             else v_scale_vecs[a]
                         )
                         p_scaled = Pa * v_scale_this * norm_factor_b
+                    elif const_expr(bf16_kv):
+                        p_scaled = Pa
                     else:
                         p_scaled = Pa * fx.Vector.filled(4, FP8_MAX, fx.Float32)
-                    words.append(_f32_to_fp8_words(p_scaled)[0])
-                p_off0 = sP_off + lane16 * SP_ROW_BYTES + warp * TOK_CHUNK + rgroup * 4
-                # NCHUNK P words scatter at stride c16//4 i32 (see phase-split).
+                    if const_expr(bf16_kv):
+                        p_chunks.append(p_scaled.to(fx.BFloat16))
+                    else:
+                        p_chunks.append(_f32_to_fp8_words(p_scaled)[0])
+                p_off0 = sP_off + lane16 * SP_ROW_BYTES + (warp * TOK_CHUNK + rgroup * 4) * QP_ELEM_BYTES
                 for a in range_constexpr(NCHUNK):
-                    _lds_store(
-                        p_off0 + a * (c16 // 4) * f32, fx.Int32, fx.Vector.from_elements([words[a]], dtype=fx.Int32)
-                    )
+                    if const_expr(bf16_kv):
+                        _lds_store(
+                            p_off0 + a * c16 * QP_ELEM_BYTES,
+                            fx.BFloat16,
+                            p_chunks[a],
+                        )
+                    else:
+                        _lds_store(
+                            p_off0 + a * c16,
+                            fx.Int32,
+                            fx.Vector.from_elements([p_chunks[a]], dtype=fx.Int32),
+                        )
                 if const_expr(head_dim == 64):
                     fx.rocdl.sched_dswr(NCHUNK)
                 for sh in (16, 32):
@@ -893,7 +1004,11 @@ def compile_pa_decode_tile(
                 gpu.barrier()
                 gsum = _ld_lw_row(sLsum_off, lane16).reduce(ReductionOp.ADD)
                 l_new = l_prev * corr_reg + gsum
-                p_ops = _lds_load(sP_off + lane16 * SP_ROW_BYTES + rgroup * 64, fx.Int64, NVOPS)
+                p_ops = _lds_load(
+                    sP_off + lane16 * SP_ROW_BYTES + rgroup * 64 * QP_ELEM_BYTES,
+                    fx.Int64,
+                    NVOPS,
+                )
                 corr_b = fx.Vector.from_elements([corr_reg], dtype=fx.Float32).broadcast_to(OP_ELEMS)
                 # Single tile: batch both vh's V loads upfront (no sibling chain
                 # to hide the latency behind).
@@ -902,7 +1017,7 @@ def compile_pa_decode_tile(
                     v_vh = v_vh_batch[vh]
                     acc = arith.constant_vector(0.0, T.f32x4)
                     for s in range_constexpr(NVOPS):
-                        acc = fx.rocdl.mfma_f32_16x16x32_fp8_fp8(T.f32x4, [v_vh[s], p_ops[s], acc, 0, 0, 0])
+                        acc = _mfma(v_vh[s], p_ops[s], acc)
                     op = fx.Vector(acc)
                     if const_expr(per_token_kv):
                         op = op * fx.Vector.from_elements([v_max_scaled], dtype=fx.Float32).broadcast_to(OP_ELEMS)
@@ -919,7 +1034,7 @@ def compile_pa_decode_tile(
             l_row = o_final[_l_slot(m)]
             safe_l = arith.select(l_row > ZERO_F, l_row, fx.Float32(1.0))
             inv_l = fx.Float32(rcp_f32(safe_l))
-            if const_expr(per_token_kv):
+            if const_expr(per_token_kv or bf16_kv):
                 o_scale = inv_l
             else:
                 o_scale = inv_l * (v_scale_f * inv_fp8)
@@ -936,7 +1051,10 @@ def compile_pa_decode_tile(
                 else:
                     base = ((seq * n_kv + kv_h) * NP + part) * TOTAL_ROWS + row
                     pout_div = fx.logical_divide(pout_ptr, fx.make_layout(OP_ELEMS, 1))
-                    pout_chunk = fx.slice(pout_div, (None, base * (head_dim // OP_ELEMS) + sub))
+                    pout_chunk = fx.slice(
+                        pout_div,
+                        (None, base * (v_head_dim // OP_ELEMS) + sub),
+                    )
                     pout_chunk.store(o_norm)
 
             for vh in range_constexpr(VHE_CHUNKS):
@@ -1010,8 +1128,8 @@ def pa_decode_tile(
     value_cache: torch.Tensor,
     block_tables: torch.Tensor,
     context_lengths: torch.Tensor,
-    key_scale: float | torch.Tensor,
-    value_scale: float | torch.Tensor,
+    key_scale: float | torch.Tensor | None,
+    value_scale: float | torch.Tensor | None,
     softmax_scale: float | None = None,
     stream=None,
     *,
@@ -1028,28 +1146,45 @@ def pa_decode_tile(
     """
     num_seqs = context_lengths.shape[0]
     total_q_rows, num_q_heads, head_dim = query.shape
+    value_head_dim = output.shape[-1]
     assert (
         total_q_rows % num_seqs == 0
     ), f"query.shape[0] ({total_q_rows}) must be a multiple of context_lengths.shape[0] ({num_seqs})"
     query_length = total_q_rows // num_seqs
     _, num_kv_heads, num_hgroups, block_size, hgroup_width = key_cache.shape
+    arch = str(get_rocm_arch()).split(":", 1)[0]
+    fp8_dtype = torch.float8_e4m3fn if "gfx95" in arch else torch.float8_e4m3fnuz
+    if key_cache.dtype not in (torch.bfloat16, fp8_dtype):
+        raise ValueError(f"pa_decode_tile supports BF16 or {fp8_dtype} KV cache on {arch}, got {key_cache.dtype}")
+    bf16_kv = key_cache.dtype == torch.bfloat16
 
-    assert num_hgroups == head_dim // 16 and hgroup_width == 16
+    expected_vector = 8 if bf16_kv else 16
+    assert num_hgroups == head_dim // expected_vector and hgroup_width == expected_vector, (
+        f"key_cache shape {tuple(key_cache.shape)} does not match head_dim={head_dim}, "
+        f"vector_width={expected_vector}"
+    )
     assert block_size in (16, 64), f"pa_decode_tile only supports block_size in (16, 64), got {block_size}"
 
     trans_v = value_cache.dim() == 5
     if trans_v:
         _, v_num_kv_heads, v_subblocks, v_head_dim, v_width = value_cache.shape
         assert (
-            v_head_dim == head_dim and v_width == 16 and v_subblocks == block_size // 16
-        ), f"value_cache shape {tuple(value_cache.shape)} doesn't match block_size={block_size}, head_dim={head_dim}"
-    else:
-        _, v_num_kv_heads, v_head_dim, v_block_size = value_cache.shape
-        assert v_head_dim == head_dim and v_block_size == block_size, (
+            v_head_dim == value_head_dim and v_width == expected_vector and v_subblocks == block_size // expected_vector
+        ), (
             f"value_cache shape {tuple(value_cache.shape)} doesn't match "
-            f"block_size={block_size}, head_dim={head_dim}"
+            f"block_size={block_size}, value_head_dim={value_head_dim}"
+        )
+    else:
+        assert not bf16_kv, "BF16 KV requires the vectorized-5D value-cache layout"
+        _, v_num_kv_heads, v_head_dim, v_block_size = value_cache.shape
+        assert v_head_dim == value_head_dim and v_block_size == block_size, (
+            f"value_cache shape {tuple(value_cache.shape)} doesn't match "
+            f"block_size={block_size}, value_head_dim={value_head_dim}"
         )
     assert v_num_kv_heads == num_kv_heads
+    assert (
+        value_cache.dtype == key_cache.dtype
+    ), f"key/value cache dtype mismatch: {key_cache.dtype} vs {value_cache.dtype}"
     assert block_tables.dtype == torch.int32, f"block_tables must be int32, got {block_tables.dtype}"
     assert context_lengths.dtype == torch.int32, f"context_lengths must be int32, got {context_lengths.dtype}"
     query_group_size = num_q_heads // num_kv_heads
@@ -1063,15 +1198,38 @@ def pa_decode_tile(
     assert (
         output.dtype == query.dtype
     ), f"pa_decode_tile requires output.dtype == query.dtype, got {output.dtype} vs {query.dtype}"
+    assert output.shape == (total_q_rows, num_q_heads, value_head_dim), (
+        "pa_decode_tile output must be [total_q_rows, num_q_heads, value_head_dim], " f"got {tuple(output.shape)}"
+    )
 
     assert query.stride(2) == 1, f"pa_decode_tile requires a contiguous head_dim axis, got strides {query.stride()}"
+    assert output.stride(2) == 1, (
+        "pa_decode_tile requires a contiguous value_head_dim axis, " f"got strides {output.stride()}"
+    )
 
     dev = query.device
-    key_scale_t = key_scale if isinstance(key_scale, torch.Tensor) else torch.tensor([float(key_scale)], device=dev)
-    value_scale_t = (
-        value_scale if isinstance(value_scale, torch.Tensor) else torch.tensor([float(value_scale)], device=dev)
-    )
-    per_token_kv = key_scale_t.dim() > 1
+    if bf16_kv:
+        if key_scale is not None or value_scale is not None:
+            raise ValueError("BF16 KV is unscaled; key_scale and value_scale must be None")
+        # The BF16 specialization does not dereference scale pointers. Reuse an
+        # existing tensor so the host path stays allocation- and graph-free.
+        key_scale_t = query
+        value_scale_t = query
+        per_token_kv = False
+    else:
+        if key_scale is None or value_scale is None:
+            raise ValueError("FP8 KV requires key_scale and value_scale")
+        key_scale_t = (
+            key_scale
+            if isinstance(key_scale, torch.Tensor)
+            else torch.tensor([float(key_scale)], dtype=torch.float32, device=dev)
+        )
+        value_scale_t = (
+            value_scale
+            if isinstance(value_scale, torch.Tensor)
+            else torch.tensor([float(value_scale)], dtype=torch.float32, device=dev)
+        )
+        per_token_kv = key_scale_t.dim() > 1
     if per_token_kv:
         assert value_scale_t.dim() > 1, "value_scale must also be per-token (dim>1) when key_scale is per-token"
         assert (
@@ -1086,12 +1244,13 @@ def pa_decode_tile(
     else:
         stride_ks_block = 0
         stride_ks_head = 0
-    assert (
-        key_scale_t.dtype == torch.float32 and key_scale_t.device == dev
-    ), f"key_scale tensor must be float32 on {dev}, got {key_scale_t.dtype} on {key_scale_t.device}"
-    assert (
-        value_scale_t.dtype == torch.float32 and value_scale_t.device == dev
-    ), f"value_scale tensor must be float32 on {dev}, got {value_scale_t.dtype} on {value_scale_t.device}"
+    if not bf16_kv:
+        assert (
+            key_scale_t.dtype == torch.float32 and key_scale_t.device == dev
+        ), f"key_scale tensor must be float32 on {dev}, got {key_scale_t.dtype} on {key_scale_t.device}"
+        assert (
+            value_scale_t.dtype == torch.float32 and value_scale_t.device == dev
+        ), f"value_scale tensor must be float32 on {dev}, got {value_scale_t.dtype} on {value_scale_t.device}"
 
     if not num_partitions:
         from kernels.attention.pa_decode_fp8 import KV_COMPUTE_BLOCK, get_recommended_splits
@@ -1105,6 +1264,7 @@ def pa_decode_tile(
 
     compiled = compile_pa_decode_tile(
         head_dim=head_dim,
+        v_head_dim=value_head_dim,
         query_group_size=query_group_size,
         block_size=int(block_size),
         num_partitions=num_partitions,
@@ -1113,6 +1273,7 @@ def pa_decode_tile(
         per_token_kv=per_token_kv,
         query_length=query_length,
         trans_v=trans_v,
+        bf16_kv=bf16_kv,
     )
     from kernels.attention.pa_decode_fp8 import _is_current_stream_capturing
 
@@ -1137,14 +1298,21 @@ def pa_decode_tile(
                 )
             pmax = torch.empty(*expected_scalar_shape, dtype=torch.float32, device=dev)
             psum = torch.empty(*expected_scalar_shape, dtype=torch.float32, device=dev)
-            pout = torch.empty(*expected_scalar_shape, head_dim, dtype=output.dtype, device=dev)
+            pout = torch.empty(
+                *expected_scalar_shape,
+                value_head_dim,
+                dtype=output.dtype,
+                device=dev,
+            )
         else:
             assert pmax.shape == expected_scalar_shape, f"pmax shape {tuple(pmax.shape)} != {expected_scalar_shape}"
             assert psum.shape == expected_scalar_shape, f"psum shape {tuple(psum.shape)} != {expected_scalar_shape}"
             assert pout.shape == (
                 *expected_scalar_shape,
-                head_dim,
-            ), f"pout shape {tuple(pout.shape)} != {(*expected_scalar_shape, head_dim)}"
+                value_head_dim,
+            ), (
+                f"pout shape {tuple(pout.shape)} != " f"{(*expected_scalar_shape, value_head_dim)}"
+            )
     s = stream or torch.cuda.current_stream()
 
     _run_compiled(
@@ -1177,7 +1345,7 @@ def pa_decode_tile(
             max_context_partition_num=num_partitions,
             query_seq_len=query_length,
             query_group_size=query_group_size,
-            head_size=head_dim,
+            head_size=value_head_dim,
             output_dtype_str=_get_output_dtype_str(output),
             logits_dtype_str=_get_output_dtype_str(pout),
         )

--- a/kernels/attention/pa_decode_tile.py
+++ b/kernels/attention/pa_decode_tile.py
@@ -71,13 +71,13 @@ def compile_pa_decode_tile(
     per_token_kv: bool = False,
     query_length: int = 1,
     trans_v: bool = True,
-    bf16_kv: bool = False,
+    kv_dtype: str = "fp8",
 ):
     """Build the tile-programming PA-decode kernel + launch wrapper.
 
-    ``block_size``, Q/K ``head_dim``, ``v_head_dim``, and ``query_dtype`` are
-    compile-time constants (lru_cache keys). ``query_length`` (MTP) and
-    ``query_group_size`` flatten into
+    ``block_size``, Q/K ``head_dim``, ``v_head_dim``, ``query_dtype``, and
+    ``kv_dtype`` are compile-time constants (lru_cache keys). ``query_length``
+    (MTP) and ``query_group_size`` flatten into
     ``TOTAL_ROWS = query_length * query_group_size``, tiled into
     ``M_TILES = ceil(TOTAL_ROWS / 16)`` independent 16-row MFMA tiles; each
     extra M-tile duplicates loop-carried state, so VGPR/LDS/occupancy scale
@@ -85,6 +85,9 @@ def compile_pa_decode_tile(
     """
     arch = str(get_rocm_arch()).split(":", 1)[0]
     is_gfx950 = "gfx95" in arch
+    if kv_dtype not in ("fp8", "bf16"):
+        raise ValueError(f"pa_decode_tile only supports kv_dtype in ('fp8', 'bf16'), got {kv_dtype!r}")
+    is_bf16_kv = kv_dtype == "bf16"
     FP8 = fx.Float8E4M3FN if is_gfx950 else fx.Float8E4M3FNUZ
     FP8_MAX = 448.0 if is_gfx950 else 240.0  # max representable magnitude of the format above
 
@@ -98,7 +101,7 @@ def compile_pa_decode_tile(
         "bf16",
     ), f"pa_decode_tile only supports query_dtype in ('f16', 'bf16'), got {query_dtype}"
     Q_DTYPE = fx.BFloat16 if query_dtype == "bf16" else fx.Float16
-    if bf16_kv:
+    if is_bf16_kv:
         if arch not in BF16_KV_SUPPORTED_ARCHS:
             raise ValueError("BF16 vectorized-5D PA decode requires gfx942 or gfx950; " f"got {arch}")
         assert query_dtype == "bf16", "BF16 KV MFMA requires a BF16 query"
@@ -124,8 +127,8 @@ def compile_pa_decode_tile(
     QK_CHUNK_ELEMS = 16
     QKHE_LOOP = head_dim // (RGROUP_QUARTERS * QK_CHUNK_ELEMS)
     assert QKHE_LOOP >= 1, f"head_dim {head_dim} must be at least {RGROUP_QUARTERS * QK_CHUNK_ELEMS}"
-    MFMA_K = BF16_MFMA_K if bf16_kv else FP8_MFMA_K
-    MFMA_VALUES_PER_LANE = 4 if bf16_kv else 8
+    MFMA_K = BF16_MFMA_K if is_bf16_kv else FP8_MFMA_K
+    MFMA_VALUES_PER_LANE = 4 if is_bf16_kv else 8
     N_SUBCHUNKS = QKHE_LOOP * (QK_CHUNK_ELEMS // MFMA_VALUES_PER_LANE)
 
     # Q-quant chunk width: NQCHUNK stays fixed at 16 (tied to `lane16`'s role
@@ -150,7 +153,7 @@ def compile_pa_decode_tile(
     # scale staging. No sO/sM/sL/sCorr: PV output is register-resident/loop-carried
     # and stored straight to global (V=A/P=B swap).
     f32 = 4
-    QP_ELEM_BYTES = 2 if bf16_kv else 1
+    QP_ELEM_BYTES = 2 if is_bf16_kv else 1
     sQ_bytes = ROWS_PADDED * head_dim * QP_ELEM_BYTES
     sP_off = sQ_bytes
     # +16B row padding breaks a 32-bank LDS conflict on the P-pack writes while
@@ -265,7 +268,7 @@ def compile_pa_decode_tile(
             return fx.Vector.from_elements([word], dtype=fx.Int64).bitcast(fx.Int16)
 
         def _mfma(a, b, acc):
-            if const_expr(bf16_kv):
+            if const_expr(is_bf16_kv):
                 return fx.rocdl.mfma_f32_16x16x16bf16_1k(
                     T.f32x4,
                     [_bf16_mfma_operand(a), _bf16_mfma_operand(b), acc, 0, 0, 0],
@@ -285,7 +288,7 @@ def compile_pa_decode_tile(
         vs_rsrc = buffer_ops.create_buffer_resource(value_scale_ptr, max_size=True)
         # Per-tensor: a single global scale, read once. Per-token: read
         # per-token instead (see _kv_scale_ops/_stage_kv_scale_to_lds below).
-        if const_expr(not per_token_kv and not bf16_kv):
+        if const_expr(not per_token_kv and not is_bf16_kv):
             key_scale = fx.Int32(
                 buffer_ops.buffer_load(ks_rsrc, arith.constant(0, type=T.i32), vec_width=1, is_scalar=True)
             ).bitcast(fx.Float32)
@@ -403,7 +406,7 @@ def compile_pa_decode_tile(
             ops = []
             for qkhe in range_constexpr(QKHE_LOOP):
                 he_idx = qkhe * RGROUP_QUARTERS + rgroup
-                if const_expr(bf16_kv):
+                if const_expr(is_bf16_kv):
                     for qkr in range_constexpr(2):
                         he8_idx = he_idx * 2 + qkr
                         base = (((phys * n_kv + kv_h) * (head_dim // 8) + he8_idx) * block_size + within_page_tok) * 8
@@ -450,7 +453,7 @@ def compile_pa_decode_tile(
         # below) and v_scale_f is unused (replaced by v_max_scaled).
         if const_expr(per_token_kv):
             scale_qk = fx.Float32(softmax_scale * LOG2E)
-        elif const_expr(bf16_kv):
+        elif const_expr(is_bf16_kv):
             scale_qk = fx.Float32(softmax_scale * LOG2E)
             v_scale_f = fx.Float32(1.0)
         else:
@@ -512,7 +515,7 @@ def compile_pa_decode_tile(
             # (a buffer load is 128b max); head_dim=256 splits into 2 pieces.
             q_units = [_q_load_chunk(base_elem + u * QLOAD_UNIT) for u in range_constexpr(N_QLOADS)]
 
-            if const_expr(bf16_kv):
+            if const_expr(is_bf16_kv):
                 for u in range_constexpr(N_QLOADS):
                     elem_off = qh_local * head_dim + lane16 * QCHUNK + u * QLOAD_UNIT
                     _lds_store(q_row_off + elem_off * 2, fx.BFloat16, q_units[u])
@@ -554,7 +557,7 @@ def compile_pa_decode_tile(
             elif flat_idx < TOTAL_ROWS:
                 _stage_q_row(m, qi, gs_head, q_row_off)
             else:
-                if const_expr(bf16_kv):
+                if const_expr(is_bf16_kv):
                     for u in range_constexpr(N_QLOADS):
                         elem_off = qh_local * head_dim + lane16 * QCHUNK + u * QLOAD_UNIT
                         _lds_store(
@@ -588,9 +591,9 @@ def compile_pa_decode_tile(
                 chunk = _lds_load(
                     q_row_off + elem_off * QP_ELEM_BYTES,
                     fx.Int64,
-                    4 if bf16_kv else 2,
+                    4 if is_bf16_kv else 2,
                 )
-                for qkr in range_constexpr(4 if bf16_kv else 2):
+                for qkr in range_constexpr(4 if is_bf16_kv else 2):
                     q_ops_all.append(chunk[qkr])
 
         # QK in NCHUNK chunks of 4 tokens: each chunk yields a f32x4
@@ -608,7 +611,7 @@ def compile_pa_decode_tile(
         # FP8 uses K32 MFMA operands; BF16 uses K16 operands packed as four
         # i16 values in each i64 word.
         NVOPS = TILE_TOK // MFMA_K
-        STEPS_PER_PAGE = block_size // (8 if bf16_kv else 16)
+        STEPS_PER_PAGE = block_size // (8 if is_bf16_kv else 16)
 
         def _v_ops(phys_row, vh):
             head_group = ((vh * VHE_SIZE) // 16) + warp
@@ -618,13 +621,13 @@ def compile_pa_decode_tile(
                 phys = fx.Int64(phys_row[sub])
                 for step in range_constexpr(STEPS_PER_PAGE):
                     if const_expr(trans_v):
-                        vector_width = 8 if bf16_kv else 16
+                        vector_width = 8 if is_bf16_kv else 16
                         base = (
                             ((phys * n_kv + kv_h) * STEPS_PER_PAGE + step) * v_head_dim + head_element
                         ) * vector_width
                     else:
                         base = ((phys * n_kv + kv_h) * v_head_dim + head_element) * block_size + step * 16
-                    if const_expr(bf16_kv):
+                    if const_expr(is_bf16_kv):
                         words = _v_load_bf16x8_words(base)
                         ops.extend([words[0], words[1]])
                     else:
@@ -692,7 +695,7 @@ def compile_pa_decode_tile(
             # q_scale doesn't depend on `m`; read the whole M_TILES-wide row once
             # (contiguous via the transposed [qh][m] sQscale layout).
             q_scale_vec = None
-            if const_expr(M_TILES > 1 and not bf16_kv):
+            if const_expr(M_TILES > 1 and not is_bf16_kv):
                 q_scale_vec = _lds_load(sQscale_off + lane16 * (M_TILES * f32), fx.Float32, M_TILES)
 
             def _lmax_off_m(m):
@@ -730,7 +733,7 @@ def compile_pa_decode_tile(
                             )
                         frag_Ss.append(fx.Vector(acc))
 
-                    scale = scale_qk if const_expr(bf16_kv) else scale_qk * fx.Float32(q_scale_vec[m])
+                    scale = scale_qk if const_expr(is_bf16_kv) else scale_qk * fx.Float32(q_scale_vec[m])
                     n_valid_tile = (causal_bound[m] - tok0).to(fx.Float32)
                     base_tok_f = fx.Int32(warp * TOK_CHUNK + rgroup * 4).to(fx.Float32)
                     thr = fx.Vector.from_elements([n_valid_tile - base_tok_f], dtype=fx.Float32).broadcast_to(4)
@@ -817,18 +820,18 @@ def compile_pa_decode_tile(
                                 else v_scale_shared[a]
                             )
                             p_scaled = Pa * v_sc * norm_factor_b
-                        elif const_expr(bf16_kv):
+                        elif const_expr(is_bf16_kv):
                             p_scaled = Pa
                         else:
                             p_scaled = Pa * fx.Vector.filled(4, FP8_MAX, fx.Float32)
-                        if const_expr(bf16_kv):
+                        if const_expr(is_bf16_kv):
                             p_chunks.append(p_scaled.to(fx.BFloat16))
                         else:
                             p_chunks.append(_f32_to_fp8_words(p_scaled)[0])
 
                     p_off0 = sP_off + lane16 * SP_ROW_BYTES + (warp * TOK_CHUNK + rgroup * 4) * QP_ELEM_BYTES
                     for a in range_constexpr(NCHUNK):
-                        if const_expr(bf16_kv):
+                        if const_expr(is_bf16_kv):
                             _lds_store(
                                 p_off0 + a * c16 * QP_ELEM_BYTES,
                                 fx.BFloat16,
@@ -902,7 +905,7 @@ def compile_pa_decode_tile(
                         _stage_kv_scale_to_lds(phys_vec1, _kv_buf_off(tt1))
                 next_state[K_SLOT] = k_next
                 # Softmax: each lane owns one qhead (lane%16); register reduce + shuffle_xor.
-                scale = scale_qk if const_expr(bf16_kv) else scale_qk * _ld1(sQscale_off, lane16)
+                scale = scale_qk if const_expr(is_bf16_kv) else scale_qk * _ld1(sQscale_off, lane16)
                 n_valid_tile = (causal_bound[0] - tok0).to(fx.Float32)
                 base_tok_f = fx.Int32(warp * TOK_CHUNK + rgroup * 4).to(fx.Float32)
                 thr = fx.Vector.from_elements([n_valid_tile - base_tok_f], dtype=fx.Float32).broadcast_to(4)
@@ -970,17 +973,17 @@ def compile_pa_decode_tile(
                             else v_scale_vecs[a]
                         )
                         p_scaled = Pa * v_scale_this * norm_factor_b
-                    elif const_expr(bf16_kv):
+                    elif const_expr(is_bf16_kv):
                         p_scaled = Pa
                     else:
                         p_scaled = Pa * fx.Vector.filled(4, FP8_MAX, fx.Float32)
-                    if const_expr(bf16_kv):
+                    if const_expr(is_bf16_kv):
                         p_chunks.append(p_scaled.to(fx.BFloat16))
                     else:
                         p_chunks.append(_f32_to_fp8_words(p_scaled)[0])
                 p_off0 = sP_off + lane16 * SP_ROW_BYTES + (warp * TOK_CHUNK + rgroup * 4) * QP_ELEM_BYTES
                 for a in range_constexpr(NCHUNK):
-                    if const_expr(bf16_kv):
+                    if const_expr(is_bf16_kv):
                         _lds_store(
                             p_off0 + a * c16 * QP_ELEM_BYTES,
                             fx.BFloat16,
@@ -1034,7 +1037,7 @@ def compile_pa_decode_tile(
             l_row = o_final[_l_slot(m)]
             safe_l = arith.select(l_row > ZERO_F, l_row, fx.Float32(1.0))
             inv_l = fx.Float32(rcp_f32(safe_l))
-            if const_expr(per_token_kv or bf16_kv):
+            if const_expr(per_token_kv or is_bf16_kv):
                 o_scale = inv_l
             else:
                 o_scale = inv_l * (v_scale_f * inv_fp8)
@@ -1156,9 +1159,10 @@ def pa_decode_tile(
     fp8_dtype = torch.float8_e4m3fn if "gfx95" in arch else torch.float8_e4m3fnuz
     if key_cache.dtype not in (torch.bfloat16, fp8_dtype):
         raise ValueError(f"pa_decode_tile supports BF16 or {fp8_dtype} KV cache on {arch}, got {key_cache.dtype}")
-    bf16_kv = key_cache.dtype == torch.bfloat16
+    is_bf16_kv = key_cache.dtype == torch.bfloat16
+    kv_dtype = "bf16" if is_bf16_kv else "fp8"
 
-    expected_vector = 8 if bf16_kv else 16
+    expected_vector = 8 if is_bf16_kv else 16
     assert num_hgroups == head_dim // expected_vector and hgroup_width == expected_vector, (
         f"key_cache shape {tuple(key_cache.shape)} does not match head_dim={head_dim}, "
         f"vector_width={expected_vector}"
@@ -1175,7 +1179,7 @@ def pa_decode_tile(
             f"block_size={block_size}, value_head_dim={value_head_dim}"
         )
     else:
-        assert not bf16_kv, "BF16 KV requires the vectorized-5D value-cache layout"
+        assert not is_bf16_kv, "BF16 KV requires the vectorized-5D value-cache layout"
         _, v_num_kv_heads, v_head_dim, v_block_size = value_cache.shape
         assert v_head_dim == value_head_dim and v_block_size == block_size, (
             f"value_cache shape {tuple(value_cache.shape)} doesn't match "
@@ -1211,7 +1215,7 @@ def pa_decode_tile(
     )
 
     dev = query.device
-    if bf16_kv:
+    if is_bf16_kv:
         if key_scale is not None or value_scale is not None:
             raise ValueError("BF16 KV is unscaled; key_scale and value_scale must be None")
         # The BF16 specialization does not dereference scale pointers. Reuse an
@@ -1247,7 +1251,7 @@ def pa_decode_tile(
     else:
         stride_ks_block = 0
         stride_ks_head = 0
-    if not bf16_kv:
+    if not is_bf16_kv:
         assert (
             key_scale_t.dtype == torch.float32 and key_scale_t.device == dev
         ), f"key_scale tensor must be float32 on {dev}, got {key_scale_t.dtype} on {key_scale_t.device}"
@@ -1276,7 +1280,7 @@ def pa_decode_tile(
         per_token_kv=per_token_kv,
         query_length=query_length,
         trans_v=trans_v,
-        bf16_kv=bf16_kv,
+        kv_dtype=kv_dtype,
     )
     from kernels.attention.pa_decode_fp8 import _is_current_stream_capturing
 

--- a/tests/kernels/test_pa.py
+++ b/tests/kernels/test_pa.py
@@ -1149,6 +1149,11 @@ def test_normal_accuracy(
 @pytest.mark.parametrize("context_length", [1027])
 @pytest.mark.parametrize("batch_size", [2])
 @pytest.mark.parametrize("block_size", [64])
+@pytest.mark.parametrize(
+    "entrypoint",
+    ["tile", "ps-allocate", "ps-preallocated"],
+    ids=["direct", "ps-allocate", "ps-preallocated"],
+)
 def test_tile_pa_vectorized_5d_matches_torch(
     compute_type: str,
     query_length: int,
@@ -1159,6 +1164,7 @@ def test_tile_pa_vectorized_5d_matches_torch(
     context_length: int,
     batch_size: int,
     block_size: int,
+    entrypoint: str,
 ) -> None:
     from kernels.attention.pa_decode_tile import pa_decode_tile
 
@@ -1241,26 +1247,170 @@ def test_tile_pa_vectorized_5d_matches_torch(
         dtype=query.dtype,
         device=device,
     )
-    pa_decode_tile(
-        output=actual,
-        query=query,
-        key_cache=key_cache,
-        value_cache=shuffle_value_cache_layout(value_cache),
-        block_tables=block_tables,
-        context_lengths=context_lengths,
-        key_scale=key_scale,
-        value_scale=value_scale,
-        softmax_scale=head_size**-0.5,
-        num_partitions=num_partitions,
-        pmax=torch.empty(partial_shape, dtype=torch.float32, device=device),
-        psum=torch.empty(partial_shape, dtype=torch.float32, device=device),
-        pout=torch.empty((*partial_shape, value_head_size), dtype=query.dtype, device=device),
-    )
+    pmax = torch.empty(partial_shape, dtype=torch.float32, device=device)
+    psum = torch.empty(partial_shape, dtype=torch.float32, device=device)
+    pout = torch.empty((*partial_shape, value_head_size), dtype=query.dtype, device=device)
+    value_cache = shuffle_value_cache_layout(value_cache)
+    if entrypoint == "direct":
+        pa_decode_tile(
+            output=actual,
+            query=query,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            block_tables=block_tables,
+            context_lengths=context_lengths,
+            key_scale=key_scale,
+            value_scale=value_scale,
+            softmax_scale=head_size**-0.5,
+            num_partitions=num_partitions,
+            pmax=pmax,
+            psum=psum,
+            pout=pout,
+        )
+    else:
+        if not HAS_FLYDSL_PS:
+            pytest.skip("FlyDSL `pa_decode_ps_launch` is not available")
+        kv_page_indices = block_tables.flatten()
+        kv_indptr = torch.arange(
+            0,
+            (batch_size + 1) * blocks_per_sequence,
+            blocks_per_sequence,
+            dtype=torch.int32,
+            device=device,
+        )
+
+        def launch_ps():
+            return flydsl_ps_launch(
+                output=actual,
+                query=query,
+                key_cache=key_cache,
+                value_cache=value_cache,
+                context_lengths=context_lengths,
+                kv_page_indices=kv_page_indices,
+                kv_indptr=kv_indptr,
+                softmax_scale=head_size**-0.5,
+                key_scale=key_scale,
+                value_scale=value_scale,
+                block_tables=block_tables,
+                max_context_partition_num=num_partitions,
+                exp_sums=psum if entrypoint == "ps-preallocated" else None,
+                max_logits=pmax if entrypoint == "ps-preallocated" else None,
+                temporary_output=pout if entrypoint == "ps-preallocated" else None,
+            )
+
+        path = launch_ps()
+        assert path == "ps_small_block"
+        if entrypoint == "ps-preallocated" and compute_type == "bf16" and query_length == 4 and value_head_size == 128:
+            capture_stream = torch.cuda.Stream()
+            capture_stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(capture_stream):
+                launch_ps()
+            torch.cuda.current_stream().wait_stream(capture_stream)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=capture_stream):
+                launch_ps()
+            graph.replay()
     torch.cuda.synchronize()
 
     tolerance = 2.0e-2 if compute_type == "fp8" else 5.0e-3
     assert bool(torch.isfinite(actual).all().item())
     torch.testing.assert_close(actual, expected, rtol=tolerance, atol=tolerance)
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@_requires_tile_pa
+@pytest.mark.parametrize(
+    ("compute_type", "block_size", "sliding_window"),
+    [
+        pytest.param("bf16", 1024, 0, id="bf16-page1024"),
+        pytest.param("fp8", 64, 128, id="asymmetric-fp8-sliding-window"),
+    ],
+)
+def test_pa_decode_ps_rejects_unsupported_bf16_asymmetric_paths(
+    compute_type: str, block_size: int, sliding_window: int
+) -> None:
+    if not HAS_FLYDSL_PS:
+        pytest.skip("FlyDSL `pa_decode_ps_launch` is not available")
+
+    device = torch.device("cuda:0")
+    head_size = 192
+    value_head_size = 128
+    num_query_heads = 16
+    num_kv_heads = 1
+    cache_dtype = dtypes.d_dtypes[compute_type]
+    vector_width = 8 if compute_type == "bf16" else 16
+    query = torch.empty(1, num_query_heads, head_size, dtype=torch.bfloat16, device=device)
+    output = torch.empty(1, num_query_heads, value_head_size, dtype=query.dtype, device=device)
+    key_cache = torch.empty(
+        1,
+        num_kv_heads,
+        head_size // vector_width,
+        block_size,
+        vector_width,
+        dtype=cache_dtype,
+        device=device,
+    )
+    value_cache = torch.empty(
+        1,
+        num_kv_heads,
+        block_size // vector_width,
+        value_head_size,
+        vector_width,
+        dtype=cache_dtype,
+        device=device,
+    )
+    scale = None
+    if compute_type == "fp8":
+        scale = torch.ones(1, dtype=torch.float32, device=device)
+
+    with pytest.raises(
+        ValueError,
+        match="BF16 KV and asymmetric value dimensions currently require",
+    ):
+        flydsl_ps_launch(
+            output=output,
+            query=query,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            context_lengths=torch.ones(1, dtype=torch.int32, device=device),
+            kv_page_indices=torch.zeros(1, dtype=torch.int32, device=device),
+            kv_indptr=torch.tensor([0, 1], dtype=torch.int32, device=device),
+            softmax_scale=head_size**-0.5,
+            key_scale=scale,
+            value_scale=scale,
+            sliding_window=sliding_window,
+            block_tables=torch.zeros((1, 1), dtype=torch.int32, device=device),
+            max_context_partition_num=1,
+        )
+
+
+@pytest.mark.l2_device
+@pytest.mark.rocm_lower
+@_requires_tile_pa
+def test_pa_decode_ps_rejects_non_divisible_gqa_heads() -> None:
+    if not HAS_FLYDSL_PS:
+        pytest.skip("FlyDSL `pa_decode_ps_launch` is not available")
+
+    device = torch.device("cuda:0")
+    query = torch.empty(1, 3, 192, dtype=torch.bfloat16, device=device)
+    output = torch.empty(1, 3, 128, dtype=query.dtype, device=device)
+    key_cache = torch.empty(1, 2, 24, 64, 8, dtype=torch.bfloat16, device=device)
+    value_cache = torch.empty(1, 2, 8, 128, 8, dtype=torch.bfloat16, device=device)
+
+    with pytest.raises(ValueError, match="must be divisible"):
+        flydsl_ps_launch(
+            output=output,
+            query=query,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            context_lengths=torch.ones(1, dtype=torch.int32, device=device),
+            kv_page_indices=torch.zeros(1, dtype=torch.int32, device=device),
+            kv_indptr=torch.tensor([0, 1], dtype=torch.int32, device=device),
+            softmax_scale=192**-0.5,
+            block_tables=torch.zeros((1, 1), dtype=torch.int32, device=device),
+            max_context_partition_num=1,
+        )
 
 
 @pytest.mark.large_shape

--- a/tests/kernels/test_pa.py
+++ b/tests/kernels/test_pa.py
@@ -128,11 +128,13 @@ def create_kv_cache(
     seed: int = 0,
     device: Optional[str] = "cuda",
     itemsize: int = 1,
+    value_head_size: Optional[int] = None,
 ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
     if cache_dtype == "fp8" and head_size % 16:
         raise ValueError(f"Does not support fp8 key cache with head_size={head_size}")
     torch_dtype = get_kv_cache_torch_dtype(cache_dtype, model_dtype)
     elements_per_vector = 16 // itemsize
+    value_head_size = head_size if value_head_size is None else value_head_size
     key_cache_shape = (
         num_blocks,
         num_heads,
@@ -140,7 +142,7 @@ def create_kv_cache(
         block_size,
         elements_per_vector,
     )
-    value_cache_shape = (num_blocks, num_heads, head_size, block_size)
+    value_cache_shape = (num_blocks, num_heads, value_head_size, block_size)
     key_caches: List[torch.Tensor] = []
     value_caches: List[torch.Tensor] = []
     setup_seed(seed)
@@ -229,15 +231,16 @@ def torch_mha_extend(
     sliding_window=0,
 ) -> torch.Tensor:
     """PyTorch reference implementation of paged attention."""
-    num_blocks, num_heads, head_size, block_size = value_cache.shape
-    softmax_scale = 1.0 / (head_size**0.5)
+    num_blocks, num_heads, value_head_size, block_size = value_cache.shape
+    key_head_size = key_cache.shape[2] * key_cache.shape[4]
+    softmax_scale = 1.0 / (key_head_size**0.5)
 
     output_dtype = query.dtype
     kv_dtype = key_cache.dtype
 
     queries_split = torch.tensor_split(query, query_output_indptr.tolist()[1:])
-    key_cache_flat = key_cache.permute(0, 3, 1, 2, 4).contiguous().view(-1, num_heads, head_size)
-    value_cache_flat = value_cache.permute(0, 3, 1, 2).contiguous().view(-1, num_heads, head_size)
+    key_cache_flat = key_cache.permute(0, 3, 1, 2, 4).contiguous().view(-1, num_heads, key_head_size)
+    value_cache_flat = value_cache.permute(0, 3, 1, 2).contiguous().view(-1, num_heads, value_head_size)
 
     batch_size = query_output_indptr.shape[0] - 1
     outputs = []
@@ -286,7 +289,8 @@ def quantize_kv_cache_symmetric(
     torch.Tensor,
     torch.Tensor,
 ]:
-    num_blocks, num_heads, head_dim, block_size = value_cache.shape
+    num_blocks, num_heads, value_head_dim, block_size = value_cache.shape
+    key_head_dim = key_cache.shape[2] * key_cache.shape[4]
     total_tokens = num_blocks * block_size
     key_cache_reshaped = key_cache.permute(0, 1, 3, 2, 4).reshape(num_blocks, num_heads, block_size, -1).contiguous()
     value_cache_reshaped = value_cache.permute(0, 1, 3, 2).reshape(num_blocks, num_heads, block_size, -1).contiguous()
@@ -298,14 +302,16 @@ def quantize_kv_cache_symmetric(
             num_blocks,
             num_heads,
             block_size,
-            head_dim // elements_per_vector,
+            key_head_dim // elements_per_vector,
             elements_per_vector,
         )
         .permute(0, 1, 3, 2, 4)
         .contiguous()
     )
     quantized_values = (
-        quantized_values.view(num_blocks, num_heads, block_size, head_dim).permute(0, 1, 3, 2).contiguous()
+        quantized_values.view(num_blocks, num_heads, block_size, value_head_dim)
+        .permute(0, 1, 3, 2)
+        .contiguous()
     )
     key_scales_flat = key_scales_original.permute(1, 0, 2, 3).contiguous().view(num_heads, total_tokens)
     value_scales_flat = value_scales_original.permute(1, 0, 2, 3).contiguous().view(num_heads, total_tokens)
@@ -331,7 +337,8 @@ def quantize_kv_cache_per_tensor(
     torch.Tensor,
     torch.Tensor,
 ]:
-    num_blocks, num_heads, head_dim, block_size = value_cache.shape
+    num_blocks, num_heads, _, block_size = value_cache.shape
+    key_head_dim = key_cache.shape[2] * key_cache.shape[4]
     elements_per_vector = 16 // quant_dtype.itemsize
     key_cache_reshaped = key_cache.permute(0, 1, 3, 2, 4).reshape(num_blocks, num_heads, block_size, -1).contiguous()
     key_cache_reshaped = (
@@ -339,7 +346,7 @@ def quantize_kv_cache_per_tensor(
             num_blocks,
             num_heads,
             block_size,
-            head_dim // elements_per_vector,
+            key_head_dim // elements_per_vector,
             elements_per_vector,
         )
         .permute(0, 1, 3, 2, 4)
@@ -1128,36 +1135,36 @@ def test_normal_accuracy(
 @pytest.mark.l2_device
 @pytest.mark.rocm_lower
 @_requires_tile_pa
-@pytest.mark.parametrize("compute_type", ["fp8"])
+@pytest.mark.parametrize(
+    ("compute_type", "query_length", "value_head_size"),
+    [
+        pytest.param("bf16", 1, 128, id="bf16-qlen1-v128"),
+        pytest.param("bf16", 1, 192, id="bf16-qlen1-v192"),
+        pytest.param("bf16", 4, 128, id="bf16-qlen4-v128"),
+        pytest.param("bf16", 4, 192, id="bf16-qlen4-v192"),
+        pytest.param("fp8", 4, 128, id="fp8-qlen4-v128"),
+        pytest.param("fp8", 4, 192, id="fp8-qlen4-v192"),
+    ],
+)
 @pytest.mark.parametrize("num_partitions", [4])
 @pytest.mark.parametrize("head_size", [192])
 @pytest.mark.parametrize("num_heads", [(16, 1)])
-@pytest.mark.parametrize("query_length", [4])
-@pytest.mark.parametrize("quant_mode", ["per_tensor"])
 @pytest.mark.parametrize("context_length", [1027])
 @pytest.mark.parametrize("batch_size", [2])
-@pytest.mark.parametrize("trans_v", [True])
-@pytest.mark.parametrize("kv_varlen", [False])
 @pytest.mark.parametrize("block_size", [64])
-@pytest.mark.parametrize("sliding_window", [0])
-def test_fp8_head_dim_192_matches_torch(
+def test_tile_pa_vectorized_5d_matches_torch(
     compute_type: str,
+    query_length: int,
+    value_head_size: int,
     num_partitions: int,
     head_size: int,
     num_heads: Tuple[int, int],
-    query_length: int,
-    quant_mode: str,
     context_length: int,
     batch_size: int,
-    trans_v: bool,
-    kv_varlen: bool,
     block_size: int,
-    sliding_window: int,
 ) -> None:
     from kernels.attention.pa_decode_tile import pa_decode_tile
 
-    assert quant_mode == "per_tensor"
-    assert not kv_varlen
     num_query_heads, num_kv_heads = num_heads
     blocks_per_sequence = triton.cdiv(context_length, block_size)
     total_blocks = batch_size * blocks_per_sequence
@@ -1182,16 +1189,28 @@ def test_fp8_head_dim_192_matches_torch(
         torch.bfloat16,
         seed=20260821,
         device=str(device),
-        itemsize=1,
+        itemsize=1 if compute_type == "fp8" else cache_dtype.itemsize,
+        value_head_size=value_head_size,
     )
-    (
-        key_cache,
-        key_scale_flat,
-        value_cache,
-        value_scale_flat,
-        key_scale,
-        value_scale,
-    ) = quantize_kv_cache_per_tensor(key_caches[0], value_caches[0], quant_dtype=cache_dtype)
+    key_cache = key_caches[0]
+    value_cache = value_caches[0]
+    key_scale_flat = None
+    value_scale_flat = None
+    key_scale = None
+    value_scale = None
+    if compute_type == "fp8":
+        (
+            key_cache,
+            key_scale_flat,
+            value_cache,
+            value_scale_flat,
+            key_scale,
+            value_scale,
+        ) = quantize_kv_cache_per_tensor(
+            key_cache,
+            value_cache,
+            quant_dtype=cache_dtype,
+        )
     block_tables = torch.arange(total_blocks - 1, -1, -1, dtype=torch.int32, device=device).reshape(
         batch_size, blocks_per_sequence
     )
@@ -1212,25 +1231,41 @@ def test_fp8_head_dim_192_matches_torch(
         query_output_indptr,
         key_scale_flat,
         value_scale_flat,
-        sliding_window=sliding_window,
     )
-    actual = torch.full_like(query, float("nan"))
+    partial_shape = (
+        batch_size,
+        num_kv_heads,
+        num_partitions,
+        query_length * (num_query_heads // num_kv_heads),
+    )
+    actual = torch.full(
+        (batch_size * query_length, num_query_heads, value_head_size),
+        float("nan"),
+        dtype=query.dtype,
+        device=device,
+    )
     pa_decode_tile(
         output=actual,
         query=query,
         key_cache=key_cache,
-        value_cache=shuffle_value_cache_layout(value_cache) if trans_v else value_cache,
+        value_cache=shuffle_value_cache_layout(value_cache),
         block_tables=block_tables,
         context_lengths=context_lengths,
         key_scale=key_scale,
         value_scale=value_scale,
         softmax_scale=head_size**-0.5,
         num_partitions=num_partitions,
+        pmax=torch.empty(partial_shape, dtype=torch.float32, device=device),
+        psum=torch.empty(partial_shape, dtype=torch.float32, device=device),
+        pout=torch.empty(
+            (*partial_shape, value_head_size), dtype=query.dtype, device=device
+        ),
     )
     torch.cuda.synchronize()
 
+    tolerance = 2.0e-2 if compute_type == "fp8" else 5.0e-3
     assert bool(torch.isfinite(actual).all().item())
-    torch.testing.assert_close(actual, expected, rtol=2.0e-2, atol=2.0e-2)
+    torch.testing.assert_close(actual, expected, rtol=tolerance, atol=tolerance)
 
 
 @pytest.mark.large_shape

--- a/tests/kernels/test_pa.py
+++ b/tests/kernels/test_pa.py
@@ -309,9 +309,7 @@ def quantize_kv_cache_symmetric(
         .contiguous()
     )
     quantized_values = (
-        quantized_values.view(num_blocks, num_heads, block_size, value_head_dim)
-        .permute(0, 1, 3, 2)
-        .contiguous()
+        quantized_values.view(num_blocks, num_heads, block_size, value_head_dim).permute(0, 1, 3, 2).contiguous()
     )
     key_scales_flat = key_scales_original.permute(1, 0, 2, 3).contiguous().view(num_heads, total_tokens)
     value_scales_flat = value_scales_original.permute(1, 0, 2, 3).contiguous().view(num_heads, total_tokens)
@@ -1032,8 +1030,7 @@ def run_multi_pa_decode_ps_test(
         sampler = random.Random(1234)
         test_configs = [cfg for cfg in test_configs if sampler.random() < sample_rate]
         print(
-            f"Using random sampling: running {len(test_configs)} out of {total} cases "
-            f"(sample_rate={sample_rate:.2%})"
+            f"Using random sampling: running {len(test_configs)} out of {total} cases (sample_rate={sample_rate:.2%})"
         )
     else:
         print(f"Running all {total} cases")
@@ -1257,9 +1254,7 @@ def test_tile_pa_vectorized_5d_matches_torch(
         num_partitions=num_partitions,
         pmax=torch.empty(partial_shape, dtype=torch.float32, device=device),
         psum=torch.empty(partial_shape, dtype=torch.float32, device=device),
-        pout=torch.empty(
-            (*partial_shape, value_head_size), dtype=query.dtype, device=device
-        ),
+        pout=torch.empty((*partial_shape, value_head_size), dtype=query.dtype, device=device),
     )
     torch.cuda.synchronize()
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Based on https://github.com/ROCm/FlyDSL/pull/1064
Add BF16 vectorized-5D KV support and allow different Q/K and V/output head dimensions in `pa_decode_tile` kernel.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Extend FlyDSL PA kernel to support Models with different K/V head dim with Both FP8 and BF16 support. 
E.g. MiMo-V2.5-Pro with Q/K D192 and V/O D128 does not need to physically pad V to 192. 
The same tile PA path is also useful for native BF16 page-64 KV on gfx942 and gfx950.

- Add a BF16 K16-MFMA specialization for vectorized-5D K/V caches.
- Derive PV accumulation, partial buffers, output stores, and reduction width
  from the physical value dimension.
- Support BF16 Q/K192 with V128/V192 and FP8 Q/K192 with V128.
- Preserve symmetric FP8 behavior and caller-owned graph-safe workspaces.

## Performance (gfx950)

Batch 32, query length 4, 16Q/1KV, Q/K D192, page 64:

| Context | AITER Gluon V192 | FlyDSL V128 | Speedup | FlyDSL V192 | Speedup |
|---:|---:|---:|---:|---:|---:|
| 16K | 0.648544 ms | 0.103483 ms | 6.267x | 0.118604 ms | 5.468x |
| 64K | 2.278582 ms | 0.331712 ms | 6.869x | 0.389114 ms | 5.856x |

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Extend test_pa_decode_tile.py to covers BF16 QL1/QL4 with V128/V192, asymmetric FP8, symmetric FP8 D192, multi-partition reduction.
`python -m pytest -q tests/kernels/test_pa.py`

## Test Result
```
python3 -m pytest -q     tests/kernels/test_pa.py  
===================================================================== test session starts =====================================================================
platform linux -- Python 3.10.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /root/workspace/mimo-opt/flydsl-upstream-prs/pr2-pa-bf16-asym/tests
configfile: pytest.ini
plugins: hypothesis-6.150.2, anyio-4.14.2
collected 2327 items                                                                                                                                          

tests/kernels/test_pa.py .............................................................................................................................. [  5%]
....................................................................................................................................................... [ 11%]
....................................................................................................................................................... [ 18%]
....................................................................................................................................................... [ 24%]
....................................................................................................................................................... [ 31%]
....................................................................................................................................................... [ 37%]
....................................................................................................................................................... [ 44%]
....................................................................................................................................................... [ 50%]
....................................................................................................................................................... [ 57%]
....................................................................................................................................................... [ 63%]
....................................................................................................................................................... [ 70%]
....................................................................................................................................................... [ 76%]
....................................................................................................................................................... [ 83%]
....................................................................................................................................................... [ 89%]
....................................................................................................................................................... [ 96%]
.......................................................................................                                                                 [100%]

====================================================================== warnings summary =======================================================================
../../../../../opt/venv/lib/python3.10/site-packages/Cython/Distutils/old_build_ext.py:15
../../../../../opt/venv/lib/python3.10/site-packages/Cython/Distutils/old_build_ext.py:15
  /opt/venv/lib/python3.10/site-packages/Cython/Distutils/old_build_ext.py:15: DeprecationWarning: dep_util is Deprecated. Use functions from setuptools instead.
    from distutils.dep_util import newer, newer_group

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================== 2327 passed, 2 warnings in 198.96s (0:03:18) =========================================================
```
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
