### PR TITLE
[CI][DO NOT MERGE] Probe: LLVM pin bump on top of #1071

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -297,6 +297,78 @@ jobs:
           docker cp flydsl_mlir_cache:/llvm-project/mlir_install.tgz ./mlir_install.tgz
           test -s ./mlir_install.tgz
 
+      # ---------------------------------------------------------------------
+      # PROBE SCAFFOLDING - PR #1072 only, never for main.
+      #
+      # The baseline entry this PR needs is keyed on main's LLVM inputs, and
+      # nothing has saved it: caches a PR creates are scoped to that PR's merge
+      # ref, so #1071 cannot warm it for anyone else. Only a push to main can.
+      #
+      # Rather than wait for that merge, build the base pin here and save it
+      # under the base key at THIS PR's own scope. First run: miss, build, save,
+      # and the rest of the chain runs against a real base MLIR. Re-run: the
+      # restore hits, exercising the actual cache path end to end.
+      # ---------------------------------------------------------------------
+      - name: Build baseline LLVM (probe scaffolding)
+        if: >-
+          steps.base-pin.outputs.pin_changed == 'true' &&
+          steps.base-mlir-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        timeout-minutes: 45
+        run: |
+          set -ex
+          docker exec -e LLVM_BUILD_PROFILE -e BASE_REPO_NAME -e BASE_COMMIT_SHA flydsl_mlir_cache bash -c '
+            set -e
+            cd /flydsl-test
+            git worktree prune || true
+            rm -rf /tmp/flydsl-ci-base-llvm
+            git fetch "https://github.com/${BASE_REPO_NAME}.git" "${BASE_COMMIT_SHA}" --no-tags --depth=1
+            git worktree add --detach /tmp/flydsl-ci-base-llvm FETCH_HEAD
+            cd /tmp/flydsl-ci-base-llvm
+            mkdir -p /llvm-project-base
+            LLVM_INSTALL_DIR=/llvm-project-base/mlir_install \
+            LLVM_INSTALL_TGZ=/llvm-project-base/mlir_install.tgz \
+              bash scripts/build_llvm.sh
+          '
+          docker cp flydsl_mlir_cache:/llvm-project-base/mlir_install.tgz ./mlir_install_base.tgz
+          test -s ./mlir_install_base.tgz
+          # Drop the second source and build tree NOW: the wheel build below
+          # would otherwise run with both LLVM trees on disk.
+          docker exec flydsl_mlir_cache bash -c "
+            rm -rf /tmp/llvm-project /llvm-project-base
+            cd /flydsl-test && git worktree remove --force /tmp/flydsl-ci-base-llvm 2>/dev/null || true
+            git -C /flydsl-test worktree prune || true
+          " || true
+          df -h / | tail -1
+
+      # actions/cache derives its version from the path list, so the entry has
+      # to be saved under the same name the restore asks for.
+      - name: Stage baseline tarball for save (probe scaffolding)
+        id: probe-stage
+        if: >-
+          steps.base-pin.outputs.pin_changed == 'true' &&
+          steps.base-mlir-cache.outputs.cache-hit != 'true' &&
+          hashFiles('mlir_install_base.tgz') != ''
+        run: |
+          set -euo pipefail
+          mv mlir_install.tgz mlir_install_shared.tgz
+          cp mlir_install_base.tgz mlir_install.tgz
+
+      - name: Save baseline MLIR cache (probe scaffolding)
+        if: steps.probe-stage.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: mlir_install.tgz
+          key: ${{ steps.keys.outputs.base }}
+
+      - name: Restore tarball names (probe scaffolding)
+        if: always() && steps.probe-stage.outcome == 'success'
+        run: |
+          set -euo pipefail
+          rm -f mlir_install.tgz
+          mv mlir_install_shared.tgz mlir_install.tgz
+
       # Checked against the VCSRevision.h the install ships: a wrong-pin baseline
       # is worse than none, since it yields a plausible number nobody questions.
       #

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -143,12 +143,109 @@ jobs:
           ref: ${{ env.GITHUB_COMMIT_SHA }}
           path: flydsl-test
 
+      # A pin bump leaves the base source uncompilable against the PR's MLIR, so
+      # the baseline wheel needs the base commit's own install. Every step gated
+      # on pin_changed is skipped for a PR that leaves the LLVM inputs alone.
+      - name: Resolve base LLVM pin
+        id: base-pin
+        # `run:` blocks are `bash -e`, and nothing decided here is worth failing
+        # prepare-mlir over: with no outputs written, the gated steps skip.
+        continue-on-error: true
+        # Some self-hosted runners rewrite GitHub URLs to a git cache, and this
+        # is the only fetch here that runs on the host, not in the container.
+        env:
+          GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
+          GIT_CONFIG_NOSYSTEM: "1"
+        run: |
+          set -uo pipefail
+          # Self-hosted workspaces are reused; drop what the last run left.
+          rm -rf base-pin
+          rm -f mlir_install_base.tgz
+          mkdir -p base-pin/thirdparty base-pin/scripts
+          if ! git -C flydsl-test fetch "https://github.com/${BASE_REPO_NAME}.git" \
+                 "${BASE_COMMIT_SHA}" --no-tags --depth=1; then
+            echo "Could not fetch base ${BASE_REPO_NAME}@${BASE_COMMIT_SHA}; treating LLVM pin as unchanged."
+            echo "pin_changed=false" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          for f in thirdparty/llvm-build-info.json thirdparty/llvm-rocdl-lld-argv0.patch scripts/build_llvm.sh; do
+            if ! git -C flydsl-test show "FETCH_HEAD:${f}" >"base-pin/${f}"; then
+              echo "Base commit has no ${f}; treating LLVM pin as unchanged."
+              echo "pin_changed=false" >>"${GITHUB_OUTPUT}"
+              exit 0
+            fi
+          done
+          changed=false
+          for f in thirdparty/llvm-build-info.json thirdparty/llvm-rocdl-lld-argv0.patch scripts/build_llvm.sh; do
+            if ! diff -q "flydsl-test/${f}" "base-pin/${f}" >/dev/null; then
+              echo "LLVM input differs from base: ${f}"
+              changed=true
+            fi
+          done
+          # sed, not python3: every other python call here runs in the container
+          # and the runners promise no host interpreter. Scoped to "upstream" so a
+          # second entry carrying its own llvm_hash cannot be picked up.
+          base_hash="$(sed -n '/"upstream"/,/}/ s/.*"llvm_hash"[[:space:]]*:[[:space:]]*"\([0-9a-f]\{40\}\)".*/\1/p' \
+            base-pin/thirdparty/llvm-build-info.json)"
+          if [ -z "${base_hash}" ]; then
+            echo "Could not read the base LLVM hash; treating LLVM pin as unchanged."
+            echo "pin_changed=false" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "pin_changed=${changed}" >>"${GITHUB_OUTPUT}"
+          echo "base_llvm_hash=${base_hash}" >>"${GITHUB_OUTPUT}"
+          echo "Base LLVM pin: ${base_hash}"
+
+      # One script for both keys so they cannot drift; content-derived, which is
+      # what makes the base commit's key computable from the extracted files.
+      - name: Compute MLIR cache keys
+        id: keys
+        run: |
+          set -euo pipefail
+          self_key="$(bash flydsl-test/scripts/ci_mlir_cache_key.sh flydsl-test)"
+          echo "self=${self_key}" >>"${GITHUB_OUTPUT}"
+          echo "Shared MLIR cache key: ${self_key}"
+          if [ "${{ steps.base-pin.outputs.pin_changed }}" = "true" ]; then
+            base_key="$(bash flydsl-test/scripts/ci_mlir_cache_key.sh base-pin)"
+            echo "base=${base_key}" >>"${GITHUB_OUTPUT}"
+            echo "Baseline MLIR cache key: ${base_key}"
+          fi
+
+      # Restored before the shared entry and under the same `path`, then moved
+      # aside: actions/cache derives its version from the path list, so an entry
+      # saved as `mlir_install.tgz` is only findable under that name. No
+      # restore-keys either - a prefix fallback would return an install built
+      # from another pin.
+      #
+      # This is the entry every PR that leaves LLVM alone restores on every run,
+      # so it stays warm. A PR that also changes MLIR_CACHE_VERSION or
+      # LLVM_BUILD_PROFILE misses, since both feed the key from the PR side.
+      - name: Restore baseline MLIR cache
+        id: base-mlir-cache
+        if: steps.base-pin.outputs.pin_changed == 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: mlir_install.tgz
+          key: ${{ steps.keys.outputs.base }}
+
+      - name: Stash baseline MLIR tarball
+        if: steps.base-mlir-cache.outputs.cache-hit == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if [ ! -s mlir_install.tgz ]; then
+            echo "::warning title=Benchmark baseline unavailable::Baseline MLIR cache reported a hit but produced no tarball."
+            rm -f mlir_install.tgz
+            exit 0
+          fi
+          mv mlir_install.tgz mlir_install_base.tgz
+
       - name: Restore shared MLIR cache
         id: mlir-cache
         uses: actions/cache/restore@v4
         with:
           path: mlir_install.tgz
-          key: mlir-install-${{ runner.os }}-${{ runner.arch }}-${{ env.MLIR_CACHE_VERSION }}-${{ env.LLVM_BUILD_PROFILE }}-${{ hashFiles('flydsl-test/thirdparty/llvm-build-info.json', 'flydsl-test/thirdparty/llvm-rocdl-lld-argv0.patch', 'flydsl-test/scripts/build_llvm.sh') }}
+          key: ${{ steps.keys.outputs.self }}
 
       - name: Start MLIR build container
         run: |
@@ -200,12 +297,56 @@ jobs:
           docker cp flydsl_mlir_cache:/llvm-project/mlir_install.tgz ./mlir_install.tgz
           test -s ./mlir_install.tgz
 
+      # Checked against the VCSRevision.h the install ships: a wrong-pin baseline
+      # is worse than none, since it yields a plausible number nobody questions.
+      #
+      # Only a cache hit produces a baseline. Building the old pin here would
+      # cost a second llvm-project clone and full LLVM build on a GPU runner, per
+      # push, for an advisory number. Revisit if the logs show misses are common.
+      - name: Unpack and verify baseline MLIR
+        id: base-mlir
+        if: steps.base-pin.outputs.pin_changed == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if [ ! -s ./mlir_install_base.tgz ]; then
+            echo "::notice title=Benchmark baseline skipped::No cached MLIR install for the base commit's LLVM (${{ steps.base-pin.outputs.base_llvm_hash }}), so the vs-main comparison is skipped; vs latest tag is unaffected. This resolves itself once main has run under that pin."
+            exit 0
+          fi
+          docker cp ./mlir_install_base.tgz flydsl_mlir_cache:/tmp/mlir_install_base.tgz
+          docker exec flydsl_mlir_cache bash -c "
+            set -e
+            rm -rf /llvm-project/mlir_install_base
+            mkdir -p /tmp/mlir_base_extract
+            tar -xzf /tmp/mlir_install_base.tgz -C /tmp/mlir_base_extract
+            mv /tmp/mlir_base_extract/mlir_install /llvm-project/mlir_install_base
+            rmdir /tmp/mlir_base_extract
+            test -d /llvm-project/mlir_install_base/lib/cmake/mlir
+          " || { echo "::warning title=Benchmark baseline unavailable::Baseline MLIR install could not be unpacked."; exit 0; }
+          want="${{ steps.base-pin.outputs.base_llvm_hash }}"
+          got="$(docker exec flydsl_mlir_cache sed -n 's/.*LLVM_REVISION R"(\([0-9a-f]\{40\}\))".*/\1/p' \
+                   /llvm-project/mlir_install_base/include/llvm/Support/VCSRevision.h 2>/dev/null)"
+          if [ -z "${got}" ]; then
+            echo "Baseline MLIR carries no VC revision; relying on the content-derived cache key alone."
+          elif [ "${got}" != "${want}" ]; then
+            echo "::warning title=Benchmark baseline unavailable::Baseline MLIR is LLVM ${got}, expected ${want}; refusing to use it."
+            docker exec flydsl_mlir_cache rm -rf /llvm-project/mlir_install_base
+            exit 0
+          else
+            echo "Baseline MLIR verified at LLVM ${got}"
+          fi
+          echo "ready=true" >>"${GITHUB_OUTPUT}"
+
       - name: Build current and base FlyDSL wheels
+        env:
+          BASE_MLIR_PATH: ${{ steps.base-mlir.outputs.ready == 'true' && '/llvm-project/mlir_install_base' || '' }}
+          BASELINE_LLVM_HASH: ${{ steps.base-pin.outputs.base_llvm_hash }}
         run: |
           docker exec \
             -e BASE_REPO_NAME \
             -e BASE_COMMIT_SHA \
             -e ROCM_PATH \
+            -e BASE_MLIR_PATH \
             flydsl_mlir_cache bash -c '
               export MLIR_PATH=/llvm-project/mlir_install
               export PATH="$(rocm-sdk path --bin):$PATH"
@@ -217,10 +358,24 @@ jobs:
           (cd flydsl-ci-wheels/pr && sha256sum -c SHA256SUMS)
           if [ -d flydsl-ci-wheels/base ]; then
             (cd flydsl-ci-wheels/base && sha256sum -c SHA256SUMS)
+            # Mark which LLVM the wheel was really built against. A bump needing
+            # no source adaptation still builds from the shared MLIR; labelling
+            # that "old LLVM" points at a codegen difference that is not there.
+            if [ -n "${BASE_MLIR_PATH}" ] && [ -n "${BASELINE_LLVM_HASH}" ]; then
+              printf '%s\n' "${BASELINE_LLVM_HASH}" >flydsl-ci-wheels/base/BASELINE_LLVM
+            fi
           else
             echo "::warning title=Baseline wheel unavailable::Uploading PR wheel without an exact base benchmark."
           fi
           (cd flydsl-ci-wheels/tools && sha256sum -c SHA256SUMS)
+
+      # The second install is the whole disk cost, and nothing below needs it.
+      - name: Drop baseline MLIR install
+        if: always() && steps.base-pin.outputs.pin_changed == 'true'
+        continue-on-error: true
+        run: |
+          rm -f ./mlir_install_base.tgz
+          docker exec flydsl_mlir_cache bash -c "rm -rf /llvm-project/mlir_install_base /tmp/mlir_install_base.tgz" || true
 
       - name: Save shared MLIR cache
         if: >-
@@ -436,6 +591,14 @@ jobs:
           elif git fetch "${base_repo_url}" "${BASE_COMMIT_SHA}" --no-tags --depth=1; then
             commit="$(git rev-parse FETCH_HEAD)"
             label="main"
+            # From prepare-mlir's marker, not from the pinned hashes: this job
+            # cannot see which MLIR the baseline wheel was compiled with.
+            display_label="main@${commit:0:8}"
+            baseline_llvm="$(cat /flydsl-ci-wheels/base/BASELINE_LLVM 2>/dev/null || true)"
+            if [ -n "${baseline_llvm}" ]; then
+              display_label="${display_label} (llvm ${baseline_llvm:0:8})"
+              echo "::notice title=Benchmark baseline uses a different LLVM::Baseline was built against LLVM ${baseline_llvm:0:8}, the PR against its own pin; deltas include LLVM codegen changes."
+            fi
             worktree="/tmp/flydsl-bench-main"
             csv="/tmp/bench_main_candidate.csv"
             output="/tmp/bench_main.out"
@@ -460,7 +623,7 @@ jobs:
               status=$?
               if [ "${status}" -eq 0 ] && [ -s "${csv}" ]; then
                 cp "${csv}" /tmp/bench_main.csv
-                echo "${label}" >/tmp/bench_main_label
+                echo "${display_label}" >/tmp/bench_main_label
               else
                 echo "Exact main benchmark baseline failed; not retrying older commits."
               fi

--- a/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
+++ b/lib/Conversion/FlyToROCDL/FlyToROCDL.cpp
@@ -771,24 +771,17 @@ public:
     if (Value tok = op.getAsyncToken())
       asyncTokenType = tok.getType();
 
-    // There are two relevant builder signatures in this MLIR:
-    // - (kernel, ..., asyncTokenType, asyncDependencies, clusterSize)
-    // - (kernel, ..., asyncObject, clusterSize)
-    // Pick the one that matches the original op structure.
-    if (Value asyncObj = adaptor.getAsyncObject()) {
-      if (!adaptor.getAsyncDependencies().empty())
-        return rewriter.notifyMatchFailure(
-            op, "launch_func has both asyncObject and asyncDependencies");
-
-      rewriter.replaceOpWithNewOp<gpu::LaunchFuncOp>(
-          op, kernelRef, grid, block, adaptor.getDynamicSharedMemorySize(),
-          adaptor.getKernelOperands(), asyncObj, clusterSize);
-      return success();
-    }
+    // The two former builder signatures (one taking asyncTokenType +
+    // asyncDependencies, one taking asyncObject) were merged upstream into a
+    // single builder that takes all of them.
+    if (adaptor.getAsyncObject() && !adaptor.getAsyncDependencies().empty())
+      return rewriter.notifyMatchFailure(op,
+                                         "launch_func has both asyncObject and asyncDependencies");
 
     rewriter.replaceOpWithNewOp<gpu::LaunchFuncOp>(
         op, kernelRef, grid, block, adaptor.getDynamicSharedMemorySize(),
-        adaptor.getKernelOperands(), asyncTokenType, adaptor.getAsyncDependencies(), clusterSize);
+        adaptor.getKernelOperands(), asyncTokenType, adaptor.getAsyncDependencies(),
+        adaptor.getAsyncObject(), clusterSize);
     return success();
   }
 };

--- a/scripts/build_ci_wheels.sh
+++ b/scripts/build_ci_wheels.sh
@@ -77,11 +77,15 @@ MLIR
 build_wheel() {
   local source_dir="$1"
   local label="$2"
+  # The baseline wheel needs the base commit's own MLIR: on a pin bump the base
+  # source predates the API change the new pin requires. The default keeps every
+  # other wheel on the shared install.
+  local mlir_path="${3:-${MLIR_PATH}}"
   local destination="${OUTPUT_DIR}/${label}"
   local wheels=()
   local fly_opt="${source_dir}/build-fly/build_py${PYTHON_SUFFIX}/bin/fly-opt"
 
-  echo "Building ${label} wheel from ${source_dir}"
+  echo "Building ${label} wheel from ${source_dir} (MLIR: ${mlir_path})"
   if ! (
     cd "${source_dir}"
     env \
@@ -89,7 +93,7 @@ build_wheel() {
       "${PYTHON_BIN_ENV}=${PYTHON_BIN}" \
       VENV_ROOT="${VENV_ROOT}" \
       ALLOW_ANY_GLIBC=1 \
-      MLIR_PATH="${MLIR_PATH}" \
+      MLIR_PATH="${mlir_path}" \
       bash scripts/build_wheels.sh
   ); then
     return 1
@@ -146,7 +150,7 @@ build_base_wheel() {
   fi
 
   trap cleanup_base_worktree EXIT
-  if ! build_wheel "${BASE_WORKTREE}" base; then
+  if ! build_wheel "${BASE_WORKTREE}" base "${BASE_MLIR_PATH:-${MLIR_PATH}}"; then
     cleanup_base_worktree
     trap - EXIT
     return 1

--- a/scripts/ci_mlir_cache_key.sh
+++ b/scripts/ci_mlir_cache_key.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+#
+# Print the actions/cache key for the MLIR install that the given tree builds.
+#
+# Derived from file *contents*, not paths, so it is computable for any commit
+# whose LLVM inputs have been extracted anywhere on disk - that is what lets a PR
+# look up the install belonging to its base commit's pin. Both workflow call
+# sites use this script; inlining the formula elsewhere would let the two keys
+# drift and return an install built from the wrong pin.
+#
+# Total by construction: a missing input contributes a marker, not an error. It
+# replaced a hashFiles() expression, which tolerated missing files too, and a PR
+# that deletes one must still get a usable key rather than a failed job.
+set -euo pipefail
+
+TREE_ROOT="${1:?usage: ci_mlir_cache_key.sh <tree-root>}"
+
+INPUTS=(
+  thirdparty/llvm-build-info.json
+  thirdparty/llvm-rocdl-lld-argv0.patch
+  scripts/build_llvm.sh
+)
+
+# Per-file digests, so moving bytes across a file boundary changes the key.
+digests=""
+for input in "${INPUTS[@]}"; do
+  if [[ -f "${TREE_ROOT}/${input}" ]]; then
+    digests+="${input}:$(sha256sum <"${TREE_ROOT}/${input}" | cut -d' ' -f1)"$'\n'
+  else
+    digests+="${input}:absent"$'\n'
+  fi
+done
+digest="$(printf '%s' "${digests}" | sha256sum | cut -c1-40)"
+
+printf 'mlir-install-%s-%s-%s-%s-%s\n' \
+  "${RUNNER_OS:?RUNNER_OS must be set}" \
+  "${RUNNER_ARCH:?RUNNER_ARCH must be set}" \
+  "${MLIR_CACHE_VERSION:?MLIR_CACHE_VERSION must be set}" \
+  "${LLVM_BUILD_PROFILE:?LLVM_BUILD_PROFILE must be set}" \
+  "${digest}"

--- a/thirdparty/llvm-build-info.json
+++ b/thirdparty/llvm-build-info.json
@@ -1,6 +1,6 @@
 {
   "upstream": {
     "repository": "https://github.com/llvm/llvm-project.git",
-    "llvm_hash": "e2a39f504fee836e4def9581bed817ecc327b9dc"
+    "llvm_hash": "941a04e69ee8fe4c7a162b2f1e215aa8df867534"
   }
 }


### PR DESCRIPTION
Throwaway probe for #1071. **Do not merge, do not review as a change** — it exists only to drive CI down the pin-bump path. #1051 is untouched; its commit is cherry-picked here.

Contents: #1071 (the baseline-MLIR change) plus @Phil-amd's commit from #1051 (`33d9959`, LLVM `e2a39f50` -> `941a04e6` and the `gpu.launch_func` adaptation).

### What this run can prove

- `Resolve base LLVM pin` reports `pin_changed=true` (verified locally against this exact tree).
- The gated steps run instead of skipping.
- On a baseline cache miss, the run degrades as designed: the skip notice names the base pin, `vs latest tag` still runs, and the PR stays green.

### What it cannot prove yet, and why

**The baseline cache will miss, and that is expected — not a bug.**

The entry it looks for is keyed `...4087a417` (main's three LLVM inputs under the new content-derived formula). Nothing has saved that yet: caches created by a PR are scoped to that PR's merge ref, so #1071's own run cannot warm it for anyone else. Only a push to main saves an entry other PRs can read.

So the positive control — cache hit, baseline wheel built against the old MLIR, a printed `current vs main` table — needs this order:

1. Merge #1071.
2. Let main's push run save the MLIR install under the new key.
3. Re-run this PR's checks.

Until step 2, a skip here is the correct behaviour, and today it is also what #1051 gets on main.

### Expected on the first run

| | |
|---|---|
| `Resolve base LLVM pin` | `pin_changed=true`, `base_llvm_hash=e2a39f50…` |
| `Restore baseline MLIR cache` | miss |
| `Unpack and verify baseline MLIR` | notice: no cached install for `e2a39f50…`, vs-main skipped |
| base wheel | built against the PR MLIR, fails to compile (the #1051 symptom), existing warning |
| `BASELINE_LLVM` marker | absent, so the table stays `main@<sha>` with no `(llvm …)` suffix |
| `vs latest tag` | runs normally |

Also note `prepare-mlir` cold-builds LLVM here: the key formula changed, so the old cache does not apply. That cost is stated in #1071.

Close this once #1071 lands and the positive control has been observed.