### PR TITLE
[CI] accelerate prepare-mlir: run the CPU builder in the manylinux image

### DIFF
--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -9,6 +9,16 @@ on:
       - main
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
+    inputs:
+      prepare_runner:
+        description: 'Runner for prepare-mlir (compile-only; no GPU needed)'
+        type: choice
+        default: build-only-flydsl
+        options:
+          - build-only-flydsl
+          - linux-flydsl-mi325-1
+          - linux-flydsl-mi355-1
+          - linux-flydsl-navi-2
 
 permissions:
   contents: read
@@ -23,7 +33,7 @@ env:
   DOCKER_IMAGE: "rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0"
   LLVM_BUILD_PROFILE: "amd-minimal"
   # Bump when the container or LLVM build environment changes incompatibly.
-  MLIR_CACHE_VERSION: "rocm7.2.4-ubuntu24.04-py3.12-v1"
+  MLIR_CACHE_VERSION: "manylinux228-rocm7.2-py3.12-v1"
   GITHUB_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
   # PRs compare against their exact base; main pushes compare against the previous commit.
@@ -131,7 +141,10 @@ jobs:
           && needs.check-signal.result == 'success'
           && (needs.detect-changes.result != 'success'
               || needs.detect-changes.outputs.code_changed == 'true') }}
-    runs-on: linux-flydsl-mi325-1
+    # Compile-only, so it runs on the CPU builder instead of holding a GPU
+    # runner. These are ARC scale sets: runs-on names exactly one, and the
+    # dispatch input is how to retarget when it is busy.
+    runs-on: ${{ inputs.prepare_runner || 'build-only-flydsl' }}
     timeout-minutes: 150
     steps:
       - name: Checkout code
@@ -276,6 +289,20 @@ jobs:
           path: mlir_install.tgz
           key: ${{ steps.keys.outputs.self }}
 
+      # Nothing publishes this tag; the fallback builds it the first time a
+      # runner needs it. Same step as build-whl.yaml.
+      - name: Pull or build manylinux Docker image
+        run: |
+          ROCM_VERSION=7.2
+          IMAGE="ghcr.io/rocm/flydsl-manylinux_2_28:rocm${ROCM_VERSION}-cp310-cp314"
+          if ! docker pull "${IMAGE}"; then
+            docker build \
+              --build-arg ROCM_VERSION="${ROCM_VERSION}" \
+              -t "${IMAGE}" \
+              - < flydsl-test/.github/workflows/Dockerfile.manylinux_2_28
+          fi
+          echo "MANYLINUX_IMAGE=${IMAGE}" >> $GITHUB_ENV
+
       - name: Start MLIR build container
         run: |
           docker ps -aq -f name=flydsl_mlir_cache | xargs -r docker stop | xargs -r docker rm || true
@@ -286,17 +313,25 @@ jobs:
             --security-opt seccomp=unconfined \
             -w /flydsl-test \
             --name flydsl_mlir_cache \
-            ${{ env.DOCKER_IMAGE }}
+            ${MANYLINUX_IMAGE}
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
+      # The image ships cmake, ninja, gcc, patchelf, git and ROCm at /opt/rocm.
       - name: Install MLIR build dependencies
         run: |
-          docker exec flydsl_mlir_cache bash -c "apt-get update && apt-get install -y cmake build-essential patchelf"
-          docker exec flydsl_mlir_cache bash -c "python3 -m pip install -U pip setuptools wheel"
-          docker exec flydsl_mlir_cache bash -c "python3 -m pip install ninja>=1.11.1"
-          docker exec flydsl_mlir_cache bash -c "if command -v rocm-sdk >/dev/null 2>&1; then rocm-sdk init; fi"
-          docker exec flydsl_mlir_cache bash -c "git config --global --add safe.directory /flydsl-test"
+          docker exec flydsl_mlir_cache bash -c '
+            for d in /opt/python/cp*; do
+              case "${d}" in *t) continue ;; esac
+              py="${d}/bin/python"
+              [ -x "${py}" ] || continue
+              ver=$("${py}" -c "import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")")
+              ln -sf "${py}" "/usr/local/bin/python${ver}"
+            done
+            ln -sf /usr/local/bin/python3.12 /usr/local/bin/python3
+          '
+          docker exec flydsl_mlir_cache bash -c "python3 -m pip install -q nanobind"
+          docker exec flydsl_mlir_cache bash -c "git config --global --add safe.directory '*'"
           sdk_root="$(docker exec flydsl_mlir_cache bash -c 'if command -v rocm-sdk >/dev/null 2>&1; then rocm-sdk path --root; elif [ -d /opt/rocm ]; then printf "/opt/rocm\n"; fi')"
           test -n "${sdk_root}"
           docker exec flydsl_mlir_cache test -d "${sdk_root}"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 [![CI](https://github.com/ROCm/FlyDSL/actions/workflows/ci.yaml/badge.svg)](https://github.com/ROCm/FlyDSL/actions/workflows/ci.yaml)
 [![Benchmark](https://github.com/ROCm/FlyDSL/actions/workflows/flydsl.yaml/badge.svg)](https://github.com/ROCm/FlyDSL/actions/workflows/flydsl.yaml)
+[![ATOM](https://github.com/ROCm/FlyDSL/actions/workflows/flydsl-atom-integration.yaml/badge.svg)](https://github.com/ROCm/FlyDSL/actions/workflows/flydsl-atom-integration.yaml)
+[![vLLM](https://github.com/ROCm/FlyDSL/actions/workflows/flydsl-vllm-integration.yaml/badge.svg)](https://github.com/ROCm/FlyDSL/actions/workflows/flydsl-vllm-integration.yaml)
+[![SGLang](https://github.com/ROCm/FlyDSL/actions/workflows/flydsl-sglang-integration.yaml/badge.svg)](https://github.com/ROCm/FlyDSL/actions/workflows/flydsl-sglang-integration.yaml)
 [![Dashboard](https://img.shields.io/badge/Performance-Dashboard-blue)](https://rocm.github.io/FlyDSL/ci-dashboard/)
 [![Docs](https://img.shields.io/badge/Docs-rocm.github.io%2FFlyDSL-blue)](https://rocm.github.io/FlyDSL)
 


### PR DESCRIPTION
## What

Two independent CI changes.

**1. `prepare-mlir` moves to the CPU builder, in the PyPI wheel image.**

`prepare-mlir` only compiles — it builds LLVM and the CI wheels and never passes `--device=/dev/kfd` (only the `test` and `multi-gpu` jobs do). It was pinned to `linux-flydsl-mi325-1` with a 150-minute timeout, holding a GPU runner for work that needs no GPU. It now runs on `build-only-flydsl` in `ghcr.io/rocm/flydsl-manylinux_2_28:rocm7.2-cp310-cp314`, the same image `build-whl.yaml` uses for the PyPI wheels.

The two halves depend on each other. Nothing publishes that ghcr tag — `build-whl.yaml` builds it locally when the pull misses. On a GPU runner the pull would always miss, so every first run would pay a cold `docker build`. On `build-only-flydsl` the image is already resident because `build-whl.yaml` builds it there. The pull-or-build fallback is kept for the first run on any runner that has not seen it.

`#1076`'s `rocm-sdk`-optional / `/opt/rocm` fallback already resolves ROCm correctly in this image, so the swap only needed the pull-or-build step, the image reference, and replacing the Ubuntu `apt-get` block with the manylinux python symlinks + `nanobind` (matching `build-whl.yaml`).

A `workflow_dispatch` input `prepare_runner` allows retargeting. These are ARC scale sets, so `runs-on` must name exactly one — a list would mean "has every one of these labels", not "any of" — and the input is the only available multi-target mechanism.

**2. README badges** for the ATOM / vLLM / SGLang nightlies, matching the existing style.

## Verification

Not run in CI yet. What was checked statically:

- `prepare-mlir` never passes `--device=/dev/kfd`; only `test` and `multi-gpu` do.
- `ci_mlir_cache_key.sh` keys on `RUNNER_OS`/`RUNNER_ARCH` only, both `Linux`/`X64` on either runner — **the runner move does not invalidate the MLIR cache**.
- `/opt/rocm` confirmed present by reading `rocm/dev-almalinux-8:7.2-complete`'s image config from the registry (`/opt/rocm/bin` on `PATH`, `/opt/rocm/lib` on `LD_LIBRARY_PATH`).
- All 12 `run:` blocks pass `bash -n`; pull-or-build is ordered before container start.
- Badge URLs return HTTP 200 with live status.

## Risks

- **`MLIR_CACHE_VERSION` bumped**, so the first run rebuilds LLVM once, then repopulates. Required — the cached install carries Python bindings built against the container's interpreter.
- **Build ROCm moves 7.2.4 → 7.2 and glibc 2.39 → 2.28**, while tests still run on the `rocm7.2.4` PyTorch image. Same build/test split the PyPI path already ships.
- **`Resolve base LLVM pin` runs `git fetch` on the host**, and host-side git on `build-only-flydsl` is unproven (`build-whl.yaml` re-clones inside its container). That step is `continue-on-error: true`, so the worst case is a missing benchmark baseline, not a failed job — but worth watching on the first run.
- Neither the wheel build nor the LLVM build has been exercised in this image on this runner. `build-whl.yaml` does both there today, which is why this is expected to work, but a `workflow_dispatch` is the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)