### PR TITLE
[gfx1250] Bf16 GEMM: Issue tdm prefetch earlier for wide tiles and add const init test

### DIFF
--- a/kernels/gemm/gemm_bf16_gfx1250.py
+++ b/kernels/gemm/gemm_bf16_gfx1250.py
@@ -41,6 +41,8 @@ def launch_gemm_bf16(
     is_f16: Constexpr[int] = 0,
     cluster_m: Constexpr[int] = 1,
     cluster_n: Constexpr[int] = 1,
+    tdm_balance: Constexpr[int] = 0,
+    wmma_b2b: Constexpr[int] = 0,
 ):
     """Requires N % tile_n == 0 and K % tile_k == 0; M is clamped per tile."""
     WMMA_M = WMMA_N = 16
@@ -57,6 +59,9 @@ def launch_gemm_bf16(
     n_acc = wmma_m_rep * wmma_n_rep
     num_waves = m_warp * n_warp
     block = num_waves * WAVE
+    tdm_parts = 2 if tdm_balance else 1  # TDM descriptors per operand
+    A_ROWS, B_ROWS = tile_m // tdm_parts, tile_n // tdm_parts
+    TDM_PW = max(1, (2 * tdm_parts) // num_waves)
     use_cluster = cluster_m > 1 or cluster_n > 1
 
     if tile_k % WMMA_K or warp_tile_m % WMMA_M or warp_tile_n % WMMA_N:
@@ -85,6 +90,8 @@ def launch_gemm_bf16(
         i32_ldb: fx.Int32,
         i32_ldc: fx.Int32,
     ):
+        if const_expr(wmma_b2b):
+            rocdl.disable_xdl_arb_stall()
         K_TILES = i32_k // tile_k
         lda_b = fx.Int64(i32_lda) * EB  # global row strides in bytes
         ldb_b = fx.Int64(i32_ldb) * EB
@@ -139,21 +146,26 @@ def launch_gemm_bf16(
         gB_base = fx.recast_iter(fx.Int8, arg_b)
         gC_base = fx.recast_iter(fx.PointerType.get(elem_cls.ir_type, arg_c.address_space), arg_c)
 
-        W_A, W_B = 0, 1 % num_waves
-        gA = _gv(gA_base, fx.Int64(blk_m) * lda_b, (tile_m, KB), (KB, 1))
-        atomA = _tdm(gA, mn_oob, lda_b, a_mask)
-        gB = _gv(gB_base, fx.Int64(blk_n) * ldb_b, (tile_n, KB), (KB, 1))
-        atomB = _tdm(gB, None, ldb_b, b_mask)
-
-        def _wcopy(w, atom, gt, lv, imm_offset):
-            if wave == w:
-                fx.copy(atom, gt, lv, imm_offset=imm_offset)
+        a_jobs = [
+            (2 * p, p, _gv(gA_base, fx.Int64(blk_m + p * A_ROWS) * lda_b, (A_ROWS, KB), (KB, 1)))
+            for p in range_constexpr(tdm_parts)
+        ]
+        b_jobs = [
+            (2 * p + 1, p, _gv(gB_base, fx.Int64(blk_n + p * B_ROWS) * ldb_b, (B_ROWS, KB), (KB, 1)))
+            for p in range_constexpr(tdm_parts)
+        ]
+        tdm_jobs = [
+            (w, _tdm(gt, mn_oob - p * A_ROWS, lda_b, a_mask), gt, p * A_ROWS * LDS_ROW, A_ROWS) for w, p, gt in a_jobs
+        ] + [(w, _tdm(gt, None, ldb_b, b_mask), gt, STAGE_A + p * B_ROWS * LDS_ROW, B_ROWS) for w, p, gt in b_jobs]
 
         def issue(s, kt):
             pa = _buf_ptr(s)
             koff = fx.Int64(kt) * fx.Int64(KB)
-            _wcopy(W_A, atomA, gA, _lv(pa, (tile_m, KB), (LDS_ROW, 1)), koff)
-            _wcopy(W_B, atomB, gB, _lv(fx.add_offset(pa, STAGE_A), (tile_n, KB), (LDS_ROW, 1)), koff)
+            for j in range_constexpr(len(tdm_jobs)):
+                w, atom, gt, lds_off, rows = tdm_jobs[j]
+                if wave == w % num_waves:
+                    dst = pa if const_expr(lds_off == 0) else fx.add_offset(pa, lds_off)
+                    fx.copy(atom, gt, _lv(dst, (rows, KB), (LDS_ROW, 1)), imm_offset=koff)
 
         wmb = wave_m * warp_tile_m
         wnb = wave_n * warp_tile_n
@@ -231,14 +243,14 @@ def launch_gemm_bf16(
         n_steady = K_TILES - (num_buffers - 1)
         for kt in range(n_steady):
             buf = _bidx(_buf_ptr(kt % num_buffers))
-            pipeline_fence(outstanding=(num_buffers - 2), use_cluster=False)
+            pipeline_fence(outstanding=TDM_PW * (num_buffers - 2), use_cluster=False)
             compute_ktile(buf, kt + (num_buffers - 1))
             if const_expr(use_cluster) and kt % num_buffers == num_buffers - 1:
                 cluster.cluster_barrier()
         for j in range_constexpr(num_buffers - 1):
             kt = n_steady + j
             buf = _bidx(_buf_ptr(kt % num_buffers))
-            pipeline_fence(outstanding=(num_buffers - 2 - j), use_cluster=False)
+            pipeline_fence(outstanding=TDM_PW * (num_buffers - 2 - j), use_cluster=False)
             compute_ktile(buf, None)
 
         accs = [c_frags[idx].load() for idx in range_constexpr(n_acc)]

--- a/kernels/gemm/gemm_bf16_gfx1250.py
+++ b/kernels/gemm/gemm_bf16_gfx1250.py
@@ -206,8 +206,12 @@ def launch_gemm_bf16(
             for ks in range_constexpr(K_WS):
                 nxt = _load_ks(buf, ks + 1) if const_expr(ks + 1 < K_WS) else None
                 rocdl.s_wait_dscnt(KS_DS if const_expr(nxt is not None) else 0)
+                if const_expr(ks == 0 and prefetch_kt is not None and wmma_m_rep > 1):
+                    rocdl.sched_barrier(0)
+                    issue(prefetch_kt % num_buffers, prefetch_kt)
+                    rocdl.sched_barrier(0)
                 _mma_ks(cur)
-                if const_expr(ks == 0 and prefetch_kt is not None):
+                if const_expr(ks == 0 and prefetch_kt is not None and wmma_m_rep == 1):
                     rocdl.sched_barrier(0)
                     issue(prefetch_kt % num_buffers, prefetch_kt)
                     rocdl.sched_barrier(0)

--- a/python/flydsl/expr/rocdl/__init__.py
+++ b/python/flydsl/expr/rocdl/__init__.py
@@ -582,8 +582,8 @@ def disable_xdl_arb_stall():
     from .. import arith as _arith
     from ..typing import T
 
-    # hwreg encoding: ID=26(SCHED_MODE), Offset=4, Size=1 -> 282
-    imm_val = _arith.unwrap(_arith.constant(282, type=T.i32))
+    # hwreg encoding: ID=26(SCHED_MODE), Offset=2, Size=1 -> 154.
+    imm_val = _arith.unwrap(_arith.constant(154, type=T.i32))
     val_val = _arith.unwrap(_arith.constant(1, type=T.i32))
 
     _llvm.call_intrinsic(None, "llvm.amdgcn.s.setreg", [imm_val, val_val], [], [])

--- a/tests/kernels/test_gemm_bf16_gfx1250.py
+++ b/tests/kernels/test_gemm_bf16_gfx1250.py
@@ -23,6 +23,7 @@ import flydsl.expr as fx  # noqa: E402
 
 from flydsl.runtime.device import get_rocm_arch  # noqa: E402
 from kernels.gemm.gemm_bf16_gfx1250 import launch_gemm_bf16  # noqa: E402
+from tests.test_common import run_perftest  # noqa: E402
 
 _DT = {"bf16": torch.bfloat16, "f16": torch.float16}
 
@@ -80,7 +81,7 @@ def _build_case(
     c = torch.zeros(M, N, dtype=dt, device="cuda")
     ref = torch.matmul(a.float(), b.float().T)
 
-    def make_args(stream):
+    def make_args(stream, c=c, a=a, b=b):
         return (
             flyc.from_c_void_p(fx.Uint8, c.data_ptr()),
             flyc.from_c_void_p(fx.Uint8, a.data_ptr()),
@@ -107,7 +108,7 @@ def _build_case(
 
     # bf16/f16 inputs with f32 accumulation: error grows with sqrt(K).
     tol = (2e-2, 2e-2 * math.sqrt(K))
-    return c, make_args, ref, tol
+    return c, a, b, make_args, ref, tol
 
 
 def _bench_us(launch, *, warmup=10, iters=100):
@@ -130,7 +131,7 @@ def _bench_us(launch, *, warmup=10, iters=100):
 
 def _run_case(M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers, dtype="bf16", **kw):
     _require_gfx1250()
-    c, make_args, ref, (rtol, atol) = _build_case(
+    c, _a, _b, make_args, ref, (rtol, atol) = _build_case(
         M, N, K, tile_m, tile_n, tile_k, m_warp, n_warp, num_buffers, dtype, **kw
     )
     compiled = flyc.compile(launch_gemm_bf16, *make_args(torch.cuda.current_stream()))
@@ -181,15 +182,17 @@ def _parse_csv_ints(value, n, name):
 
 
 def _parse_init_mode(value):
-    """'random' -> None; 'const' or 'const,<float>' -> constant A/B fill (default 0.1)."""
+    """'random' -> None; 'zero' -> 0.0; 'const' or 'const,<float>' -> constant A/B fill (default 0.1)."""
     if value == "random":
         return None
+    if value == "zero":
+        return 0.0
     if value == "const":
         return 0.1
     kind, _, num = value.partition(",")
     if kind == "const" and num:
         return float(num)
-    raise SystemExit(f"--init-mode expects 'random', 'const', or 'const,<float>', got {value!r}")
+    raise SystemExit(f"--init-mode expects 'random', 'zero', 'const', or 'const,<float>', got {value!r}")
 
 
 def _print_table(headers, rows):
@@ -221,7 +224,13 @@ def _main():
         nargs="+",
         default=["random", "const"],
         metavar="MODE",
-        help="A/B fill(s): 'random' and/or 'const' (0.1) or 'const,<float>' (default: both)",
+        help="A/B fill(s): 'random', 'zero', 'const' (0.1) or 'const,<float>' (default: random+const)",
+    )
+    parser.add_argument(
+        "-rotate_buf",
+        action="store_true",
+        help="benchmark via run_perftest with rotating buffers: cycle through deep-copied A/B/C "
+        "sets (auto-sized from L2 cache) to defeat caching; default reuses one set (needs -bench)",
     )
     parser.add_argument(
         "--tdm-balance",
@@ -254,7 +263,7 @@ def _main():
     rows = []
     sweep = itertools.product(shapes, dtypes, args.init_mode, args.tdm_balance, args.wmma_b2b)
     for (M, N, K), dtype, init, tdm_bal, b2b in sweep:
-        c, make_args, ref, (rtol, atol) = _build_case(
+        c, a, b, make_args, ref, (rtol, atol) = _build_case(
             M,
             N,
             K,
@@ -274,7 +283,15 @@ def _main():
         ok = torch.allclose(c.float(), ref, rtol=rtol, atol=atol)
         perf = ["-", "-", "-"]
         if args.bench:
-            us = _bench_us(lambda: compiled(*make_args(torch.cuda.current_stream())))
+            if args.rotate_buf:
+
+                def _launch(c_t, a_t, b_t):
+                    compiled(*make_args(torch.cuda.current_stream(), c_t, a_t, b_t))
+
+                # num_rotate_args=0 lets run_perftest auto-size the rotating buffer set.
+                _, us = run_perftest(_launch, c, a, b, num_iters=100, num_warmup=10, num_rotate_args=0)
+            else:
+                us = _bench_us(lambda: compiled(*make_args(torch.cuda.current_stream())))
             moved = _bytes_moved(M, N, K)
             perf = [f"{us:.3f}", f"{_tflops(M, N, K, us):.2f}", f"{moved / (us * 1e-6) / 1e12:.3f}"]
         rows.append(

--- a/tests/kernels/test_gemm_bf16_gfx1250.py
+++ b/tests/kernels/test_gemm_bf16_gfx1250.py
@@ -64,6 +64,8 @@ def _build_case(
     cluster_m=1,
     cluster_n=1,
     const_val=None,
+    tdm_balance=0,
+    wmma_b2b=0,
 ):
     """Inputs, a make_args(stream) thunk, the f32 reference, and tolerances."""
     if (N // tile_n) % cluster_n:
@@ -99,6 +101,8 @@ def _build_case(
             1 if dtype == "f16" else 0,
             cluster_m,
             cluster_n,
+            tdm_balance,
+            wmma_b2b,
         )
 
     # bf16/f16 inputs with f32 accumulation: error grows with sqrt(K).
@@ -219,6 +223,26 @@ def _main():
         metavar="MODE",
         help="A/B fill(s): 'random' and/or 'const' (0.1) or 'const,<float>' (default: both)",
     )
+    parser.add_argument(
+        "--tdm-balance",
+        nargs="+",
+        type=int,
+        default=[0],
+        choices=[0, 1],
+        metavar="0|1",
+        help="TDM staging: 0 = one fat descriptor per operand, 1 = each operand halved "
+        "over two waves. Pass both to sweep (default: 0)",
+    )
+    parser.add_argument(
+        "--wmma-b2b",
+        nargs="+",
+        type=int,
+        default=[0],
+        choices=[0, 1],
+        metavar="0|1",
+        help="1 sets SCHED_MODE.DISABLE_XDL_ARB_STALL so a wave can issue back-to-back "
+        "WMMAs. Pass both to sweep (default: 0)",
+    )
     args = parser.parse_args()
 
     shapes = [_parse_csv_ints(v, 3, "mnk") for v in args.mnk]
@@ -228,7 +252,8 @@ def _main():
     dtypes = args.dtype if isinstance(args.dtype, list) else [args.dtype]
 
     rows = []
-    for (M, N, K), dtype, init in itertools.product(shapes, dtypes, args.init_mode):
+    sweep = itertools.product(shapes, dtypes, args.init_mode, args.tdm_balance, args.wmma_b2b)
+    for (M, N, K), dtype, init, tdm_bal, b2b in sweep:
         c, make_args, ref, (rtol, atol) = _build_case(
             M,
             N,
@@ -240,6 +265,8 @@ def _main():
             cluster_m=cluster[0],
             cluster_n=cluster[1],
             const_val=_parse_init_mode(init),
+            tdm_balance=tdm_bal,
+            wmma_b2b=b2b,
         )
         compiled = flyc.compile(launch_gemm_bf16, *make_args(torch.cuda.current_stream()))
         torch.cuda.synchronize()
@@ -257,6 +284,8 @@ def _main():
                 str(K),
                 dtype,
                 init,
+                str(tdm_bal),
+                str(b2b),
                 *perf,
                 f"{max_err:.4g}",
                 f"{rel_err:.3g}",
@@ -269,7 +298,21 @@ def _main():
         f"nb={args.nb} cluster={cluster[0]},{cluster[1]}"
     )
     _print_table(
-        ["M", "N", "K", "dtype", "init_mode", "latency us", "TFLOPS", "BW TB/s", "max_err", "rel_err", "result"],
+        [
+            "M",
+            "N",
+            "K",
+            "dtype",
+            "init_mode",
+            "tdm_bal",
+            "wmma_b2b",
+            "latency us",
+            "TFLOPS",
+            "BW TB/s",
+            "max_err",
+            "rel_err",
+            "result",
+        ],
         rows,
     )
     if any(r[-1] == "FAIL" for r in rows):

--- a/tests/kernels/test_gemm_bf16_gfx1250.py
+++ b/tests/kernels/test_gemm_bf16_gfx1250.py
@@ -63,14 +63,18 @@ def _build_case(
     *,
     cluster_m=1,
     cluster_n=1,
+    const_val=None,
 ):
     """Inputs, a make_args(stream) thunk, the f32 reference, and tolerances."""
     if (N // tile_n) % cluster_n:
         raise ValueError(f"cluster_n={cluster_n} needs N/tile_n={N // tile_n} to be a multiple of it")
-    torch.manual_seed(0)
     dt = _DT[dtype]
-    a = torch.randn(M, K, dtype=torch.float32, device="cuda").to(dt)
-    b = torch.randn(N, K, dtype=torch.float32, device="cuda").to(dt)
+    if const_val is None:
+        a = torch.randn(M, K, dtype=torch.float32, device="cuda").to(dt)
+        b = torch.randn(N, K, dtype=torch.float32, device="cuda").to(dt)
+    else:
+        a = torch.full((M, K), const_val, dtype=dt, device="cuda")
+        b = torch.full((N, K), const_val, dtype=dt, device="cuda")
     c = torch.zeros(M, N, dtype=dt, device="cuda")
     ref = torch.matmul(a.float(), b.float().T)
 
@@ -172,6 +176,18 @@ def _parse_csv_ints(value, n, name):
     return parts
 
 
+def _parse_init_mode(value):
+    """'random' -> None; 'const' or 'const,<float>' -> constant A/B fill (default 0.1)."""
+    if value == "random":
+        return None
+    if value == "const":
+        return 0.1
+    kind, _, num = value.partition(",")
+    if kind == "const" and num:
+        return float(num)
+    raise SystemExit(f"--init-mode expects 'random', 'const', or 'const,<float>', got {value!r}")
+
+
 def _print_table(headers, rows):
     widths = [max(len(h), *(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
 
@@ -196,6 +212,13 @@ def _main():
     parser.add_argument("-dtype", default="bf16", choices=["bf16", "f16"], nargs="+")
     parser.add_argument("-cluster", default="1,1", help="cluster_m,cluster_n (1,1 disables clustering)")
     parser.add_argument("-bench", action="store_true", help="also measure perf (warmup=10, iters=100)")
+    parser.add_argument(
+        "--init-mode",
+        nargs="+",
+        default=["random", "const"],
+        metavar="MODE",
+        help="A/B fill(s): 'random' and/or 'const' (0.1) or 'const,<float>' (default: both)",
+    )
     args = parser.parse_args()
 
     shapes = [_parse_csv_ints(v, 3, "mnk") for v in args.mnk]
@@ -205,7 +228,7 @@ def _main():
     dtypes = args.dtype if isinstance(args.dtype, list) else [args.dtype]
 
     rows = []
-    for (M, N, K), dtype in itertools.product(shapes, dtypes):
+    for (M, N, K), dtype, init in itertools.product(shapes, dtypes, args.init_mode):
         c, make_args, ref, (rtol, atol) = _build_case(
             M,
             N,
@@ -216,6 +239,7 @@ def _main():
             dtype,
             cluster_m=cluster[0],
             cluster_n=cluster[1],
+            const_val=_parse_init_mode(init),
         )
         compiled = flyc.compile(launch_gemm_bf16, *make_args(torch.cuda.current_stream()))
         torch.cuda.synchronize()
@@ -227,14 +251,27 @@ def _main():
             moved = _bytes_moved(M, N, K)
             perf = [f"{us:.3f}", f"{_tflops(M, N, K, us):.2f}", f"{moved / (us * 1e-6) / 1e12:.3f}"]
         rows.append(
-            [str(M), str(N), str(K), dtype, *perf, f"{max_err:.4g}", f"{rel_err:.3g}", "PASS" if ok else "FAIL"]
+            [
+                str(M),
+                str(N),
+                str(K),
+                dtype,
+                init,
+                *perf,
+                f"{max_err:.4g}",
+                f"{rel_err:.3g}",
+                "PASS" if ok else "FAIL",
+            ]
         )
 
     print(
         f"\ntiles={tiles[0]},{tiles[1]},{tiles[2]} warps={warps[0]},{warps[1]} "
         f"nb={args.nb} cluster={cluster[0]},{cluster[1]}"
     )
-    _print_table(["M", "N", "K", "dtype", "latency us", "TFLOPS", "BW TB/s", "max_err", "rel_err", "result"], rows)
+    _print_table(
+        ["M", "N", "K", "dtype", "init_mode", "latency us", "TFLOPS", "BW TB/s", "max_err", "rel_err", "result"],
+        rows,
+    )
     if any(r[-1] == "FAIL" for r in rows):
         raise SystemExit(1)
 


### PR DESCRIPTION
## Motivation

Add TDM split and disable-xdl-arb-stall experimental options. 
Issue tdm prefetch earlier for tile_M=64 and add const initialization for test_bf16_gemm.

## Technical Details

Issue tdm prefetch earlier for tile_M=64 and add const initialization for test_bf16_gemm.


## Test Plan

- Unit tests: `python3 tests/kernels/test_gemm_bf16_gfx1250.py`.
- Sweep B2B WMMA, TDM balance: 
``` bash
python3 tests/kernels/test_gemm_bf16_gfx1250.py -mnk 64,65536,16384 -tiles 64,256,128 \
  -warps 1,4 -nb 3 -cluster 1,4 -bench --tdm-balance 0 1 --wmma-b2b 0 1
```

## Test Result

All PASS.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
