### PR TITLE
[CI] Strip the MLIR install before tarring it

### DIFF
--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -175,6 +175,26 @@ if [[ "${LLVM_PACKAGE_INSTALL}" == "1" ]]; then
     exit 1
   fi
 
+  # The install tree is ~80% bin/, and those binaries carry a symbol table the
+  # build does not need: stripping takes ~20% off the tarball, which the CI
+  # cache transfers on every job. Static archives are left alone - they gained
+  # nothing when measured, and stripping an archive can drop symbols the link
+  # still needs. Set LLVM_STRIP_INSTALL=0 to keep symbols for crash backtraces.
+  if [[ "${LLVM_STRIP_INSTALL:-1}" == "1" ]] && command -v strip >/dev/null 2>&1; then
+    echo "Stripping installed binaries and shared libraries..."
+    before_kb=$(du -sk "${LLVM_INSTALL_DIR}" | cut -f1)
+    # -type f skips the symlinks in bin/; non-ELF entries (the Python and Perl
+    # helper scripts) simply fail to strip and are skipped.
+    find "${LLVM_INSTALL_DIR}/bin" "${LLVM_INSTALL_DIR}/lib" \
+         "${LLVM_INSTALL_DIR}/python_packages" \
+         -type f ! -name '*.a' -print0 2>/dev/null |
+      while IFS= read -r -d '' f; do
+        strip --strip-unneeded "${f}" 2>/dev/null || true
+      done
+    after_kb=$(du -sk "${LLVM_INSTALL_DIR}" | cut -f1)
+    echo "Install tree: $((before_kb / 1024)) MB -> $((after_kb / 1024)) MB"
+  fi
+
   echo "Creating tarball..."
   # The install tree may still have files whose mtimes change (e.g. Python bytecode caches),
   # which can cause GNU tar to exit(1) with "file changed as we read it". Treat those as


### PR DESCRIPTION
## Why

`mlir_install.tgz` is ~1.4 GB and the CI cache moves it on every `prepare-mlir` run. #1046 already had to add a retry around the restore because the transfer was being interrupted mid-download (`Received 1010827264 of 1396566653 (72.4%), 1.6 MBs/sec`).

Measured on a real 6.8 GB install, `bin/` is the problem:

| | size | share of tree |
|---|---|---|
| `bin/` (146 tools) | 4832 MB | 70% |
| `lib/` (558 `.a` + shared) | 1.6 GB | 24% |
| `python_packages/` | 325 MB | 5% |
| `include/` | 190 MB | 3% |

Those binaries carry a symbol table nothing in the build or the tests reads.

## What

Strip executables and shared libraries in the install prefix after `cmake --install`, before the tarball is created.

- **Static archives are excluded.** They carry no debug info — `strip --strip-debug` on `libMLIRSPIRVDialect.a` returned 45 MB → 45 MB — and stripping an archive can drop symbols the link still needs.
- `--strip-unneeded`, not `--strip-all`: measured identical on an executable (both 303 → 230 MB) and safe for `.so`.
- `find -type f` leaves the 18 symlinks in `bin/` alone; the 7 non-ELF helper scripts (`git-clang-format`, `scan-build`, …) fail to strip and are skipped.
- `LLVM_STRIP_INSTALL=0` keeps symbols when a readable crash backtrace matters more than the transfer. This is a real tradeoff: `LLVM_ENABLE_ASSERTIONS=ON` is set, and stripped binaries give LLVM's crash handler addresses without names.

## Measurements

| | before | after |
|---|---|---|
| `mlir-opt` on disk | 303 MB | 230 MB |
| `mlir-opt` gzipped | 97 MB | 80 MB |

≈ **20% off the tarball**.

## Verification

Run against a real install tree at `/data/felix/llvm-project/mlir_install`:

- The exact `smoke_test_rocdl` from `build_ci_wheels.sh` (`gpu-module-to-binary{format=fatbin}` for gfx942) **passes on a stripped `mlir-opt`** — emits `gpu.binary` and `bin = `.
- `mlir-tblgen --version` still runs after stripping.
- Exercised the real `find`/`strip` pipeline on a mixed subset: `.a` byte-identical (sha256 match), Python helper script intact, symlink intact.
- `bash -n` clean.

Not verified: a full LLVM build + FlyDSL link against a stripped install. The link consumes `lib/*.a`, which this does not touch.

## Follow-up

The bigger prize is not stripping but *not installing* the unused tools. FlyDSL uses exactly four binaries — `mlir-opt`, `FileCheck`, `mlir-tblgen`, `llvm-config` — totalling 386 MB of 4832 MB, so **92% of `bin/` is dead weight** (`mlir-rewrite` 259M, `mlir-transform-opt` 220M, `mlir-reduce` 212M, `mlir-lsp-server` 192M, `mlir-query` 177M, plus `opt`/`llc`/`llvm-*`).

That cannot be done by deleting files: `LLVMExports-release.cmake` populates `_IMPORT_CHECK_FILES_FOR_<tool>` for all 86 LLVM + 17 MLIR imported executables, and `LLVMExports.cmake:1191` raises `FATAL_ERROR` when one is missing, which would break `find_package(LLVM)` in the wheel build. It has to happen at configure time (`LLVM_BUILD_TOOLS=OFF` and similar), which needs a real CI build to validate. That would take the tarball toward ~400 MB and cut build time too.

## Note

`scripts/build_llvm.sh` is an MLIR cache-key input, so this invalidates the MLIR cache in `flydsl.yaml`, `build-whl.yaml` and `build-custom-llvm-tools.yaml` — one rebuild each, then they repopulate smaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)