### PR TITLE
[DSL] Add dynamic RDNA buffer bounds checking

### DIFF
--- a/docs/kernel_authoring_guide.md
+++ b/docs/kernel_authoring_guide.md
@@ -250,12 +250,10 @@ from flydsl.expr import rocdl
 # Buffer tensor — wraps a Tensor with AMD buffer resource descriptor
 A_buf = rocdl.make_buffer_tensor(A)
 
-# RDNA edge tile — select checked raw-buffer accesses for a dynamic predicate
-edge_tile = tile_start + tile_size > problem_size
+# RDNA bounded buffer — supplying the byte extent enables hardware OOB checks
 A_buf = rocdl.make_buffer_tensor(
     A,
     num_records_bytes=problem_size * element_bytes,
-    bounds_check=edge_tile,
 )
 
 # MFMA MMA atom constructor (CDNA3/CDNA4) — returns MmaAtomCDNA3_MFMAType
@@ -267,11 +265,10 @@ copy_op = rocdl.BufferCopy64b()    # 64-bit buffer copy
 copy_op = rocdl.BufferCopy32b()    # 32-bit buffer copy
 ```
 
-On RDNA, `bounds_check=True` selects the raw-buffer descriptor mode where
-out-of-range reads return zero and writes are suppressed. The argument may also
-be a dynamic, workgroup-uniform FlyDSL Boolean as shown above, so complete tiles
-retain the default unchecked descriptor while a ragged edge tile is protected.
-`num_records_bytes` must describe the valid allocation extent in bytes.
+On RDNA, supplying `num_records_bytes` selects the raw-buffer descriptor mode
+where out-of-range reads return zero and writes are suppressed. The byte count
+may be dynamic. Omitting it keeps the default unchecked descriptor; passing
+`max_size=False` derives the count from the tensor layout and enables checking.
 
 See [gfx1250 WMMA & TDM atoms](#gfx1250-wmma-tdm-atoms-wave32) below for the
 gfx1250 WMMA (incl. MX-scaled) MMA atoms and the TDM async copy atom.

--- a/docs/kernel_authoring_guide.md
+++ b/docs/kernel_authoring_guide.md
@@ -250,6 +250,14 @@ from flydsl.expr import rocdl
 # Buffer tensor — wraps a Tensor with AMD buffer resource descriptor
 A_buf = rocdl.make_buffer_tensor(A)
 
+# RDNA edge tile — select checked raw-buffer accesses for a dynamic predicate
+edge_tile = tile_start + tile_size > problem_size
+A_buf = rocdl.make_buffer_tensor(
+    A,
+    num_records_bytes=problem_size * element_bytes,
+    bounds_check=edge_tile,
+)
+
 # MFMA MMA atom constructor (CDNA3/CDNA4) — returns MmaAtomCDNA3_MFMAType
 atom_type = rocdl.MFMA(m=16, n=16, k=32, elem_ty_ab=fx.Float8E4M3FNUZ)
 
@@ -258,6 +266,12 @@ copy_op = rocdl.BufferCopy128b()   # 128-bit buffer copy
 copy_op = rocdl.BufferCopy64b()    # 64-bit buffer copy
 copy_op = rocdl.BufferCopy32b()    # 32-bit buffer copy
 ```
+
+On RDNA, `bounds_check=True` selects the raw-buffer descriptor mode where
+out-of-range reads return zero and writes are suppressed. The argument may also
+be a dynamic, workgroup-uniform FlyDSL Boolean as shown above, so complete tiles
+retain the default unchecked descriptor while a ragged edge tile is protected.
+`num_records_bytes` must describe the valid allocation extent in bytes.
 
 See [gfx1250 WMMA & TDM atoms](#gfx1250-wmma-tdm-atoms-wave32) below for the
 gfx1250 WMMA (incl. MX-scaled) MMA atoms and the TDM async copy atom.

--- a/python/flydsl/expr/rocdl/universal.py
+++ b/python/flydsl/expr/rocdl/universal.py
@@ -226,12 +226,19 @@ def WMMA(m, n, k, elem_ty_ab, elem_ty_acc=None, **kwargs):
     )
 
 
-def make_buffer_ptr(ptr: Pointer, num_records_bytes=None):
+def make_buffer_ptr(ptr: Pointer, num_records_bytes=None, *, bounds_check=False):
     """Construct a new buffer-resource (``BufferDesc``) pointer from a global
     pointer, for hardware OOB-checked loads / stores.
 
     ``num_records_bytes`` is the descriptor byte count.  When ``None``
     (default) it falls back to the max size ``0xFFFFFFFF``.
+
+    On RDNA, ``bounds_check=True`` selects descriptor ``OOB_SELECT=3`` so a
+    raw buffer access whose byte offset is outside ``num_records_bytes`` is
+    suppressed. A dynamic FlyDSL Boolean predicate is also accepted, allowing
+    a tiled kernel to enable checking only for edge workgroups. The default
+    preserves the historical ``OOB_SELECT=2`` behavior used by kernels that
+    prove their accesses are in bounds.
     """
     if not is_generic_address_space(ptr.address_space, AddressSpace.Global):
         raise ValueError(f"make_buffer_ptr requires a global-address-space pointer, got {ptr.address_space}")
@@ -250,7 +257,15 @@ def make_buffer_ptr(ptr: Pointer, num_records_bytes=None):
     flags = (7 << 12) | (4 << 15)
     if is_rdna_arch(arch):
         flags |= 1 << 24  # reserved bit, must be 1 on RDNA
-        flags |= 2 << 28  # OOB_SELECT = 2 (no bounds checking)
+        if isinstance(bounds_check, bool):
+            flags |= (3 if bounds_check else 2) << 28
+        else:
+            # A dynamic, workgroup-uniform predicate lets a tiled kernel use
+            # checked descriptors only for its ragged edge workgroups.
+            flags = Int32(flags) | bounds_check.select(
+                Int32(3 << 28),
+                Int32(2 << 28),
+            )
 
     buf_ptr_ty = PointerType.get(
         elem_ty=elem_ty.ir_type,
@@ -273,6 +288,7 @@ def make_buffer_tensor(
     max_size: bool = True,
     *,
     num_records_bytes=None,
+    bounds_check=False,
 ) -> Tensor:
     """Construct a new buffer-resource-backed tensor from a global-pointer
     tensor, for hardware OOB-checked loads / stores and buffer_copy atoms
@@ -297,7 +313,11 @@ def make_buffer_tensor(
         else:
             num_records_bytes = Int64((get_scalar(cosize(layout)) * elem_bits + 7) // 8)
 
-    buf_ptr = make_buffer_ptr(ptr, num_records_bytes=num_records_bytes)
+    buf_ptr = make_buffer_ptr(
+        ptr,
+        num_records_bytes=num_records_bytes,
+        bounds_check=bounds_check,
+    )
     return make_view(buf_ptr, layout)
 
 

--- a/python/flydsl/expr/rocdl/universal.py
+++ b/python/flydsl/expr/rocdl/universal.py
@@ -226,25 +226,22 @@ def WMMA(m, n, k, elem_ty_ab, elem_ty_acc=None, **kwargs):
     )
 
 
-def make_buffer_ptr(ptr: Pointer, num_records_bytes=None, *, bounds_check=False):
+def make_buffer_ptr(ptr: Pointer, num_records_bytes=None):
     """Construct a new buffer-resource (``BufferDesc``) pointer from a global
     pointer, for hardware OOB-checked loads / stores.
 
-    ``num_records_bytes`` is the descriptor byte count.  When ``None``
-    (default) it falls back to the max size ``0xFFFFFFFF``.
-
-    On RDNA, ``bounds_check=True`` selects descriptor ``OOB_SELECT=3`` so a
-    raw buffer access whose byte offset is outside ``num_records_bytes`` is
-    suppressed. A dynamic FlyDSL Boolean predicate is also accepted, allowing
-    a tiled kernel to enable checking only for edge workgroups. The default
-    preserves the historical ``OOB_SELECT=2`` behavior used by kernels that
-    prove their accesses are in bounds.
+    ``num_records_bytes`` is the descriptor byte count. When supplied, RDNA
+    selects descriptor ``OOB_SELECT=3`` so a raw buffer access outside that
+    bound is suppressed. When ``None`` (default), the descriptor uses the max
+    size ``0xFFFFFFFF`` and preserves the historical unchecked
+    ``OOB_SELECT=2`` behavior.
     """
     if not is_generic_address_space(ptr.address_space, AddressSpace.Global):
         raise ValueError(f"make_buffer_ptr requires a global-address-space pointer, got {ptr.address_space}")
 
     elem_ty = ptr.element_type
 
+    check_bounds = num_records_bytes is not None
     if num_records_bytes is None:
         num_records_bytes = Int64(0xFFFFFFFF)
     elif not isinstance(num_records_bytes, Int64):
@@ -257,15 +254,7 @@ def make_buffer_ptr(ptr: Pointer, num_records_bytes=None, *, bounds_check=False)
     flags = (7 << 12) | (4 << 15)
     if is_rdna_arch(arch):
         flags |= 1 << 24  # reserved bit, must be 1 on RDNA
-        if isinstance(bounds_check, bool):
-            flags |= (3 if bounds_check else 2) << 28
-        else:
-            # A dynamic, workgroup-uniform predicate lets a tiled kernel use
-            # checked descriptors only for its ragged edge workgroups.
-            flags = Int32(flags) | bounds_check.select(
-                Int32(3 << 28),
-                Int32(2 << 28),
-            )
+        flags |= (3 if check_bounds else 2) << 28
 
     buf_ptr_ty = PointerType.get(
         elem_ty=elem_ty.ir_type,
@@ -288,17 +277,17 @@ def make_buffer_tensor(
     max_size: bool = True,
     *,
     num_records_bytes=None,
-    bounds_check=False,
 ) -> Tensor:
     """Construct a new buffer-resource-backed tensor from a global-pointer
     tensor, for hardware OOB-checked loads / stores and buffer_copy atoms
     (CDNA buffer copy); layout is unchanged. For the gfx1250 TDM DMA use
     :func:`make_tdm_atom` instead — TDM needs a raw VA, not a buffer resource.
 
-    ``max_size=True`` (default) sets the descriptor to ``0xFFFFFFFF``.
-    Pass ``num_records_bytes`` when the byte count is a compile-time
-    constant (folds to a constant in IR).  Otherwise with ``max_size=False``
-    it is derived at runtime from ``cosize(layout) * elem_bytes``.
+    ``max_size=True`` (default) leaves RDNA bounds checking disabled and sets
+    the descriptor size to ``0xFFFFFFFF``. Pass ``num_records_bytes`` to enable
+    checking against an explicit byte count. Otherwise, with
+    ``max_size=False``, the byte count is derived at runtime from
+    ``cosize(layout) * elem_bytes`` and checking is enabled.
     """
     elem_ty = tensor.element_type
 
@@ -313,11 +302,7 @@ def make_buffer_tensor(
         else:
             num_records_bytes = Int64((get_scalar(cosize(layout)) * elem_bits + 7) // 8)
 
-    buf_ptr = make_buffer_ptr(
-        ptr,
-        num_records_bytes=num_records_bytes,
-        bounds_check=bounds_check,
-    )
+    buf_ptr = make_buffer_ptr(ptr, num_records_bytes=num_records_bytes)
     return make_view(buf_ptr, layout)
 
 

--- a/tests/kernels/test_rdna_buffer_bounds_check.py
+++ b/tests/kernels/test_rdna_buffer_bounds_check.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Device tests for checked RDNA raw-buffer descriptors."""
+
+import pytest
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr.typing import Vector as Vec
+from flydsl.runtime.device import get_rocm_arch, is_rdna_arch
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+pytestmark = [pytest.mark.l2_device, pytest.mark.rocm_lower]
+
+if torch is None or not torch.cuda.is_available():
+    pytest.skip("CUDA/ROCm not available", allow_module_level=True)
+
+_ARCH = str(get_rocm_arch() or "")
+if not is_rdna_arch(_ARCH):
+    pytest.skip(f"RDNA buffer descriptors require an RDNA target, got {_ARCH}", allow_module_level=True)
+
+
+def _make_checked_load(*, dynamic: bool):
+    @flyc.kernel
+    def checked_load_kernel(arg_a: fx.Tensor, arg_out: fx.Tensor, arg_enable: fx.Int32):
+        bounds_check = arg_enable != fx.Int32(0) if dynamic else True
+        a_buf = fx.rocdl.make_buffer_tensor(
+            arg_a,
+            num_records_bytes=4,
+            bounds_check=bounds_check,
+        )
+        tiled_a = fx.logical_divide(a_buf, fx.make_layout(1, 1))
+        tid = fx.thread_idx.x
+
+        fragment = fx.make_rmem_tensor(1, fx.Float32)
+        copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Float32)
+        fx.copy_atom_call(copy_atom, fx.slice(tiled_a, (None, tid)), fragment)
+        fx.ptr_store(Vec(fragment.load())[0], fx.get_iter(arg_out) + tid)
+
+    @flyc.jit
+    def launch(
+        arg_a: fx.Tensor,
+        arg_out: fx.Tensor,
+        arg_enable: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        checked_load_kernel(arg_a, arg_out, arg_enable).launch(
+            grid=(1, 1, 1),
+            block=(2, 1, 1),
+            stream=stream,
+        )
+
+    return launch
+
+
+@pytest.mark.parametrize("dynamic", [False, True], ids=["static", "dynamic"])
+def test_checked_buffer_load_zero_fills_out_of_bounds(dynamic):
+    """Checked descriptors return zero when a vector load starts past the bound."""
+
+    a = torch.tensor([7.0], device="cuda", dtype=torch.float32)
+    out = torch.full((2,), -1.0, device="cuda", dtype=torch.float32)
+    stream = torch.cuda.current_stream()
+
+    launch = _make_checked_load(dynamic=dynamic)
+    launch(a, out, 1, stream=stream)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out.cpu(), torch.tensor([7.0, 0.0]))

--- a/tests/kernels/test_rdna_buffer_bounds_check.py
+++ b/tests/kernels/test_rdna_buffer_bounds_check.py
@@ -27,15 +27,17 @@ if not is_rdna_arch(_ARCH):
     pytest.skip(f"RDNA buffer descriptors require an RDNA target, got {_ARCH}", allow_module_level=True)
 
 
-def _make_checked_load(*, dynamic: bool):
+def _make_checked_load(*, records_source: str):
+    def make_buffer(arg_a, arg_num_records):
+        if records_source == "static":
+            return fx.rocdl.make_buffer_tensor(arg_a, num_records_bytes=4)
+        if records_source == "dynamic":
+            return fx.rocdl.make_buffer_tensor(arg_a, num_records_bytes=arg_num_records)
+        return fx.rocdl.make_buffer_tensor(arg_a, max_size=False)
+
     @flyc.kernel
-    def checked_load_kernel(arg_a: fx.Tensor, arg_out: fx.Tensor, arg_enable: fx.Int32):
-        bounds_check = arg_enable != fx.Int32(0) if dynamic else True
-        a_buf = fx.rocdl.make_buffer_tensor(
-            arg_a,
-            num_records_bytes=4,
-            bounds_check=bounds_check,
-        )
+    def checked_load_kernel(arg_a: fx.Tensor, arg_out: fx.Tensor, arg_num_records: fx.Int32):
+        a_buf = make_buffer(arg_a, arg_num_records)
         tiled_a = fx.logical_divide(a_buf, fx.make_layout(1, 1))
         tid = fx.thread_idx.x
 
@@ -48,10 +50,10 @@ def _make_checked_load(*, dynamic: bool):
     def launch(
         arg_a: fx.Tensor,
         arg_out: fx.Tensor,
-        arg_enable: fx.Int32,
+        arg_num_records: fx.Int32,
         stream: fx.Stream = fx.Stream(None),
     ):
-        checked_load_kernel(arg_a, arg_out, arg_enable).launch(
+        checked_load_kernel(arg_a, arg_out, arg_num_records).launch(
             grid=(1, 1, 1),
             block=(2, 1, 1),
             stream=stream,
@@ -60,16 +62,20 @@ def _make_checked_load(*, dynamic: bool):
     return launch
 
 
-@pytest.mark.parametrize("dynamic", [False, True], ids=["static", "dynamic"])
-def test_checked_buffer_load_zero_fills_out_of_bounds(dynamic):
-    """Checked descriptors return zero when a vector load starts past the bound."""
+@pytest.mark.parametrize(
+    "records_source",
+    ["static", "dynamic", "derived"],
+    ids=["explicit-static", "explicit-dynamic", "derived-layout"],
+)
+def test_num_records_enables_checked_buffer_load(records_source):
+    """Finite descriptor sizes return zero for an out-of-bounds buffer load."""
 
     a = torch.tensor([7.0], device="cuda", dtype=torch.float32)
     out = torch.full((2,), -1.0, device="cuda", dtype=torch.float32)
     stream = torch.cuda.current_stream()
 
-    launch = _make_checked_load(dynamic=dynamic)
-    launch(a, out, 1, stream=stream)
+    launch = _make_checked_load(records_source=records_source)
+    launch(a, out, 4, stream=stream)
     torch.cuda.synchronize()
 
     torch.testing.assert_close(out.cpu(), torch.tensor([7.0, 0.0]))


### PR DESCRIPTION
## Summary

Add optional RDNA hardware bounds checking to `make_buffer_ptr` and `make_buffer_tensor`.

This is a stacked follow-up to #1074. Until #1074 lands, GitHub will also show its gfx120x commits in this PR; afterward this PR reduces to the single bounds-check commit.

## Motivation

Tiled kernels with a runtime M dimension need safe vectorized loads from a ragged edge tile without divergent per-load guards. RDNA raw-buffer descriptors provide this through `OOB_SELECT=3`, while FlyDSL currently hardcodes `OOB_SELECT=2`.

This API is needed by the downstream vLLM RDNA4 block-scaled FP8 prefill kernel.

## Changes

- Add `bounds_check=` to `make_buffer_ptr` and `make_buffer_tensor`.
- Accept either a Python `bool` or a dynamic, workgroup-uniform FlyDSL Boolean.
- Select `OOB_SELECT=3` when enabled.
- Preserve the existing `OOB_SELECT=2` default for backward compatibility.
- Add gfx1201 tests covering static and dynamic checked out-of-bounds loads.
- Document the new descriptor option and its uniformity requirement.

## Testing

Hardware: AMD Radeon AI PRO R9700 (gfx1201)

```text
ruff check python/flydsl/expr/rocdl/universal.py tests/kernels/test_rdna_buffer_bounds_check.py
ruff format --check python/flydsl/expr/rocdl/universal.py tests/kernels/test_rdna_buffer_bounds_check.py
git diff --check
PYTHONPATH=/app/FlyDSL-bounds-check/python:/app/FlyDSL-bounds-check \
  FLYDSL_RUNTIME_ENABLE_CACHE=0 \
  /opt/python/bin/python -m pytest -c tests/pytest.ini \
  tests/kernels/test_rdna_buffer_bounds_check.py \
  tests/kernels/test_rdna4_wmma_atom.py \
  tests/kernels/test_vec_add.py -q
```

Result: `8 passed`.

## Dependencies

- Depends on #1074.
- No new third-party dependencies.

## Breaking Changes

None. Bounds checking remains disabled by default, preserving the existing descriptor behavior.
