### PR TITLE
[CI] Run aiter CSV MoE and HGEMM in the wheel/PyPI test job

### DIFF
--- a/.github/scripts/find_rocm_path.py
+++ b/.github/scripts/find_rocm_path.py
@@ -37,12 +37,25 @@ def _module_root(name: str) -> Path | None:
     return Path(spec.submodule_search_locations[0])
 
 
+def _soname_version(path: Path) -> tuple[int, ...]:
+    """Numeric soname suffix, e.g. libamdhip64.so.7.2 -> (7, 2)."""
+    suffix = path.name[len("libamdhip64.so") :].lstrip(".")
+    parts: list[int] = []
+    for piece in suffix.split("."):
+        if not piece.isdigit():
+            break
+        parts.append(int(piece))
+    return tuple(parts)
+
+
 def _hip64_libs(root: Path) -> list[Path]:
     hits: list[Path] = []
     for sub in ("lib", "lib64"):
-        hits.extend(sorted(Path(root, sub).glob("libamdhip64.so")))
-        hits.extend(sorted(Path(root, sub).glob("libamdhip64.so.*")))
-    return hits
+        hits.extend(Path(root, sub).glob("libamdhip64.so"))
+        hits.extend(Path(root, sub).glob("libamdhip64.so.*"))
+    # Highest ABI major first; sonames must be ordered numerically, not as strings
+    # (".so.10" sorts before ".so.7" lexicographically).
+    return sorted(hits, key=_soname_version, reverse=True)
 
 
 def _unversioned(root: Path) -> Path | None:
@@ -111,6 +124,11 @@ def _ensure_unversioned(root: Path) -> Path:
     versioned = libs[0]
     in_place = versioned.parent / "libamdhip64.so"
     try:
+        # A dangling link (left by an earlier `rocm-sdk init` against a since-removed
+        # version) is invisible to _unversioned's exists() check but still occupies
+        # the name, so symlink_to would raise FileExistsError.
+        if in_place.is_symlink() and not in_place.exists():
+            in_place.unlink()
         in_place.symlink_to(versioned.name)
         print(f"created {in_place} -> {versioned.name}", file=sys.stderr)
         return root
@@ -120,13 +138,22 @@ def _ensure_unversioned(root: Path) -> Path:
     if LINK_ROOT.exists():
         shutil.rmtree(LINK_ROOT)
     LINK_ROOT.mkdir(parents=True)
-    for sub in ("lib", "lib64", "include", "bin", "hip", "llvm", "share"):
+    # "lib" is deliberately excluded: aliasing it onto root/lib would put the
+    # recovery symlink back in the directory whose unwritability got us here.
+    for sub in ("lib64", "include", "bin", "hip", "llvm", "share"):
         src = root / sub
         if src.exists():
             (LINK_ROOT / sub).symlink_to(src)
     libdir = LINK_ROOT / "lib"
-    libdir.mkdir(exist_ok=True)
-    (libdir / "libamdhip64.so").symlink_to(versioned.resolve())
+    libdir.mkdir()
+    src_lib = root / "lib"
+    if src_lib.is_dir():
+        for entry in src_lib.iterdir():
+            (libdir / entry.name).symlink_to(entry)
+    link = libdir / "libamdhip64.so"
+    if link.is_symlink() or link.exists():
+        link.unlink()
+    link.symlink_to(versioned.resolve())
     print(f"wrapper ROCM_PATH={LINK_ROOT} libamdhip64.so -> {versioned}", file=sys.stderr)
     return LINK_ROOT
 

--- a/.github/scripts/find_rocm_path.py
+++ b/.github/scripts/find_rocm_path.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Print a ROCm root that aiter can pass to -L... -lamdhip64.
+
+The PyPI/nightly wheel-test image (ROCm 7.14 PyTorch) is TheRock pip-ROCm:
+there is no /opt/rocm, ``hipcc`` lives in the venv, and ``_rocm_sdk_core``
+only ships the versioned soname ``libamdhip64.so.N``. The unversioned
+``libamdhip64.so`` that ``ld`` needs lives in ``rocm-sdk-devel`` after
+``rocm-sdk init``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+AMD_ROCM_INDEX = "https://repo.amd.com/rocm/whl-multi-arch/"
+LINK_ROOT = Path("/tmp/flydsl_rocm_home")
+
+
+def _module_root(name: str) -> Path | None:
+    try:
+        spec = importlib.util.find_spec(name)
+    except (ImportError, ValueError):
+        return None
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    return Path(spec.submodule_search_locations[0])
+
+
+def _hip64_libs(root: Path) -> list[Path]:
+    hits: list[Path] = []
+    for sub in ("lib", "lib64"):
+        hits.extend(sorted(Path(root, sub).glob("libamdhip64.so")))
+        hits.extend(sorted(Path(root, sub).glob("libamdhip64.so.*")))
+    return hits
+
+
+def _unversioned(root: Path) -> Path | None:
+    for sub in ("lib", "lib64"):
+        cand = root / sub / "libamdhip64.so"
+        if cand.exists():
+            return cand
+    return None
+
+
+def _rocm_sdk_root() -> Path | None:
+    exe = shutil.which("rocm-sdk")
+    if not exe:
+        return None
+    proc = subprocess.run([exe, "path", "--root"], check=False, capture_output=True, text=True)
+    out = (proc.stdout or "").strip()
+    return Path(out) if out else None
+
+
+def _candidate_roots() -> list[Path]:
+    roots: list[Path] = []
+    env = os.environ.get("ROCM_PATH") or os.environ.get("ROCM_HOME")
+    if env:
+        roots.append(Path(env))
+    for name in ("_rocm_sdk_devel", "_rocm_sdk_core", "_rocm_sdk_libraries"):
+        loc = _module_root(name)
+        if loc is not None:
+            roots.append(loc)
+    sdk = _rocm_sdk_root()
+    if sdk is not None:
+        roots.append(sdk)
+    roots.extend(Path(p) for p in ("/opt/rocm", "/opt/rocm-7.14.0", "/opt/rocm-7.14"))
+    roots.extend(sorted(Path("/opt").glob("rocm*")))
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for root in roots:
+        key = str(root.resolve()) if root.exists() else str(root)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(root)
+    return unique
+
+
+def _pick_root() -> Path | None:
+    with_unversioned: list[Path] = []
+    with_versioned: list[Path] = []
+    for root in _candidate_roots():
+        if _unversioned(root) is not None:
+            with_unversioned.append(root)
+        elif _hip64_libs(root):
+            with_versioned.append(root)
+    if with_unversioned:
+        return with_unversioned[0]
+    if with_versioned:
+        return with_versioned[0]
+    return None
+
+
+def _ensure_unversioned(root: Path) -> Path:
+    if _unversioned(root) is not None:
+        return root
+    libs = _hip64_libs(root)
+    if not libs:
+        raise FileNotFoundError(f"no libamdhip64 under {root}")
+    versioned = libs[0]
+    in_place = versioned.parent / "libamdhip64.so"
+    try:
+        in_place.symlink_to(versioned.name)
+        print(f"created {in_place} -> {versioned.name}", file=sys.stderr)
+        return root
+    except OSError as exc:
+        print(f"could not symlink {in_place}: {exc}", file=sys.stderr)
+
+    if LINK_ROOT.exists():
+        shutil.rmtree(LINK_ROOT)
+    LINK_ROOT.mkdir(parents=True)
+    for sub in ("lib", "lib64", "include", "bin", "hip", "llvm", "share"):
+        src = root / sub
+        if src.exists():
+            (LINK_ROOT / sub).symlink_to(src)
+    libdir = LINK_ROOT / "lib"
+    libdir.mkdir(exist_ok=True)
+    (libdir / "libamdhip64.so").symlink_to(versioned.resolve())
+    print(f"wrapper ROCM_PATH={LINK_ROOT} libamdhip64.so -> {versioned}", file=sys.stderr)
+    return LINK_ROOT
+
+
+def _pkg_version(*names: str) -> str | None:
+    import importlib.metadata as metadata
+
+    for name in names:
+        try:
+            return metadata.version(name)
+        except metadata.PackageNotFoundError:
+            continue
+    return None
+
+
+def _pip_install(spec: str, extra: list[str]) -> bool:
+    cmd = [sys.executable, "-m", "pip", "install", spec, *extra]
+    print(" ".join(cmd), file=sys.stderr)
+    return subprocess.run(cmd, check=False).returncode == 0
+
+
+def install_devel() -> None:
+    if _module_root("_rocm_sdk_devel") is not None:
+        print("_rocm_sdk_devel already present", file=sys.stderr)
+        return
+    ver = _pkg_version("rocm-sdk-core", "rocm")
+    specs = [f"rocm[devel]=={ver}", f"rocm-sdk-devel=={ver}"] if ver else ["rocm[devel]", "rocm-sdk-devel"]
+    extras = [
+        [],
+        ["--extra-index-url", AMD_ROCM_INDEX],
+    ]
+    for spec in specs:
+        for extra in extras:
+            if _pip_install(spec, extra):
+                return
+    print("warning: could not pip install rocm-sdk-devel", file=sys.stderr)
+
+
+def rocm_sdk_init() -> None:
+    exe = shutil.which("rocm-sdk")
+    if not exe:
+        return
+    print("running rocm-sdk init", file=sys.stderr)
+    subprocess.run([exe, "init"], check=False)
+
+
+def dump_debug() -> None:
+    print("failed to locate libamdhip64.so*", file=sys.stderr)
+    for cmd in (
+        ["bash", "-lc", "command -v hipcc; command -v rocm-sdk; ls -ld /opt/rocm /opt/rocm-* 2>/dev/null || true"],
+        ["bash", "-lc", "ls -l /opt/rocm*/lib/libamdhip64.so* 2>/dev/null || true"],
+    ):
+        subprocess.run(cmd, check=False)
+    for name in ("_rocm_sdk_devel", "_rocm_sdk_core", "_rocm_sdk_libraries"):
+        loc = _module_root(name)
+        print(f"{name}={loc}", file=sys.stderr)
+        if loc is not None:
+            for p in _hip64_libs(loc):
+                print(f"  {p}", file=sys.stderr)
+    sdk = _rocm_sdk_root()
+    print(f"rocm-sdk path --root={sdk}", file=sys.stderr)
+    for pattern in (
+        "/opt/venv/**/libamdhip64.so*",
+        "/usr/**/libamdhip64.so*",
+        "/opt/rocm*/**/libamdhip64.so*",
+    ):
+        hits = glob.glob(pattern, recursive=True)
+        for hit in hits[:20]:
+            print(hit, file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ensure-devel",
+        action="store_true",
+        help="pip install matching rocm-sdk-devel and run rocm-sdk init",
+    )
+    args = parser.parse_args()
+    if args.ensure_devel:
+        install_devel()
+        rocm_sdk_init()
+    root = _pick_root()
+    if root is None:
+        dump_debug()
+        return 1
+    root = _ensure_unversioned(root)
+    print(root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/generate_summary.py
+++ b/.github/scripts/generate_summary.py
@@ -95,9 +95,17 @@ def test_summary(summary: Path) -> None:
         ["Run tests", f"`{tests_outcome}`"],
         ["Run benchmarks", f"`{bench_outcome}`"],
     ]
+    aiter_log = os.environ.get("SUMMARY_AITER_LOG", "")
     # A gated-off step reports the literal string "skipped", which is truthy.
-    if aiter_outcome and aiter_outcome != "skipped":
+    aiter_ran = bool(aiter_outcome) and aiter_outcome != "skipped"
+    if aiter_ran:
         step_rows.append(["Aiter CSV MoE / HGEMM", f"`{aiter_outcome}`"])
+        # The comparison is informational and cannot fail the step, so put the
+        # verdict in the status table rather than only in the block below.
+        regress = _aiter_regress_count(aiter_log) if aiter_log else None
+        if regress is not None:
+            note = "none" if regress == 0 else f"**{regress}** (see table below)"
+            step_rows.append(["Aiter perf regressions vs pin", note])
     _table(
         summary,
         ["Step", "Status"],
@@ -106,8 +114,7 @@ def test_summary(summary: Path) -> None:
 
     _write_test_results(summary, test_log)
     _write_bench_results(summary, bench_log)
-    aiter_log = os.environ.get("SUMMARY_AITER_LOG", "")
-    if aiter_log and aiter_outcome and aiter_outcome != "skipped":
+    if aiter_log and aiter_ran:
         _write_aiter_compare(summary, aiter_log)
 
 
@@ -208,6 +215,15 @@ def _extract_perf_table(text: str) -> list[str]:
         lambda line: line.startswith("op "),
         lambda line: "Benchmark Summary" in line,
     )
+
+
+def _aiter_regress_count(log_path: str) -> int | None:
+    """REGRESS count from compare_benchmark.py's summary block, if it ran."""
+    log = Path(log_path)
+    if not log.is_file():
+        return None
+    match = _first_match(r"^  REGRESS:\s+\d+", log.read_text(errors="replace"))
+    return int(match.split()[-1]) if match else None
 
 
 def _write_aiter_compare(summary: Path, log_path: str) -> None:

--- a/.github/scripts/generate_summary.py
+++ b/.github/scripts/generate_summary.py
@@ -6,9 +6,9 @@
 """Generate GitHub Actions job summaries for FlyDSL CI.
 
 Usage:
-    python3 scripts/generate_summary.py build
-    python3 scripts/generate_summary.py test
-    python3 scripts/generate_summary.py promote
+    python3 .github/scripts/generate_summary.py build
+    python3 .github/scripts/generate_summary.py test
+    python3 .github/scripts/generate_summary.py promote
 
 Each mode reads its inputs from environment variables and appends
 Markdown to $GITHUB_STEP_SUMMARY.
@@ -95,7 +95,8 @@ def test_summary(summary: Path) -> None:
         ["Run tests", f"`{tests_outcome}`"],
         ["Run benchmarks", f"`{bench_outcome}`"],
     ]
-    if aiter_outcome:
+    # A gated-off step reports the literal string "skipped", which is truthy.
+    if aiter_outcome and aiter_outcome != "skipped":
         step_rows.append(["Aiter CSV MoE / HGEMM", f"`{aiter_outcome}`"])
     _table(
         summary,
@@ -106,7 +107,7 @@ def test_summary(summary: Path) -> None:
     _write_test_results(summary, test_log)
     _write_bench_results(summary, bench_log)
     aiter_log = os.environ.get("SUMMARY_AITER_LOG", "")
-    if aiter_log:
+    if aiter_log and aiter_outcome and aiter_outcome != "skipped":
         _write_aiter_compare(summary, aiter_log)
 
 
@@ -142,13 +143,7 @@ def _write_bench_results(summary: Path, log_path: str) -> None:
 
     perf_block = _extract_perf_table(text)
     if perf_block:
-        _out(summary, "### Benchmark Results")
-        _out(summary)
-        _out(summary, "```")
-        for line in perf_block[:30]:
-            _out(summary, line)
-        _out(summary, "```")
-        _out(summary)
+        _write_block(summary, "### Benchmark Results", perf_block, 30)
 
     for pattern in (r"^Total:.*", r"^Success:.*", r"^Failed:.*"):
         match = _first_match(pattern, text)
@@ -157,40 +152,87 @@ def _write_bench_results(summary: Path, log_path: str) -> None:
     _out(summary)
 
 
-def _extract_perf_table(text: str) -> list[str]:
-    """Return lines between the 'op' header and 'Benchmark Summary'."""
+def _capture_block(text, start_pred, end_pred, inclusive_end=False) -> list[str]:
+    """Return the lines from the first start_pred match to the first end_pred match.
+
+    Without an end_pred the capture would run to the end of the log, so every
+    caller must supply one.
+    """
     lines: list[str] = []
     capturing = False
     for line in text.splitlines():
-        if not capturing and line.startswith("op "):
+        if not capturing and start_pred(line):
             capturing = True
         if capturing:
-            if "Benchmark Summary" in line:
+            if end_pred(line):
+                if inclusive_end:
+                    lines.append(line)
                 break
             lines.append(line)
     return lines
+
+
+def _trim(lines: list[str], limit: int, tail_pred=None) -> list[str]:
+    """Cap lines at limit, marking what was dropped.
+
+    With tail_pred, the block starting at the first match is always kept: the
+    aiter sweep is far longer than the cap and its verdict is the last thing in
+    the block, so plain head truncation would silently drop it.
+    """
+    if len(lines) <= limit:
+        return lines
+    tail: list[str] = []
+    if tail_pred is not None:
+        idx = next((i for i, line in enumerate(lines) if tail_pred(line)), None)
+        if idx is not None and len(lines) - idx < limit - 1:
+            tail = lines[idx:]
+    head = lines[: max(limit - len(tail) - 1, 0)]
+    dropped = len(lines) - len(head) - len(tail)
+    return head + [f"... {dropped} line(s) omitted; see the step log ..."] + tail
+
+
+def _write_block(summary: Path, title: str, lines: list[str], limit: int, tail_pred=None) -> None:
+    _out(summary, title)
+    _out(summary)
+    _out(summary, "```")
+    for line in _trim(lines, limit, tail_pred):
+        _out(summary, line)
+    _out(summary, "```")
+    _out(summary)
+
+
+def _extract_perf_table(text: str) -> list[str]:
+    """Return lines between the 'op' header and 'Benchmark Summary'."""
+    return _capture_block(
+        text,
+        lambda line: line.startswith("op "),
+        lambda line: "Benchmark Summary" in line,
+    )
 
 
 def _write_aiter_compare(summary: Path, log_path: str) -> None:
     log = Path(log_path)
     if not log.is_file():
         return
-    lines = []
-    capturing = False
-    for line in log.read_text(errors="replace").splitlines():
-        if line.startswith("=== Tuned op bench:"):
-            capturing = True
-        if capturing:
-            lines.append(line)
+    text = log.read_text(errors="replace")
+    # compare_benchmark.py ends its report with the "SKIPPED:" counter; without
+    # that sentinel the capture would swallow the trailing pip output too.
+    lines = _capture_block(
+        text,
+        lambda line: line.startswith("=== Tuned op bench:"),
+        lambda line: line.startswith("  SKIPPED:"),
+        inclusive_end=True,
+    )
+    title = "### Aiter CSV: wheel vs aiter-main flydsl pin"
     if not lines:
+        # The banner comes from aiter's compare_benchmark.py, which is unpinned.
+        # Say so rather than dropping the table from an otherwise green summary.
+        _out(summary, title)
+        _out(summary)
+        _out(summary, "No comparison block found in the aiter log (banner may have changed upstream).")
+        _out(summary)
         return
-    _out(summary, "### Aiter CSV: wheel vs aiter-main flydsl pin")
-    _out(summary)
-    _out(summary, "```")
-    for line in lines[:80]:
-        _out(summary, line)
-    _out(summary, "```")
-    _out(summary)
+    _write_block(summary, title, lines, 80, tail_pred=lambda line: line.startswith("Summary:"))
 
 
 # ── Promote summary ─────────────────────────────────────────────────────────

--- a/.github/workflows/build-whl.yaml
+++ b/.github/workflows/build-whl.yaml
@@ -166,7 +166,7 @@ jobs:
         run: |
           SUMMARY_LLVM_COMMIT="$(python3 -c "import json; print(json.load(open('flydsl/thirdparty/llvm-build-info.json'))['upstream']['llvm_hash'])")"
           export SUMMARY_LLVM_COMMIT
-          python3 flydsl/scripts/generate_summary.py build
+          python3 flydsl/.github/scripts/generate_summary.py build
 
       - name: Configure AWS credentials
         if: ${{ github.repository_owner == 'ROCm' && inputs.upload_s3_staging }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,11 @@ on:
         description: 'Docker base image for test'
         type: string
         default: "rocm/pytorch:rocm7.14_ubuntu24.04_py3.11_pytorch_release_2.12.0@sha256:05743468394cc8f9cce06822635836a31ddfd5956bac36976666d7057713441d"
+      aiter_ref:
+        description: 'aiter branch/tag for the current CSV run (compared against aiter main)'
+        type: string
+        default: 'main'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: true
@@ -36,6 +41,7 @@ jobs:
     uses: ./.github/workflows/test-whl.yaml
     with:
       docker_image: ${{ inputs.docker_image || 'rocm/pytorch:rocm7.14_ubuntu24.04_py3.11_pytorch_release_2.12.0@sha256:05743468394cc8f9cce06822635836a31ddfd5956bac36976666d7057713441d' }}
+      aiter_ref: ${{ inputs.aiter_ref || 'main' }}
     permissions:
       contents: read
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ on:
         type: string
         default: "rocm/pytorch:rocm7.14_ubuntu24.04_py3.11_pytorch_release_2.12.0@sha256:05743468394cc8f9cce06822635836a31ddfd5956bac36976666d7057713441d"
       aiter_ref:
-        description: 'aiter branch/tag for the current CSV run (compared against aiter main)'
+        description: 'aiter branch/tag for the current CSV run (default main). Compared against flydsl== from aiter main requirements.txt.'
         type: string
         default: 'main'
 

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           sparse-checkout: |
             scripts/install_awscli.sh
-            scripts/generate_summary.py
+            .github/scripts/generate_summary.py
           path: flydsl
 
       - name: Configure AWS credentials
@@ -75,5 +75,5 @@ jobs:
           SUMMARY_S3_SOURCE: "s3://framework-whls-${{ inputs.release_type }}/whl-staging/gfx942-gfx950"
           SUMMARY_S3_DEST: "s3://framework-whls-${{ inputs.release_type }}/whl/gfx942-gfx950"
           SUMMARY_WHEEL_NAMES: ${{ inputs.wheel_names }}
-        run: python3 flydsl/scripts/generate_summary.py promote
+        run: python3 flydsl/.github/scripts/generate_summary.py promote
 

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -8,7 +8,7 @@ on:
         type: string
         required: true
       aiter_ref:
-        description: 'aiter branch or tag for the current CSV/HGEMM run (compared against aiter main)'
+        description: 'aiter branch/tag for the current CSV/HGEMM run (default main). Compared against flydsl== from aiter main requirements.txt.'
         type: string
         required: false
         default: 'main'
@@ -104,8 +104,8 @@ jobs:
           fi
 
       # gfx950: aiter CSV MoE (kimik3/dsv4/glm5 from aiter main) + HGEMM.
-      # Current checkout is inputs.aiter_ref; when that is not main, also run
-      # aiter main and compare the two tuned_op_bench.csv files.
+      # Current: wheel under test (PyPI tag / nightly) + aiter at aiter_ref.
+      # Baseline: flydsl== pinned in aiter main requirements.txt, same aiter + CSV.
       - name: Prepare aiter
         if: ${{ !contains(matrix.runners, 'mi325') }}
         env:
@@ -140,34 +140,39 @@ jobs:
           fi
           CFG="${MAIN_ROOT}/aiter/configs/model_configs"
           FMOE="${CFG}/kimik3_a8w4_tuned_fmoe.csv:${CFG}/dsv4_fp8fp4_tuned_fmoe.csv:${CFG}/glm5_fp4_tuned_fmoe.csv"
+          PIN="$(awk -F== '/^flydsl==/{print $2; exit}' "${MAIN_ROOT}/requirements.txt" | awk -F';' '{print $1}' | tr -d '[:space:]')"
+          if [ -z "${PIN}" ]; then
+            echo "aiter main requirements.txt has no flydsl== pin" >&2
+            exit 1
+          fi
 
           run_moe_csv() {
-            root="$1"
-            out="$2"
+            out="$1"
+            cache="$2"
             rm -f "${out}"
-            export PYTHONPATH="${root}:${PYTHONPATH_BASE}"
-            export AITER_REPO="${root}"
+            export PYTHONPATH="/tmp/aiter:${PYTHONPATH_BASE}"
+            export AITER_REPO=/tmp/aiter
             export AITER_CONFIG_FMOE="${FMOE}"
             export AITER_TUNED_OP_BENCH_CSV="${out}"
-            export FLYDSL_RUNTIME_CACHE_DIR="/tmp/flydsl_cache_$(basename "${root}")"
-            python3 "${root}/op_tests/test_moe_2stage.py" --no-legacy --csv-filter flydsl_
+            export FLYDSL_RUNTIME_CACHE_DIR="${cache}"
+            python3 /tmp/aiter/op_tests/test_moe_2stage.py --no-legacy --csv-filter flydsl_
           }
 
-          echo "=== aiter current (${REF}) CSV MoE ==="
-          run_moe_csv /tmp/aiter /tmp/tuned_op_bench_current.csv
+          echo "=== current wheel CSV MoE (aiter ${REF}) ==="
+          run_moe_csv /tmp/tuned_op_bench_current.csv /tmp/flydsl_cache_current
           PYTHONPATH="/tmp/aiter:${PYTHONPATH_BASE}" AITER_REPO=/tmp/aiter python3 /tmp/aiter/op_tests/test_flydsl_hgemm.py
 
-          if [ -d /tmp/aiter-main ]; then
-            echo "=== aiter main CSV MoE ==="
-            run_moe_csv /tmp/aiter-main /tmp/tuned_op_bench_main.csv
-            python3 /tmp/aiter-main/.github/scripts/compare_benchmark.py \
-              /tmp/tuned_op_bench_main.csv \
-              /tmp/tuned_op_bench_current.csv \
-              --baseline-label "aiter-main" \
-              --current-label "aiter-${REF}"
-          else
-            echo "aiter_ref is main; skipping vs-main CSV compare"
-          fi
+          echo "=== aiter-main requirements flydsl==${PIN} CSV MoE ==="
+          python3 -m pip install --force-reinstall --no-deps --only-binary=:all: "flydsl==${PIN}"
+          run_moe_csv /tmp/tuned_op_bench_main.csv /tmp/flydsl_cache_main_pin
+
+          python3 "${MAIN_ROOT}/.github/scripts/compare_benchmark.py" \
+            /tmp/tuned_op_bench_main.csv \
+            /tmp/tuned_op_bench_current.csv \
+            --baseline-label "flydsl==${PIN}" \
+            --current-label "flydsl-wheel (aiter ${REF})"
+
+          python3 -m pip install --force-reinstall --no-deps --no-index --find-links=/dist flydsl
           BASH
 
       - name: Show aiter logs

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -7,6 +7,11 @@ on:
         description: 'Docker base image for testing'
         type: string
         required: true
+      aiter_ref:
+        description: 'aiter branch or tag for the current CSV/HGEMM run (compared against aiter main)'
+        type: string
+        required: false
+        default: 'main'
 
 jobs:
   test:
@@ -98,27 +103,71 @@ jobs:
             cat *.log || true
           fi
 
-      # gfx950 only: aiter FlyDSL kernels + kimik3/dsv4/glm5 tuned-fmoe CSVs.
+      # gfx950: aiter CSV MoE (kimik3/dsv4/glm5 from aiter main) + HGEMM.
+      # Current checkout is inputs.aiter_ref; when that is not main, also run
+      # aiter main and compare the two tuned_op_bench.csv files.
       - name: Prepare aiter
         if: ${{ !contains(matrix.runners, 'mi325') }}
+        env:
+          AITER_REF: ${{ inputs.aiter_ref }}
         run: |
-          docker exec flydsl_test bash -c "rm -rf /tmp/aiter && git clone --depth 1 --recursive --shallow-submodules https://github.com/ROCm/aiter.git /tmp/aiter"
-          docker exec flydsl_test bash -c "python3 -c \"from pathlib import Path; src = Path('/tmp/aiter/requirements.txt'); dst = Path('/tmp/aiter/requirements-flydsl-ci.txt'); lines = [line for line in src.read_text().splitlines() if line.strip() and not line.strip().startswith('flydsl==')]; dst.write_text('\\n'.join(lines) + '\\n')\" && python3 -m pip install -r /tmp/aiter/requirements-flydsl-ci.txt"
+          docker exec -e AITER_REF -i flydsl_test bash <<'BASH'
+          set -euo pipefail
+          REF="${AITER_REF:-main}"
+          rm -rf /tmp/aiter /tmp/aiter-main
+          git clone --depth 1 --recursive --shallow-submodules --branch "${REF}" https://github.com/ROCm/aiter.git /tmp/aiter
+          if [ "${REF}" != "main" ]; then
+            git clone --depth 1 --recursive --shallow-submodules --branch main https://github.com/ROCm/aiter.git /tmp/aiter-main
+          fi
+          python3 -c "from pathlib import Path; src = Path('/tmp/aiter/requirements.txt'); dst = Path('/tmp/aiter/requirements-flydsl-ci.txt'); lines = [line for line in src.read_text().splitlines() if line.strip() and not line.strip().startswith('flydsl==')]; dst.write_text('\\n'.join(lines) + '\\n')"
+          python3 -m pip install -r /tmp/aiter/requirements-flydsl-ci.txt
+          BASH
 
       - name: Run aiter CSV MoE and HGEMM
         id: aiter
         if: ${{ !contains(matrix.runners, 'mi325') }}
-        timeout-minutes: 180
+        timeout-minutes: 360
+        env:
+          AITER_REF: ${{ inputs.aiter_ref }}
         run: |
-          docker exec -i flydsl_test bash <<'BASH' 2>&1 | tee /tmp/aiter_output.log
+          docker exec -e AITER_REF -i flydsl_test bash <<'BASH' 2>&1 | tee /tmp/aiter_output.log
           set -euo pipefail
-          export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
-          export AITER_REPO=/tmp/aiter
-          CFG=/tmp/aiter/aiter/configs/model_configs
-          export AITER_CONFIG_FMOE="${CFG}/kimik3_a8w4_tuned_fmoe.csv:${CFG}/dsv4_fp8fp4_tuned_fmoe.csv:${CFG}/glm5_fp4_tuned_fmoe.csv"
-          cd /tmp/aiter
-          python3 op_tests/test_moe_2stage.py --no-legacy --csv-filter flydsl_
-          python3 op_tests/test_flydsl_hgemm.py
+          REF="${AITER_REF:-main}"
+          PYTHONPATH_BASE="${PYTHONPATH:-}"
+          MAIN_ROOT=/tmp/aiter
+          if [ -d /tmp/aiter-main ]; then
+            MAIN_ROOT=/tmp/aiter-main
+          fi
+          CFG="${MAIN_ROOT}/aiter/configs/model_configs"
+          FMOE="${CFG}/kimik3_a8w4_tuned_fmoe.csv:${CFG}/dsv4_fp8fp4_tuned_fmoe.csv:${CFG}/glm5_fp4_tuned_fmoe.csv"
+
+          run_moe_csv() {
+            root="$1"
+            out="$2"
+            rm -f "${out}"
+            export PYTHONPATH="${root}:${PYTHONPATH_BASE}"
+            export AITER_REPO="${root}"
+            export AITER_CONFIG_FMOE="${FMOE}"
+            export AITER_TUNED_OP_BENCH_CSV="${out}"
+            export FLYDSL_RUNTIME_CACHE_DIR="/tmp/flydsl_cache_$(basename "${root}")"
+            python3 "${root}/op_tests/test_moe_2stage.py" --no-legacy --csv-filter flydsl_
+          }
+
+          echo "=== aiter current (${REF}) CSV MoE ==="
+          run_moe_csv /tmp/aiter /tmp/tuned_op_bench_current.csv
+          PYTHONPATH="/tmp/aiter:${PYTHONPATH_BASE}" AITER_REPO=/tmp/aiter python3 /tmp/aiter/op_tests/test_flydsl_hgemm.py
+
+          if [ -d /tmp/aiter-main ]; then
+            echo "=== aiter main CSV MoE ==="
+            run_moe_csv /tmp/aiter-main /tmp/tuned_op_bench_main.csv
+            python3 /tmp/aiter-main/.github/scripts/compare_benchmark.py \
+              /tmp/tuned_op_bench_main.csv \
+              /tmp/tuned_op_bench_current.csv \
+              --baseline-label "aiter-main" \
+              --current-label "aiter-${REF}"
+          else
+            echo "aiter_ref is main; skipping vs-main CSV compare"
+          fi
           BASH
 
       - name: Show aiter logs
@@ -138,6 +187,7 @@ jobs:
           SUMMARY_AITER_OUTCOME: ${{ steps.aiter.outcome }}
           SUMMARY_TEST_LOG: /tmp/test_output.log
           SUMMARY_BENCH_LOG: /tmp/bench_output.log
+          SUMMARY_AITER_LOG: /tmp/aiter_output.log
         run: python3 flydsl/scripts/generate_summary.py test
 
       - name: Clean up

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -98,6 +98,36 @@ jobs:
             cat *.log || true
           fi
 
+      # gfx950 only: aiter FlyDSL kernels + kimik3/dsv4/glm5 tuned-fmoe CSVs.
+      - name: Prepare aiter
+        if: ${{ !contains(matrix.runners, 'mi325') }}
+        run: |
+          docker exec flydsl_test bash -c "rm -rf /tmp/aiter && git clone --depth 1 --recursive --shallow-submodules https://github.com/ROCm/aiter.git /tmp/aiter"
+          docker exec flydsl_test bash -c "python3 -c \"from pathlib import Path; src = Path('/tmp/aiter/requirements.txt'); dst = Path('/tmp/aiter/requirements-flydsl-ci.txt'); lines = [line for line in src.read_text().splitlines() if line.strip() and not line.strip().startswith('flydsl==')]; dst.write_text('\\n'.join(lines) + '\\n')\" && python3 -m pip install -r /tmp/aiter/requirements-flydsl-ci.txt"
+
+      - name: Run aiter CSV MoE and HGEMM
+        id: aiter
+        if: ${{ !contains(matrix.runners, 'mi325') }}
+        timeout-minutes: 180
+        run: |
+          docker exec -i flydsl_test bash <<'BASH' 2>&1 | tee /tmp/aiter_output.log
+          set -euo pipefail
+          export PYTHONPATH=/tmp/aiter:${PYTHONPATH:-}
+          export AITER_REPO=/tmp/aiter
+          CFG=/tmp/aiter/aiter/configs/model_configs
+          export AITER_CONFIG_FMOE="${CFG}/kimik3_a8w4_tuned_fmoe.csv:${CFG}/dsv4_fp8fp4_tuned_fmoe.csv:${CFG}/glm5_fp4_tuned_fmoe.csv"
+          cd /tmp/aiter
+          python3 op_tests/test_moe_2stage.py --no-legacy --csv-filter flydsl_
+          python3 op_tests/test_flydsl_hgemm.py
+          BASH
+
+      - name: Show aiter logs
+        if: failure()
+        run: |
+          if [ -f /tmp/aiter_output.log ]; then
+            tail -n 200 /tmp/aiter_output.log
+          fi
+
       - name: Test summary
         if: always()
         env:
@@ -105,6 +135,7 @@ jobs:
           SUMMARY_INSTALL_OUTCOME: ${{ steps.install.outcome }}
           SUMMARY_TESTS_OUTCOME: ${{ steps.tests.outcome }}
           SUMMARY_BENCHMARKS_OUTCOME: ${{ steps.benchmarks.outcome }}
+          SUMMARY_AITER_OUTCOME: ${{ steps.aiter.outcome }}
           SUMMARY_TEST_LOG: /tmp/test_output.log
           SUMMARY_BENCH_LOG: /tmp/bench_output.log
         run: python3 flydsl/scripts/generate_summary.py test

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -8,10 +8,10 @@ on:
         type: string
         required: true
       aiter_ref:
-        description: 'aiter branch/tag for the current CSV/HGEMM run (default main). Compared against flydsl== from aiter main requirements.txt.'
+        description: 'aiter branch/tag for the CSV/HGEMM stage. Empty (the default) skips the stage entirely; callers opt in by passing a ref. Compared against flydsl== from aiter main requirements.txt.'
         type: string
         required: false
-        default: 'main'
+        default: ''
 
 jobs:
   test:
@@ -103,11 +103,13 @@ jobs:
             cat *.log || true
           fi
 
-      # gfx950: aiter CSV MoE (kimik3/dsv4/glm5 from aiter main) + HGEMM.
+      # aiter CSV MoE (kimik3/dsv4/glm5 from aiter main) + HGEMM.
       # Current: wheel under test (PyPI tag / nightly) + aiter at aiter_ref.
       # Baseline: flydsl== pinned in aiter main requirements.txt, same aiter + CSV.
+      # Opt-in (caller passes aiter_ref) and restricted to gfx950 runners: the CSVs
+      # are FP4/A4W4 workloads that moe_gemm_2stage rejects outside gfx94*/gfx95*.
       - name: Prepare aiter
-        if: ${{ !contains(matrix.runners, 'mi325') }}
+        if: ${{ inputs.aiter_ref != '' && contains(matrix.runners, 'mi35') }}
         env:
           AITER_REF: ${{ inputs.aiter_ref }}
         run: |
@@ -130,8 +132,8 @@ jobs:
 
       - name: Run aiter CSV MoE and HGEMM
         id: aiter
-        if: ${{ !contains(matrix.runners, 'mi325') }}
-        timeout-minutes: 360
+        if: ${{ inputs.aiter_ref != '' && contains(matrix.runners, 'mi35') }}
+        timeout-minutes: 120
         env:
           AITER_REF: ${{ inputs.aiter_ref }}
         run: |
@@ -146,10 +148,18 @@ jobs:
           export LIBRARY_PATH="${ROCM_PATH}/lib:${ROCM_PATH}/lib64:${LIBRARY_PATH:-}"
           export LD_LIBRARY_PATH="${ROCM_PATH}/lib:${ROCM_PATH}/lib64:${LD_LIBRARY_PATH:-}"
           # hipcc in this image rejects --offload-arch=native and then compiles
-          # every gfx*; pin to the live GPU (these jobs are gfx950-only).
+          # every gfx*; pin to the live GPU.
           if [ -z "${GPU_ARCHS:-}" ]; then
             GPU_ARCHS="$(rocminfo 2>/dev/null | grep -m1 -oE 'gfx[0-9a-z]+' || true)"
-            GPU_ARCHS="${GPU_ARCHS:-gfx950}"
+          fi
+          if [ -z "${GPU_ARCHS:-}" ]; then
+            GPU_ARCHS="$(rocm_agent_enumerator -name 2>/dev/null | grep -m1 -oE 'gfx[0-9a-z]+' || true)"
+          fi
+          if [ -z "${GPU_ARCHS:-}" ]; then
+            # Guessing here silently compiles for the wrong arch; make it visible.
+            echo "could not detect GPU arch (rocminfo and rocm_agent_enumerator unavailable)" >&2
+            echo "set GPU_ARCHS explicitly to run this stage" >&2
+            exit 1
           fi
           export GPU_ARCHS
           echo "aiter JIT env ROCM_PATH=${ROCM_PATH} GPU_ARCHS=${GPU_ARCHS}"
@@ -179,6 +189,13 @@ jobs:
             python3 /tmp/aiter/op_tests/test_moe_2stage.py --no-legacy --csv-filter flydsl_
           }
 
+          # The baseline pin below replaces the wheel under test in this container.
+          # Restore it on every exit path, not just the happy one.
+          restore_wheel() {
+            python3 -m pip install --force-reinstall --no-deps --no-index --find-links=/dist flydsl
+          }
+          trap restore_wheel EXIT
+
           echo "=== current wheel CSV MoE (aiter ${REF}) ==="
           run_moe_csv /tmp/tuned_op_bench_current.csv /tmp/flydsl_cache_current
           PYTHONPATH="/tmp/aiter:${PYTHONPATH_BASE}" AITER_REPO=/tmp/aiter python3 /tmp/aiter/op_tests/test_flydsl_hgemm.py
@@ -191,9 +208,8 @@ jobs:
             /tmp/tuned_op_bench_main.csv \
             /tmp/tuned_op_bench_current.csv \
             --baseline-label "flydsl==${PIN}" \
-            --current-label "flydsl-wheel (aiter ${REF})"
-
-          python3 -m pip install --force-reinstall --no-deps --no-index --find-links=/dist flydsl
+            --current-label "flydsl-wheel (aiter ${REF})" \
+            --fail-on-regress
           BASH
 
       - name: Show aiter logs
@@ -213,8 +229,10 @@ jobs:
           SUMMARY_AITER_OUTCOME: ${{ steps.aiter.outcome }}
           SUMMARY_TEST_LOG: /tmp/test_output.log
           SUMMARY_BENCH_LOG: /tmp/bench_output.log
-          SUMMARY_AITER_LOG: /tmp/aiter_output.log
-        run: python3 flydsl/scripts/generate_summary.py test
+          # Host /tmp survives between jobs and only the aiter leg truncates this
+          # file, so pass it only when the step actually ran on this leg.
+          SUMMARY_AITER_LOG: ${{ (steps.aiter.outcome == 'success' || steps.aiter.outcome == 'failure') && '/tmp/aiter_output.log' || '' }}
+        run: python3 flydsl/.github/scripts/generate_summary.py test
 
       - name: Clean up
         if: always()

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -121,6 +121,8 @@ jobs:
           fi
           python3 -c "from pathlib import Path; src = Path('/tmp/aiter/requirements.txt'); dst = Path('/tmp/aiter/requirements-flydsl-ci.txt'); lines = [line for line in src.read_text().splitlines() if line.strip() and not line.strip().startswith('flydsl==')]; dst.write_text('\\n'.join(lines) + '\\n')"
           python3 -m pip install -r /tmp/aiter/requirements-flydsl-ci.txt
+          # test_moe_2stage.py calls DataFrame.to_markdown() after the CSV sweep.
+          python3 -m pip install tabulate
           # 7.14 PyTorch image: TheRock pip-ROCm. libamdhip64.so (unversioned) is
           # in rocm-sdk-devel after `rocm-sdk init`; core only has libamdhip64.so.N.
           python3 /flydsl/.github/scripts/find_rocm_path.py --ensure-devel

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -135,7 +135,9 @@ jobs:
           set -euo pipefail
           # hipcc in this image lives under the venv; without ROCM_PATH aiter
           # treats /opt/venv as ROCm home and links -L/opt/venv/lib -lamdhip64.
-          if [ -z "${ROCM_PATH:-}" ]; then
+          # Initialize before any ${ROCM_PATH} expansion: set -u aborts otherwise.
+          ROCM_PATH="${ROCM_PATH:-}"
+          if [ -z "${ROCM_PATH}" ]; then
             if command -v rocm-sdk >/dev/null 2>&1; then
               _sdk="$(rocm-sdk path --root 2>/dev/null || true)"
               if [ -n "${_sdk}" ] && { [ -e "${_sdk}/lib/libamdhip64.so" ] || [ -e "${_sdk}/lib64/libamdhip64.so" ]; }; then

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -200,16 +200,24 @@ jobs:
           run_moe_csv /tmp/tuned_op_bench_current.csv /tmp/flydsl_cache_current
           PYTHONPATH="/tmp/aiter:${PYTHONPATH_BASE}" AITER_REPO=/tmp/aiter python3 /tmp/aiter/op_tests/test_flydsl_hgemm.py
 
-          echo "=== aiter-main requirements flydsl==${PIN} CSV MoE ==="
-          python3 -m pip install --force-reinstall --no-deps --only-binary=:all: "flydsl==${PIN}"
-          run_moe_csv /tmp/tuned_op_bench_main.csv /tmp/flydsl_cache_main_pin
-
-          python3 "${MAIN_ROOT}/.github/scripts/compare_benchmark.py" \
-            /tmp/tuned_op_bench_main.csv \
-            /tmp/tuned_op_bench_current.csv \
-            --baseline-label "flydsl==${PIN}" \
-            --current-label "flydsl-wheel (aiter ${REF})" \
-            --fail-on-regress
+          # Everything above validates the wheel under test and is fatal.
+          # The baseline comparison below is informational: it benchmarks a
+          # different published flydsl, so kernel choice legitimately differs and
+          # a single noisy config out of ~250 must not fail the release job.
+          # && chaining (not set -e) so a failure short-circuits and returns here.
+          perf_compare() {
+            echo "=== aiter-main requirements flydsl==${PIN} CSV MoE ===" \
+              && python3 -m pip install --force-reinstall --no-deps --only-binary=:all: "flydsl==${PIN}" \
+              && run_moe_csv /tmp/tuned_op_bench_main.csv /tmp/flydsl_cache_main_pin \
+              && python3 "${MAIN_ROOT}/.github/scripts/compare_benchmark.py" \
+                /tmp/tuned_op_bench_main.csv \
+                /tmp/tuned_op_bench_current.csv \
+                --baseline-label "flydsl==${PIN}" \
+                --current-label "flydsl-wheel (aiter ${REF})"
+          }
+          if ! perf_compare; then
+            echo "WARNING: perf comparison did not complete; reported but not failing the job" >&2
+          fi
           BASH
 
       - name: Show aiter logs

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -137,7 +137,10 @@ jobs:
           # treats /opt/venv as ROCm home and links -L/opt/venv/lib -lamdhip64.
           if [ -z "${ROCM_PATH:-}" ]; then
             if command -v rocm-sdk >/dev/null 2>&1; then
-              ROCM_PATH="$(rocm-sdk path --root 2>/dev/null || true)"
+              _sdk="$(rocm-sdk path --root 2>/dev/null || true)"
+              if [ -n "${_sdk}" ] && { [ -e "${_sdk}/lib/libamdhip64.so" ] || [ -e "${_sdk}/lib64/libamdhip64.so" ]; }; then
+                ROCM_PATH="${_sdk}"
+              fi
             fi
           fi
           if [ -z "${ROCM_PATH}" ]; then

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -121,6 +121,9 @@ jobs:
           fi
           python3 -c "from pathlib import Path; src = Path('/tmp/aiter/requirements.txt'); dst = Path('/tmp/aiter/requirements-flydsl-ci.txt'); lines = [line for line in src.read_text().splitlines() if line.strip() and not line.strip().startswith('flydsl==')]; dst.write_text('\\n'.join(lines) + '\\n')"
           python3 -m pip install -r /tmp/aiter/requirements-flydsl-ci.txt
+          # 7.14 PyTorch image: TheRock pip-ROCm. libamdhip64.so (unversioned) is
+          # in rocm-sdk-devel after `rocm-sdk init`; core only has libamdhip64.so.N.
+          python3 /flydsl/.github/scripts/find_rocm_path.py --ensure-devel
           BASH
 
       - name: Run aiter CSV MoE and HGEMM
@@ -135,32 +138,7 @@ jobs:
           set -euo pipefail
           # hipcc in this image lives under the venv; without ROCM_PATH aiter
           # treats /opt/venv as ROCm home and links -L/opt/venv/lib -lamdhip64.
-          # Initialize before any ${ROCM_PATH} expansion: set -u aborts otherwise.
-          ROCM_PATH="${ROCM_PATH:-}"
-          if [ -z "${ROCM_PATH}" ]; then
-            if command -v rocm-sdk >/dev/null 2>&1; then
-              _sdk="$(rocm-sdk path --root 2>/dev/null || true)"
-              if [ -n "${_sdk}" ] && { [ -e "${_sdk}/lib/libamdhip64.so" ] || [ -e "${_sdk}/lib64/libamdhip64.so" ]; }; then
-                ROCM_PATH="${_sdk}"
-              fi
-            fi
-          fi
-          if [ -z "${ROCM_PATH}" ]; then
-            for cand in /opt/rocm /opt/rocm-7.14.0 /opt/rocm-7.14; do
-              if [ -e "${cand}/lib/libamdhip64.so" ] || [ -e "${cand}/lib64/libamdhip64.so" ]; then
-                ROCM_PATH="${cand}"
-                break
-              fi
-            done
-          fi
-          if [ -z "${ROCM_PATH}" ]; then
-            echo "ROCM_PATH is unset and libamdhip64.so was not found under /opt/rocm*" >&2
-            exit 1
-          fi
-          if [ ! -e "${ROCM_PATH}/lib/libamdhip64.so" ] && [ ! -e "${ROCM_PATH}/lib64/libamdhip64.so" ]; then
-            echo "libamdhip64.so not found under ${ROCM_PATH}" >&2
-            exit 1
-          fi
+          ROCM_PATH="$(python3 /flydsl/.github/scripts/find_rocm_path.py)"
           export ROCM_PATH
           export ROCM_HOME="${ROCM_HOME:-$ROCM_PATH}"
           export LIBRARY_PATH="${ROCM_PATH}/lib:${ROCM_PATH}/lib64:${LIBRARY_PATH:-}"

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -130,8 +130,44 @@ jobs:
         env:
           AITER_REF: ${{ inputs.aiter_ref }}
         run: |
+          set -euo pipefail
           docker exec -e AITER_REF -i flydsl_test bash <<'BASH' 2>&1 | tee /tmp/aiter_output.log
           set -euo pipefail
+          # hipcc in this image lives under the venv; without ROCM_PATH aiter
+          # treats /opt/venv as ROCm home and links -L/opt/venv/lib -lamdhip64.
+          if [ -z "${ROCM_PATH:-}" ]; then
+            if command -v rocm-sdk >/dev/null 2>&1; then
+              ROCM_PATH="$(rocm-sdk path --root 2>/dev/null || true)"
+            fi
+          fi
+          if [ -z "${ROCM_PATH}" ]; then
+            for cand in /opt/rocm /opt/rocm-7.14.0 /opt/rocm-7.14; do
+              if [ -e "${cand}/lib/libamdhip64.so" ] || [ -e "${cand}/lib64/libamdhip64.so" ]; then
+                ROCM_PATH="${cand}"
+                break
+              fi
+            done
+          fi
+          if [ -z "${ROCM_PATH}" ]; then
+            echo "ROCM_PATH is unset and libamdhip64.so was not found under /opt/rocm*" >&2
+            exit 1
+          fi
+          if [ ! -e "${ROCM_PATH}/lib/libamdhip64.so" ] && [ ! -e "${ROCM_PATH}/lib64/libamdhip64.so" ]; then
+            echo "libamdhip64.so not found under ${ROCM_PATH}" >&2
+            exit 1
+          fi
+          export ROCM_PATH
+          export ROCM_HOME="${ROCM_HOME:-$ROCM_PATH}"
+          export LIBRARY_PATH="${ROCM_PATH}/lib:${ROCM_PATH}/lib64:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${ROCM_PATH}/lib:${ROCM_PATH}/lib64:${LD_LIBRARY_PATH:-}"
+          # hipcc in this image rejects --offload-arch=native and then compiles
+          # every gfx*; pin to the live GPU (these jobs are gfx950-only).
+          if [ -z "${GPU_ARCHS:-}" ]; then
+            GPU_ARCHS="$(rocminfo 2>/dev/null | grep -m1 -oE 'gfx[0-9a-z]+' || true)"
+            GPU_ARCHS="${GPU_ARCHS:-gfx950}"
+          fi
+          export GPU_ARCHS
+          echo "aiter JIT env ROCM_PATH=${ROCM_PATH} GPU_ARCHS=${GPU_ARCHS}"
           REF="${AITER_REF:-main}"
           PYTHONPATH_BASE="${PYTHONPATH:-}"
           MAIN_ROOT=/tmp/aiter

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -84,19 +84,23 @@ def test_summary(summary: Path) -> None:
     install_outcome = os.environ.get("SUMMARY_INSTALL_OUTCOME", "unknown")
     tests_outcome = os.environ.get("SUMMARY_TESTS_OUTCOME", "unknown")
     bench_outcome = os.environ.get("SUMMARY_BENCHMARKS_OUTCOME", "unknown")
+    aiter_outcome = os.environ.get("SUMMARY_AITER_OUTCOME")
     test_log = os.environ.get("SUMMARY_TEST_LOG", "/tmp/test_output.log")
     bench_log = os.environ.get("SUMMARY_BENCH_LOG", "/tmp/bench_output.log")
 
     _out(summary, f"## Test Summary (`{runner}`)")
     _out(summary)
+    step_rows = [
+        ["Install wheels", f"`{install_outcome}`"],
+        ["Run tests", f"`{tests_outcome}`"],
+        ["Run benchmarks", f"`{bench_outcome}`"],
+    ]
+    if aiter_outcome:
+        step_rows.append(["Aiter CSV MoE / HGEMM", f"`{aiter_outcome}`"])
     _table(
         summary,
         ["Step", "Status"],
-        [
-            ["Install wheels", f"`{install_outcome}`"],
-            ["Run tests", f"`{tests_outcome}`"],
-            ["Run benchmarks", f"`{bench_outcome}`"],
-        ],
+        step_rows,
     )
 
     _write_test_results(summary, test_log)

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -184,7 +184,7 @@ def _write_aiter_compare(summary: Path, log_path: str) -> None:
             lines.append(line)
     if not lines:
         return
-    _out(summary, "### Aiter CSV vs main")
+    _out(summary, "### Aiter CSV: wheel vs aiter-main flydsl pin")
     _out(summary)
     _out(summary, "```")
     for line in lines[:80]:

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -105,6 +105,9 @@ def test_summary(summary: Path) -> None:
 
     _write_test_results(summary, test_log)
     _write_bench_results(summary, bench_log)
+    aiter_log = os.environ.get("SUMMARY_AITER_LOG", "")
+    if aiter_log:
+        _write_aiter_compare(summary, aiter_log)
 
 
 def _write_test_results(summary: Path, log_path: str) -> None:
@@ -166,6 +169,28 @@ def _extract_perf_table(text: str) -> list[str]:
                 break
             lines.append(line)
     return lines
+
+
+def _write_aiter_compare(summary: Path, log_path: str) -> None:
+    log = Path(log_path)
+    if not log.is_file():
+        return
+    lines = []
+    capturing = False
+    for line in log.read_text(errors="replace").splitlines():
+        if line.startswith("=== Tuned op bench:"):
+            capturing = True
+        if capturing:
+            lines.append(line)
+    if not lines:
+        return
+    _out(summary, "### Aiter CSV vs main")
+    _out(summary)
+    _out(summary, "```")
+    for line in lines[:80]:
+        _out(summary, line)
+    _out(summary, "```")
+    _out(summary)
 
 
 # ── Promote summary ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- In `test-whl.yaml` (used by publish-to-PyPI and nightly), clone aiter the same way PR CI does, then run aiter's own tests instead of a FlyDSL-side CSV rewriter.
- MoE: `op_tests/test_moe_2stage.py --no-legacy --csv-filter flydsl_` with `AITER_CONFIG_FMOE` pointed at Kimi K3 / DSV4 / GLM5 tuned-fmoe CSVs. `--csv-filter` also turns off aiter's AOT-only guard so a freshly built wheel can JIT.
- HGEMM: `python3 op_tests/test_flydsl_hgemm.py`. gfx950 runners only (skip mi325 / gfx942).

## Test plan
- [x] Local: aiter HGEMM `test_gemm_a16w16_acc_main_loop` nt/bf16/2048³ passed
- [x] Local: `test_moe_2stage.py --no-legacy --csv-filter flydsl_` on one GLM5 CSV row launched FlyDSL stage1/stage2 and finished
- [ ] CI `test-whl` gfx950 job: Prepare aiter + CSV MoE + HGEMM
- [ ] Confirm mi325 skips the aiter steps