### PR TITLE
[CI] Retry the baseline MLIR cache restore once

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -224,13 +224,41 @@ jobs:
       - name: Restore baseline MLIR cache
         id: base-mlir-cache
         if: steps.base-pin.outputs.pin_changed == 'true'
+        continue-on-error: true
+        timeout-minutes: 25
+        uses: actions/cache/restore@v4
+        with:
+          path: mlir_install.tgz
+          key: ${{ steps.keys.outputs.base }}
+
+      # This install is ~1.4 GB and these runners are spread across regions, so
+      # the transfer is slow enough (~1.6 MB/s observed) to be interrupted:
+      #
+      #   Received 1010827264 of 1396566653 (72.4%), 1.6 MBs/sec
+      #   ##[warning]Failed to restore: Server failed to authenticate the
+      #             request ... Authorization header ... signature.
+      #   Cache not found for input keys: mlir-install-...-4087a417...
+      #
+      # The entry was there and matched; the blob SAS auth failed mid-download,
+      # which actions/cache reports as a plain miss. One retry costs nothing on
+      # the normal path and is the difference between having a baseline and
+      # silently not having one.
+      - name: Retry baseline MLIR cache restore
+        id: base-mlir-cache-retry
+        if: >-
+          steps.base-pin.outputs.pin_changed == 'true' &&
+          steps.base-mlir-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        timeout-minutes: 25
         uses: actions/cache/restore@v4
         with:
           path: mlir_install.tgz
           key: ${{ steps.keys.outputs.base }}
 
       - name: Stash baseline MLIR tarball
-        if: steps.base-mlir-cache.outputs.cache-hit == 'true'
+        if: >-
+          steps.base-mlir-cache.outputs.cache-hit == 'true' ||
+          steps.base-mlir-cache-retry.outputs.cache-hit == 'true'
         continue-on-error: true
         run: |
           set -uo pipefail


### PR DESCRIPTION
Follow-up to #1071. A benchmark baseline was lost to a network fault, not to a missing cache entry.

## What happened

On #1051 ([run 33117631657](https://github.com/ROCm/FlyDSL/actions/runs/33117631657)), `Restore baseline MLIR cache`:

```
Received 1010827264 of 1396566653 (72.4%), 1.6 MBs/sec
##[warning]Failed to restore: Server failed to authenticate the request.
          Make sure the value of Authorization header is formed correctly including the signature.
Cache not found for input keys: mlir-install-Linux-X64-...-4087a417...
```

`1396566653` is the **exact size** of the entry sitting at `refs/heads/main`:

| ref | created | size | last accessed |
|---|---|---|---|
| `refs/heads/main` | 2026-08-27 11:50:16 | 1,396,566,653 | 2026-08-29 06:26 |

So the key was right, the scope was right, the entry was found and 72% downloaded — then the blob SAS auth failed and `actions/cache` reported it as a plain miss. The run fell back to building the baseline wheel against the PR MLIR, where a pin bump cannot compile, and the vs-main comparison was gone.

Same run, the PR-scoped shared entry (1.42 GB) downloaded fine, so this is intermittent rather than a systematic refusal. The signature is already on record for these runners: they are spread across regions, and Azure blob SAS is sensitive to clock skew and to proxies on the path.

## The change

One retry on the baseline restore, gated on the first attempt missing. No cost when the first works. Both attempts get `timeout-minutes: 25` so a stalled transfer cannot eat the job budget instead — at 1.6 MB/s a 1.4 GB restore already takes ~15 minutes.

## What this does not fix

`Restore shared MLIR cache` has the same exposure, and failing there is more expensive: a 45-minute cold LLVM rebuild. That is pre-existing behaviour, out of scope here, and the durable fix is the one an earlier investigation landed for the test jobs — move off the cache auth path onto artifacts.