### PR TITLE
[CI] Bypass runner git-cache rewrite in sglang/vllm nightlies

### DIFF
--- a/.github/workflows/flydsl-sglang-integration.yaml
+++ b/.github/workflows/flydsl-sglang-integration.yaml
@@ -61,10 +61,17 @@ jobs:
 
     env:
       GPU_ARCH: gfx950
+      # Keep checkout independent of runner-local git-cache rewrites.
+      GIT_CONFIG_GLOBAL: /dev/null
+      GIT_CONFIG_NOSYSTEM: "1"
 
     steps:
       - name: Checkout FlyDSL utility scripts
         uses: actions/checkout@v4
+        env:
+          # Keep checkout independent of runner-local git-cache rewrites.
+          GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
+          GIT_CONFIG_NOSYSTEM: "1"
         with:
           sparse-checkout: |
             scripts/install_awscli.sh
@@ -72,6 +79,10 @@ jobs:
 
       - name: Checkout aiter downstream script
         uses: actions/checkout@v4
+        env:
+          # Keep checkout independent of runner-local git-cache rewrites.
+          GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
+          GIT_CONFIG_NOSYSTEM: "1"
         with:
           repository: ${{ env.AITER_REPOSITORY }}
           ref: ${{ env.AITER_REF }}

--- a/.github/workflows/flydsl-vllm-integration.yaml
+++ b/.github/workflows/flydsl-vllm-integration.yaml
@@ -25,9 +25,17 @@ jobs:
     runs-on: build-only-flydsl
     permissions:
       contents: read
+    env:
+      # Keep checkout independent of runner-local git-cache rewrites.
+      GIT_CONFIG_GLOBAL: /dev/null
+      GIT_CONFIG_NOSYSTEM: "1"
     steps:
       - name: Checkout upstream aiter repo
         uses: actions/checkout@v4
+        env:
+          # Keep checkout independent of runner-local git-cache rewrites.
+          GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
+          GIT_CONFIG_NOSYSTEM: "1"
         with:
           repository: ${{ env.AITER_REPOSITORY }}
           ref: ${{ env.AITER_REF }}
@@ -115,9 +123,18 @@ jobs:
             extra_args: --block-size 1 --trust-remote-code
             extra_env_args: -e VLLM_USE_TRITON_FLASH_ATTN=0
 
+    env:
+      # Keep checkout independent of runner-local git-cache rewrites.
+      GIT_CONFIG_GLOBAL: /dev/null
+      GIT_CONFIG_NOSYSTEM: "1"
+
     steps:
       - name: Checkout FlyDSL utility scripts
         uses: actions/checkout@v4
+        env:
+          # Keep checkout independent of runner-local git-cache rewrites.
+          GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
+          GIT_CONFIG_NOSYSTEM: "1"
         with:
           sparse-checkout: |
             scripts/install_awscli.sh
@@ -125,6 +142,10 @@ jobs:
 
       - name: Checkout aiter helper script
         uses: actions/checkout@v4
+        env:
+          # Keep checkout independent of runner-local git-cache rewrites.
+          GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig
+          GIT_CONFIG_NOSYSTEM: "1"
         with:
           repository: ${{ env.AITER_REPOSITORY }}
           ref: ${{ env.AITER_REF }}


### PR DESCRIPTION
## Problem

The [SGLang nightly](https://github.com/ROCm/FlyDSL/actions/runs/33590079989) fails before any test runs. Both 8-GPU jobs die at the very first step, `Checkout FlyDSL utility scripts`:

```
fatal: unable to access 'http://git-cache.git-cache.svc.cluster.local/ROCm/FlyDSL/':
Failed to connect to git-cache.git-cache.svc.cluster.local port 80 after 342 ms: Couldn't connect to server
The process '/usr/bin/git' failed with exit code 128
```

The `linux-flydsl-mi355-8` runners carry a global git config that rewrites GitHub URLs to an in-cluster git-cache mirror. That mirror is not reachable from these runners, so checkout fails after all three retries.

## Fix

Apply the workaround already used by `flydsl.yaml`, `test-whl.yaml`, `promote.yaml` and `flydsl-atom-integration.yaml`:

- job-level `GIT_CONFIG_GLOBAL: /dev/null` + `GIT_CONFIG_NOSYSTEM: "1"` so no git invocation in the job picks up the rewrite;
- per-checkout-step `GIT_CONFIG_GLOBAL: ${{ runner.temp }}/flydsl-gitconfig` so `actions/checkout` still has a writable config for its auth header.

Covers `flydsl-sglang-integration.yaml` (the failing workflow) and `flydsl-vllm-integration.yaml`, which has the identical gap on the same runner pool and is the next nightly to break.

Side effect: the host-side `git clone` of sglang (`flydsl-sglang-integration.yaml`) was subject to the same rewrite and is now fixed too.

## Verification

YAML parses; the change is a copy of the pattern proven on the other self-hosted workflows. The real check is the next nightly or a manual `workflow_dispatch` on this branch — it cannot be validated locally, since it depends on runner-side config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)