### PR TITLE
[CI] Add MI35x runners for validation tests

### DIFF
--- a/.github/dashboard/ingest/parse_bench.py
+++ b/.github/dashboard/ingest/parse_bench.py
@@ -38,6 +38,7 @@ from typing import Optional
 DEFAULT_REGRESSION_PCT = -3.0
 
 # Stable runner -> GPU arch map (the only durable identity of each CI box).
+# The MI35x validation runners are intentionally omitted from dashboard ingestion.
 RUNNER_ARCH = {
     "linux-flydsl-mi355-1": "gfx950",  # MI355 / MI350X
     "linux-flydsl-mi355-8": "gfx950",

--- a/.github/dashboard/ingest/test_ingest.py
+++ b/.github/dashboard/ingest/test_ingest.py
@@ -189,6 +189,7 @@ def test_merge_history_sorted_by_ts_then_runner_op_shape():
 # --------------------------------------------------------------------------- #
 def test_runner_of_matches_known_box_and_rejects_unknown():
     assert ingest.runner_of("test (linux-flydsl-mi355-1)") == "linux-flydsl-mi355-1"
+    assert ingest.runner_of("test (linux-flydsl-mi35x-1)") is None  # MI35x test results stay out of the dashboard
     assert ingest.runner_of("test (linux-flydsl-unknown-9)") is None  # not in RUNNER_ARCH
     assert ingest.runner_of("build") is None
     assert ingest.runner_of("") is None

--- a/.github/runner-config.yml
+++ b/.github/runner-config.yml
@@ -13,6 +13,12 @@ runners:
   linux-flydsl-mi355-8:
     gpu_arch: MI355
     gpu_count: 8
+  linux-flydsl-mi35x-1:
+    gpu_arch: MI350
+    gpu_count: 1
+  linux-flydsl-mi35x-8:
+    gpu_arch: MI350
+    gpu_count: 8
   linux-flydsl-navi-2:
     gpu_arch: Navi
     gpu_count: 2

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -104,6 +104,7 @@ jobs:
         runners: [
           'linux-flydsl-mi325-1',
           'linux-flydsl-mi355-1',
+          'linux-flydsl-mi35x-1',
           'linux-flydsl-navi-2',
         ]
     runs-on: ubuntu-latest
@@ -430,6 +431,7 @@ jobs:
         runners: [
           'linux-flydsl-mi325-1',
           'linux-flydsl-mi355-1',
+          'linux-flydsl-mi35x-1',
           'linux-flydsl-navi-2',
         ]
       fail-fast: false
@@ -725,7 +727,7 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Multi-GPU communication operator tests: ONLY for 8-GPU runners.
-  # Runs on BOTH linux-flydsl-mi325-8 AND linux-flydsl-mi355-8 independently.
+  # Runs on linux-flydsl-mi325-8, linux-flydsl-mi355-8, and linux-flydsl-mi35x-8 independently.
   # Triggered when PR has label "multi-gpu" (added by a maintainer), or when
   # the workflow is manually dispatched.
   # fail-fast: false ensures both runners always complete even if one fails.
@@ -754,6 +756,7 @@ jobs:
         runners: [
           'linux-flydsl-mi325-8',
           'linux-flydsl-mi355-8',
+          'linux-flydsl-mi35x-8',
         ]
       fail-fast: false
     runs-on: ${{ matrix.runners }}

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -17,7 +17,7 @@ jobs:
       GIT_CONFIG_NOSYSTEM: "1"
     strategy:
       matrix:
-        runners: ['linux-flydsl-mi325-1', 'linux-flydsl-mi355-1']
+        runners: ['linux-flydsl-mi325-1', 'linux-flydsl-mi355-1', 'linux-flydsl-mi35x-1']
       fail-fast: false
     runs-on: ${{ matrix.runners }}
     permissions:


### PR DESCRIPTION
Run selected single- and multi-GPU tests on the MI35x runner pools without ingesting their benchmark results into the performance dashboard.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
