### PR TITLE
FlashAttention FP8: Added support for asymmetric head dimensions, variable sequence lengths (varlen), and KV splitting

### DIFF
--- a/kernels/attention/flash_attn_fp8_gfx950.py
+++ b/kernels/attention/flash_attn_fp8_gfx950.py
@@ -27,6 +27,7 @@ from kernels.attention.flash_attn_utils import (
     DualwaveSplitKCombineHelper,
     _make_dualwave_swp_fp8_traits,
     _s_setprio,
+    _waitcnt_vm_n,
     _stagger_extra_barrier_if_one,
     dualwave_splitk_workspace_elems,  # noqa: F401
 )
@@ -37,6 +38,7 @@ from kernels.common.tensor_shim import _run_compiled
 def build_flash_attn_dualwave_swp_fp8_module(
     num_heads,
     head_dim,
+    head_dim_v=None,
     causal=True,
     dtype_str="bf16",
     num_kv_heads=None,
@@ -50,7 +52,9 @@ def build_flash_attn_dualwave_swp_fp8_module(
     num_kv_splits=1,
     varlen=False,
     cross_seqlen=False,
+    block_m=256,
     _xcd_swizzle=False,
+    batch_interleave_group=1,
 ):
     """Build the gfx950 D=128 dual-wave flash-attention launcher.
 
@@ -62,31 +66,29 @@ def build_flash_attn_dualwave_swp_fp8_module(
 
     if not gpu_arch.startswith("gfx950"):
         raise RuntimeError(f"flash_attn_dualwave_swp requires gfx950+ (uses ds_read_tr16_b64), got {gpu_arch}")
-    if head_dim != 128:
-        raise RuntimeError(f"flash_attn_dualwave_swp is D=128 only, got head_dim={head_dim}")
+    if head_dim_v is None:
+        head_dim_v = head_dim
+    if head_dim % 64 or head_dim_v % 32:
+        raise RuntimeError(
+            f"flash_attn_dualwave_swp fp8 needs head_dim % 64 == 0 and head_dim_v % 32 == 0, "
+            f"got head_dim={head_dim}, head_dim_v={head_dim_v}"
+        )
     if dtype_str not in ("bf16", "f16", "fp8"):
         raise RuntimeError(f"flash_attn_dualwave_swp supports bf16/f16/fp8 only, got dtype={dtype_str}")
-    # fp8 is dense-only for now: split-K and packed varlen are not implemented for
-    # fp8, so reject them at the builder boundary rather than building a path that
-    # would silently produce wrong results.
-    if dtype_str == "fp8" and int(num_kv_splits) > 1:
-        raise RuntimeError(f"fp8 flash_attn does not support split-K (num_kv_splits={num_kv_splits})")
-    if dtype_str == "fp8" and varlen:
-        raise RuntimeError("fp8 flash_attn does not support packed varlen (cu_seqlens)")
 
     if num_kv_heads is None:
         num_kv_heads = num_heads
     assert num_heads % num_kv_heads == 0
     NUM_KV_SPLITS = int(num_kv_splits)
     assert NUM_KV_SPLITS >= 1
-    if varlen and num_kv_splits and int(num_kv_splits) > 1:
-        raise ValueError("varlen is not supported together with num_kv_splits > 1")
 
     # All compile-time tile/layout constants live in the fp8 traits object.
     traits = _make_dualwave_swp_fp8_traits(
         num_heads,
         num_kv_heads,
         head_dim,
+        head_dim_v=head_dim_v,
+        block_m=block_m,
         causal=causal,
         waves_per_eu=waves_per_eu,
         daz=daz,
@@ -99,23 +101,29 @@ def build_flash_attn_dualwave_swp_fp8_module(
         varlen=varlen,
         cross_seqlen=cross_seqlen,
         xcd_swizzle=_xcd_swizzle,
+        batch_interleave_group=batch_interleave_group,
     )
     # Builder-level aliases used by SharedStorage and the launch/compile wrappers.
     SPLITK = traits.SPLITK
     BLOCK_M = traits.BLOCK_M
     BLOCK_SIZE = traits.BLOCK_SIZE
     HEAD_DIM = traits.HEAD_DIM
+    HEAD_DIM_V = traits.HEAD_DIM_V
     NUM_HEADS_Q = traits.NUM_HEADS_Q
+    BATCH_INTERLEAVE_GROUP = traits.BATCH_INTERLEAVE_GROUP
     DEFAULT_STRIDE_Q_N = traits.DEFAULT_STRIDE_Q_N
+    DEFAULT_STRIDE_O_N = traits.DEFAULT_STRIDE_O_N
     DEFAULT_STRIDE_KV_N = traits.DEFAULT_STRIDE_KV_N
     _dualwave_swp_fp8_cache_tag = traits.cache_tag
     _lds_elem_dtype = dtype_to_elem_type(traits.DTYPE_STR)
+
+    _q_lds_elems = BLOCK_M * HEAD_DIM if traits.QLDS else 16
 
     @fx.struct
     class SharedStorage:
         kv: fx.Array[_lds_elem_dtype, traits.LDS_KV_TOTAL_SIZE, 16]
         vt: fx.Array[fx.BFloat16, traits.VT_BF16_TOTAL, 16]
-        q: fx.Array[_lds_elem_dtype, BLOCK_M * HEAD_DIM, 16]
+        q: fx.Array[_lds_elem_dtype, _q_lds_elems, 16]
 
     # BN128: two BLOCK_N=64 KV tiles per iteration, one merged softmax correction.
     @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
@@ -194,6 +202,17 @@ def build_flash_attn_dualwave_swp_fp8_module(
             rocdl.s_barrier()
             rocdl.sched_barrier(0)
 
+        DMA_PER_ITER = const_expr(2 * ctx.NUM_DMA_K + 2)
+
+        def _iter_end_bar():
+            if const_expr(traits.VDMA):
+                _waitcnt_vm_n(DMA_PER_ITER)
+            else:
+                rocdl.s_waitcnt(0)
+            rocdl.sched_barrier(0)
+            rocdl.s_barrier()
+            rocdl.sched_barrier(0)
+
         def _softmax_part(v_s, l_row, m_new):
             v_s = softmax_helper.sub_m(v_s, m_new)
             v_p = softmax_helper.exp2(v_s, 0, 16)
@@ -234,16 +253,22 @@ def build_flash_attn_dualwave_swp_fp8_module(
                 m_tile = softmax_helper.floor_masked_max(m_tile)
             return m_tile
 
+        def _load_q_regs():
+            ctx.init_q_row()
+            return ctx.q_row, (gemm_helper.load_q_wide() if const_expr(traits.QREG) else None)
+
+        if const_expr(not traits.QLDS):
+            q_row, q_wide = _load_q_regs()
+        else:
+            q_row, q_wide = None, None
+
         kv_gmem_to_lds.load_k(t0 * BN, t0 % fx.Index(NPF))
-        q_loader.stage_q_to_lds()
-        rocdl.s_waitcnt(0)
-        rocdl.sched_barrier(0)
-        rocdl.s_barrier()
-
-        ctx.init_q_row()
-        q_row = ctx.q_row
-
-        q_wide = gemm_helper.load_q_wide() if const_expr(traits.QREG) else None
+        if const_expr(traits.QLDS):
+            q_loader.stage_q_to_lds()
+            rocdl.s_waitcnt(0)
+            rocdl.sched_barrier(0)
+            rocdl.s_barrier()
+            q_row, q_wide = _load_q_regs()
 
         kv_gmem_to_lds.load_k((t0 + 1) * BN, (t0 + 1) % fx.Index(NPF))
         kv_gmem_to_lds.load_v(t0 * BN, t0 % fx.Index(NPF))
@@ -252,7 +277,10 @@ def build_flash_attn_dualwave_swp_fp8_module(
         kv_gmem_to_lds.load_k((t0 + 3) * BN, (t0 + 3) % fx.Index(NPF))
         kv_gmem_to_lds.load_v((t0 + 2) * BN, (t0 + 2) % fx.Index(NPF))
         kv_gmem_to_lds.load_v((t0 + 3) * BN, (t0 + 3) % fx.Index(NPF))
-        rocdl.s_waitcnt(0)
+        if const_expr(traits.QLDS or not traits.VDMA):
+            rocdl.s_waitcnt(0)
+        else:
+            _waitcnt_vm_n(DMA_PER_ITER)
         rocdl.sched_barrier(0)
         rocdl.s_barrier()
         rocdl.sched_barrier(0)
@@ -322,15 +350,9 @@ def build_flash_attn_dualwave_swp_fp8_module(
                 if const_expr(TPV):
                     _pp_prio(1)
                     v_o = _pv_part(v_p_b, v_v_b, v_o)
-                    rocdl.s_waitcnt(0)
-                    rocdl.sched_barrier(0)
-                    rocdl.s_barrier()
-                    rocdl.sched_barrier(0)
+                    _iter_end_bar()
                 else:
-                    rocdl.s_waitcnt(0)
-                    rocdl.sched_barrier(0)
-                    rocdl.s_barrier()
-                    rocdl.sched_barrier(0)
+                    _iter_end_bar()
                     _pp_prio(1)
                     v_o = _pv_part(v_p_b, v_v_b, v_o)
             else:
@@ -343,10 +365,7 @@ def build_flash_attn_dualwave_swp_fp8_module(
                 v_o, l_row = _subtile_tail(v_s_b, v_v_b, v_o, l_row, m_new)
                 m_row = m_new
 
-                rocdl.s_waitcnt(0)
-                rocdl.sched_barrier(0)
-                rocdl.s_barrier()
-                rocdl.sched_barrier(0)
+                _iter_end_bar()
 
             loop_results = yield [m_row, l_row] + v_o + [nn_a_buf]
         m_row = loop_results[0]
@@ -359,23 +378,28 @@ def build_flash_attn_dualwave_swp_fp8_module(
             inv_l = ArithValue(inv_l) * ctx.vd_fp8
         softmax_helper.scale_o(v_o, inv_l)
         rocdl.s_barrier()
-        output_store.store_final_o(v_o, q_row)
+        if const_expr(not SPLITK):
+            output_store.store_final_o(v_o, q_row)
+        else:
+            output_store.store_splitk_partial_o(v_o, m_row, l_row, q_row)
+            output_store.store_empty_split()
 
     # Combine kernel: out = sum_s w_s * O_s / sum_s w_s * l_s, w_s = exp2(m_s - m_max).
     # One wave row of 32 lanes covers a (b, h, s) row, 4 contiguous cols/lane.
     COMBINE_BLOCK = 256
-    COMBINE_LANES_PER_ROW = traits.HEAD_DIM // 4
+    COMBINE_LANES_PER_ROW = traits.HEAD_DIM_V // 4
     COMBINE_ROWS_PER_BLOCK = COMBINE_BLOCK // COMBINE_LANES_PER_ROW
 
     @flyc.kernel(known_block_size=[COMBINE_BLOCK, 1, 1])
     def flash_attn_splitk_combine_kernel(
         O: fx.Tensor,  # noqa: E741
         WS: fx.Tensor,
+        CuSeqQ: fx.Tensor,
         batch_size: fx.Int32,
         seq_len: fx.Int32,
         stride_q_n: fx.Int32,
     ):
-        ctx = DualwaveSplitKCombineContext(traits, O, WS, batch_size, seq_len, stride_q_n)
+        ctx = DualwaveSplitKCombineContext(traits, O, WS, batch_size, seq_len, stride_q_n, CuSeqQ=CuSeqQ)
         ctx.init_types_and_constants()
         ctx.init_runtime_indices()
         ctx.init_thread_mapping(COMBINE_ROWS_PER_BLOCK, COMBINE_LANES_PER_ROW)
@@ -416,6 +440,8 @@ def build_flash_attn_dualwave_swp_fp8_module(
         num_q_blocks = (sl_idx + BLOCK_M - 1) // BLOCK_M
         if const_expr(SPLITK):
             grid_z = bs_idx * NUM_KV_SPLITS
+        elif const_expr(BATCH_INTERLEAVE_GROUP > 1):
+            grid_z = bs_idx // BATCH_INTERLEAVE_GROUP
         else:
             grid_z = bs_idx
 
@@ -450,13 +476,15 @@ def build_flash_attn_dualwave_swp_fp8_module(
                 "passthrough": passthrough_entries,
             },
         ).launch(
-            grid=(NUM_HEADS_Q, num_q_blocks, grid_z),
+            grid=(NUM_HEADS_Q * BATCH_INTERLEAVE_GROUP, num_q_blocks, grid_z),
             block=(BLOCK_SIZE, 1, 1),
             stream=stream,
         )
         if const_expr(SPLITK):
             combine_rows = bs_idx * NUM_HEADS_Q * sl_idx
-            flash_attn_splitk_combine_kernel(O, DebugCounts, batch_size, seq_len, stride_q_n).launch(
+            flash_attn_splitk_combine_kernel(
+                O, DebugCounts, CuSeqQ, batch_size, seq_len, fx.Int32(DEFAULT_STRIDE_O_N)
+            ).launch(
                 grid=(combine_rows // COMBINE_ROWS_PER_BLOCK, 1, 1),
                 block=(COMBINE_BLOCK, 1, 1),
                 stream=stream,
@@ -627,8 +655,10 @@ def build_flash_attn_dualwave_swp_fp8_module(
         launch_xcd = build_flash_attn_dualwave_swp_fp8_module(
             num_heads,
             head_dim,
+            head_dim_v=head_dim_v,
             causal=causal,
             dtype_str=dtype_str,
+            block_m=block_m,
             num_kv_heads=num_kv_heads,
             waves_per_eu=waves_per_eu,
             daz=daz,

--- a/kernels/attention/flash_attn_fp8_gfx950.py
+++ b/kernels/attention/flash_attn_fp8_gfx950.py
@@ -27,8 +27,8 @@ from kernels.attention.flash_attn_utils import (
     DualwaveSplitKCombineHelper,
     _make_dualwave_swp_fp8_traits,
     _s_setprio,
-    _waitcnt_vm_n,
     _stagger_extra_barrier_if_one,
+    _waitcnt_vm_n,
     dualwave_splitk_workspace_elems,  # noqa: F401
 )
 from kernels.common.kernels_common import dtype_to_elem_type
@@ -108,7 +108,6 @@ def build_flash_attn_dualwave_swp_fp8_module(
     BLOCK_M = traits.BLOCK_M
     BLOCK_SIZE = traits.BLOCK_SIZE
     HEAD_DIM = traits.HEAD_DIM
-    HEAD_DIM_V = traits.HEAD_DIM_V
     NUM_HEADS_Q = traits.NUM_HEADS_Q
     BATCH_INTERLEAVE_GROUP = traits.BATCH_INTERLEAVE_GROUP
     DEFAULT_STRIDE_Q_N = traits.DEFAULT_STRIDE_Q_N

--- a/kernels/attention/flash_attn_fp8_gfx950.py
+++ b/kernels/attention/flash_attn_fp8_gfx950.py
@@ -58,12 +58,10 @@ def build_flash_attn_dualwave_swp_fp8_module(
 ):
     """Build the gfx950 dual-wave fp8 flash-attention launcher.
 
-    ``head_dim`` is the QK reduction width and ``head_dim_v`` the V/output width;
-    they differ for the 192/128 pair. ``varlen`` builds the packed variant: Q/O
-    are ``[total_q, H, D]``, K/V are ``[total_kv, H_kv, D]``, and per-batch ranges
-    come from int32 ``cu_seqlens_q`` / ``cu_seqlens_kv``. ``num_kv_splits > 1``
-    adds the split-KV partial store plus the combine pass. Head-dim and LDS
-    validation lives in ``_make_dualwave_swp_fp8_traits``."""
+    ``head_dim`` is the QK reduction width and ``head_dim_v`` the V/output width.
+    ``varlen`` builds the packed variant (Q/O ``[total_q, H, D]``, K/V
+    ``[total_kv, H_kv, D]``, ranges from int32 ``cu_seqlens_q`` / ``cu_seqlens_kv``);
+    ``num_kv_splits > 1`` adds the partial store plus the combine pass."""
     gpu_arch = get_hip_arch()
 
     if not gpu_arch.startswith("gfx950"):
@@ -113,9 +111,7 @@ def build_flash_attn_dualwave_swp_fp8_module(
     _dualwave_swp_fp8_cache_tag = traits.cache_tag
     _lds_elem_dtype = dtype_to_elem_type(traits.DTYPE_STR)
 
-    # Q only goes through LDS when it fits (head_dim <= 128); otherwise it is read
-    # straight into VGPRs and this array is unused. fx.Array rejects a length of 0,
-    # so the stub is one 16-byte line, which the allocator then drops.
+    # Q skips LDS for head_dim > 128; fx.Array rejects 0, so keep a 16-elem stub.
     _q_lds_elems = BLOCK_M * HEAD_DIM if traits.QLDS else 16
 
     @fx.struct
@@ -274,7 +270,6 @@ def build_flash_attn_dualwave_swp_fp8_module(
         kv_gmem_to_lds.load_v((t0 + 2) * BN, (t0 + 2) % fx.Index(NPF))
         kv_gmem_to_lds.load_v((t0 + 3) * BN, (t0 + 3) % fx.Index(NPF))
         if const_expr(traits.QLDS):
-            # Q was staged through LDS, so the staging stores have to land too.
             rocdl.s_waitcnt(0)
         else:
             _waitcnt_vm_n(DMA_PER_ITER)
@@ -370,9 +365,7 @@ def build_flash_attn_dualwave_swp_fp8_module(
         v_o = [loop_results[2 + i] for i in range_constexpr(D_CHUNKS)]
 
         inv_l_rcp = rocdl.rcp(T.f32, _raw(l_row))
-        # `select` yields a raw ir.Value; type it once here rather than re-wrapping per use.
         inv_l = fx.Float32((fx.Float32(l_row) > ctx.c_zero_f).select(inv_l_rcp, ctx.c_zero_f))
-        # The fp8 PV MMA consumed P and V unscaled, so V's descale lands here.
         inv_l = inv_l * ctx.vd_fp8
         softmax_helper.scale_o(v_o, inv_l)
         rocdl.s_barrier()
@@ -479,13 +472,10 @@ def build_flash_attn_dualwave_swp_fp8_module(
             stream=stream,
         )
         if const_expr(SPLITK):
-            # Rounded up, and one batch per y block so the combine kernel's O
-            # descriptor stays wave-uniform; the tail rows mask themselves off.
+            # One batch per y block keeps the combine kernel's O descriptor wave-uniform.
             combine_rows = NUM_HEADS_Q * sl_idx
             combine_blocks = (combine_rows + (COMBINE_ROWS_PER_BLOCK - 1)) // COMBINE_ROWS_PER_BLOCK
-            # Must be the same O stride the main kernel used: it honours the
-            # caller's stride_q_n for O when the V head dim matches Q's, and only
-            # falls back to the derived one when they differ.
+            # Same O stride the main kernel used.
             if const_expr(traits.HEAD_DIM_V == HEAD_DIM):
                 stride_o_n = stride_q_n
             else:
@@ -538,8 +528,7 @@ def build_flash_attn_dualwave_swp_fp8_module(
         # seq_len_kv defaults to seq_len (self-attention / equal Q,KV lengths).
         if seq_len_kv is None:
             seq_len_kv = seq_len
-        # The grid folds BATCH_INTERLEAVE_GROUP batches into blockIdx.x and divides
-        # blockIdx.z by it, so a remainder means whole batches are never launched.
+        # The grid divides blockIdx.z by the group; a remainder drops whole batches.
         if BATCH_INTERLEAVE_GROUP > 1 and batch_size % BATCH_INTERLEAVE_GROUP:
             raise ValueError(
                 f"flash_attn_dualwave_swp fp8: batch_interleave_group={BATCH_INTERLEAVE_GROUP} requires "
@@ -665,10 +654,6 @@ def build_flash_attn_dualwave_swp_fp8_module(
         and num_heads % NUM_XCD_GFX950 == 0
     ):
         block_m = traits.BLOCK_M
-        # Same build, only the swizzle differs: every build parameter has to be
-        # forwarded, batch_interleave_group included. It is 1 on this branch
-        # today (the swizzle needs `not causal`, the interleave needs `causal`),
-        # but a silently short argument list is what breaks when that changes.
         launch_xcd = build_flash_attn_dualwave_swp_fp8_module(
             num_heads,
             head_dim,

--- a/kernels/attention/flash_attn_fp8_gfx950.py
+++ b/kernels/attention/flash_attn_fp8_gfx950.py
@@ -56,12 +56,7 @@ def build_flash_attn_dualwave_swp_fp8_module(
     _xcd_swizzle=False,
     batch_interleave_group=1,
 ):
-    """Build the gfx950 dual-wave fp8 flash-attention launcher.
-
-    ``head_dim`` is the QK reduction width and ``head_dim_v`` the V/output width.
-    ``varlen`` builds the packed variant (Q/O ``[total_q, H, D]``, K/V
-    ``[total_kv, H_kv, D]``, ranges from int32 ``cu_seqlens_q`` / ``cu_seqlens_kv``);
-    ``num_kv_splits > 1`` adds the partial store plus the combine pass."""
+    """Build the gfx950 dual-wave fp8 launcher (dense, packed varlen, or split-K)."""
     gpu_arch = get_hip_arch()
 
     if not gpu_arch.startswith("gfx950"):
@@ -111,7 +106,7 @@ def build_flash_attn_dualwave_swp_fp8_module(
     _dualwave_swp_fp8_cache_tag = traits.cache_tag
     _lds_elem_dtype = dtype_to_elem_type(traits.DTYPE_STR)
 
-    # Q skips LDS for head_dim > 128; fx.Array rejects 0, so keep a 16-elem stub.
+    # fx.Array rejects a length of 0.
     _q_lds_elems = BLOCK_M * HEAD_DIM if traits.QLDS else 16
 
     @fx.struct
@@ -475,7 +470,6 @@ def build_flash_attn_dualwave_swp_fp8_module(
             # One batch per y block keeps the combine kernel's O descriptor wave-uniform.
             combine_rows = NUM_HEADS_Q * sl_idx
             combine_blocks = (combine_rows + (COMBINE_ROWS_PER_BLOCK - 1)) // COMBINE_ROWS_PER_BLOCK
-            # Same O stride the main kernel used.
             if const_expr(traits.HEAD_DIM_V == HEAD_DIM):
                 stride_o_n = stride_q_n
             else:
@@ -528,7 +522,6 @@ def build_flash_attn_dualwave_swp_fp8_module(
         # seq_len_kv defaults to seq_len (self-attention / equal Q,KV lengths).
         if seq_len_kv is None:
             seq_len_kv = seq_len
-        # The grid divides blockIdx.z by the group; a remainder drops whole batches.
         if BATCH_INTERLEAVE_GROUP > 1 and batch_size % BATCH_INTERLEAVE_GROUP:
             raise ValueError(
                 f"flash_attn_dualwave_swp fp8: batch_interleave_group={BATCH_INTERLEAVE_GROUP} requires "

--- a/kernels/attention/flash_attn_fp8_gfx950.py
+++ b/kernels/attention/flash_attn_fp8_gfx950.py
@@ -10,7 +10,6 @@ import flydsl.expr as fx
 from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import const_expr, range_constexpr, rocdl
 from flydsl.expr.typing import T
-from flydsl.expr.utils.arith import ArithValue
 from flydsl.expr.utils.arith import _to_raw as _raw
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from kernels.attention.flash_attn_utils import (
@@ -29,6 +28,7 @@ from kernels.attention.flash_attn_utils import (
     _s_setprio,
     _stagger_extra_barrier_if_one,
     _waitcnt_vm_n,
+    dualwave_fp8_dma_per_iter,
     dualwave_splitk_workspace_elems,  # noqa: F401
 )
 from kernels.common.kernels_common import dtype_to_elem_type
@@ -56,23 +56,20 @@ def build_flash_attn_dualwave_swp_fp8_module(
     _xcd_swizzle=False,
     batch_interleave_group=1,
 ):
-    """Build the gfx950 D=128 dual-wave flash-attention launcher.
+    """Build the gfx950 dual-wave fp8 flash-attention launcher.
 
-    The dense path supports bf16/f16/fp8 QKV. ``varlen`` builds the packed
-    self-attention variant for bf16/f16: Q/O are ``[total_q, H, D]``, K/V are
-    ``[total_kv, H_kv, D]``, and per-batch ranges come from int32
-    ``cu_seqlens_q`` / ``cu_seqlens_kv``. fp8 currently stays dense-only."""
+    ``head_dim`` is the QK reduction width and ``head_dim_v`` the V/output width;
+    they differ for the 192/128 pair. ``varlen`` builds the packed variant: Q/O
+    are ``[total_q, H, D]``, K/V are ``[total_kv, H_kv, D]``, and per-batch ranges
+    come from int32 ``cu_seqlens_q`` / ``cu_seqlens_kv``. ``num_kv_splits > 1``
+    adds the split-KV partial store plus the combine pass. Head-dim and LDS
+    validation lives in ``_make_dualwave_swp_fp8_traits``."""
     gpu_arch = get_hip_arch()
 
     if not gpu_arch.startswith("gfx950"):
         raise RuntimeError(f"flash_attn_dualwave_swp requires gfx950+ (uses ds_read_tr16_b64), got {gpu_arch}")
     if head_dim_v is None:
         head_dim_v = head_dim
-    if head_dim % 64 or head_dim_v % 32:
-        raise RuntimeError(
-            f"flash_attn_dualwave_swp fp8 needs head_dim % 64 == 0 and head_dim_v % 32 == 0, "
-            f"got head_dim={head_dim}, head_dim_v={head_dim_v}"
-        )
     if dtype_str not in ("bf16", "f16", "fp8"):
         raise RuntimeError(f"flash_attn_dualwave_swp supports bf16/f16/fp8 only, got dtype={dtype_str}")
 
@@ -116,6 +113,9 @@ def build_flash_attn_dualwave_swp_fp8_module(
     _dualwave_swp_fp8_cache_tag = traits.cache_tag
     _lds_elem_dtype = dtype_to_elem_type(traits.DTYPE_STR)
 
+    # Q only goes through LDS when it fits (head_dim <= 128); otherwise it is read
+    # straight into VGPRs and this array is unused. fx.Array rejects a length of 0,
+    # so the stub is one 16-byte line, which the allocator then drops.
     _q_lds_elems = BLOCK_M * HEAD_DIM if traits.QLDS else 16
 
     @fx.struct
@@ -201,13 +201,10 @@ def build_flash_attn_dualwave_swp_fp8_module(
             rocdl.s_barrier()
             rocdl.sched_barrier(0)
 
-        DMA_PER_ITER = const_expr(2 * ctx.NUM_DMA_K + 2)
+        DMA_PER_ITER = const_expr(dualwave_fp8_dma_per_iter(traits))
 
         def _iter_end_bar():
-            if const_expr(traits.VDMA):
-                _waitcnt_vm_n(DMA_PER_ITER)
-            else:
-                rocdl.s_waitcnt(0)
+            _waitcnt_vm_n(DMA_PER_ITER)
             rocdl.sched_barrier(0)
             rocdl.s_barrier()
             rocdl.sched_barrier(0)
@@ -254,7 +251,7 @@ def build_flash_attn_dualwave_swp_fp8_module(
 
         def _load_q_regs():
             ctx.init_q_row()
-            return ctx.q_row, (gemm_helper.load_q_wide() if const_expr(traits.QREG) else None)
+            return ctx.q_row, gemm_helper.load_q_wide()
 
         if const_expr(not traits.QLDS):
             q_row, q_wide = _load_q_regs()
@@ -276,7 +273,8 @@ def build_flash_attn_dualwave_swp_fp8_module(
         kv_gmem_to_lds.load_k((t0 + 3) * BN, (t0 + 3) % fx.Index(NPF))
         kv_gmem_to_lds.load_v((t0 + 2) * BN, (t0 + 2) % fx.Index(NPF))
         kv_gmem_to_lds.load_v((t0 + 3) * BN, (t0 + 3) % fx.Index(NPF))
-        if const_expr(traits.QLDS or not traits.VDMA):
+        if const_expr(traits.QLDS):
+            # Q was staged through LDS, so the staging stores have to land too.
             rocdl.s_waitcnt(0)
         else:
             _waitcnt_vm_n(DMA_PER_ITER)
@@ -372,9 +370,10 @@ def build_flash_attn_dualwave_swp_fp8_module(
         v_o = [loop_results[2 + i] for i in range_constexpr(D_CHUNKS)]
 
         inv_l_rcp = rocdl.rcp(T.f32, _raw(l_row))
-        inv_l = ArithValue(fx.Float32(l_row) > ctx.c_zero_f).select(inv_l_rcp, ctx.c_zero_f)
-        if const_expr(traits.FP8_PV):
-            inv_l = ArithValue(inv_l) * ctx.vd_fp8
+        # `select` yields a raw ir.Value; type it once here rather than re-wrapping per use.
+        inv_l = fx.Float32((fx.Float32(l_row) > ctx.c_zero_f).select(inv_l_rcp, ctx.c_zero_f))
+        # The fp8 PV MMA consumed P and V unscaled, so V's descale lands here.
+        inv_l = inv_l * ctx.vd_fp8
         softmax_helper.scale_o(v_o, inv_l)
         rocdl.s_barrier()
         if const_expr(not SPLITK):
@@ -396,9 +395,9 @@ def build_flash_attn_dualwave_swp_fp8_module(
         CuSeqQ: fx.Tensor,
         batch_size: fx.Int32,
         seq_len: fx.Int32,
-        stride_q_n: fx.Int32,
+        stride_o_n: fx.Int32,
     ):
-        ctx = DualwaveSplitKCombineContext(traits, O, WS, batch_size, seq_len, stride_q_n, CuSeqQ=CuSeqQ)
+        ctx = DualwaveSplitKCombineContext(traits, O, WS, batch_size, seq_len, stride_o_n, CuSeqQ=CuSeqQ)
         ctx.init_types_and_constants()
         ctx.init_runtime_indices()
         ctx.init_thread_mapping(COMBINE_ROWS_PER_BLOCK, COMBINE_LANES_PER_ROW)
@@ -480,11 +479,19 @@ def build_flash_attn_dualwave_swp_fp8_module(
             stream=stream,
         )
         if const_expr(SPLITK):
-            combine_rows = bs_idx * NUM_HEADS_Q * sl_idx
-            flash_attn_splitk_combine_kernel(
-                O, DebugCounts, CuSeqQ, batch_size, seq_len, fx.Int32(DEFAULT_STRIDE_O_N)
-            ).launch(
-                grid=(combine_rows // COMBINE_ROWS_PER_BLOCK, 1, 1),
+            # Rounded up, and one batch per y block so the combine kernel's O
+            # descriptor stays wave-uniform; the tail rows mask themselves off.
+            combine_rows = NUM_HEADS_Q * sl_idx
+            combine_blocks = (combine_rows + (COMBINE_ROWS_PER_BLOCK - 1)) // COMBINE_ROWS_PER_BLOCK
+            # Must be the same O stride the main kernel used: it honours the
+            # caller's stride_q_n for O when the V head dim matches Q's, and only
+            # falls back to the derived one when they differ.
+            if const_expr(traits.HEAD_DIM_V == HEAD_DIM):
+                stride_o_n = stride_q_n
+            else:
+                stride_o_n = fx.Int32(DEFAULT_STRIDE_O_N)
+            flash_attn_splitk_combine_kernel(O, DebugCounts, CuSeqQ, batch_size, seq_len, stride_o_n).launch(
+                grid=(combine_blocks, bs_idx, 1),
                 block=(COMBINE_BLOCK, 1, 1),
                 stream=stream,
             )
@@ -531,6 +538,13 @@ def build_flash_attn_dualwave_swp_fp8_module(
         # seq_len_kv defaults to seq_len (self-attention / equal Q,KV lengths).
         if seq_len_kv is None:
             seq_len_kv = seq_len
+        # The grid folds BATCH_INTERLEAVE_GROUP batches into blockIdx.x and divides
+        # blockIdx.z by it, so a remainder means whole batches are never launched.
+        if BATCH_INTERLEAVE_GROUP > 1 and batch_size % BATCH_INTERLEAVE_GROUP:
+            raise ValueError(
+                f"flash_attn_dualwave_swp fp8: batch_interleave_group={BATCH_INTERLEAVE_GROUP} requires "
+                f"batch_size divisible by it, got batch_size={batch_size}"
+            )
         if SPLITK:
             if workspace is None:
                 raise ValueError("num_kv_splits > 1 requires a fp32 workspace (see dualwave_splitk_workspace_elems)")
@@ -651,6 +665,10 @@ def build_flash_attn_dualwave_swp_fp8_module(
         and num_heads % NUM_XCD_GFX950 == 0
     ):
         block_m = traits.BLOCK_M
+        # Same build, only the swizzle differs: every build parameter has to be
+        # forwarded, batch_interleave_group included. It is 1 on this branch
+        # today (the swizzle needs `not causal`, the interleave needs `causal`),
+        # but a silently short argument list is what breaks when that changes.
         launch_xcd = build_flash_attn_dualwave_swp_fp8_module(
             num_heads,
             head_dim,
@@ -669,6 +687,7 @@ def build_flash_attn_dualwave_swp_fp8_module(
             num_kv_splits=num_kv_splits,
             varlen=varlen,
             cross_seqlen=cross_seqlen,
+            batch_interleave_group=batch_interleave_group,
             _xcd_swizzle=True,
         )
 

--- a/kernels/attention/flash_attn_gfx950.py
+++ b/kernels/attention/flash_attn_gfx950.py
@@ -909,9 +909,9 @@ def build_flash_attn_dualwave_swp_module(
         Sink: fx.Tensor,
         batch_size: fx.Int32,
         seq_len: fx.Int32,
-        stride_o_n: fx.Int32,
+        stride_q_n: fx.Int32,
     ):
-        ctx = DualwaveSplitKCombineContext(traits, O, WS, batch_size, seq_len, stride_o_n, LSE=LSE, Sink=Sink)
+        ctx = DualwaveSplitKCombineContext(traits, O, WS, batch_size, seq_len, stride_q_n, LSE=LSE, Sink=Sink)
         ctx.init_types_and_constants()
         ctx.init_runtime_indices()
         ctx.init_thread_mapping(COMBINE_ROWS_PER_BLOCK, COMBINE_LANES_PER_ROW)
@@ -1008,8 +1008,7 @@ def build_flash_attn_dualwave_swp_module(
             stream=stream,
         )
         if const_expr(traits.SPLITK):
-            # Rounded up, and one batch per y block so the combine kernel's O
-            # descriptor stays wave-uniform; the tail rows mask themselves off.
+            # One batch per y block keeps the combine kernel's O descriptor wave-uniform.
             combine_rows = traits.NUM_HEADS_Q * sl_idx
             combine_blocks = (combine_rows + (COMBINE_ROWS_PER_BLOCK - 1)) // COMBINE_ROWS_PER_BLOCK
             flash_attn_splitk_combine_kernel(O, DebugCounts, LSE, Sink, batch_size, seq_len, stride_q_n).launch(

--- a/kernels/attention/flash_attn_gfx950.py
+++ b/kernels/attention/flash_attn_gfx950.py
@@ -909,9 +909,9 @@ def build_flash_attn_dualwave_swp_module(
         Sink: fx.Tensor,
         batch_size: fx.Int32,
         seq_len: fx.Int32,
-        stride_q_n: fx.Int32,
+        stride_o_n: fx.Int32,
     ):
-        ctx = DualwaveSplitKCombineContext(traits, O, WS, batch_size, seq_len, stride_q_n, LSE=LSE, Sink=Sink)
+        ctx = DualwaveSplitKCombineContext(traits, O, WS, batch_size, seq_len, stride_o_n, LSE=LSE, Sink=Sink)
         ctx.init_types_and_constants()
         ctx.init_runtime_indices()
         ctx.init_thread_mapping(COMBINE_ROWS_PER_BLOCK, COMBINE_LANES_PER_ROW)
@@ -1008,9 +1008,12 @@ def build_flash_attn_dualwave_swp_module(
             stream=stream,
         )
         if const_expr(traits.SPLITK):
-            combine_rows = bs_idx * traits.NUM_HEADS_Q * sl_idx
+            # Rounded up, and one batch per y block so the combine kernel's O
+            # descriptor stays wave-uniform; the tail rows mask themselves off.
+            combine_rows = traits.NUM_HEADS_Q * sl_idx
+            combine_blocks = (combine_rows + (COMBINE_ROWS_PER_BLOCK - 1)) // COMBINE_ROWS_PER_BLOCK
             flash_attn_splitk_combine_kernel(O, DebugCounts, LSE, Sink, batch_size, seq_len, stride_q_n).launch(
-                grid=(combine_rows // COMBINE_ROWS_PER_BLOCK, 1, 1),
+                grid=(combine_blocks, bs_idx, 1),
                 block=(COMBINE_BLOCK, 1, 1),
                 stream=stream,
             )

--- a/kernels/attention/flash_attn_interface.py
+++ b/kernels/attention/flash_attn_interface.py
@@ -92,8 +92,7 @@ def _fp8_auto_kv_splits(
 ) -> int:
     """Pick num_kv_splits by minimising `rounds(s) * (FIXED + tiles/s)`.
 
-    ``block_m`` must be the tile `_fp8_auto_block_m` chose; it sets the workgroup
-    count and therefore whether splitting has idle CUs left to fill.
+    ``block_m`` must be the tile `_fp8_auto_block_m` chose; it sets the workgroup count.
     """
     wgs = num_heads * -(-seqlen_q // block_m) * batch
     kv_tiles = -(-seqlen_kv // _FP8_BLOCK_N)
@@ -930,7 +929,6 @@ def flydsl_flash_attn_func(
     # contiguous tensor is still contiguous, so one launch per entry divides the
     # flat dim by B at no copy. bf16 passes the natural 4-D shape and is exempt.
     if dtype_str == "fp8" and not paged_kv and max(q.numel(), k.numel(), v.numel()) >= _FP8_MAX_FLAT_ELEMS:
-        # Packed varlen has no batch axis to slice, so it can only be rejected.
         _packed = cu_seqlens_q is not None or cu_seqlens_kv is not None or q.dim() != 4
         if _packed or q.shape[0] == 1:
             raise NotImplementedError(
@@ -1080,7 +1078,6 @@ def flydsl_flash_attn_func(
     if k.shape[-1] != D:
         raise ValueError(f"flydsl_flash_attn_func: K head_dim ({k.shape[-1]}) must match Q head_dim ({D})")
     if tuple(v.shape[:-1]) != tuple(k.shape[:-1]):
-        # V's descriptor takes num_records from K's token count.
         raise ValueError(
             f"flydsl_flash_attn_func: V must match K in every dim but the last, got "
             f"v={tuple(v.shape)}, k={tuple(k.shape)}"

--- a/kernels/attention/flash_attn_interface.py
+++ b/kernels/attention/flash_attn_interface.py
@@ -61,43 +61,73 @@ def _fp8_rescale_threshold(seqlen_kv: int) -> float:
     return 6.0 if seqlen_kv <= _FP8_LONG_SEQ else 4.0
 
 
+# Split-K autotuning constants, all tuned at D=Dv=128. Measured across 26
+# shapes (B 1..32, S 512..16384, H 8/16/32) the picks land 1.4% off the
+# per-shape best of {1, 2, 4, 8, 16}; the visible misses are long causal
+# self-attention, which the CAUSAL_SKEW branch below limits to {1, 2}.
+# Fewer KV tiles per split than this and the fixed per-workgroup cost dominates.
 _FP8_AUTOSPLIT_MIN_TILES = 16
-_FP8_AUTOSPLIT_MIN_TILES_CAUSAL = 16
+# The combine pass allocates a fp32 workspace; past 1 GiB take the unsplit path.
 _FP8_AUTOSPLIT_MAX_WS_BYTES = 1 << 30
+# Matches DualwaveSwpFp8Traits.BLOCK_N; the heuristics run before traits exist.
 _FP8_BLOCK_N = 64
 _FP8_AUTOSPLIT_CANDIDATES = tuple(range(1, 17))
+# Per-workgroup cost in KV-tile units (Q gather, pipeline fill, O store).
 _FP8_AUTOSPLIT_FIXED_TILES = 10.4
+# Below this retained-score fraction the causal triangle is skewed enough that
+# the makespan model misprices splits; fall back to the 1-or-2 decision.
 _FP8_AUTOSPLIT_CAUSAL_SKEW = 0.75
+# Dense split-K must beat unsplit by this margin to pay for the combine launch.
 _FP8_AUTOSPLIT_DENSE_MARGIN = 0.85
 
 
-_FP8_NARROW_MAX_KV_TILES = 48
-_FP8_NARROW_MIN_TILES_2ROUND = 24
-_FP8_NARROW_MIN_WGS_CAUSAL = 150
-
-
 def _fp8_auto_block_m(batch: int, num_heads: int, seqlen_q: int, seqlen_kv: int, causal: bool, num_cu: int) -> int:
-    """Pick BLOCK_M (256 wide / 128 narrow) for an fp8 shape."""
-    kv_tiles = -(-seqlen_kv // _FP8_BLOCK_N)
-    if kv_tiles > _FP8_NARROW_MAX_KV_TILES:
-        return DUALWAVE_SWP_BLOCK_M
+    """Pick BLOCK_M (256 wide / 128 narrow) for an fp8 shape.
+
+    Take the narrow tile only when it still fits the GPU in one round, i.e. when
+    the wide tile would leave CUs idle. Neither the mask mode nor the KV length
+    enters: splitting causal off and picking narrow when the GPU is *already*
+    full is the wrong direction -- it doubles the workgroup count and halves the
+    work per group.
+
+    Scored against the per-shape best of {128, 256} on three measured sweeps
+    (block_m forced both ways, split-K off, 30-iteration medians):
+
+        table                    shapes   mean   worst
+        D=Dv=128 causal            72     0.08%   3.5%
+        D=Dv=128 non-causal        72     0.00%   0.0%
+        D=192/Dv=128 causal        30     0.96%  11.2%
+
+    A causal-only branch measured 13.5% mean / 37.5% worst on the first table.
+    Thresholds of num_cu/2 and 2*num_cu are both worse (1.2% and 3.1% mean).
+
+    The 192/128 residual is the known limitation: per-tile cost scales with
+    (head_dim + head_dim_v), so the wider pair keeps the narrow tile profitable
+    at higher occupancy than this shape-only rule admits.
+    """
     narrow = DUALWAVE_SWP_BLOCK_M // 2
-    wide_wgs = num_heads * -(-seqlen_q // DUALWAVE_SWP_BLOCK_M) * batch
     narrow_wgs = num_heads * -(-seqlen_q // narrow) * batch
-    if causal:
-        return narrow if wide_wgs >= _FP8_NARROW_MIN_WGS_CAUSAL else DUALWAVE_SWP_BLOCK_M
-    if narrow_wgs <= num_cu:
-        return narrow
-    if wide_wgs <= num_cu and kv_tiles >= _FP8_NARROW_MIN_TILES_2ROUND:
-        return narrow
-    return DUALWAVE_SWP_BLOCK_M
+    return narrow if narrow_wgs <= num_cu else DUALWAVE_SWP_BLOCK_M
 
 
 def _fp8_auto_kv_splits(
-    batch: int, num_heads: int, seqlen_q: int, seqlen_kv: int, causal: bool, num_cu: int, varlen: bool = False
+    batch: int,
+    num_heads: int,
+    seqlen_q: int,
+    seqlen_kv: int,
+    causal: bool,
+    num_cu: int,
+    varlen: bool = False,
+    block_m: int = DUALWAVE_SWP_BLOCK_M,
 ) -> int:
-    """Pick num_kv_splits by minimising `rounds(s) * (FIXED + tiles/s)`."""
-    wgs = num_heads * -(-seqlen_q // DUALWAVE_SWP_BLOCK_M) * batch
+    """Pick num_kv_splits by minimising `rounds(s) * (FIXED + tiles/s)`.
+
+    ``block_m`` must be the tile `_fp8_auto_block_m` already chose: it sets how
+    many workgroups the shape produces, and therefore whether splitting has any
+    idle CUs left to fill. Assuming the wide tile while the narrow one is built
+    halves the workgroup estimate and splits a GPU that is already full.
+    """
+    wgs = num_heads * -(-seqlen_q // block_m) * batch
     kv_tiles = -(-seqlen_kv // _FP8_BLOCK_N)
 
     if not causal:
@@ -107,7 +137,7 @@ def _fp8_auto_kv_splits(
     else:
         kept = 0.5 * seqlen_kv / seqlen_q
     if kept < _FP8_AUTOSPLIT_CAUSAL_SKEW:
-        if wgs < num_cu and kv_tiles // 2 >= _FP8_AUTOSPLIT_MIN_TILES_CAUSAL:
+        if wgs < num_cu and kv_tiles // 2 >= _FP8_AUTOSPLIT_MIN_TILES:
             return 2
         return 1
 
@@ -763,8 +793,11 @@ def flydsl_flash_attn_func(
     block_table: Optional[torch.Tensor] = None,
     seqlen_k: Optional[torch.Tensor] = None,
     kv_cache_layout: str = "linear",
-    # Split-K (gfx950 only, seq_len >= 384, D=64/128, bf16/f16).
-    num_kv_splits: int = 1,
+    # Split-K (gfx950 only, seq_len >= 384, D=64/128, bf16/f16). ``None`` lets
+    # fp8 pick a split count; an explicit ``1`` keeps the kernel unsplit.
+    num_kv_splits: Optional[int] = None,
+    # fp8 BLOCK_M override (128 or 256). ``None`` lets the interface pick.
+    fp8_block_m: Optional[int] = None,
     # Additive attention bias, folded into the scores after sm_scale and before
     # masking. gfx950 DUALWAVE_SWP only (dense / varlen / split-K / paged KV).
     bias: Optional[torch.Tensor] = None,
@@ -831,6 +864,11 @@ def flydsl_flash_attn_func(
             native paged-KV path, which supports ``bias`` but not
             ``alibi_slopes``, ``sink``, ``return_lse``, or fp8.
         num_kv_splits: Split-K factor (>1: gfx950 only, D=64/128, bf16/f16, seq>=384).
+            ``None`` (the default) lets fp8 pick, which costs a second kernel
+            launch and a fp32 workspace of up to 1 GiB; pass ``1`` to keep the
+            kernel unsplit, or an explicit count to pin your own.
+        fp8_block_m: Pin the fp8 tile height to 128 or 256 instead of letting
+            the interface choose. fp8 only.
         bias: Additive attention bias with the same dtype as q, folded in as
             ``softmax(q @ k^T * sm_scale + bias)`` -- after the scale, before the
             causal/padding mask. Dense: ``[Sq, Skv]``, broadcast over batch and
@@ -899,6 +937,13 @@ def flydsl_flash_attn_func(
         raise ValueError(f"flydsl_flash_attn_func: q/k/v must share dtype; got {q.dtype}/{k.dtype}/{v.dtype}")
 
     dtype_str = _dtype_str(q)
+    # `None` means "choose for me"; an explicit 1 means "leave it alone", so a
+    # caller who already tuned their own split count does not silently get a
+    # second kernel launch and a fp32 workspace allocation. Only fp8 has an
+    # autotuner, so every other path just reads the normalised int.
+    _auto_splits = num_kv_splits is None
+    if _auto_splits:
+        num_kv_splits = 1
     if return_lse and dtype_str == "fp8":
         raise NotImplementedError("flydsl_flash_attn_func: return_lse is not supported for fp8")
     paged_kv = any(x is not None for x in (block_table, seqlen_k))
@@ -925,21 +970,22 @@ def flydsl_flash_attn_func(
     # an over-long KV. Batch entries are independent and a leading slice of a
     # contiguous tensor is still contiguous, so one launch per entry divides the
     # flat dim by B at no copy. bf16 passes the natural 4-D shape and is exempt.
-    if (
-        dtype_str == "fp8"
-        and not paged_kv
-        and cu_seqlens_q is None
-        and cu_seqlens_kv is None
-        and q.dim() == 4
-        and max(q.numel(), k.numel(), v.numel()) >= _FP8_MAX_FLAT_ELEMS
-    ):
-        if q.shape[0] == 1:
-            # Out of batch to divide by. Launching would abort inside the C ABI
-            # with a struct.error naming neither the tensor nor the limit.
+    # Varlen inputs are packed on a single token axis, so there is no batch axis
+    # to slice; they can only be rejected.
+    if dtype_str == "fp8" and not paged_kv and max(q.numel(), k.numel(), v.numel()) >= _FP8_MAX_FLAT_ELEMS:
+        _packed = cu_seqlens_q is not None or cu_seqlens_kv is not None or q.dim() != 4
+        if _packed or q.shape[0] == 1:
+            # Nothing to divide by. Launching would abort inside the C ABI with a
+            # struct.error naming neither the tensor nor the limit.
+            _why = (
+                "varlen Q/K/V are packed on one token axis and cannot be split per batch entry"
+                if _packed
+                else "there is only one batch entry to divide by"
+            )
             raise NotImplementedError(
-                "flydsl_flash_attn_func: fp8 flattens Q/K/V/O and packs the dynamic dim as int32, so a "
-                f"single batch entry cannot exceed {_FP8_MAX_FLAT_ELEMS} elements; got q={q.numel()}, "
-                f"k={k.numel()}, v={v.numel()}. Shorten the sequence or use bf16."
+                "flydsl_flash_attn_func: fp8 flattens Q/K/V/O and packs the dynamic dim as int32, so no "
+                f"tensor may reach {_FP8_MAX_FLAT_ELEMS} elements; got q={q.numel()}, k={k.numel()}, "
+                f"v={v.numel()} and {_why}. Shorten the sequence or use bf16."
             )
         kw = dict(
             causal=causal,
@@ -948,7 +994,10 @@ def flydsl_flash_attn_func(
             max_seqlen_kv=max_seqlen_kv,
             cross_seqlen=cross_seqlen,
             kv_cache_layout=kv_cache_layout,
-            num_kv_splits=num_kv_splits,
+            # Hand the sub-launches back the sentinel, not the normalised 1, so
+            # each per-batch slice re-runs the autotuner for its own shape.
+            num_kv_splits=None if _auto_splits else num_kv_splits,
+            fp8_block_m=fp8_block_m,
             q_descale=q_descale,
             k_descale=k_descale,
             v_descale=v_descale,
@@ -965,7 +1014,12 @@ def flydsl_flash_attn_func(
             # afterwards would consume the parts on the ambient stream while the
             # kernels are still running on `stream`, and would hold two full
             # outputs at a size where one is already several GB.
-            out = torch.empty(q.shape, dtype=torch.bfloat16 if dtype_str == "fp8" else q.dtype, device=q.device)
+            # O is Dv wide, which is not q's last dim on the 192/128 pair.
+            out = torch.empty(
+                q.shape[:-1] + (v.shape[-1],),
+                dtype=torch.bfloat16 if dtype_str == "fp8" else q.dtype,
+                device=q.device,
+            )
         for i in range(q.shape[0]):
             sl = slice(i, i + 1)
             flydsl_flash_attn_func(q[sl].contiguous(), k[sl].contiguous(), v[sl].contiguous(), out=out[sl], **kw)
@@ -1077,6 +1131,13 @@ def flydsl_flash_attn_func(
         )
     if k.shape[-1] != D:
         raise ValueError(f"flydsl_flash_attn_func: K head_dim ({k.shape[-1]}) must match Q head_dim ({D})")
+    if tuple(v.shape[:-1]) != tuple(k.shape[:-1]):
+        # The V descriptor takes its num_records from K's token count, so a
+        # shorter V reads past the end without the buffer clamp catching it.
+        raise ValueError(
+            f"flydsl_flash_attn_func: V must match K in every dim but the last, got "
+            f"v={tuple(v.shape)}, k={tuple(k.shape)}"
+        )
 
     if has_bias:
         # Bias rows are indexed by q token, columns by the per-batch-local key.
@@ -1114,11 +1175,19 @@ def flydsl_flash_attn_func(
     _fp8_block_m = DUALWAVE_SWP_BLOCK_M
     if dtype_str == "fp8":
         _skv_bm = (int(max_seqlen_kv) if cross else Sq) if varlen else int(Skv)
-        _fp8_block_m = _fp8_auto_block_m(B, H, Sq, _skv_bm, causal, _dense_light_cu(q.device))
+        _fp8_block_m = (
+            _fp8_auto_block_m(B, H, Sq, _skv_bm, causal, _dense_light_cu(q.device))
+            if fp8_block_m is None
+            else int(fp8_block_m)
+        )
+    elif fp8_block_m is not None:
+        raise ValueError(f"flydsl_flash_attn_func: fp8_block_m applies to fp8 only, got dtype {dtype_str}")
 
-    if dtype_str == "fp8" and int(num_kv_splits) == 1 and Sq >= 384:
+    if dtype_str == "fp8" and _auto_splits and Sq >= 384:
         _skv_eff = (int(max_seqlen_kv) if cross else Sq) if varlen else int(Skv)
-        _auto = _fp8_auto_kv_splits(B, H, Sq, _skv_eff, causal, _dense_light_cu(q.device), varlen=varlen)
+        _auto = _fp8_auto_kv_splits(
+            B, H, Sq, _skv_eff, causal, _dense_light_cu(q.device), varlen=varlen, block_m=_fp8_block_m
+        )
         if _auto > 1 and dualwave_splitk_workspace_elems(B, H, Sq, _auto, head_dim=Dv) * 4 <= (
             _FP8_AUTOSPLIT_MAX_WS_BYTES
         ):
@@ -1249,7 +1318,19 @@ def flydsl_flash_attn_func(
                     f"flydsl_flash_attn_func: {_term} requires the gfx950 DUALWAVE_SWP path "
                     f"(D=64/128, bf16/f16, gfx950); got D={D}, dtype={dtype_str}, arch='{_arch or 'unknown'}'"
                 )
+            # bias/ALiBi force dualwave: the generic dense kernel folds in neither.
             if debug_lazy or has_bias or has_alibi or has_sink or (can_dualwave and _dense_routes_to_dualwave(B, Sq)):
+                # Workgroups map to XCDs as linear_id % 8, and linear_id is
+                # bx + by*H + bz*H*nqb, so with H % 8 == 0 a head-fast grid pins
+                # head h to XCD h % 8. The ~256 resident workgroups span all H
+                # heads within one batch, leaving each XCD to juggle H/8 K/V
+                # streams against its L2 slice. The head-slow remap in
+                # _init_dualwave_thread_mapping puts the resident window inside a
+                # single head instead: 1 stream. Measured penalty for leaving it
+                # off tracks H/8 (-6% at 8 streams, -3% at 4, nil at <=2), not the
+                # hit rate and not traffic volume. Bijective, so output is
+                # unchanged. NB: that function's own comment states the opposite
+                # rationale ("scatter across all XCDs") and is wrong.
                 num_q_blocks = -(-int(Sq) // DUALWAVE_SWP_BLOCK_M)
                 if dualwave_swp_xcd_swizzle is None:
                     xcd_swizzle = not causal and H % NUM_XCD_GFX950 == 0 and num_q_blocks >= MIN_Q_BLOCKS_XCD_SWIZZLE

--- a/kernels/attention/flash_attn_interface.py
+++ b/kernels/attention/flash_attn_interface.py
@@ -61,59 +61,18 @@ def _fp8_rescale_threshold(seqlen_kv: int) -> float:
     return 6.0 if seqlen_kv <= _FP8_LONG_SEQ else 4.0
 
 
-# Split-K autotuning constants, all tuned at D=Dv=128. Measured across 26
-# shapes (B 1..32, S 512..16384, H 8/16/32) the picks land 1.4% off the
-# per-shape best of {1, 2, 4, 8, 16}; the visible misses are long causal
-# self-attention, which the CAUSAL_SKEW branch below limits to {1, 2}.
-# Fewer KV tiles per split than this and the fixed per-workgroup cost dominates.
 _FP8_AUTOSPLIT_MIN_TILES = 16
-# The combine pass allocates a fp32 workspace; past 1 GiB take the unsplit path.
 _FP8_AUTOSPLIT_MAX_WS_BYTES = 1 << 30
-# Matches DualwaveSwpFp8Traits.BLOCK_N; the heuristics run before traits exist.
 _FP8_BLOCK_N = 64
 _FP8_AUTOSPLIT_CANDIDATES = tuple(range(1, 17))
-# Per-workgroup cost in KV-tile units (Q gather, pipeline fill, O store).
 _FP8_AUTOSPLIT_FIXED_TILES = 10.4
-# Below this retained-score fraction the causal triangle is skewed enough that
-# the makespan model misprices splits; fall back to the 1-or-2 decision.
 _FP8_AUTOSPLIT_CAUSAL_SKEW = 0.75
-# Dense split-K must beat unsplit by this margin to pay for the combine launch.
 _FP8_AUTOSPLIT_DENSE_MARGIN = 0.85
-
-
-# Past this KV length the wide tile wins regardless of occupancy: the narrow tile
-# doubles the workgroup count without shortening any of them, and -- more
-# importantly -- it inflates the workgroup estimate `_fp8_auto_kv_splits` reads,
-# which then declines a split that would have paid. Dropping this early-out cost
-# 7.3% on packed 2614/16384 cross-attention (the narrow tile blocks a 5-way split
-# worth 231us vs 248us) while saving 0.2% on the split-K-off sweeps.
 _FP8_NARROW_MAX_KV_TILES = 48
 
 
 def _fp8_auto_block_m(batch: int, num_heads: int, seqlen_q: int, seqlen_kv: int, causal: bool, num_cu: int) -> int:
-    """Pick BLOCK_M (256 wide / 128 narrow) for an fp8 shape.
-
-    Short KV: take the narrow tile only when it still fits the GPU in one round,
-    i.e. when the wide tile would leave CUs idle. The mask mode does not enter --
-    splitting causal off and picking narrow when the GPU is *already* full is the
-    wrong direction, since it doubles the workgroup count and halves the work per
-    group. Long KV: always wide, and let split-K supply the parallelism.
-
-    Scored against the per-shape best of {128, 256} on three measured sweeps
-    (block_m forced both ways, split-K off, 30-iteration medians):
-
-        table                    shapes   mean   worst
-        D=Dv=128 causal            72     0.25%  12.2%
-        D=Dv=128 non-causal        72     0.17%  11.9%
-        D=192/Dv=128 causal        30     1.67%  21.3%
-
-    A causal-only branch measured 13.5% mean / 37.5% worst on the first table.
-    Thresholds of num_cu/2 and 2*num_cu are both worse (1.2% and 3.1% mean).
-
-    Those sweeps pin split-K off, so they cannot see this choice feeding
-    `_fp8_auto_kv_splits`; the long-KV shapes where the two interact are covered
-    by the early-out above instead.
-    """
+    """Pick BLOCK_M (256 wide / 128 narrow) for an fp8 shape."""
     kv_tiles = -(-seqlen_kv // _FP8_BLOCK_N)
     if kv_tiles > _FP8_NARROW_MAX_KV_TILES:
         return DUALWAVE_SWP_BLOCK_M
@@ -133,17 +92,8 @@ def _fp8_auto_kv_splits(
 ) -> int:
     """Pick num_kv_splits by minimising `rounds(s) * (FIXED + tiles/s)`.
 
-    ``block_m`` must be the tile `_fp8_auto_block_m` already chose: it sets how
-    many workgroups the shape produces, and therefore whether splitting has any
-    idle CUs left to fill. Assuming the wide tile while the narrow one is built
-    halves the workgroup estimate and splits a GPU that is already full.
-
-    varlen takes the same rule as dense. Exempting it from the margin check below
-    made it split *more* eagerly than dense, which measured worse on 4 of 7 packed
-    shapes (mean 5.3% off the per-shape best of {1,2,4,8,16} vs 3.3% with the
-    margin applied). Skipping varlen entirely is far worse still (35% mean, 233%
-    on one short-Q/long-KV shape) -- packed prefill against a long cache is
-    exactly what split-K is for.
+    ``block_m`` must be the tile `_fp8_auto_block_m` chose; it sets the workgroup
+    count and therefore whether splitting has idle CUs left to fill.
     """
     wgs = num_heads * -(-seqlen_q // block_m) * batch
     kv_tiles = -(-seqlen_kv // _FP8_BLOCK_N)
@@ -811,10 +761,8 @@ def flydsl_flash_attn_func(
     block_table: Optional[torch.Tensor] = None,
     seqlen_k: Optional[torch.Tensor] = None,
     kv_cache_layout: str = "linear",
-    # Split-K (gfx950 only, seq_len >= 384, D=64/128, bf16/f16). ``None`` lets
-    # fp8 pick a split count; an explicit ``1`` keeps the kernel unsplit.
+    # Split-K (gfx950 only, seq_len >= 384, D=64/128, bf16/f16).
     num_kv_splits: Optional[int] = None,
-    # fp8 BLOCK_M override (128 or 256). ``None`` lets the interface pick.
     fp8_block_m: Optional[int] = None,
     # Additive attention bias, folded into the scores after sm_scale and before
     # masking. gfx950 DUALWAVE_SWP only (dense / varlen / split-K / paged KV).
@@ -882,11 +830,8 @@ def flydsl_flash_attn_func(
             native paged-KV path, which supports ``bias`` but not
             ``alibi_slopes``, ``sink``, ``return_lse``, or fp8.
         num_kv_splits: Split-K factor (>1: gfx950 only, D=64/128, bf16/f16, seq>=384).
-            ``None`` (the default) lets fp8 pick, which costs a second kernel
-            launch and a fp32 workspace of up to 1 GiB; pass ``1`` to keep the
-            kernel unsplit, or an explicit count to pin your own.
-        fp8_block_m: Pin the fp8 tile height to 128 or 256 instead of letting
-            the interface choose. fp8 only.
+            ``None`` lets fp8 autotune it; ``1`` keeps the kernel unsplit.
+        fp8_block_m: Pin the fp8 tile height to 128 or 256. fp8 only.
         bias: Additive attention bias with the same dtype as q, folded in as
             ``softmax(q @ k^T * sm_scale + bias)`` -- after the scale, before the
             causal/padding mask. Dense: ``[Sq, Skv]``, broadcast over batch and
@@ -955,10 +900,6 @@ def flydsl_flash_attn_func(
         raise ValueError(f"flydsl_flash_attn_func: q/k/v must share dtype; got {q.dtype}/{k.dtype}/{v.dtype}")
 
     dtype_str = _dtype_str(q)
-    # `None` means "choose for me"; an explicit 1 means "leave it alone", so a
-    # caller who already tuned their own split count does not silently get a
-    # second kernel launch and a fp32 workspace allocation. Only fp8 has an
-    # autotuner, so every other path just reads the normalised int.
     _auto_splits = num_kv_splits is None
     if _auto_splits:
         num_kv_splits = 1
@@ -988,22 +929,14 @@ def flydsl_flash_attn_func(
     # an over-long KV. Batch entries are independent and a leading slice of a
     # contiguous tensor is still contiguous, so one launch per entry divides the
     # flat dim by B at no copy. bf16 passes the natural 4-D shape and is exempt.
-    # Varlen inputs are packed on a single token axis, so there is no batch axis
-    # to slice; they can only be rejected.
     if dtype_str == "fp8" and not paged_kv and max(q.numel(), k.numel(), v.numel()) >= _FP8_MAX_FLAT_ELEMS:
+        # Packed varlen has no batch axis to slice, so it can only be rejected.
         _packed = cu_seqlens_q is not None or cu_seqlens_kv is not None or q.dim() != 4
         if _packed or q.shape[0] == 1:
-            # Nothing to divide by. Launching would abort inside the C ABI with a
-            # struct.error naming neither the tensor nor the limit.
-            _why = (
-                "varlen Q/K/V are packed on one token axis and cannot be split per batch entry"
-                if _packed
-                else "there is only one batch entry to divide by"
-            )
             raise NotImplementedError(
                 "flydsl_flash_attn_func: fp8 flattens Q/K/V/O and packs the dynamic dim as int32, so no "
                 f"tensor may reach {_FP8_MAX_FLAT_ELEMS} elements; got q={q.numel()}, k={k.numel()}, "
-                f"v={v.numel()} and {_why}. Shorten the sequence or use bf16."
+                f"v={v.numel()}. Shorten the sequence or use bf16."
             )
         kw = dict(
             causal=causal,
@@ -1012,8 +945,6 @@ def flydsl_flash_attn_func(
             max_seqlen_kv=max_seqlen_kv,
             cross_seqlen=cross_seqlen,
             kv_cache_layout=kv_cache_layout,
-            # Hand the sub-launches back the sentinel, not the normalised 1, so
-            # each per-batch slice re-runs the autotuner for its own shape.
             num_kv_splits=None if _auto_splits else num_kv_splits,
             fp8_block_m=fp8_block_m,
             q_descale=q_descale,
@@ -1032,7 +963,6 @@ def flydsl_flash_attn_func(
             # afterwards would consume the parts on the ambient stream while the
             # kernels are still running on `stream`, and would hold two full
             # outputs at a size where one is already several GB.
-            # O is Dv wide, which is not q's last dim on the 192/128 pair.
             out = torch.empty(
                 q.shape[:-1] + (v.shape[-1],),
                 dtype=torch.bfloat16 if dtype_str == "fp8" else q.dtype,
@@ -1150,8 +1080,7 @@ def flydsl_flash_attn_func(
     if k.shape[-1] != D:
         raise ValueError(f"flydsl_flash_attn_func: K head_dim ({k.shape[-1]}) must match Q head_dim ({D})")
     if tuple(v.shape[:-1]) != tuple(k.shape[:-1]):
-        # The V descriptor takes its num_records from K's token count, so a
-        # shorter V reads past the end without the buffer clamp catching it.
+        # V's descriptor takes num_records from K's token count.
         raise ValueError(
             f"flydsl_flash_attn_func: V must match K in every dim but the last, got "
             f"v={tuple(v.shape)}, k={tuple(k.shape)}"

--- a/kernels/attention/flash_attn_interface.py
+++ b/kernels/attention/flash_attn_interface.py
@@ -81,30 +81,42 @@ _FP8_AUTOSPLIT_CAUSAL_SKEW = 0.75
 _FP8_AUTOSPLIT_DENSE_MARGIN = 0.85
 
 
+# Past this KV length the wide tile wins regardless of occupancy: the narrow tile
+# doubles the workgroup count without shortening any of them, and -- more
+# importantly -- it inflates the workgroup estimate `_fp8_auto_kv_splits` reads,
+# which then declines a split that would have paid. Dropping this early-out cost
+# 7.3% on packed 2614/16384 cross-attention (the narrow tile blocks a 5-way split
+# worth 231us vs 248us) while saving 0.2% on the split-K-off sweeps.
+_FP8_NARROW_MAX_KV_TILES = 48
+
+
 def _fp8_auto_block_m(batch: int, num_heads: int, seqlen_q: int, seqlen_kv: int, causal: bool, num_cu: int) -> int:
     """Pick BLOCK_M (256 wide / 128 narrow) for an fp8 shape.
 
-    Take the narrow tile only when it still fits the GPU in one round, i.e. when
-    the wide tile would leave CUs idle. Neither the mask mode nor the KV length
-    enters: splitting causal off and picking narrow when the GPU is *already*
-    full is the wrong direction -- it doubles the workgroup count and halves the
-    work per group.
+    Short KV: take the narrow tile only when it still fits the GPU in one round,
+    i.e. when the wide tile would leave CUs idle. The mask mode does not enter --
+    splitting causal off and picking narrow when the GPU is *already* full is the
+    wrong direction, since it doubles the workgroup count and halves the work per
+    group. Long KV: always wide, and let split-K supply the parallelism.
 
     Scored against the per-shape best of {128, 256} on three measured sweeps
     (block_m forced both ways, split-K off, 30-iteration medians):
 
         table                    shapes   mean   worst
-        D=Dv=128 causal            72     0.08%   3.5%
-        D=Dv=128 non-causal        72     0.00%   0.0%
-        D=192/Dv=128 causal        30     0.96%  11.2%
+        D=Dv=128 causal            72     0.25%  12.2%
+        D=Dv=128 non-causal        72     0.17%  11.9%
+        D=192/Dv=128 causal        30     1.67%  21.3%
 
     A causal-only branch measured 13.5% mean / 37.5% worst on the first table.
     Thresholds of num_cu/2 and 2*num_cu are both worse (1.2% and 3.1% mean).
 
-    The 192/128 residual is the known limitation: per-tile cost scales with
-    (head_dim + head_dim_v), so the wider pair keeps the narrow tile profitable
-    at higher occupancy than this shape-only rule admits.
+    Those sweeps pin split-K off, so they cannot see this choice feeding
+    `_fp8_auto_kv_splits`; the long-KV shapes where the two interact are covered
+    by the early-out above instead.
     """
+    kv_tiles = -(-seqlen_kv // _FP8_BLOCK_N)
+    if kv_tiles > _FP8_NARROW_MAX_KV_TILES:
+        return DUALWAVE_SWP_BLOCK_M
     narrow = DUALWAVE_SWP_BLOCK_M // 2
     narrow_wgs = num_heads * -(-seqlen_q // narrow) * batch
     return narrow if narrow_wgs <= num_cu else DUALWAVE_SWP_BLOCK_M
@@ -117,7 +129,6 @@ def _fp8_auto_kv_splits(
     seqlen_kv: int,
     causal: bool,
     num_cu: int,
-    varlen: bool = False,
     block_m: int = DUALWAVE_SWP_BLOCK_M,
 ) -> int:
     """Pick num_kv_splits by minimising `rounds(s) * (FIXED + tiles/s)`.
@@ -126,6 +137,13 @@ def _fp8_auto_kv_splits(
     many workgroups the shape produces, and therefore whether splitting has any
     idle CUs left to fill. Assuming the wide tile while the narrow one is built
     halves the workgroup estimate and splits a GPU that is already full.
+
+    varlen takes the same rule as dense. Exempting it from the margin check below
+    made it split *more* eagerly than dense, which measured worse on 4 of 7 packed
+    shapes (mean 5.3% off the per-shape best of {1,2,4,8,16} vs 3.3% with the
+    margin applied). Skipping varlen entirely is far worse still (35% mean, 233%
+    on one short-Q/long-KV shape) -- packed prefill against a long cache is
+    exactly what split-K is for.
     """
     wgs = num_heads * -(-seqlen_q // block_m) * batch
     kv_tiles = -(-seqlen_kv // _FP8_BLOCK_N)
@@ -147,8 +165,8 @@ def _fp8_auto_kv_splits(
 
     usable = [s for s in _FP8_AUTOSPLIT_CANDIDATES if s == 1 or kv_tiles // s >= _FP8_AUTOSPLIT_MIN_TILES]
     best = min(usable, key=makespan)
-    if best == 1 or varlen:
-        return best
+    if best == 1:
+        return 1
     return best if makespan(best) <= _FP8_AUTOSPLIT_DENSE_MARGIN * makespan(1) else 1
 
 
@@ -1185,9 +1203,7 @@ def flydsl_flash_attn_func(
 
     if dtype_str == "fp8" and _auto_splits and Sq >= 384:
         _skv_eff = (int(max_seqlen_kv) if cross else Sq) if varlen else int(Skv)
-        _auto = _fp8_auto_kv_splits(
-            B, H, Sq, _skv_eff, causal, _dense_light_cu(q.device), varlen=varlen, block_m=_fp8_block_m
-        )
+        _auto = _fp8_auto_kv_splits(B, H, Sq, _skv_eff, causal, _dense_light_cu(q.device), block_m=_fp8_block_m)
         if _auto > 1 and dualwave_splitk_workspace_elems(B, H, Sq, _auto, head_dim=Dv) * 4 <= (
             _FP8_AUTOSPLIT_MAX_WS_BYTES
         ):

--- a/kernels/attention/flash_attn_interface.py
+++ b/kernels/attention/flash_attn_interface.py
@@ -1262,17 +1262,6 @@ def flydsl_flash_attn_func(
                 )
             # bias/ALiBi force dualwave: the generic dense kernel folds in neither.
             if debug_lazy or has_bias or has_alibi or has_sink or (can_dualwave and _dense_routes_to_dualwave(B, Sq)):
-                # Workgroups map to XCDs as linear_id % 8, and linear_id is
-                # bx + by*H + bz*H*nqb, so with H % 8 == 0 a head-fast grid pins
-                # head h to XCD h % 8. The ~256 resident workgroups span all H
-                # heads within one batch, leaving each XCD to juggle H/8 K/V
-                # streams against its L2 slice. The head-slow remap in
-                # _init_dualwave_thread_mapping puts the resident window inside a
-                # single head instead: 1 stream. Measured penalty for leaving it
-                # off tracks H/8 (-6% at 8 streams, -3% at 4, nil at <=2), not the
-                # hit rate and not traffic volume. Bijective, so output is
-                # unchanged. NB: that function's own comment states the opposite
-                # rationale ("scatter across all XCDs") and is wrong.
                 num_q_blocks = -(-int(Sq) // DUALWAVE_SWP_BLOCK_M)
                 if dualwave_swp_xcd_swizzle is None:
                     xcd_swizzle = not causal and H % NUM_XCD_GFX950 == 0 and num_q_blocks >= MIN_Q_BLOCKS_XCD_SWIZZLE

--- a/kernels/attention/flash_attn_interface.py
+++ b/kernels/attention/flash_attn_interface.py
@@ -104,9 +104,10 @@ def _fp8_auto_kv_splits(
     else:
         kept = 0.5 * seqlen_kv / seqlen_q
     if kept < _FP8_AUTOSPLIT_CAUSAL_SKEW:
-        if wgs < num_cu and kv_tiles // 2 >= _FP8_AUTOSPLIT_MIN_TILES:
-            return 2
-        return 1
+        if kv_tiles // 2 < _FP8_AUTOSPLIT_MIN_TILES or wgs > num_cu:
+            return 1
+        interleaved = _fp8_batch_interleave_group(batch, causal, seqlen_q != seqlen_kv, 1) > 1
+        return 1 if wgs == num_cu and interleaved else 2
 
     def makespan(splits: int) -> float:
         n = wgs * splits

--- a/kernels/attention/flash_attn_interface.py
+++ b/kernels/attention/flash_attn_interface.py
@@ -61,6 +61,67 @@ def _fp8_rescale_threshold(seqlen_kv: int) -> float:
     return 6.0 if seqlen_kv <= _FP8_LONG_SEQ else 4.0
 
 
+_FP8_AUTOSPLIT_MIN_TILES = 16
+_FP8_AUTOSPLIT_MIN_TILES_CAUSAL = 16
+_FP8_AUTOSPLIT_MAX_WS_BYTES = 1 << 30
+_FP8_BLOCK_N = 64
+_FP8_AUTOSPLIT_CANDIDATES = tuple(range(1, 17))
+_FP8_AUTOSPLIT_FIXED_TILES = 10.4
+_FP8_AUTOSPLIT_CAUSAL_SKEW = 0.75
+_FP8_AUTOSPLIT_DENSE_MARGIN = 0.85
+
+
+_FP8_NARROW_MAX_KV_TILES = 48
+_FP8_NARROW_MIN_TILES_2ROUND = 24
+_FP8_NARROW_MIN_WGS_CAUSAL = 150
+
+
+def _fp8_auto_block_m(batch: int, num_heads: int, seqlen_q: int, seqlen_kv: int, causal: bool, num_cu: int) -> int:
+    """Pick BLOCK_M (256 wide / 128 narrow) for an fp8 shape."""
+    kv_tiles = -(-seqlen_kv // _FP8_BLOCK_N)
+    if kv_tiles > _FP8_NARROW_MAX_KV_TILES:
+        return DUALWAVE_SWP_BLOCK_M
+    narrow = DUALWAVE_SWP_BLOCK_M // 2
+    wide_wgs = num_heads * -(-seqlen_q // DUALWAVE_SWP_BLOCK_M) * batch
+    narrow_wgs = num_heads * -(-seqlen_q // narrow) * batch
+    if causal:
+        return narrow if wide_wgs >= _FP8_NARROW_MIN_WGS_CAUSAL else DUALWAVE_SWP_BLOCK_M
+    if narrow_wgs <= num_cu:
+        return narrow
+    if wide_wgs <= num_cu and kv_tiles >= _FP8_NARROW_MIN_TILES_2ROUND:
+        return narrow
+    return DUALWAVE_SWP_BLOCK_M
+
+
+def _fp8_auto_kv_splits(
+    batch: int, num_heads: int, seqlen_q: int, seqlen_kv: int, causal: bool, num_cu: int, varlen: bool = False
+) -> int:
+    """Pick num_kv_splits by minimising `rounds(s) * (FIXED + tiles/s)`."""
+    wgs = num_heads * -(-seqlen_q // DUALWAVE_SWP_BLOCK_M) * batch
+    kv_tiles = -(-seqlen_kv // _FP8_BLOCK_N)
+
+    if not causal:
+        kept = 1.0
+    elif seqlen_q <= seqlen_kv:
+        kept = max(0.0, 1.0 - (seqlen_q - 1) / (2.0 * seqlen_kv))
+    else:
+        kept = 0.5 * seqlen_kv / seqlen_q
+    if kept < _FP8_AUTOSPLIT_CAUSAL_SKEW:
+        if wgs < num_cu and kv_tiles // 2 >= _FP8_AUTOSPLIT_MIN_TILES_CAUSAL:
+            return 2
+        return 1
+
+    def makespan(splits: int) -> float:
+        n = wgs * splits
+        return (-(-n // num_cu)) * (_FP8_AUTOSPLIT_FIXED_TILES + -(-kv_tiles // splits))
+
+    usable = [s for s in _FP8_AUTOSPLIT_CANDIDATES if s == 1 or kv_tiles // s >= _FP8_AUTOSPLIT_MIN_TILES]
+    best = min(usable, key=makespan)
+    if best == 1 or varlen:
+        return best
+    return best if makespan(best) <= _FP8_AUTOSPLIT_DENSE_MARGIN * makespan(1) else 1
+
+
 def _dtype_str(t: torch.Tensor) -> str:
     s = _DTYPE_MAP.get(t.dtype)
     if s is None:
@@ -179,6 +240,16 @@ def _build_dense_dualwave(
     )
 
 
+_FP8_BATCH_INTERLEAVE_GROUP = 2
+
+
+def _fp8_batch_interleave_group(batch: int, causal: bool, cross: bool, num_kv_splits: int) -> int:
+    if not causal or cross or num_kv_splits > 1:
+        return 1
+    g = _FP8_BATCH_INTERLEAVE_GROUP
+    return g if batch % g == 0 else 1
+
+
 @functools.lru_cache(maxsize=128)
 def _build_dense_fp8(
     num_heads: int,
@@ -190,13 +261,21 @@ def _build_dense_fp8(
     lazy_rescale: bool,
     setprio: bool,
     enable_stagger: bool,
+    head_dim: int = 128,
+    head_dim_v: int | None = None,
+    varlen: bool = False,
+    cross_seqlen: bool = False,
+    num_kv_splits: int = 1,
+    block_m: int = 256,
+    batch_interleave_group: int = 1,
 ):
-    """Build (and cache) the dense gfx950 fp8 launcher."""
+    """Build (and cache) the gfx950 fp8 launcher (dense, packed varlen, or split-K)."""
     from kernels.attention.flash_attn_fp8_gfx950 import build_flash_attn_dualwave_swp_fp8_module
 
     return build_flash_attn_dualwave_swp_fp8_module(
         num_heads=num_heads,
-        head_dim=128,
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
         causal=causal,
         dtype_str="fp8",
         num_kv_heads=num_kv_heads,
@@ -206,6 +285,11 @@ def _build_dense_fp8(
         dualwave_swp_lazy_rescale=lazy_rescale,
         dualwave_swp_setprio=setprio,
         dualwave_swp_enable_stagger=enable_stagger,
+        varlen=varlen,
+        cross_seqlen=cross_seqlen,
+        num_kv_splits=num_kv_splits,
+        block_m=block_m,
+        batch_interleave_group=batch_interleave_group,
     )
 
 
@@ -933,10 +1017,6 @@ def flydsl_flash_attn_func(
     varlen = cu_seqlens_q is not None
 
     if dtype_str == "fp8":
-        if varlen:
-            raise NotImplementedError("flydsl_flash_attn_func: fp8 flash_attn does not support varlen")
-        if num_kv_splits > 1:
-            raise NotImplementedError("flydsl_flash_attn_func: fp8 flash_attn does not support split-K")
         if debug_counts is not None:
             raise NotImplementedError("flydsl_flash_attn_func: fp8 flash_attn does not support debug_counts")
         if any(x is None for x in (q_descale, k_descale, v_descale)):
@@ -953,8 +1033,11 @@ def flydsl_flash_attn_func(
         raise ValueError("flydsl_flash_attn_func: cu_seqlens_kv required when cu_seqlens_q is given")
     if not varlen and cu_seqlens_kv is not None:
         raise ValueError("flydsl_flash_attn_func: cu_seqlens_q required when cu_seqlens_kv is given")
-    if varlen and num_kv_splits > 1:
-        raise ValueError("flydsl_flash_attn_func: varlen + split-K (num_kv_splits>1) is not supported")
+    if varlen and num_kv_splits > 1 and dtype_str != "fp8":
+        raise ValueError(
+            "flydsl_flash_attn_func: varlen + split-K (num_kv_splits>1) is bf16/f16-unsupported; "
+            "only the fp8 launcher builds a varlen split-K kernel"
+        )
 
     # ── shape inference ─────────────────────────────────────────────────────
     if varlen:
@@ -985,6 +1068,15 @@ def flydsl_flash_attn_func(
         raise ValueError(f"flydsl_flash_attn_func: num_heads ({H}) must be divisible by num_kv_heads ({num_kv_heads})")
     if D < 64 or D % 32 != 0:
         raise ValueError(f"flydsl_flash_attn_func: head_dim ({D}) must be >= 64 and a multiple of 32")
+
+    Dv = int(v.shape[-1])
+    if Dv != D and dtype_str != "fp8":
+        raise NotImplementedError(
+            f"flydsl_flash_attn_func: a V head_dim ({Dv}) different from the QK head_dim ({D}) "
+            f"is fp8-only, got dtype {dtype_str}"
+        )
+    if k.shape[-1] != D:
+        raise ValueError(f"flydsl_flash_attn_func: K head_dim ({k.shape[-1]}) must match Q head_dim ({D})")
 
     if has_bias:
         # Bias rows are indexed by q token, columns by the per-batch-local key.
@@ -1019,16 +1111,37 @@ def flydsl_flash_attn_func(
     if has_sink and sink.shape[0] != H:
         raise ValueError(f"flydsl_flash_attn_func: sink must be [num_heads={H}], got {tuple(sink.shape)}")
 
+    _fp8_block_m = DUALWAVE_SWP_BLOCK_M
+    if dtype_str == "fp8":
+        _skv_bm = (int(max_seqlen_kv) if cross else Sq) if varlen else int(Skv)
+        _fp8_block_m = _fp8_auto_block_m(B, H, Sq, _skv_bm, causal, _dense_light_cu(q.device))
+
+    if dtype_str == "fp8" and int(num_kv_splits) == 1 and Sq >= 384:
+        _skv_eff = (int(max_seqlen_kv) if cross else Sq) if varlen else int(Skv)
+        _auto = _fp8_auto_kv_splits(B, H, Sq, _skv_eff, causal, _dense_light_cu(q.device), varlen=varlen)
+        if _auto > 1 and dualwave_splitk_workspace_elems(B, H, Sq, _auto, head_dim=Dv) * 4 <= (
+            _FP8_AUTOSPLIT_MAX_WS_BYTES
+        ):
+            num_kv_splits = _auto
+
     splitk = num_kv_splits > 1
 
     # ── split-K eligibility guard (SKIP analogous to run_splitk_config) ────
     if splitk:
-        if D not in (64, 128) or dtype_str not in ("bf16", "f16") or Sq < 384:
-            raise ValueError(
-                f"flydsl_flash_attn_func: split-K requires D=64/128, dtype bf16/f16, seq_len>=384; "
-                f"got D={D}, dtype={dtype_str}, seq_len={Sq}"
-            )
-        ws_elems = dualwave_splitk_workspace_elems(B, H, Sq, int(num_kv_splits), head_dim=D)
+        if Sq < 384:
+            raise ValueError(f"flydsl_flash_attn_func: split-K requires seq_len>=384, got {Sq}")
+        if dtype_str != "fp8":
+            if D not in (64, 128) or dtype_str not in ("bf16", "f16"):
+                raise ValueError(
+                    f"flydsl_flash_attn_func: split-K requires D=64/128, dtype bf16/f16/fp8; "
+                    f"got D={D}, dtype={dtype_str}"
+                )
+            if Skv != Sq:
+                raise ValueError(
+                    f"flydsl_flash_attn_func: split-K (num_kv_splits>1) requires seq_len_kv == seq_len_q; "
+                    f"got seq_len_q={Sq}, seq_len_kv={Skv}"
+                )
+        ws_elems = dualwave_splitk_workspace_elems(B, H, Sq, int(num_kv_splits), head_dim=Dv)
 
     # ── build (cached) ──────────────────────────────────────────────────────
     debug_lazy = debug_counts is not None
@@ -1036,7 +1149,30 @@ def flydsl_flash_attn_func(
     with torch.cuda.device(q.device.index):
         launch_stream = torch.cuda.current_stream(q.device) if stream is None else stream
 
-        if splitk:
+        if dtype_str == "fp8":
+            _arch = _gpu_arch(q.device)
+            if not _arch.startswith("gfx950"):
+                raise ValueError(f"flydsl_flash_attn_func: fp8 requires gfx950, got '{_arch or 'unknown'}'")
+            _skv_hint = (int(max_seqlen_kv) if cross else Sq) if varlen else int(Skv)
+            exe = _build_dense_fp8(
+                num_heads=H,
+                num_kv_heads=num_kv_heads,
+                causal=causal,
+                rescale_threshold=_fp8_rescale_threshold(_skv_hint),
+                waves_per_eu=waves_per_eu,
+                daz=daz,
+                lazy_rescale=dualwave_swp_lazy_rescale,
+                setprio=dualwave_swp_setprio,
+                enable_stagger=dualwave_swp_enable_stagger,
+                head_dim=D,
+                head_dim_v=Dv,
+                varlen=varlen,
+                cross_seqlen=cross,
+                num_kv_splits=int(num_kv_splits),
+                block_m=_fp8_block_m,
+                batch_interleave_group=_fp8_batch_interleave_group(B, causal, cross, int(num_kv_splits)),
+            )
+        elif splitk:
             exe = _build_splitk(
                 num_heads=H,
                 num_kv_heads=num_kv_heads,
@@ -1104,98 +1240,74 @@ def flydsl_flash_attn_func(
                 )
         else:
             _arch = _gpu_arch(q.device)
-            if dtype_str == "fp8":
-                if not _arch.startswith("gfx950"):
-                    raise ValueError(f"flydsl_flash_attn_func: fp8 requires gfx950, got '{_arch or 'unknown'}'")
-                exe = _build_dense_fp8(
+            can_dualwave = D in (64, 128) and dtype_str in ("bf16", "f16") and _arch.startswith("gfx950")
+            if debug_lazy and not can_dualwave:
+                raise NotImplementedError(
+                    "flydsl_flash_attn_func: debug_counts requires the gfx950 DUALWAVE_SWP path"
+                )
+            if (has_bias or has_alibi or has_sink) and not can_dualwave:
+                _term = "bias" if has_bias else ("alibi_slopes" if has_alibi else "sink")
+                raise NotImplementedError(
+                    f"flydsl_flash_attn_func: {_term} requires the gfx950 DUALWAVE_SWP path "
+                    f"(D=64/128, bf16/f16, gfx950); got D={D}, dtype={dtype_str}, arch='{_arch or 'unknown'}'"
+                )
+            if (
+                debug_lazy
+                or has_bias
+                or has_alibi
+                or has_sink
+                or (can_dualwave and _dense_routes_to_dualwave(B, Sq))
+            ):
+                num_q_blocks = -(-int(Sq) // DUALWAVE_SWP_BLOCK_M)
+                if dualwave_swp_xcd_swizzle is None:
+                    xcd_swizzle = (
+                        not causal and H % NUM_XCD_GFX950 == 0 and num_q_blocks >= MIN_Q_BLOCKS_XCD_SWIZZLE
+                    )
+                else:
+                    xcd_swizzle = dualwave_swp_xcd_swizzle
+                exe = _build_dense_dualwave(
                     num_heads=H,
                     num_kv_heads=num_kv_heads,
+                    head_dim=D,
                     causal=causal,
-                    rescale_threshold=_fp8_rescale_threshold(int(Skv)),
+                    dtype_str=dtype_str,
+                    cross_seqlen=cross,
                     waves_per_eu=waves_per_eu,
                     daz=daz,
                     lazy_rescale=dualwave_swp_lazy_rescale,
                     setprio=dualwave_swp_setprio,
+                    debug_lazy_counts=debug_lazy,
                     enable_stagger=dualwave_swp_enable_stagger,
+                    return_lse=return_lse,
+                    has_bias=has_bias,
+                    has_alibi=has_alibi,
+                    has_sink=has_sink,
+                    xcd_swizzle=xcd_swizzle,
                 )
             else:
-                can_dualwave = D in (64, 128) and dtype_str in ("bf16", "f16") and _arch.startswith("gfx950")
-                if debug_lazy and not can_dualwave:
-                    raise NotImplementedError(
-                        "flydsl_flash_attn_func: debug_counts requires the gfx950 DUALWAVE_SWP path"
-                    )
-                if (has_bias or has_alibi or has_sink) and not can_dualwave:
-                    _term = "bias" if has_bias else ("alibi_slopes" if has_alibi else "sink")
-                    raise NotImplementedError(
-                        f"flydsl_flash_attn_func: {_term} requires the gfx950 DUALWAVE_SWP path "
-                        f"(D=64/128, bf16/f16, gfx950); got D={D}, dtype={dtype_str}, arch='{_arch or 'unknown'}'"
-                    )
-                # bias/ALiBi force dualwave: the generic dense kernel folds in neither.
-                if (
-                    debug_lazy
-                    or has_bias
-                    or has_alibi
-                    or has_sink
-                    or (can_dualwave and _dense_routes_to_dualwave(B, Sq))
-                ):
-                    # Workgroups map to XCDs as linear_id % 8, and linear_id is
-                    # bx + by*H + bz*H*nqb, so with H % 8 == 0 a head-fast grid pins
-                    # head h to XCD h % 8. The ~256 resident workgroups span all H
-                    # heads within one batch, leaving each XCD to juggle H/8 K/V
-                    # streams against its L2 slice. The head-slow remap in
-                    # _init_dualwave_thread_mapping puts the resident window inside a
-                    # single head instead: 1 stream. Measured penalty for leaving it
-                    # off tracks H/8 (-6% at 8 streams, -3% at 4, nil at <=2), not the
-                    # hit rate and not traffic volume. Bijective, so output is
-                    # unchanged. NB: that function's own comment states the opposite
-                    # rationale ("scatter across all XCDs") and is wrong.
-                    num_q_blocks = -(-int(Sq) // DUALWAVE_SWP_BLOCK_M)
-                    if dualwave_swp_xcd_swizzle is None:
-                        xcd_swizzle = (
-                            not causal and H % NUM_XCD_GFX950 == 0 and num_q_blocks >= MIN_Q_BLOCKS_XCD_SWIZZLE
-                        )
-                    else:
-                        xcd_swizzle = dualwave_swp_xcd_swizzle
-                    exe = _build_dense_dualwave(
-                        num_heads=H,
-                        num_kv_heads=num_kv_heads,
-                        head_dim=D,
-                        causal=causal,
-                        dtype_str=dtype_str,
-                        cross_seqlen=cross,
-                        waves_per_eu=waves_per_eu,
-                        daz=daz,
-                        lazy_rescale=dualwave_swp_lazy_rescale,
-                        setprio=dualwave_swp_setprio,
-                        debug_lazy_counts=debug_lazy,
-                        enable_stagger=dualwave_swp_enable_stagger,
-                        return_lse=return_lse,
-                        has_bias=has_bias,
-                        has_alibi=has_alibi,
-                        has_sink=has_sink,
-                        xcd_swizzle=xcd_swizzle,
-                    )
-                else:
-                    block_m, flat_work_group_size, path_tag = _dense_generic_tile(B, Sq, H, D, dtype_str, q.device)
-                    exe = _build_dense(
-                        num_heads=H,
-                        num_kv_heads=num_kv_heads,
-                        head_dim=D,
-                        causal=causal,
-                        dtype_str=dtype_str,
-                        cross_seqlen=cross,
-                        block_m=block_m,
-                        flat_work_group_size=flat_work_group_size,
-                        path_tag=path_tag,
-                        waves_per_eu=waves_per_eu,
-                        daz=daz,
-                        return_lse=return_lse,
-                    )
+                block_m, flat_work_group_size, path_tag = _dense_generic_tile(B, Sq, H, D, dtype_str, q.device)
+                exe = _build_dense(
+                    num_heads=H,
+                    num_kv_heads=num_kv_heads,
+                    head_dim=D,
+                    causal=causal,
+                    dtype_str=dtype_str,
+                    cross_seqlen=cross,
+                    block_m=block_m,
+                    flat_work_group_size=flat_work_group_size,
+                    path_tag=path_tag,
+                    waves_per_eu=waves_per_eu,
+                    daz=daz,
+                    return_lse=return_lse,
+                )
 
         # ── allocate output ─────────────────────────────────────────────────
+        _out_shape = tuple(q.shape[:-1]) + (Dv,)
         if out is None:
             out_dtype = torch.bfloat16 if dtype_str == "fp8" else q.dtype
-            out = torch.empty(q.shape, dtype=out_dtype, device=q.device)
+            out = torch.empty(_out_shape, dtype=out_dtype, device=q.device)
+        elif tuple(out.shape) != _out_shape:
+            raise ValueError(f"flydsl_flash_attn_func: out must be {_out_shape}, got {tuple(out.shape)}")
         elif dtype_str == "fp8" and out.dtype != torch.bfloat16:
             raise ValueError(f"flydsl_flash_attn_func: fp8 output must be bf16, got {out.dtype}")
         elif dtype_str != "fp8" and out.dtype != q.dtype:
@@ -1226,7 +1338,18 @@ def flydsl_flash_attn_func(
             _bias_kw["alibi_slopes"] = alibi_slopes
         if has_sink:
             _bias_kw["sink"] = sink
-        if splitk:
+        if dtype_str == "fp8":
+            kwargs = dict(stream=launch_stream, q_descale=q_descale, k_descale=k_descale, v_descale=v_descale)
+            if splitk:
+                kwargs["workspace"] = torch.empty(ws_elems, dtype=torch.float32, device=q.device)
+            if varlen:
+                kwargs.update(cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_kv)
+                if cross:
+                    kwargs["seq_len_kv"] = int(max_seqlen_kv)
+            elif cross:
+                kwargs["seq_len_kv"] = Skv
+            exe(q_flat, k_flat, v_flat, o_flat, B, Sq, **kwargs)
+        elif splitk:
             _ws = torch.empty(ws_elems, dtype=torch.float32, device=q.device)
             exe(q_flat, k_flat, v_flat, o_flat, B, Sq, workspace=_ws, lse=lse, stream=launch_stream, **_bias_kw)
         elif varlen:

--- a/kernels/attention/flash_attn_interface.py
+++ b/kernels/attention/flash_attn_interface.py
@@ -1242,27 +1242,17 @@ def flydsl_flash_attn_func(
             _arch = _gpu_arch(q.device)
             can_dualwave = D in (64, 128) and dtype_str in ("bf16", "f16") and _arch.startswith("gfx950")
             if debug_lazy and not can_dualwave:
-                raise NotImplementedError(
-                    "flydsl_flash_attn_func: debug_counts requires the gfx950 DUALWAVE_SWP path"
-                )
+                raise NotImplementedError("flydsl_flash_attn_func: debug_counts requires the gfx950 DUALWAVE_SWP path")
             if (has_bias or has_alibi or has_sink) and not can_dualwave:
                 _term = "bias" if has_bias else ("alibi_slopes" if has_alibi else "sink")
                 raise NotImplementedError(
                     f"flydsl_flash_attn_func: {_term} requires the gfx950 DUALWAVE_SWP path "
                     f"(D=64/128, bf16/f16, gfx950); got D={D}, dtype={dtype_str}, arch='{_arch or 'unknown'}'"
                 )
-            if (
-                debug_lazy
-                or has_bias
-                or has_alibi
-                or has_sink
-                or (can_dualwave and _dense_routes_to_dualwave(B, Sq))
-            ):
+            if debug_lazy or has_bias or has_alibi or has_sink or (can_dualwave and _dense_routes_to_dualwave(B, Sq)):
                 num_q_blocks = -(-int(Sq) // DUALWAVE_SWP_BLOCK_M)
                 if dualwave_swp_xcd_swizzle is None:
-                    xcd_swizzle = (
-                        not causal and H % NUM_XCD_GFX950 == 0 and num_q_blocks >= MIN_Q_BLOCKS_XCD_SWIZZLE
-                    )
+                    xcd_swizzle = not causal and H % NUM_XCD_GFX950 == 0 and num_q_blocks >= MIN_Q_BLOCKS_XCD_SWIZZLE
                 else:
                     xcd_swizzle = dualwave_swp_xcd_swizzle
                 exe = _build_dense_dualwave(

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -2053,12 +2053,6 @@ def _make_dualwave_swp_fp8_traits(
 
 
 def dualwave_fp8_dma_per_iter(traits):
-    """Vector-memory instructions the least-loaded wave issues per main-loop iteration.
-
-    `_waitcnt_vm_n(N)` is a no-op unless N is at most what this wave issues. K is
-    exec-masked so every wave issues each pass; V's trailing pass sits behind a
-    wave-uniform branch, so its minimum is the floor.
-    """
     rows_per_wave = -(-traits.BLOCK_N // traits.NUM_WAVES)
     k_instr = sum(-(-(rows_per_wave * (chunk // traits.VEC_KV)) // traits.WARP_SIZE) for chunk in traits.K_BAND_CHUNK)
     num_dma_v = (traits.BLOCK_N * (traits.HEAD_DIM_V // 16) * 16) // (
@@ -5362,12 +5356,6 @@ class DualwaveSplitKCombineContext:
         self.batch_size_v = fx.Index(self.batch_size)
 
     def init_thread_mapping(self, combine_rows_per_block, combine_lanes_per_row):
-        """Map (blockIdx.x, blockIdx.y, tid) to one (batch, head, token) output row.
-
-        blockIdx.y carries the batch: the O buffer resource is wave-scoped, so a
-        per-thread batch_idx would hand a whole wave one batch's descriptor when a
-        batch boundary falls inside it.
-        """
         traits = self.traits
         self.tid = fx.Index(gpu.thread_idx.x)
         self.blk = fx.Index(gpu.block_idx.x)

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -1983,8 +1983,8 @@ def _make_dualwave_swp_fp8_traits(
         raise RuntimeError(
             f"fp8 flash attention head_dim={head_dim}/head_dim_v={head_dim_v} at block_m={block_m} "
             f"needs {lds_bytes} B of LDS, over the {LDS_BYTES_GFX950} B gfx950 workgroup limit. "
-            "The footprint grows by ~25 KB per +64 of head_dim and ~12 KB per +32 of head_dim_v; "
-            "head_dim + head_dim_v <= 384 is the supported envelope."
+            "Largest head_dim_v that fits: 192 at head_dim 64/128/192, 160 at 256, 96 at 320; "
+            "head_dim 384 and above never fits."
         )
 
     return DualwaveSwpFp8Traits(
@@ -4539,8 +4539,6 @@ class DualwaveFp8KernelContext:
         self.o_store_reg_128 = fx.make_rmem_tensor(fx.make_layout(4, 1), fx.Int32)
         # fp8 global->LDS DMA uses i8 destination typing; K/V LDS reads are byte-addressed.
         self.lds_ptr_ty = fx.PointerType.get(fx.Int8.ir_type, 2, traits.DMA_BYTES)
-        self.bf16_mma_atom = fx.make_mma_atom(fx.rocdl.MFMA(32, 32, 16, fx.BFloat16))
-        self.v_fp8_load64_atom = fx.make_copy_atom(fx.rocdl.BufferCopy64b(), fx.Int32)
 
     def init_descale(self):
         def _load_scale_scalar(tensor):
@@ -4730,13 +4728,6 @@ class DualwaveFp8GemmHelper(DualwaveFp8KernelContext):
             words.append(fx.Int32(w))
         return Vec.from_elements(words, fx.Int32).ir_value()
 
-    def _p_to_fp8_i32x8(self, v_p):
-        p_lo, p_hi = v_p
-        f32 = []
-        for pk in (p_lo[0], p_lo[1], p_hi[0], p_hi[1]):
-            f32 += self._v8bf16_to_f32(pk)
-        return self._pack_fp8_i32x8(f32)
-
     def _v_concat_i32x8(self, v_v, dc):
         words = []
         for ks in range_constexpr(4):
@@ -4744,12 +4735,6 @@ class DualwaveFp8GemmHelper(DualwaveFp8KernelContext):
             words.append(fx.Int32(v2[0]))
             words.append(fx.Int32(v2[1]))
         return Vec.from_elements(words, fx.Int32).ir_value()
-
-    def _v_to_fp8_i32x8(self, v_v, dc):
-        f32 = []
-        for step in range_constexpr(4):
-            f32 += self._v8bf16_to_f32(v_v[step][dc])
-        return self._pack_fp8_i32x8(f32)
 
     def _load_q_wide_lds(self):
         traits = self.traits

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -1022,9 +1022,7 @@ def _init_dualwave_thread_mapping(ctx):
     elif const_expr(batch_interleave_group > 1):
         linear_head_batch = fx.Index(gpu.block_idx.x)
         ctx.h_idx = linear_head_batch % traits.NUM_HEADS_Q
-        ctx.batch_idx = (
-            fx.Index(gpu.block_idx.z) * batch_interleave_group + linear_head_batch // traits.NUM_HEADS_Q
-        )
+        ctx.batch_idx = fx.Index(gpu.block_idx.z) * batch_interleave_group + linear_head_batch // traits.NUM_HEADS_Q
         ctx.q_block_idx = fx.Index(gpu.block_idx.y)
     else:
         ctx.h_idx = fx.Index(gpu.block_idx.x)
@@ -1946,8 +1944,7 @@ def _make_dualwave_swp_fp8_traits(
         head_dim_v = head_dim
     if head_dim % 64 or head_dim_v % 32:
         raise RuntimeError(
-            f"fp8 flash attention needs head_dim % 64 == 0 and head_dim_v % 32 == 0, "
-            f"got {head_dim}/{head_dim_v}"
+            f"fp8 flash attention needs head_dim % 64 == 0 and head_dim_v % 32 == 0, " f"got {head_dim}/{head_dim_v}"
         )
     block_n = 64
     k_sub_n = 32

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -1044,7 +1044,7 @@ def _init_dualwave_thread_mapping(ctx):
         T.i32,
         (_tid_i32 // fx.Int32(traits.WARP_SIZE)).ir_value(),
     )
-    # Two stagger groups, whatever the wave count (bf16 keeps its old divisor of 4).
+    # Two stagger groups, whatever the wave count.
     ctx.stagger_i32 = arith.divsi(_wave_id_uni_i32, as_mlir_value(fx.Int32(traits.NUM_WAVES // 2)))
     ctx.wave_id_uni = fx.Index(_wave_id_uni_i32)
 
@@ -1778,11 +1778,7 @@ def _make_dualwave_swp_traits(
 
 @dataclass(frozen=True)
 class DualwaveSwpFp8Traits:
-    """Pure compile-time tile/layout constants for the gfx950 DUALWAVE_SWP fp8 kernel.
-
-    fp8 runs a single path: WIDE QK (32x32x64 mfma_scale) feeding an fp8 PV MMA
-    that consumes V straight out of the ``vt`` LDS scratch. ``ELEM_BYTES`` is 1
-    (Q/K/V are fp8); the bf16 output is ``OUT_ELEM_BYTES``."""
+    """Pure compile-time tile/layout constants for the gfx950 DUALWAVE_SWP fp8 kernel."""
 
     BLOCK_M: int
     BLOCK_N: int
@@ -1902,13 +1898,11 @@ def _make_dualwave_swp_fp8_traits(
     xcd_swizzle=False,
     batch_interleave_group=1,
 ):
-    """Build gfx950 DUALWAVE_SWP fp8 compile-time layout traits (dtype fixed to fp8).
+    """Build gfx950 DUALWAVE_SWP fp8 compile-time layout traits.
 
-    ``head_dim`` is the QK reduction width and ``head_dim_v`` the V (and output)
-    width; they differ for the 192/128 pair. ``head_dim`` must be a multiple of
-    64 -- the fp8 QK MFMA is 32x32x64, so it splits into head_dim//64 slices with
-    no padding. ``head_dim_v`` tiles in 32-wide D_CHUNKs and so only has to be a
-    multiple of 32, but the validated range is 64..192 (see below)."""
+    ``head_dim`` is the QK reduction width (a multiple of 64: the QK MFMA is
+    32x32x64) and ``head_dim_v`` the V/output width, tiled in 32-wide D_CHUNKs.
+    """
     if head_dim_v is None:
         head_dim_v = head_dim
     if head_dim % 64:
@@ -1973,7 +1967,7 @@ def _make_dualwave_swp_fp8_traits(
     dualwave_swp_k_buf_base = tuple(i * dualwave_swp_kv_per_buffer for i in range(num_prefetch_k))
     dualwave_swp_v_buf_base = tuple(smem_k_tile_elems + i * dualwave_swp_kv_per_buffer for i in range(num_prefetch_k))
 
-    # V scratch is typed bf16 (hence the /2); +128 covers the DMA base alignment.
+    # The +128 covers the alignment the DMA base is rounded up to.
     eb_bf = 2
     fp8_v_tile_bytes = (block_n // 8) * (head_dim_v // 16) * 128
     vt_bf16_total = num_prefetch_k * (fp8_v_tile_bytes // eb_bf) + 128
@@ -1982,7 +1976,6 @@ def _make_dualwave_swp_fp8_traits(
 
     qlds = head_dim <= 128
 
-    # Reject here; at launch this is a bare hipErrorIllegalState naming no shape.
     lds_bytes = lds_kv_total_size * elem_bytes + vt_bf16_total * eb_bf
     if qlds:
         lds_bytes += block_m * head_dim * elem_bytes
@@ -2062,10 +2055,9 @@ def _make_dualwave_swp_fp8_traits(
 def dualwave_fp8_dma_per_iter(traits):
     """Vector-memory instructions the least-loaded wave issues per main-loop iteration.
 
-    `_waitcnt_vm_n(N)` only retires the previous iteration's DMAs when N is at
-    most what this wave issues; overshooting makes the wait a no-op. K is
-    exec-masked so every wave issues each pass; V's trailing pass is behind a
-    wave-uniform branch, so its minimum is the floor. Two KV tiles per iteration.
+    `_waitcnt_vm_n(N)` is a no-op unless N is at most what this wave issues. K is
+    exec-masked so every wave issues each pass; V's trailing pass sits behind a
+    wave-uniform branch, so its minimum is the floor.
     """
     rows_per_wave = -(-traits.BLOCK_N // traits.NUM_WAVES)
     k_instr = sum(-(-(rows_per_wave * (chunk // traits.VEC_KV)) // traits.WARP_SIZE) for chunk in traits.K_BAND_CHUNK)
@@ -4776,12 +4768,7 @@ class DualwaveFp8GemmHelper(DualwaveFp8KernelContext):
         return packs
 
     def _load_q_wide_global(self):
-        """Pull this lane's Q operands straight from global into VGPRs.
-
-        Used when Q is not staged through LDS (head_dim > 128, where the staging
-        buffer would not fit alongside the KV ring). Q is read exactly once, so
-        the only thing LDS bought was coalescing on that single pass.
-        """
+        """Pull this lane's Q operands straight from global into VGPRs (head_dim > 128)."""
         traits = self.traits
         d_base = self.lane_div_32 * 32
         packs = []
@@ -4844,10 +4831,9 @@ class DualwaveFp8KvGmemToLdsLoader(DualwaveFp8KernelContext):
     def load_k(self, tile_start, buf_id):
         """DMA one K tile into LDS, one pass per head-dim band.
 
-        A band's LDS line is this wave's 8 n-rows of `chunk` bytes, laid out
-        row-contiguous so the QK read can index it as (band, row, 64-byte slice).
-        The 64-byte tail band at head_dim 192 needs only 4 lanes per row, so its
-        pass runs on the low 32 lanes and moves no padding.
+        A band's LDS line is this wave's n-rows of `chunk` bytes, row-contiguous,
+        so the QK read indexes it as (band, row, 64-byte slice). The 64-byte tail
+        band at head_dim 192 runs on the low 32 lanes and moves no padding.
         """
         traits = self.traits
         eb = traits.ELEM_BYTES
@@ -5380,8 +5366,7 @@ class DualwaveSplitKCombineContext:
 
         blockIdx.y carries the batch: the O buffer resource is wave-scoped, so a
         per-thread batch_idx would hand a whole wave one batch's descriptor when a
-        batch boundary falls inside it. Rows the rounded-up x grid adds past the
-        batch, and threads past the block's own rows, fold into `row_valid`.
+        batch boundary falls inside it.
         """
         traits = self.traits
         self.tid = fx.Index(gpu.thread_idx.x)

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -5022,25 +5022,36 @@ class DualwaveFp8KvGmemToLdsLoader(DualwaveFp8KernelContext):
 
     def _stage_v_fp8_block_dma(self, tile_start, buf_id):
         traits = self.traits
-        v_tile_bytes = (traits.BLOCK_N // 8) * (traits.HEAD_DIM_V // 16) * 128
+        nbands = traits.HEAD_DIM_V // 16
+        v_tile_bytes = (traits.BLOCK_N // 8) * nbands * 128
         buf_off = buf_id * v_tile_bytes
         aligned_base = ((self.lds_vt_base_idx + fx.Index(127)) // fx.Index(128)) * fx.Index(128)
-        groups = traits.BLOCK_N // 8
-        passes = -(-groups // traits.NUM_WAVES)
+        # The tile is BLOCK_N * nbands 16-byte slots, and one DMA instruction moves a
+        # whole wave of them. Hand out instructions, not row-groups: a wave's LDS
+        # destination is then always a full WARP_SIZE*16 span, so nothing has to be
+        # masked off inside a wave. buffer_load...lds strides the LDS write by lane
+        # regardless of exec, so an intra-wave mask would still write past the span.
+        per_dma = traits.WARP_SIZE * traits.VEC_KV * traits.ELEM_BYTES
+        slots_per_group = 8 * nbands
+        num_dma = (traits.BLOCK_N * nbands * 16) // per_dma
+        passes = -(-num_dma // traits.NUM_WAVES)
         for pas in range_constexpr(passes):
-            grp = self.wave_id_uni + fx.Index(pas * traits.NUM_WAVES)
-            lds_addr = aligned_base + fx.Index(buf_off) + grp * fx.Index(1024)
-            dest_n = fx.Int32(grp * fx.Index(8) + self.lane % fx.Index(8))
+            dma_id = self.wave_id_uni + fx.Index(pas * traits.NUM_WAVES)
+            slot = dma_id * fx.Index(traits.WARP_SIZE) + self.lane
+            lds_addr = aligned_base + fx.Index(buf_off) + dma_id * fx.Index(per_dma)
+            grp = slot // fx.Index(slots_per_group)
+            rem = slot % fx.Index(slots_per_group)
+            dest_n = fx.Int32(grp * fx.Index(8) + rem % fx.Index(8))
             w16 = dest_n % fx.Int32(16)
             c_add = (w16 >= fx.Int32(4)) & (w16 < fx.Int32(8))
             c_sub = (w16 >= fx.Int32(8)) & (w16 < fx.Int32(12))
             n = dest_n + c_add.select(fx.Int32(4), fx.Int32(0)) - c_sub.select(fx.Int32(4), fx.Int32(0))
-            d_block = self.lane // fx.Index(8)
+            d_block = rem // fx.Index(8)
             src_elem = self.v_gmem_elem_offset + fx.Index(n) * self.stride_v_n_v + d_block * fx.Index(16)
-            if const_expr(groups % traits.NUM_WAVES == 0 or pas < passes - 1):
+            if const_expr(num_dma % traits.NUM_WAVES == 0 or pas < passes - 1):
                 self.buffer_load_lds_128(self.v_div, lds_addr, src_elem, tile_start * self.stride_v_n_v)
             else:
-                self._load_v_group_if_in_tile(lds_addr, src_elem, tile_start, grp, groups)
+                self._load_v_group_if_in_tile(lds_addr, src_elem, tile_start, dma_id, num_dma)
 
     def _load_v_group_if_in_tile(self, lds_addr, src_elem, tile_start, grp, groups):
         soffset = tile_start * self.stride_v_n_v
@@ -5372,23 +5383,19 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
             all_below = arith.cmpi(arith.CmpIPredicate.eq, as_mlir_value(ballot), _read_exec_i64())
             all_below = llvm.intr_expect(all_below, arith.constant(1, type=ir.IntegerType.get_signless(1)))
 
-            o0, o1, o2, o3 = (
-                as_mlir_value(v_o[0]),
-                as_mlir_value(v_o[1]),
-                as_mlir_value(v_o[2]),
-                as_mlir_value(v_o[3]),
-            )
+            o_out = [as_mlir_value(v_o[dc]) for dc in range_constexpr(self.traits.D_CHUNKS)]
             m_out = as_mlir_value(m_row)
             l_out = as_mlir_value(l_row)
             vp_out = self.v_p_to_vec32(v_p)
             if fx.Boolean(all_below):
                 pass
             else:
-                m_new, corr, (o0, o1, o2, o3) = self._lazy_correction(v_o, m_row, m_tile_max)
+                m_new, corr, scaled_accs = self._lazy_correction(v_o, m_row, m_tile_max)
+                o_out = [as_mlir_value(scaled_accs[dc]) for dc in range_constexpr(self.traits.D_CHUNKS)]
                 vp_out = self.v_p_to_vec32(self.scale_v_p(v_p, corr))
                 l_out = as_mlir_value(l_row * corr)
                 m_out = self.anchor_scalar_f32(m_new)
-            return ([o0, o1, o2, o3], m_out, l_out, self.v_vec32_to_p(vp_out))
+            return (o_out, m_out, l_out, self.v_vec32_to_p(vp_out))
 
         return _run(v_o, m_row, l_row, m_tile_max, v_p)
 
@@ -5402,21 +5409,17 @@ class DualwaveFp8SoftmaxHelper(DualwaveFp8KernelContext):
             all_below = arith.cmpi(arith.CmpIPredicate.eq, as_mlir_value(ballot), _read_exec_i64())
             all_below = llvm.intr_expect(all_below, arith.constant(1, type=ir.IntegerType.get_signless(1)))
 
-            o0, o1, o2, o3 = (
-                as_mlir_value(v_o[0]),
-                as_mlir_value(v_o[1]),
-                as_mlir_value(v_o[2]),
-                as_mlir_value(v_o[3]),
-            )
+            o_out = [as_mlir_value(v_o[dc]) for dc in range_constexpr(self.traits.D_CHUNKS)]
             m_out = as_mlir_value(m_row)
             l_out = as_mlir_value(l_row)
             if fx.Boolean(all_below):
                 pass
             else:
-                m_new, corr, (o0, o1, o2, o3) = self._lazy_correction(v_o, m_row, m_tile_max)
+                m_new, corr, scaled_accs = self._lazy_correction(v_o, m_row, m_tile_max)
+                o_out = [as_mlir_value(scaled_accs[dc]) for dc in range_constexpr(self.traits.D_CHUNKS)]
                 l_out = as_mlir_value(l_row * corr)
                 m_out = self.anchor_scalar_f32(m_new)
-            return ([o0, o1, o2, o3], m_out, l_out)
+            return (o_out, m_out, l_out)
 
         return _run(v_o, m_row, l_row, m_tile_max)
 

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -31,8 +31,6 @@ from kernels.common.kernels_common import dtype_to_elem_type
 _LOG2E = host_math.log2(host_math.e)
 # gfx950 (MI350/MI355X): 8 XCDs, each with a private ~4 MB L2.
 NUM_XCD_GFX950 = 8
-# LDS a single gfx950 workgroup may request. Past this the request is rejected
-# at codegen ("local memory exceeds limit") or at launch (hipErrorIllegalState).
 LDS_BYTES_GFX950 = 160 * 1024
 MIN_Q_BLOCKS_XCD_SWIZZLE = 64
 # The dual-wave 8-wave CTA fixes the q-block height; callers need it to count
@@ -48,12 +46,7 @@ _LDS_ALIAS_DOMAIN = '#llvm.alias_scope_domain<id = "flydsl.dualwave_swp.lds">'
 
 
 def _waitcnt_vm_n(n):
-    """Wait until at most `n` vector-memory ops are outstanding; lgkmcnt/expcnt unconstrained.
-
-    The keyword form packs the per-arch bitfield (the counter field widths differ
-    between CDNA and RDNA), so the split vmcnt encoding does not have to be
-    open-coded here.
-    """
+    """Emit s_waitcnt vmcnt(n) only."""
     rocdl.s_waitcnt(vmcnt=n)
 
 
@@ -562,12 +555,7 @@ def _dualwave_lds_noalias_scopes(name, scope_names):
 
 
 def _cu_load(div, idx, cu_atom, cu_v1i32):
-    """Load cu_seqlens[idx] into an SGPR.
-
-    ``idx`` must be wave-uniform: the readfirstlane keeps lane 0's value for the
-    whole wave, so a per-lane index would silently give every lane lane 0's
-    answer. Every caller derives ``idx`` from a kernel argument or a block index.
-    """
+    """Load cu_seqlens[idx] into an SGPR. ``idx`` must be wave-uniform."""
     v = fly.copy_atom_call_ssa([cu_v1i32], cu_atom, fx.slice(div, (None, fx.Int32(idx))))
     return fx.Index(rocdl.readfirstlane(T.i32, as_mlir_value(fx.Int32(Vec(v, (1,), fx.Int32)[0]))))
 
@@ -1056,9 +1044,7 @@ def _init_dualwave_thread_mapping(ctx):
         T.i32,
         (_tid_i32 // fx.Int32(traits.WARP_SIZE)).ir_value(),
     )
-    # Two stagger groups, whatever the wave count. This is shared with the bf16
-    # path, where NUM_WAVES is 8 and the divisor stays the 4 it always was; it
-    # only moves for the fp8 4-wave (block_m=128) build.
+    # Two stagger groups, whatever the wave count (bf16 keeps its old divisor of 4).
     ctx.stagger_i32 = arith.divsi(_wave_id_uni_i32, as_mlir_value(fx.Int32(traits.NUM_WAVES // 2)))
     ctx.wave_id_uni = fx.Index(_wave_id_uni_i32)
 
@@ -1848,8 +1834,6 @@ class DualwaveSwpFp8Traits:
     LDS_KV_TOTAL_SIZE: int
     DUALWAVE_SWP_K_BUF_BASE: tuple[int, int]
     DUALWAVE_SWP_V_BUF_BASE: tuple[int, int]
-    # V scratch: fp8 V arrives already permuted into the PV MMA layout. Sized in
-    # bf16 elements because the LDS array is typed bf16.
     VT_BF16_TOTAL: int
     DUALWAVE_SWP_RESCALE_THRESHOLD: float
     SCHED_MFMA_MASK: int
@@ -1892,8 +1876,6 @@ class DualwaveSwpFp8Traits:
             self.NUM_PREFETCH_K,
             self.XCD_SWIZZLE,
             self.BATCH_INTERLEAVE_GROUP,
-            # block_m is a build parameter now, and it moves the tile shape, the
-            # wave count, the LDS layout and the grid.
             self.BLOCK_M,
             self.BLOCK_SIZE,
             self.NUM_WAVES,
@@ -1931,10 +1913,8 @@ def _make_dualwave_swp_fp8_traits(
         head_dim_v = head_dim
     if head_dim % 64:
         raise RuntimeError(f"fp8 flash attention needs head_dim % 64 == 0, got head_dim={head_dim}")
-    # D_CHUNKS == head_dim_v // 32 must land in [2, 6]. Below 2, `_anchor_v_o`
-    # builds a single-element inline-asm struct and LLVM aborts the process;
-    # above 6 the kernel launches but miscomputes the high D_CHUNKs (measured at
-    # head_dim_v=224: min_cos 0.83, error confined to output columns 128..191).
+    # D_CHUNKS == head_dim_v // 32 must land in [2, 6]: below 2 `_anchor_v_o`
+    # aborts LLVM, above 6 the high D_CHUNKs come back wrong.
     if head_dim_v % 32 or not 64 <= head_dim_v <= 192:
         raise RuntimeError(
             "fp8 flash attention needs 64 <= head_dim_v <= 192 and head_dim_v % 32 == 0, "
@@ -1987,18 +1967,13 @@ def _make_dualwave_swp_fp8_traits(
         for _o in range(0, chunk, 64):
             k_ws_band.append(_bi)
             k_ws_off.append(_o)
-    # The BN128 pipeline (two BLOCK_N=64 tiles per iteration, 6-deep K ring, V
-    # staged by DMA straight into its MMA layout) is the only fp8 pipeline left;
-    # split-K and varlen run on it too.
     num_prefetch_k = 6
     dualwave_swp_kv_per_buffer = smem_k_tile_elems
     lds_kv_total_size = num_prefetch_k * dualwave_swp_kv_per_buffer
     dualwave_swp_k_buf_base = tuple(i * dualwave_swp_kv_per_buffer for i in range(num_prefetch_k))
     dualwave_swp_v_buf_base = tuple(smem_k_tile_elems + i * dualwave_swp_kv_per_buffer for i in range(num_prefetch_k))
 
-    # V scratch: fp8 V is DMA'd in already permuted into the PV MMA layout. The
-    # array is typed bf16, hence the /2; the trailing 128 covers the 128-byte
-    # alignment the DMA base is rounded up to.
+    # V scratch is typed bf16 (hence the /2); +128 covers the DMA base alignment.
     eb_bf = 2
     fp8_v_tile_bytes = (block_n // 8) * (head_dim_v // 16) * 128
     vt_bf16_total = num_prefetch_k * (fp8_v_tile_bytes // eb_bf) + 128
@@ -2007,11 +1982,7 @@ def _make_dualwave_swp_fp8_traits(
 
     qlds = head_dim <= 128
 
-    # SharedStorage is {K/V ring, bf16 V transpose scratch, staged Q}; the Q stub
-    # allocated when not QLDS is never read and the allocator drops it. The
-    # footprint is fixed by (head_dim, head_dim_v, block_m), so reject it here --
-    # otherwise it surfaces as "local memory exceeds limit" at codegen or a bare
-    # hipErrorIllegalState at launch, neither of which names a head dim.
+    # Reject here; at launch this is a bare hipErrorIllegalState naming no shape.
     lds_bytes = lds_kv_total_size * elem_bytes + vt_bf16_total * eb_bf
     if qlds:
         lds_bytes += block_m * head_dim * elem_bytes
@@ -2089,23 +2060,12 @@ def _make_dualwave_swp_fp8_traits(
 
 
 def dualwave_fp8_dma_per_iter(traits):
-    """Vector-memory instructions the *least* loaded wave issues per main-loop iteration.
+    """Vector-memory instructions the least-loaded wave issues per main-loop iteration.
 
-    `_waitcnt_vm_n(N)` only forces the previous iteration's DMAs to retire when N
-    is at most the count this wave actually issues; overshooting turns the wait
-    into a no-op and the end-of-iteration barrier then releases with LDS writes
-    still in flight. Waves that issue more than the minimum just over-wait, which
-    is safe.
-
-    K (`DualwaveFp8KvGmemToLdsLoader.load_k`): every wave issues one DMA per pass
-    per band, the tail band's partial pass included -- it is exec-masked, not
-    branched, so the instruction still issues.
-
-    V (`_stage_v_fp8_block_dma`): the trailing pass is guarded by a wave-uniform
-    `dma_id < num_dma`, so waves past the end issue nothing at all and the
-    minimum is the floor, not the ceiling.
-
-    The main loop consumes two KV tiles per iteration, hence the factor of two.
+    `_waitcnt_vm_n(N)` only retires the previous iteration's DMAs when N is at
+    most what this wave issues; overshooting makes the wait a no-op. K is
+    exec-masked so every wave issues each pass; V's trailing pass is behind a
+    wave-uniform branch, so its minimum is the floor. Two KV tiles per iteration.
     """
     rows_per_wave = -(-traits.BLOCK_N // traits.NUM_WAVES)
     k_instr = sum(-(-(rows_per_wave * (chunk // traits.VEC_KV)) // traits.WARP_SIZE) for chunk in traits.K_BAND_CHUNK)
@@ -5418,15 +5378,10 @@ class DualwaveSplitKCombineContext:
     def init_thread_mapping(self, combine_rows_per_block, combine_lanes_per_row):
         """Map (blockIdx.x, blockIdx.y, tid) to one (batch, head, token) output row.
 
-        blockIdx.y carries the batch so that `batch_idx` -- which the O buffer
-        resource is built from -- is block-uniform. A buffer resource is
-        wave-scoped, so deriving it per thread would give every lane of a wave
-        one batch's base pointer and num_records even when a batch boundary
-        falls inside the wave.
-
-        The x grid rounds up, and when combine_lanes_per_row does not divide the
-        block the trailing threads map past the block's own rows; both are folded
-        into `row_valid` by steering those threads to `rows_per_batch`.
+        blockIdx.y carries the batch: the O buffer resource is wave-scoped, so a
+        per-thread batch_idx would hand a whole wave one batch's descriptor when a
+        batch boundary falls inside it. Rows the rounded-up x grid adds past the
+        batch, and threads past the block's own rows, fold into `row_valid`.
         """
         traits = self.traits
         self.tid = fx.Index(gpu.thread_idx.x)
@@ -5467,7 +5422,6 @@ class DualwaveSplitKCombineContext:
             per_batch_elems = self.seq_len_v * self.stride_o_n_v
             batch_byte_off = self.batch_idx * per_batch_elems * fx.Index(2)
             nrec_bytes = per_batch_elems * fx.Index(2)
-        # Kept so out-of-range rows can steer their store past num_records.
         self.o_nrec_bytes = nrec_bytes
         self.o_rsrc = buffer_ops.create_buffer_resource_from_addr(
             as_mlir_value(fx.Int64(fx.ptrtoint(fx.get_iter(self.O))) + fx.Int64(batch_byte_off)),
@@ -5611,8 +5565,7 @@ class DualwaveSplitKCombineHelper(DualwaveSplitKCombineContext):
 
     def store_output(self, o_pack):
         o_global = self.seq_idx * self.stride_o_n_v + self.q_head_idx * self.traits.HEAD_DIM_V + self.col
-        # Rows the rounded-up grid added past the end of the batch aim at
-        # num_records, which the buffer drops.
+        # Out-of-range rows aim past num_records, which the buffer drops.
         o_off = self.row_valid.select(o_global * fx.Index(2), self.o_nrec_bytes)
         buffer_ops.buffer_store(
             o_pack.ir_value(),

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -31,15 +31,13 @@ from kernels.common.kernels_common import dtype_to_elem_type
 _LOG2E = host_math.log2(host_math.e)
 # gfx950 (MI350/MI355X): 8 XCDs, each with a private ~4 MB L2.
 NUM_XCD_GFX950 = 8
+# LDS a single gfx950 workgroup may request. Past this the request is rejected
+# at codegen ("local memory exceeds limit") or at launch (hipErrorIllegalState).
+LDS_BYTES_GFX950 = 160 * 1024
 MIN_Q_BLOCKS_XCD_SWIZZLE = 64
 # The dual-wave 8-wave CTA fixes the q-block height; callers need it to count
 # q-blocks before any traits object exists.
 DUALWAVE_SWP_BLOCK_M = 256
-# s_waitcnt bitfield encoding
-_VMCNT_LO_MASK = 0xF
-_LGKMCNT_EXPCNT_BASE = 0x3F70
-_VMCNT_HI_SHIFT = 14
-_VMCNT_HI_MASK = 0x3
 scf_if_dispatch = ReplaceIfWithDispatch.scf_if_dispatch
 
 
@@ -50,9 +48,13 @@ _LDS_ALIAS_DOMAIN = '#llvm.alias_scope_domain<id = "flydsl.dualwave_swp.lds">'
 
 
 def _waitcnt_vm_n(n):
-    """Emit s_waitcnt vmcnt(n) only (lgkmcnt=63, expcnt=7)."""
-    val = (n & _VMCNT_LO_MASK) | _LGKMCNT_EXPCNT_BASE | (((n >> 4) & _VMCNT_HI_MASK) << _VMCNT_HI_SHIFT)
-    rocdl.s_waitcnt(val)
+    """Wait until at most `n` vector-memory ops are outstanding; lgkmcnt/expcnt unconstrained.
+
+    The keyword form packs the per-arch bitfield (the counter field widths differ
+    between CDNA and RDNA), so the split vmcnt encoding does not have to be
+    open-coded here.
+    """
+    rocdl.s_waitcnt(vmcnt=n)
 
 
 def _s_waitcnt(val):
@@ -560,6 +562,12 @@ def _dualwave_lds_noalias_scopes(name, scope_names):
 
 
 def _cu_load(div, idx, cu_atom, cu_v1i32):
+    """Load cu_seqlens[idx] into an SGPR.
+
+    ``idx`` must be wave-uniform: the readfirstlane keeps lane 0's value for the
+    whole wave, so a per-lane index would silently give every lane lane 0's
+    answer. Every caller derives ``idx`` from a kernel argument or a block index.
+    """
     v = fly.copy_atom_call_ssa([cu_v1i32], cu_atom, fx.slice(div, (None, fx.Int32(idx))))
     return fx.Index(rocdl.readfirstlane(T.i32, as_mlir_value(fx.Int32(Vec(v, (1,), fx.Int32)[0]))))
 
@@ -1048,6 +1056,9 @@ def _init_dualwave_thread_mapping(ctx):
         T.i32,
         (_tid_i32 // fx.Int32(traits.WARP_SIZE)).ir_value(),
     )
+    # Two stagger groups, whatever the wave count. This is shared with the bf16
+    # path, where NUM_WAVES is 8 and the divisor stays the 4 it always was; it
+    # only moves for the fp8 4-wave (block_m=128) build.
     ctx.stagger_i32 = arith.divsi(_wave_id_uni_i32, as_mlir_value(fx.Int32(traits.NUM_WAVES // 2)))
     ctx.wave_id_uni = fx.Index(_wave_id_uni_i32)
 
@@ -1783,9 +1794,9 @@ def _make_dualwave_swp_traits(
 class DualwaveSwpFp8Traits:
     """Pure compile-time tile/layout constants for the gfx950 DUALWAVE_SWP fp8 kernel.
 
-    fp8 runs a single path: WIDE QK (32x32x64 mfma_scale) feeding HIPREC PV (fp8 V
-    dequantized into a bf16 ``vt`` LDS scratch, then a bf16 PV MMA). The ``*_BF``
-    fields describe that bf16 vt layout; ``ELEM_BYTES`` is 1 (Q/K/V are fp8)."""
+    fp8 runs a single path: WIDE QK (32x32x64 mfma_scale) feeding an fp8 PV MMA
+    that consumes V straight out of the ``vt`` LDS scratch. ``ELEM_BYTES`` is 1
+    (Q/K/V are fp8); the bf16 output is ``OUT_ELEM_BYTES``."""
 
     BLOCK_M: int
     BLOCK_N: int
@@ -1814,12 +1825,6 @@ class DualwaveSwpFp8Traits:
     SPLITK: bool
     VARLEN: bool
     CROSS_SEQLEN: bool
-    FP8_PV: bool
-    FP8_PV_DIRECT: bool
-    BN128: bool
-    BN128_PF: bool
-    QREG: bool
-    VDMA: bool
     DEFAULT_STRIDE_Q_N: int
     DEFAULT_STRIDE_KV_N: int
     DEFAULT_STRIDE_V_N: int
@@ -1834,11 +1839,8 @@ class DualwaveSwpFp8Traits:
     DMA_BYTES: int
     ELEM_BYTES: int
     OUT_ELEM_BYTES: int
-    D_128B_SIZE: int
     VEC_KV: int
     LANE_SPLIT_KV: int
-    SMEM_N_RPT: int
-    SMEM_D_RPT: int
     SMEM_K_LINE_STRIDE: int
     SMEM_K_TILE_ELEMS: int
     NUM_PREFETCH_K: int
@@ -1846,23 +1848,9 @@ class DualwaveSwpFp8Traits:
     LDS_KV_TOTAL_SIZE: int
     DUALWAVE_SWP_K_BUF_BASE: tuple[int, int]
     DUALWAVE_SWP_V_BUF_BASE: tuple[int, int]
-    # bf16 vt scratch layout (HIPREC V dequant target + transpose read strides).
-    EB_BF: int
-    D128_BF: int
-    VEC_BF: int
-    SDRPT_BF: int
-    SNRPT_BF: int
-    VLS_BF: int
-    VT_BF16_ELEMS: int
+    # V scratch: fp8 V arrives already permuted into the PV MMA layout. Sized in
+    # bf16 elements because the LDS array is typed bf16.
     VT_BF16_TOTAL: int
-    URV_GRPK_BF: int
-    URV_GRP_N_BF: int
-    URV_LANE_LO_BF: int
-    URV_LANE_HI_BF: int
-    URV_STEPK_BF: int
-    URV_DC_AXIS0_BF: int
-    URV_DC_AXIS1_BF: int
-    URV_I5_BF: int
     DUALWAVE_SWP_RESCALE_THRESHOLD: float
     SCHED_MFMA_MASK: int
     SCHED_VALU_MASK: int
@@ -1900,17 +1888,15 @@ class DualwaveSwpFp8Traits:
             self.ELEM_BYTES,
             self.OUT_ELEM_BYTES,
             self.LANE_SPLIT_KV,
-            self.VT_BF16_ELEMS,
             self.VT_BF16_TOTAL,
-            self.FP8_PV,
-            self.FP8_PV_DIRECT,
             self.NUM_PREFETCH_K,
-            self.BN128,
-            self.BN128_PF,
-            self.QREG,
-            self.VDMA,
             self.XCD_SWIZZLE,
             self.BATCH_INTERLEAVE_GROUP,
+            # block_m is a build parameter now, and it moves the tile shape, the
+            # wave count, the LDS layout and the grid.
+            self.BLOCK_M,
+            self.BLOCK_SIZE,
+            self.NUM_WAVES,
         )
 
 
@@ -1937,14 +1923,22 @@ def _make_dualwave_swp_fp8_traits(
     """Build gfx950 DUALWAVE_SWP fp8 compile-time layout traits (dtype fixed to fp8).
 
     ``head_dim`` is the QK reduction width and ``head_dim_v`` the V (and output)
-    width; they differ for the 192/128 pair. Both must be multiples of 64 -- the
-    fp8 QK MFMA is 32x32x64, so head_dim splits into head_dim//64 slices with no
-    padding, and the V/O side tiles in 32-wide D_CHUNKs."""
+    width; they differ for the 192/128 pair. ``head_dim`` must be a multiple of
+    64 -- the fp8 QK MFMA is 32x32x64, so it splits into head_dim//64 slices with
+    no padding. ``head_dim_v`` tiles in 32-wide D_CHUNKs and so only has to be a
+    multiple of 32, but the validated range is 64..192 (see below)."""
     if head_dim_v is None:
         head_dim_v = head_dim
-    if head_dim % 64 or head_dim_v % 32:
+    if head_dim % 64:
+        raise RuntimeError(f"fp8 flash attention needs head_dim % 64 == 0, got head_dim={head_dim}")
+    # D_CHUNKS == head_dim_v // 32 must land in [2, 6]. Below 2, `_anchor_v_o`
+    # builds a single-element inline-asm struct and LLVM aborts the process;
+    # above 6 the kernel launches but miscomputes the high D_CHUNKs (measured at
+    # head_dim_v=224: min_cos 0.83, error confined to output columns 128..191).
+    if head_dim_v % 32 or not 64 <= head_dim_v <= 192:
         raise RuntimeError(
-            f"fp8 flash attention needs head_dim % 64 == 0 and head_dim_v % 32 == 0, " f"got {head_dim}/{head_dim_v}"
+            "fp8 flash attention needs 64 <= head_dim_v <= 192 and head_dim_v % 32 == 0, "
+            f"got head_dim_v={head_dim_v} (head_dim={head_dim})"
         )
     block_n = 64
     k_sub_n = 32
@@ -1969,18 +1963,11 @@ def _make_dualwave_swp_fp8_traits(
     # fp8: Q/K/V are 1B; O is bf16 (2B). ELEM_BYTES=1 drives the fp8 address math.
     elem_bytes = 1
     out_elem_bytes = 2
-    d_128b_size = 128 // elem_bytes
     vec_kv = 16 // elem_bytes
     lane_split_kv = 8
     smem_linear_wave = warp_size * 16 // elem_bytes
-    smem_n_per_wave = smem_linear_wave // d_128b_size
-    smem_n_rpt = block_n // smem_n_per_wave
-    smem_d_rpt = head_dim_v // d_128b_size
     smem_k_pad = 16 // elem_bytes
-    smem_v_pad = 64 // elem_bytes
     smem_k_line_stride = smem_linear_wave + smem_k_pad
-    smem_v_line_stride = smem_linear_wave + smem_v_pad
-    smem_v_tile_elems = smem_n_rpt * smem_d_rpt * smem_v_line_stride
 
     rows_per_wave_dma = -(-block_n // num_waves)
     k_band_chunk, k_band_base, k_band_line_stride, k_band_global_d = [], [], [], []
@@ -2000,44 +1987,41 @@ def _make_dualwave_swp_fp8_traits(
         for _o in range(0, chunk, 64):
             k_ws_band.append(_bi)
             k_ws_off.append(_o)
-    bn128 = True
-    bn128_pf = bn128
-    qreg = bn128_pf
-    vdma = bn128_pf
-    deep_ring = bn128
-    num_prefetch_k = (6 if bn128_pf else 4) if deep_ring else 2
-    if bn128_pf:
-        dualwave_swp_kv_per_buffer = smem_k_tile_elems
-    else:
-        dualwave_swp_kv_per_buffer = smem_k_tile_elems + smem_v_tile_elems
+    # The BN128 pipeline (two BLOCK_N=64 tiles per iteration, 6-deep K ring, V
+    # staged by DMA straight into its MMA layout) is the only fp8 pipeline left;
+    # split-K and varlen run on it too.
+    num_prefetch_k = 6
+    dualwave_swp_kv_per_buffer = smem_k_tile_elems
     lds_kv_total_size = num_prefetch_k * dualwave_swp_kv_per_buffer
     dualwave_swp_k_buf_base = tuple(i * dualwave_swp_kv_per_buffer for i in range(num_prefetch_k))
     dualwave_swp_v_buf_base = tuple(smem_k_tile_elems + i * dualwave_swp_kv_per_buffer for i in range(num_prefetch_k))
 
-    # bf16 vt scratch layout: HIPREC dequantizes fp8 V into these positions so the
-    # proven bf16 V transpose read (ds_read_tr16) + bf16 PV MMA are reused unchanged.
+    # V scratch: fp8 V is DMA'd in already permuted into the PV MMA layout. The
+    # array is typed bf16, hence the /2; the trailing 128 covers the 128-byte
+    # alignment the DMA base is rounded up to.
     eb_bf = 2
-    d128_bf = 128 // eb_bf
-    vec_bf = 16 // eb_bf
-    slw_bf = warp_size * 16 // eb_bf
-    snrpt_bf = block_n // (slw_bf // d128_bf)
-    sdrpt_bf = head_dim_v // d128_bf
-    vls_bf = slw_bf + 64 // eb_bf
-    vt_bf16_elems = snrpt_bf * sdrpt_bf * vls_bf
     fp8_v_tile_bytes = (block_n // 8) * (head_dim_v // 16) * 128
-    if bn128_pf:
-        vt_bf16_total = num_prefetch_k * (fp8_v_tile_bytes // eb_bf) + 128
-    else:
-        vt_bf16_total = (2 if deep_ring else num_prefetch_k) * vt_bf16_elems
+    vt_bf16_total = num_prefetch_k * (fp8_v_tile_bytes // eb_bf) + 128
 
     splitk = num_kv_splits > 1
 
     qlds = head_dim <= 128
 
-    fp8_pv = os.getenv("FLYDSL_FA_FP8_PV", "0") == "1"
-    fp8_pv_direct = bn128
-    if fp8_pv_direct:
-        fp8_pv = True
+    # SharedStorage is {K/V ring, bf16 V transpose scratch, staged Q}; the Q stub
+    # allocated when not QLDS is never read and the allocator drops it. The
+    # footprint is fixed by (head_dim, head_dim_v, block_m), so reject it here --
+    # otherwise it surfaces as "local memory exceeds limit" at codegen or a bare
+    # hipErrorIllegalState at launch, neither of which names a head dim.
+    lds_bytes = lds_kv_total_size * elem_bytes + vt_bf16_total * eb_bf
+    if qlds:
+        lds_bytes += block_m * head_dim * elem_bytes
+    if lds_bytes > LDS_BYTES_GFX950:
+        raise RuntimeError(
+            f"fp8 flash attention head_dim={head_dim}/head_dim_v={head_dim_v} at block_m={block_m} "
+            f"needs {lds_bytes} B of LDS, over the {LDS_BYTES_GFX950} B gfx950 workgroup limit. "
+            "The footprint grows by ~25 KB per +64 of head_dim and ~12 KB per +32 of head_dim_v; "
+            "head_dim + head_dim_v <= 384 is the supported envelope."
+        )
 
     return DualwaveSwpFp8Traits(
         BLOCK_M=block_m,
@@ -2067,12 +2051,6 @@ def _make_dualwave_swp_fp8_traits(
         SPLITK=splitk,
         VARLEN=bool(varlen),
         CROSS_SEQLEN=bool(cross_seqlen),
-        FP8_PV=fp8_pv,
-        FP8_PV_DIRECT=bool(fp8_pv_direct),
-        BN128=bool(bn128),
-        BN128_PF=bool(bn128_pf),
-        QREG=bool(qreg),
-        VDMA=bool(vdma),
         DEFAULT_STRIDE_Q_N=default_stride_q_n,
         DEFAULT_STRIDE_KV_N=default_stride_kv_n,
         DEFAULT_STRIDE_V_N=default_stride_v_n,
@@ -2087,11 +2065,8 @@ def _make_dualwave_swp_fp8_traits(
         DMA_BYTES=16,
         ELEM_BYTES=elem_bytes,
         OUT_ELEM_BYTES=out_elem_bytes,
-        D_128B_SIZE=d_128b_size,
         VEC_KV=vec_kv,
         LANE_SPLIT_KV=lane_split_kv,
-        SMEM_N_RPT=smem_n_rpt,
-        SMEM_D_RPT=smem_d_rpt,
         SMEM_K_LINE_STRIDE=smem_k_line_stride,
         SMEM_K_TILE_ELEMS=smem_k_tile_elems,
         NUM_PREFETCH_K=num_prefetch_k,
@@ -2099,22 +2074,7 @@ def _make_dualwave_swp_fp8_traits(
         LDS_KV_TOTAL_SIZE=lds_kv_total_size,
         DUALWAVE_SWP_K_BUF_BASE=dualwave_swp_k_buf_base,
         DUALWAVE_SWP_V_BUF_BASE=dualwave_swp_v_buf_base,
-        EB_BF=eb_bf,
-        D128_BF=d128_bf,
-        VEC_BF=vec_bf,
-        SDRPT_BF=sdrpt_bf,
-        SNRPT_BF=snrpt_bf,
-        VLS_BF=vls_bf,
-        VT_BF16_ELEMS=vt_bf16_elems,
         VT_BF16_TOTAL=vt_bf16_total,
-        URV_GRPK_BF=4 * vls_bf,
-        URV_GRP_N_BF=16,
-        URV_LANE_LO_BF=4,
-        URV_LANE_HI_BF=vls_bf,
-        URV_STEPK_BF=128,
-        URV_DC_AXIS0_BF=snrpt_bf * vls_bf,
-        URV_DC_AXIS1_BF=32,
-        URV_I5_BF=d128_bf,
         DUALWAVE_SWP_RESCALE_THRESHOLD=rescale_threshold,
         SCHED_MFMA_MASK=0x008,
         SCHED_VALU_MASK=0x002,
@@ -2126,6 +2086,34 @@ def _make_dualwave_swp_fp8_traits(
         XCD_SWIZZLE=bool(xcd_swizzle),
         BATCH_INTERLEAVE_GROUP=int(batch_interleave_group),
     )
+
+
+def dualwave_fp8_dma_per_iter(traits):
+    """Vector-memory instructions the *least* loaded wave issues per main-loop iteration.
+
+    `_waitcnt_vm_n(N)` only forces the previous iteration's DMAs to retire when N
+    is at most the count this wave actually issues; overshooting turns the wait
+    into a no-op and the end-of-iteration barrier then releases with LDS writes
+    still in flight. Waves that issue more than the minimum just over-wait, which
+    is safe.
+
+    K (`DualwaveFp8KvGmemToLdsLoader.load_k`): every wave issues one DMA per pass
+    per band, the tail band's partial pass included -- it is exec-masked, not
+    branched, so the instruction still issues.
+
+    V (`_stage_v_fp8_block_dma`): the trailing pass is guarded by a wave-uniform
+    `dma_id < num_dma`, so waves past the end issue nothing at all and the
+    minimum is the floor, not the ceiling.
+
+    The main loop consumes two KV tiles per iteration, hence the factor of two.
+    """
+    rows_per_wave = -(-traits.BLOCK_N // traits.NUM_WAVES)
+    k_instr = sum(-(-(rows_per_wave * (chunk // traits.VEC_KV)) // traits.WARP_SIZE) for chunk in traits.K_BAND_CHUNK)
+    num_dma_v = (traits.BLOCK_N * (traits.HEAD_DIM_V // 16) * 16) // (
+        traits.WARP_SIZE * traits.VEC_KV * traits.ELEM_BYTES
+    )
+    v_instr_min = num_dma_v // traits.NUM_WAVES
+    return 2 * k_instr + 2 * v_instr_min
 
 
 # Kernel context
@@ -4483,7 +4471,6 @@ class DualwaveFp8KernelContext:
         self.p_elem = fx.BFloat16
         self.v4bf16_type = Vec.make_type(4, fx.BFloat16)
         self.NUM_DMA_K = len(traits.K_BAND_CHUNK)
-        self.NUM_DMA_V = traits.SMEM_D_RPT
         self.c_neg_inf = fx.Float32(float("-inf"))
         self.c_neg_floor = fx.Float32(-3.0e38)
         self.c_zero_f = fx.Float32(0.0)
@@ -4504,6 +4491,13 @@ class DualwaveFp8KernelContext:
             self.stride_o_n_v = fx.Index(traits.DEFAULT_STRIDE_O_N)
 
     def init_causal_lpt_order(self):
+        """Issue causal q-blocks longest-first by reversing the q-block grid axis.
+
+        Causal work per q-block grows with the block index and workgroups dispatch in
+        flattened-id order, so the natural order issues the heaviest block last and the
+        makespan carries its tail. Must run after init_thread_mapping and before
+        init_sequence_lengths / init_tile_bounds / init_q_row read q_start.
+        """
         traits = self.traits
         num_q_blocks = (self.seq_len_v + traits.BLOCK_M - 1) // traits.BLOCK_M
         self.q_block_idx = num_q_blocks - fx.Index(1) - self.q_block_idx
@@ -4780,13 +4774,6 @@ class DualwaveFp8GemmHelper(DualwaveFp8KernelContext):
             ],
         )
 
-    def _mfma_acc_bf16(self, a_v8, b_v8, c_v16):
-        return fly.mma_atom_call_ssa([self.v16f32_type], self.bf16_mma_atom, a_v8, b_v8, c_v16)
-
-    def _v8bf16_to_f32(self, v8):
-        f32 = Vec(llvm.FPExtOp(Vec.make_type(8, fx.Float32), as_mlir_value(v8)).result, (8,), fx.Float32)
-        return [f32[i] for i in range_constexpr(8)]
-
     def _pack_fp8_i32x8(self, f32_vals):
         c0 = llvm.mlir_poison(T.i32)
         words = []
@@ -4818,20 +4805,6 @@ class DualwaveFp8GemmHelper(DualwaveFp8KernelContext):
             f32 += self._v8bf16_to_f32(v_v[step][dc])
         return self._pack_fp8_i32x8(f32)
 
-    def _pv_fp8(self, v_p, v_v, v_o):
-        p_fp8 = self._p_to_fp8_i32x8(v_p)
-        for dc in range_constexpr(self.traits.D_CHUNKS):
-            v_op = self._v_concat_i32x8(v_v, dc)
-            v_o[dc] = self._mfma_acc_fp8_wide(v_op, p_fp8, v_o[dc])
-        return v_o
-
-    def _pv_step_fp8(self, step, v_p, v_v, v_o):
-        if const_expr(step == 0):
-            self._pv_p_fp8_cache = self._p_to_fp8_i32x8(v_p)
-        v_op = self._v_concat_i32x8(v_v, step)
-        v_o[step] = self._mfma_acc_fp8_wide(v_op, self._pv_p_fp8_cache, v_o[step])
-        return v_o
-
     def _load_q_wide_lds(self):
         traits = self.traits
         q_row_in_block = self.ctx_ref.q_row_in_block
@@ -4846,7 +4819,7 @@ class DualwaveFp8GemmHelper(DualwaveFp8KernelContext):
         """Pull this lane's Q operands straight from global into VGPRs.
 
         Used when Q is not staged through LDS (head_dim > 128, where the staging
-        buffer would not fit alongside the KV ring). QREG reads Q exactly once, so
+        buffer would not fit alongside the KV ring). Q is read exactly once, so
         the only thing LDS bought was coalescing on that single pass.
         """
         traits = self.traits
@@ -4874,28 +4847,13 @@ class DualwaveFp8GemmHelper(DualwaveFp8KernelContext):
             q_w = q_all_wide[ws]
             v_s_lo = self._mfma_acc_fp8_wide(k_lo[ws], q_w, v_s_lo)
             v_s_hi = self._mfma_acc_fp8_wide(k_hi[ws], q_w, v_s_hi)
-        if const_expr(traits.QREG):
-            n_ds = const_expr(traits.HEAD_DIM // 64 * 4)
-            n_mfma = const_expr(traits.HEAD_DIM // 64 * 2)
-            rocdl.sched_group_barrier(traits.SCHED_DS_READ_MASK, n_ds // 2, 12)
-            rocdl.sched_group_barrier(traits.SCHED_MFMA_MASK, 1, 12)
-            rocdl.sched_group_barrier(traits.SCHED_DS_READ_MASK, n_ds // 2, 12)
-            rocdl.sched_group_barrier(traits.SCHED_MFMA_MASK, n_mfma - 1, 12)
+        n_ds = const_expr(traits.HEAD_DIM // 64 * 4)
+        n_mfma = const_expr(traits.HEAD_DIM // 64 * 2)
+        rocdl.sched_group_barrier(traits.SCHED_DS_READ_MASK, n_ds // 2, 12)
+        rocdl.sched_group_barrier(traits.SCHED_MFMA_MASK, 1, 12)
+        rocdl.sched_group_barrier(traits.SCHED_DS_READ_MASK, n_ds // 2, 12)
+        rocdl.sched_group_barrier(traits.SCHED_MFMA_MASK, n_mfma - 1, 12)
         return (v_s_lo, v_s_hi)
-
-    def pv_step_k(self, step, v_p, v_v, v_o):
-        if const_expr(self.traits.FP8_PV):
-            return self._pv_step_fp8(step, v_p, v_v, v_o)
-        # HIPREC PV: P and V are both v8 bf16, accumulated by a bf16 MMA.
-        v_p_lo, v_p_hi = v_p
-        v_pk = v_v[step]
-        if const_expr(step < 2):
-            p_pk = v_p_lo[step]
-        else:
-            p_pk = v_p_hi[step - 2]
-        for dc in range_constexpr(self.traits.D_CHUNKS):
-            v_o[dc] = self._mfma_acc_bf16(v_pk[dc], p_pk, v_o[dc])
-        return v_o
 
     def cast_p_fp8_direct(self, v_p):
         lo_partial_list, hi_full = v_p
@@ -4916,13 +4874,7 @@ class DualwaveFp8GemmHelper(DualwaveFp8KernelContext):
         return v_o
 
     def pv(self, v_p, v_v, v_o):
-        if const_expr(self.traits.FP8_PV_DIRECT):
-            return self._pv_fp8_direct(v_p, v_v, v_o)
-        if const_expr(self.traits.FP8_PV):
-            return self._pv_fp8(v_p, v_v, v_o)
-        for step in range_constexpr(4):
-            v_o = self.pv_step_k(step, v_p, v_v, v_o)
-        return v_o
+        return self._pv_fp8_direct(v_p, v_v, v_o)
 
 
 class DualwaveFp8KvGmemToLdsLoader(DualwaveFp8KernelContext):
@@ -4973,49 +4925,7 @@ class DualwaveFp8KvGmemToLdsLoader(DualwaveFp8KernelContext):
         _run()
 
     def load_v(self, tile_start, buf_id):
-        if const_expr(self.traits.FP8_PV):
-            self._stage_v_fp8_block(tile_start, buf_id)
-        else:
-            self._stage_vt_dequant_fp8(tile_start, buf_id)
-
-    def zero_v_fp8_lds(self):
-        traits = self.traits
-        v_tile_bytes = (traits.BLOCK_N // 8) * (traits.HEAD_DIM_V // 16) * 128
-        total = 2 * v_tile_bytes
-        aligned_base = ((self.lds_vt_base_idx + fx.Index(127)) // fx.Index(128)) * fx.Index(128)
-        zero = Vec.from_elements([fx.Int32(0) for _ in range_constexpr(4)], fx.Int32)
-        per = total // (traits.BLOCK_SIZE)  # bytes per thread
-        for i in range_constexpr(per // 16):
-            off = aligned_base + self.tid * fx.Index(per) + fx.Index(i * 16)
-            p = buffer_ops.create_llvm_ptr(off, address_space=3)
-            llvm.StoreOp(as_mlir_value(zero), p, alignment=16)
-
-    def _stage_v_fp8_block(self, tile_start, buf_id):
-        traits = self.traits
-        if const_expr(traits.VDMA):
-            return self._stage_v_fp8_block_dma(tile_start, buf_id)
-        v_tile_bytes = (traits.BLOCK_N // 8) * (traits.HEAD_DIM_V // 16) * 128
-        buf_off = buf_id * v_tile_bytes
-        n = self.wave_id * fx.Index(8) + self.lane // fx.Index(8)
-        d_block = self.lane % fx.Index(8)
-        src_elem = (
-            self.v_gmem_elem_offset + n * self.stride_v_n_v + d_block * fx.Index(16) + tile_start * self.stride_v_n_v
-        )
-        v16 = fly.copy_atom_call_ssa(
-            [Vec.make_type(4, fx.Int32)], self.load_atom_128, fx.slice(self.v_div, (None, fx.Int32(src_elem)))
-        )
-        n_i = fx.Int32(n)
-        w16 = n_i % fx.Int32(16)
-        c_add = (w16 >= fx.Int32(4)) & (w16 < fx.Int32(8))
-        c_sub = (w16 >= fx.Int32(8)) & (w16 < fx.Int32(12))
-        dest_n = n_i + c_add.select(fx.Int32(4), fx.Int32(0)) - c_sub.select(fx.Int32(4), fx.Int32(0))
-        dest_wave = fx.Index(dest_n // fx.Int32(8))
-        dest_m = fx.Index(dest_n % fx.Int32(8))
-        block = dest_wave * fx.Index(8) + self.lane % fx.Index(8)
-        aligned_base = ((self.lds_vt_base_idx + fx.Index(127)) // fx.Index(128)) * fx.Index(128)
-        byte_off = aligned_base + fx.Index(buf_off) + block * fx.Index(128) + fx.Index(16) * dest_m
-        lds_ptr = buffer_ops.create_llvm_ptr(byte_off, address_space=3)
-        llvm.StoreOp(as_mlir_value(Vec(v16)), lds_ptr, alignment=16)
+        self._stage_v_fp8_block_dma(tile_start, buf_id)
 
     def _stage_v_fp8_block_dma(self, tile_start, buf_id):
         traits = self.traits
@@ -5061,38 +4971,6 @@ class DualwaveFp8KvGmemToLdsLoader(DualwaveFp8KernelContext):
 
         _run()
 
-    def _stage_vt_dequant_fp8(self, tile_start, buf_id):
-        # Dequantize fp8 V into the exact bf16 V staging positions. The two d-iters
-        # load 8 fp8 at D offsets 64 apart; a contiguous 16B load would gather wrong.
-        traits = self.traits
-        vt_buf = buf_id * traits.VT_BF16_ELEMS
-        n_in_tile = self.n_in_warp * traits.NUM_WAVES + self.wave_id
-        for d in range_constexpr(traits.SDRPT_BF):
-            global_d = self.d_bucket * traits.VEC_BF + (d * traits.D128_BF)
-            src_elem = (
-                self.v_gmem_elem_offset + n_in_tile * self.stride_v_n_v + global_d + tile_start * self.stride_v_n_v
-            )
-            v_i32x2 = fly.copy_atom_call_ssa(
-                [self.v2i32_type], self.v_fp8_load64_atom, fx.slice(self.v_div, (None, fx.Int32(src_elem)))
-            )
-            v_words = Vec(v_i32x2, (2,), fx.Int32)
-            bf = []
-            for w in range_constexpr(2):
-                word = as_mlir_value(fx.Int32(v_words[w]))
-                lo2 = Vec(rocdl.cvt_pk_f32_fp8(Vec.make_type(2, fx.Float32), word, False), (2,), fx.Float32)
-                hi2 = Vec(rocdl.cvt_pk_f32_fp8(Vec.make_type(2, fx.Float32), word, True), (2,), fx.Float32)
-                for e in (lo2[0], lo2[1], hi2[0], hi2[1]):
-                    bf.append(fx.Float32(e) * self.vd_fp8)
-            v8bf = self.bf16_trunc_pack_v8(bf)
-            byte_off = (
-                vt_buf
-                + self.wave_id_uni * traits.VLS_BF
-                + d * traits.SNRPT_BF * traits.VLS_BF
-                + self.lane * traits.VEC_BF
-            ) * traits.EB_BF
-            lds_ptr = buffer_ops.get_element_ptr(self.lds_vt_base_ptr, byte_offset=byte_off, elem_type=T.i8)
-            llvm.StoreOp(as_mlir_value(v8bf), lds_ptr, alignment=16)
-
 
 class DualwaveFp8KvLdsToVgprLoader(DualwaveFp8KernelContext):
     def __init__(self, ctx):
@@ -5122,32 +5000,13 @@ class DualwaveFp8KvLdsToVgprLoader(DualwaveFp8KernelContext):
         return (_read_strip(n_lo), _read_strip(n_hi))
 
     def load_v(self, buf_id):
-        if const_expr(self.traits.FP8_PV):
-            return self._load_v_fp8_block(buf_id)
-        # Read all V packs from the bf16 vt scratch for buffer `buf_id`.
-        traits = self.traits
-        urv = (
-            self.lane_div_32 * traits.URV_GRPK_BF
-            + ((self.lane % 16) // 4) * traits.URV_LANE_HI_BF
-            + ((self.lane // 16) % 2) * traits.URV_GRP_N_BF
-            + (self.lane % 4) * traits.URV_LANE_LO_BF
-        )
-        packs = [[None] * traits.D_CHUNKS for _ in range(4)]
-        for dc in range_constexpr(traits.D_CHUNKS):
-            dc_off = (dc // 2) * traits.URV_DC_AXIS0_BF + (dc % 2) * traits.URV_DC_AXIS1_BF
-            for k_substep in range_constexpr(4):
-                imm_lo = (k_substep * traits.URV_STEPK_BF + dc_off) * traits.EB_BF
-                byte0 = (urv + buf_id * traits.VT_BF16_ELEMS) * traits.EB_BF + self.lds_vt_base_idx
-                a = _ds_read_tr16_b64_imm(self.v4bf16_type, fx.Int32(byte0), imm_lo)
-                b = _ds_read_tr16_b64_imm(self.v4bf16_type, fx.Int32(byte0), imm_lo + traits.URV_I5_BF * traits.EB_BF)
-                packs[k_substep][dc] = Vec(a).shuffle(Vec(b), [0, 1, 2, 3, 4, 5, 6, 7]).ir_value()
-        return packs
+        return self._load_v_fp8_block(buf_id)
 
     def _load_v_fp8_block(self, buf_id):
         traits = self.traits
         v_tile_bytes = (traits.BLOCK_N // 8) * (traits.HEAD_DIM_V // 16) * 128
         buf_off = buf_id * v_tile_bytes
-        nbands = traits.HEAD_DIM_V // 16  # 8
+        nbands = traits.HEAD_DIM_V // 16
         rh = (self.lane % fx.Index(32)) // fx.Index(16)
         l16 = self.lane % fx.Index(16)
         lane_hi = self.lane // fx.Index(32)
@@ -5521,7 +5380,7 @@ class DualwaveSplitKCombineContext:
         WS=None,
         batch_size=None,
         seq_len=None,
-        stride_q_n=None,
+        stride_o_n=None,
         LSE=None,
         Sink=None,
         CuSeqQ=None,
@@ -5540,7 +5399,7 @@ class DualwaveSplitKCombineContext:
         self.CuSeqQ = CuSeqQ
         self.batch_size = batch_size
         self.seq_len = seq_len
-        self.stride_q_n = stride_q_n
+        self.stride_o_n = stride_o_n
 
     def init_types_and_constants(self):
         self.out_dtype_str = "bf16" if self.traits.DTYPE_STR == "fp8" else self.traits.DTYPE_STR
@@ -5553,20 +5412,34 @@ class DualwaveSplitKCombineContext:
 
     def init_runtime_indices(self):
         self.seq_len_v = fx.Index(self.seq_len)
-        self.stride_q_n_v = fx.Index(self.stride_q_n)
+        self.stride_o_n_v = fx.Index(self.stride_o_n)
         self.batch_size_v = fx.Index(self.batch_size)
 
     def init_thread_mapping(self, combine_rows_per_block, combine_lanes_per_row):
+        """Map (blockIdx.x, blockIdx.y, tid) to one (batch, head, token) output row.
+
+        blockIdx.y carries the batch so that `batch_idx` -- which the O buffer
+        resource is built from -- is block-uniform. A buffer resource is
+        wave-scoped, so deriving it per thread would give every lane of a wave
+        one batch's base pointer and num_records even when a batch boundary
+        falls inside the wave.
+
+        The x grid rounds up, and when combine_lanes_per_row does not divide the
+        block the trailing threads map past the block's own rows; both are folded
+        into `row_valid` by steering those threads to `rows_per_batch`.
+        """
         traits = self.traits
         self.tid = fx.Index(gpu.thread_idx.x)
         self.blk = fx.Index(gpu.block_idx.x)
-        self.row = self.blk * combine_rows_per_block + self.tid // combine_lanes_per_row
+        self.batch_idx = fx.Index(gpu.block_idx.y)
         self.col = (self.tid % combine_lanes_per_row) * 4
-        heads_per_batch = self.seq_len_v * traits.NUM_HEADS_Q
-        self.batch_idx = self.row // heads_per_batch
-        rem = self.row % heads_per_batch
-        self.q_head_idx = rem // self.seq_len_v
-        self.seq_idx = rem % self.seq_len_v
+        rows_per_batch = self.seq_len_v * traits.NUM_HEADS_Q
+        row_raw = self.blk * combine_rows_per_block + self.tid // combine_lanes_per_row
+        threads_in_use = fx.Index(combine_rows_per_block * combine_lanes_per_row)
+        self.row = (self.tid < threads_in_use).select(row_raw, rows_per_batch)
+        self.row_valid = self.row < rows_per_batch
+        self.q_head_idx = self.row // self.seq_len_v
+        self.seq_idx = self.row % self.seq_len_v
 
     def init_workspace(self):
         traits = self.traits
@@ -5588,12 +5461,14 @@ class DualwaveSplitKCombineContext:
             _cu_v1i32 = Vec.make_type(1, fx.Int32)
             q_tok_base = _cu_load(_cuq_div, self.batch_idx, _cu_atom, _cu_v1i32)
             q_tok_end = _cu_load(_cuq_div, self.batch_idx + fx.Index(1), _cu_atom, _cu_v1i32)
-            batch_byte_off = q_tok_base * self.stride_q_n_v * fx.Index(2)
-            nrec_bytes = (q_tok_end - q_tok_base) * self.stride_q_n_v * fx.Index(2)
+            batch_byte_off = q_tok_base * self.stride_o_n_v * fx.Index(2)
+            nrec_bytes = (q_tok_end - q_tok_base) * self.stride_o_n_v * fx.Index(2)
         else:
-            per_batch_elems = self.seq_len_v * self.stride_q_n_v
+            per_batch_elems = self.seq_len_v * self.stride_o_n_v
             batch_byte_off = self.batch_idx * per_batch_elems * fx.Index(2)
             nrec_bytes = per_batch_elems * fx.Index(2)
+        # Kept so out-of-range rows can steer their store past num_records.
+        self.o_nrec_bytes = nrec_bytes
         self.o_rsrc = buffer_ops.create_buffer_resource_from_addr(
             as_mlir_value(fx.Int64(fx.ptrtoint(fx.get_iter(self.O))) + fx.Int64(batch_byte_off)),
             num_records_bytes=as_mlir_value(fx.Int64(nrec_bytes)),
@@ -5730,15 +5605,19 @@ class DualwaveSplitKCombineHelper(DualwaveSplitKCombineContext):
         lse_per_batch_bytes = lse_per_batch_elems * fx.Index(4)
         lse_rsrc = _make_ws_rsrc(lse_base_i64, self.batch_idx * lse_per_batch_bytes, lse_per_batch_bytes)
         lse_val = m_max * self.c_ln2_f + fx.log(den, fastmath=self.fm_fast)
-        lse_off = fx.Index((self.col == fx.Index(0)).select(self.local_ml_idx, lse_per_batch_elems))
+        lse_in_range = self.row_valid.select(self.local_ml_idx, lse_per_batch_elems)
+        lse_off = fx.Index((self.col == fx.Index(0)).select(lse_in_range, lse_per_batch_elems))
         buffer_ops.buffer_store(as_mlir_value(fx.Float32(lse_val)), lse_rsrc, as_mlir_value(fx.Int32(lse_off)))
 
     def store_output(self, o_pack):
-        o_global = self.seq_idx * self.stride_q_n_v + self.q_head_idx * self.traits.HEAD_DIM_V + self.col
+        o_global = self.seq_idx * self.stride_o_n_v + self.q_head_idx * self.traits.HEAD_DIM_V + self.col
+        # Rows the rounded-up grid added past the end of the batch aim at
+        # num_records, which the buffer drops.
+        o_off = self.row_valid.select(o_global * fx.Index(2), self.o_nrec_bytes)
         buffer_ops.buffer_store(
             o_pack.ir_value(),
             self.o_rsrc,
-            as_mlir_value(fx.Int32(o_global * fx.Index(2))),
+            as_mlir_value(fx.Int32(o_off)),
             offset_is_bytes=True,
         )
 

--- a/kernels/attention/flash_attn_utils.py
+++ b/kernels/attention/flash_attn_utils.py
@@ -561,7 +561,7 @@ def _dualwave_lds_noalias_scopes(name, scope_names):
 
 def _cu_load(div, idx, cu_atom, cu_v1i32):
     v = fly.copy_atom_call_ssa([cu_v1i32], cu_atom, fx.slice(div, (None, fx.Int32(idx))))
-    return fx.Index(Vec(v, (1,), fx.Int32)[0])
+    return fx.Index(rocdl.readfirstlane(T.i32, as_mlir_value(fx.Int32(Vec(v, (1,), fx.Int32)[0]))))
 
 
 def _make_page_view(
@@ -1005,6 +1005,7 @@ def _init_dualwave_thread_mapping(ctx):
 
     Shared verbatim by DualwaveKernelContext and DualwaveFp8KernelContext."""
     traits = ctx.traits
+    batch_interleave_group = getattr(traits, "BATCH_INTERLEAVE_GROUP", 1)
     # Swizzled Head-first Mapping (arXiv:2511.02132): the grid is head-fast, so one
     # head's q-blocks scatter across all XCDs and each re-streams its K/V. Re-derive
     # (head, q_block) with head as the slow axis to keep them on one XCD. Bijective,
@@ -1018,6 +1019,13 @@ def _init_dualwave_thread_mapping(ctx):
         linear_wg = fx.Index(gpu.block_idx.x) + fx.Index(gpu.block_idx.y) * fx.Index(traits.NUM_HEADS_Q)
         ctx.h_idx = linear_wg // num_q_blocks
         ctx.q_block_idx = linear_wg % num_q_blocks
+    elif const_expr(batch_interleave_group > 1):
+        linear_head_batch = fx.Index(gpu.block_idx.x)
+        ctx.h_idx = linear_head_batch % traits.NUM_HEADS_Q
+        ctx.batch_idx = (
+            fx.Index(gpu.block_idx.z) * batch_interleave_group + linear_head_batch // traits.NUM_HEADS_Q
+        )
+        ctx.q_block_idx = fx.Index(gpu.block_idx.y)
     else:
         ctx.h_idx = fx.Index(gpu.block_idx.x)
         ctx.q_block_idx = fx.Index(gpu.block_idx.y)
@@ -1025,6 +1033,8 @@ def _init_dualwave_thread_mapping(ctx):
         ctx.bz_idx = fx.Index(gpu.block_idx.z)
         ctx.batch_idx = ctx.bz_idx // traits.NUM_KV_SPLITS
         ctx.split_idx = ctx.bz_idx % traits.NUM_KV_SPLITS
+    elif const_expr(batch_interleave_group > 1):
+        ctx.split_idx = None
     else:
         ctx.batch_idx = fx.Index(gpu.block_idx.z)
         ctx.split_idx = None
@@ -1040,7 +1050,7 @@ def _init_dualwave_thread_mapping(ctx):
         T.i32,
         (_tid_i32 // fx.Int32(traits.WARP_SIZE)).ir_value(),
     )
-    ctx.stagger_i32 = arith.divsi(_wave_id_uni_i32, as_mlir_value(fx.Int32(4)))
+    ctx.stagger_i32 = arith.divsi(_wave_id_uni_i32, as_mlir_value(fx.Int32(traits.NUM_WAVES // 2)))
     ctx.wave_id_uni = fx.Index(_wave_id_uni_i32)
 
     ctx.wave_q_offset = ctx.wave_id * traits.ROWS_PER_WAVE
@@ -1499,6 +1509,7 @@ class DualwaveSwpTraits:
     BLOCK_SIZE: int
     ROWS_PER_WAVE: int
     HEAD_DIM: int
+    HEAD_DIM_V: int
     K_STEP_QK: int
     K_STEPS_QK: int
     D_CHUNK: int
@@ -1697,6 +1708,7 @@ def _make_dualwave_swp_traits(
         BLOCK_SIZE=block_size,
         ROWS_PER_WAVE=rows_per_wave,
         HEAD_DIM=head_dim,
+        HEAD_DIM_V=head_dim,
         K_STEP_QK=k_step_qk,
         K_STEPS_QK=k_steps_qk,
         D_CHUNK=d_chunk,
@@ -1785,6 +1797,7 @@ class DualwaveSwpFp8Traits:
     BLOCK_SIZE: int
     ROWS_PER_WAVE: int
     HEAD_DIM: int
+    HEAD_DIM_V: int
     D_CHUNK: int
     D_CHUNKS: int
     PV_K_STEPS: int
@@ -1811,6 +1824,15 @@ class DualwaveSwpFp8Traits:
     VDMA: bool
     DEFAULT_STRIDE_Q_N: int
     DEFAULT_STRIDE_KV_N: int
+    DEFAULT_STRIDE_V_N: int
+    DEFAULT_STRIDE_O_N: int
+    QLDS: bool
+    K_BAND_CHUNK: tuple[int, ...]
+    K_BAND_BASE: tuple[int, ...]
+    K_BAND_LINE_STRIDE: tuple[int, ...]
+    K_BAND_GLOBAL_D: tuple[int, ...]
+    K_WS_BAND: tuple[int, ...]
+    K_WS_OFF: tuple[int, ...]
     DMA_BYTES: int
     ELEM_BYTES: int
     OUT_ELEM_BYTES: int
@@ -1852,6 +1874,7 @@ class DualwaveSwpFp8Traits:
     NEG_INF_F32_BITS: int
     LGKMCNT_0_ONLY: int
     XCD_SWIZZLE: bool = False
+    BATCH_INTERLEAVE_GROUP: int = 1
 
     @property
     def cache_tag(self):
@@ -1872,6 +1895,9 @@ class DualwaveSwpFp8Traits:
             self.SPLITK,
             self.VARLEN,
             self.CROSS_SEQLEN,
+            self.HEAD_DIM_V,
+            self.QLDS,
+            self.K_BAND_CHUNK,
             "fp8_wide_qk_hiprec_pv",
             self.ELEM_BYTES,
             self.OUT_ELEM_BYTES,
@@ -1886,6 +1912,7 @@ class DualwaveSwpFp8Traits:
             self.QREG,
             self.VDMA,
             self.XCD_SWIZZLE,
+            self.BATCH_INTERLEAVE_GROUP,
         )
 
 
@@ -1894,6 +1921,8 @@ def _make_dualwave_swp_fp8_traits(
     num_kv_heads,
     head_dim,
     rescale_threshold,
+    head_dim_v=None,
+    block_m=256,
     causal=True,
     waves_per_eu=2,
     daz=True,
@@ -1905,25 +1934,40 @@ def _make_dualwave_swp_fp8_traits(
     varlen=False,
     cross_seqlen=False,
     xcd_swizzle=False,
+    batch_interleave_group=1,
 ):
-    """Build gfx950 DUALWAVE_SWP fp8 compile-time layout traits (dtype fixed to fp8)."""
-    # Tile shape and wave geometry follow the gfx950 dual-wave 8-wave CTA.
-    block_m = 256
+    """Build gfx950 DUALWAVE_SWP fp8 compile-time layout traits (dtype fixed to fp8).
+
+    ``head_dim`` is the QK reduction width and ``head_dim_v`` the V (and output)
+    width; they differ for the 192/128 pair. Both must be multiples of 64 -- the
+    fp8 QK MFMA is 32x32x64, so head_dim splits into head_dim//64 slices with no
+    padding, and the V/O side tiles in 32-wide D_CHUNKs."""
+    if head_dim_v is None:
+        head_dim_v = head_dim
+    if head_dim % 64 or head_dim_v % 32:
+        raise RuntimeError(
+            f"fp8 flash attention needs head_dim % 64 == 0 and head_dim_v % 32 == 0, "
+            f"got {head_dim}/{head_dim_v}"
+        )
     block_n = 64
     k_sub_n = 32
     warp_size = 64
-    num_waves = 8
-    block_size = num_waves * warp_size
     rows_per_wave = 32
+    if block_m % rows_per_wave or block_m // rows_per_wave not in (4, 8):
+        raise RuntimeError(f"fp8 flash attention supports block_m 128 (4 waves) or 256 (8 waves), got {block_m}")
+    num_waves = block_m // rows_per_wave
+    block_size = num_waves * warp_size
 
     d_chunk = 32
-    d_chunks = head_dim // d_chunk
+    d_chunks = head_dim_v // d_chunk
     pv_k_step = 16
     pv_k_steps = k_sub_n // pv_k_step
 
     gqa_group_size = num_heads // num_kv_heads
     default_stride_q_n = num_heads * head_dim
     default_stride_kv_n = num_kv_heads * head_dim
+    default_stride_v_n = num_kv_heads * head_dim_v
+    default_stride_o_n = num_heads * head_dim_v
 
     # fp8: Q/K/V are 1B; O is bf16 (2B). ELEM_BYTES=1 drives the fp8 address math.
     elem_bytes = 1
@@ -1934,14 +1978,32 @@ def _make_dualwave_swp_fp8_traits(
     smem_linear_wave = warp_size * 16 // elem_bytes
     smem_n_per_wave = smem_linear_wave // d_128b_size
     smem_n_rpt = block_n // smem_n_per_wave
-    smem_d_rpt = head_dim // d_128b_size
+    smem_d_rpt = head_dim_v // d_128b_size
     smem_k_pad = 16 // elem_bytes
     smem_v_pad = 64 // elem_bytes
     smem_k_line_stride = smem_linear_wave + smem_k_pad
     smem_v_line_stride = smem_linear_wave + smem_v_pad
-    smem_k_tile_elems = smem_n_rpt * smem_d_rpt * smem_k_line_stride
     smem_v_tile_elems = smem_n_rpt * smem_d_rpt * smem_v_line_stride
-    bn128 = (num_kv_splits <= 1) and (not varlen)
+
+    rows_per_wave_dma = -(-block_n // num_waves)
+    k_band_chunk, k_band_base, k_band_line_stride, k_band_global_d = [], [], [], []
+    _off, _cursor = 0, 0
+    while _off < head_dim:
+        chunk = 128 if head_dim - _off >= 128 else head_dim - _off
+        line_stride = rows_per_wave_dma * chunk + smem_k_pad
+        k_band_chunk.append(chunk)
+        k_band_base.append(_cursor)
+        k_band_line_stride.append(line_stride)
+        k_band_global_d.append(_off)
+        _cursor += num_waves * line_stride
+        _off += chunk
+    smem_k_tile_elems = _cursor
+    k_ws_band, k_ws_off = [], []
+    for _bi, chunk in enumerate(k_band_chunk):
+        for _o in range(0, chunk, 64):
+            k_ws_band.append(_bi)
+            k_ws_off.append(_o)
+    bn128 = True
     bn128_pf = bn128
     qreg = bn128_pf
     vdma = bn128_pf
@@ -1962,16 +2024,18 @@ def _make_dualwave_swp_fp8_traits(
     vec_bf = 16 // eb_bf
     slw_bf = warp_size * 16 // eb_bf
     snrpt_bf = block_n // (slw_bf // d128_bf)
-    sdrpt_bf = head_dim // d128_bf
+    sdrpt_bf = head_dim_v // d128_bf
     vls_bf = slw_bf + 64 // eb_bf
     vt_bf16_elems = snrpt_bf * sdrpt_bf * vls_bf
-    fp8_v_tile_bytes = (block_n // 8) * (head_dim // 16) * 128
+    fp8_v_tile_bytes = (block_n // 8) * (head_dim_v // 16) * 128
     if bn128_pf:
         vt_bf16_total = num_prefetch_k * (fp8_v_tile_bytes // eb_bf) + 128
     else:
         vt_bf16_total = (2 if deep_ring else num_prefetch_k) * vt_bf16_elems
 
     splitk = num_kv_splits > 1
+
+    qlds = head_dim <= 128
 
     fp8_pv = os.getenv("FLYDSL_FA_FP8_PV", "0") == "1"
     fp8_pv_direct = bn128
@@ -1987,6 +2051,7 @@ def _make_dualwave_swp_fp8_traits(
         BLOCK_SIZE=block_size,
         ROWS_PER_WAVE=rows_per_wave,
         HEAD_DIM=head_dim,
+        HEAD_DIM_V=head_dim_v,
         D_CHUNK=d_chunk,
         D_CHUNKS=d_chunks,
         PV_K_STEPS=pv_k_steps,
@@ -2013,6 +2078,15 @@ def _make_dualwave_swp_fp8_traits(
         VDMA=bool(vdma),
         DEFAULT_STRIDE_Q_N=default_stride_q_n,
         DEFAULT_STRIDE_KV_N=default_stride_kv_n,
+        DEFAULT_STRIDE_V_N=default_stride_v_n,
+        DEFAULT_STRIDE_O_N=default_stride_o_n,
+        QLDS=bool(qlds),
+        K_BAND_CHUNK=tuple(k_band_chunk),
+        K_BAND_BASE=tuple(k_band_base),
+        K_BAND_LINE_STRIDE=tuple(k_band_line_stride),
+        K_BAND_GLOBAL_D=tuple(k_band_global_d),
+        K_WS_BAND=tuple(k_ws_band),
+        K_WS_OFF=tuple(k_ws_off),
         DMA_BYTES=16,
         ELEM_BYTES=elem_bytes,
         OUT_ELEM_BYTES=out_elem_bytes,
@@ -2053,6 +2127,7 @@ def _make_dualwave_swp_fp8_traits(
         NEG_INF_F32_BITS=0xFF800000,
         LGKMCNT_0_ONLY=0xC07F,
         XCD_SWIZZLE=bool(xcd_swizzle),
+        BATCH_INTERLEAVE_GROUP=int(batch_interleave_group),
     )
 
 
@@ -4410,7 +4485,7 @@ class DualwaveFp8KernelContext:
         self.v2i32_type = Vec.make_type(2, fx.Int32)
         self.p_elem = fx.BFloat16
         self.v4bf16_type = Vec.make_type(4, fx.BFloat16)
-        self.NUM_DMA_K = traits.SMEM_D_RPT
+        self.NUM_DMA_K = len(traits.K_BAND_CHUNK)
         self.NUM_DMA_V = traits.SMEM_D_RPT
         self.c_neg_inf = fx.Float32(float("-inf"))
         self.c_neg_floor = fx.Float32(-3.0e38)
@@ -4419,19 +4494,19 @@ class DualwaveFp8KernelContext:
         self.c_zero_v16f32 = Vec.filled(16, 0.0, fx.Float32)
 
     def init_runtime_indices(self):
+        traits = self.traits
         self.seq_len_v = fx.Index(self.seq_len)
         self.seq_len_kv_v = fx.Index(self.seq_len_kv)
         self.stride_q_n_v = fx.Index(self.stride_q_n)
         self.stride_kv_n_v = fx.Index(self.stride_kv_n)
+        if traits.HEAD_DIM_V == traits.HEAD_DIM:
+            self.stride_v_n_v = self.stride_kv_n_v
+            self.stride_o_n_v = self.stride_q_n_v
+        else:
+            self.stride_v_n_v = fx.Index(traits.DEFAULT_STRIDE_V_N)
+            self.stride_o_n_v = fx.Index(traits.DEFAULT_STRIDE_O_N)
 
     def init_causal_lpt_order(self):
-        """Issue causal q-blocks longest-first by reversing the q-block grid axis.
-
-        Causal work per q-block grows with the block index and workgroups dispatch in
-        flattened-id order, so the natural order issues the heaviest block last and the
-        makespan carries its tail. Must run after init_thread_mapping and before
-        init_sequence_lengths / init_tile_bounds / init_q_row read q_start.
-        """
         traits = self.traits
         num_q_blocks = (self.seq_len_v + traits.BLOCK_M - 1) // traits.BLOCK_M
         self.q_block_idx = num_q_blocks - fx.Index(1) - self.q_block_idx
@@ -4486,13 +4561,15 @@ class DualwaveFp8KernelContext:
             self.q_tok_base + self.q_start
         ) * self.stride_q_n_v + self.q_head_idx * traits.HEAD_DIM
         self.kv_gmem_elem_offset = self.kv_tok_base * self.stride_kv_n_v + self.kv_head_idx * traits.HEAD_DIM
+        self.v_gmem_elem_offset = self.kv_tok_base * self.stride_v_n_v + self.kv_head_idx * traits.HEAD_DIM_V
 
     def init_descriptors(self):
         traits = self.traits
         eb = traits.ELEM_BYTES
         q_nrec_bytes = as_mlir_value(self.q_tok_end * self.stride_q_n_v * eb)
         kv_nrec_bytes = as_mlir_value(self.kv_tok_end * self.stride_kv_n_v * eb)
-        o_nrec_bytes = as_mlir_value(self.q_tok_end * self.stride_q_n_v * traits.OUT_ELEM_BYTES)
+        v_nrec_bytes = as_mlir_value(self.kv_tok_end * self.stride_v_n_v * eb)
+        o_nrec_bytes = as_mlir_value(self.q_tok_end * self.stride_o_n_v * traits.OUT_ELEM_BYTES)
 
         def _make_buf_div(tensor, nrec_bytes):
             # fp8 Q/K/V buffer views are i8-typed so DMA and register loads share one
@@ -4509,7 +4586,7 @@ class DualwaveFp8KernelContext:
 
         self.q_div = _make_buf_div(self.Q, q_nrec_bytes)
         self.k_div = _make_buf_div(self.K, kv_nrec_bytes)
-        self.v_div = _make_buf_div(self.V, kv_nrec_bytes)
+        self.v_div = _make_buf_div(self.V, v_nrec_bytes)
         self.o_div = fx.logical_divide(
             fx.rocdl.make_buffer_tensor(self.O, num_records_bytes=o_nrec_bytes), fx.make_layout(1, 1)
         )
@@ -4550,11 +4627,12 @@ class DualwaveFp8KernelContext:
         kv_tile_size = traits.BLOCK_N
         num_kv_tiles = (self.seqlen_kv_v + kv_tile_size - 1) // kv_tile_size
         if const_expr(traits.CAUSAL):
-            causal_end_i32 = fx.Int32(self.q_start + traits.BLOCK_M) + self.delta_i32
-            causal_end_i32 = fx.Int32((causal_end_i32 > fx.Int32(0)).select(causal_end_i32, fx.Int32(0)))
+            causal_end_raw_i32 = fx.Int32(self.q_start + traits.BLOCK_M) + self.delta_i32
+            causal_end_i32 = fx.Int32((causal_end_raw_i32 > fx.Int32(0)).select(causal_end_raw_i32, fx.Int32(0)))
             causal_num_tiles = (fx.Index(causal_end_i32) + kv_tile_size - 1) // kv_tile_size
             max_num_tiles = fx.Index((causal_num_tiles < num_kv_tiles).select(causal_num_tiles, num_kv_tiles))
         else:
+            causal_end_raw_i32 = None
             max_num_tiles = num_kv_tiles
         # Pipeline needs an EVEN tile count >= 4; extra tiles read 0 (num_records) and are masked.
         max_num_tiles = ((max_num_tiles + fx.Index(1)) // fx.Index(2)) * fx.Index(2)
@@ -4572,6 +4650,16 @@ class DualwaveFp8KernelContext:
             split_t0 = 0
             split_t_end = max_num_tiles
             self.split_nonempty = None
+
+        if const_expr(traits.VARLEN or (traits.CAUSAL and traits.CROSS_SEQLEN)):
+            active = None
+            if const_expr(traits.VARLEN):
+                active = self.q_start < self.seqlen_q_v
+            if const_expr(traits.CAUSAL and traits.CROSS_SEQLEN):
+                in_mask = causal_end_raw_i32 > fx.Int32(0)
+                active = in_mask if active is None else (active & in_mask)
+            split_t_end = fx.Index(active.select(split_t_end, split_t0))
+
         self.split_t0 = split_t0
         self.split_t_end = split_t_end
 
@@ -4635,6 +4723,10 @@ class DualwaveFp8KernelContext:
 
     def global_idx_q(self, token_idx, col):
         return (self.q_tok_base + token_idx) * self.stride_q_n_v + self.q_head_idx * self.traits.HEAD_DIM + col
+
+    def global_idx_o(self, token_idx, col):
+        """Element index into O, which is HEAD_DIM_V wide (not HEAD_DIM)."""
+        return (self.q_tok_base + token_idx) * self.stride_o_n_v + self.q_head_idx * self.traits.HEAD_DIM_V + col
 
     def read_i32x8_lds(self, base_ptr, byte_row):
         halves = []
@@ -4753,8 +4845,27 @@ class DualwaveFp8GemmHelper(DualwaveFp8KernelContext):
             packs.append(self.read_i32x8_lds(self.lds_q_base_ptr, fx.Int32(byte_row)))
         return packs
 
+    def _load_q_wide_global(self):
+        """Pull this lane's Q operands straight from global into VGPRs.
+
+        Used when Q is not staged through LDS (head_dim > 128, where the staging
+        buffer would not fit alongside the KV ring). QREG reads Q exactly once, so
+        the only thing LDS bought was coalescing on that single pass.
+        """
+        traits = self.traits
+        d_base = self.lane_div_32 * 32
+        packs = []
+        for ws in range_constexpr(traits.HEAD_DIM // 64):
+            elem = self.global_idx_q(self.ctx_ref.q_row, fx.Index(ws * 64) + d_base)
+            lo = self.buffer_load_128(elem)
+            hi = self.buffer_load_128(elem + fx.Index(16))
+            packs.append(Vec(lo).shuffle(Vec(hi), [0, 1, 2, 3, 4, 5, 6, 7]).ir_value())
+        return packs
+
     def load_q_wide(self):
-        return self._load_q_wide_lds()
+        if const_expr(self.traits.QLDS):
+            return self._load_q_wide_lds()
+        return self._load_q_wide_global()
 
     def qk(self, v_k, q_wide=None):
         traits = self.traits
@@ -4822,19 +4933,47 @@ class DualwaveFp8KvGmemToLdsLoader(DualwaveFp8KernelContext):
         super().__init__(ctx)
 
     def load_k(self, tile_start, buf_id):
+        """DMA one K tile into LDS, one pass per head-dim band.
+
+        A band's LDS line is this wave's 8 n-rows of `chunk` bytes, laid out
+        row-contiguous so the QK read can index it as (band, row, 64-byte slice).
+        The 64-byte tail band at head_dim 192 needs only 4 lanes per row, so its
+        pass runs on the low 32 lanes and moves no padding.
+        """
         traits = self.traits
         eb = traits.ELEM_BYTES
         k_lds_byte_base = self.lds_kv_base_idx + self.k_buf_base(buf_id) * eb
+        rows_per_wave = -(-traits.BLOCK_N // traits.NUM_WAVES)
         for d in range_constexpr(self.NUM_DMA_K):
-            lds_addr = (
+            lanes_per_row = traits.K_BAND_CHUNK[d] // traits.VEC_KV
+            slots = rows_per_wave * lanes_per_row
+            band_base = (
                 k_lds_byte_base
-                + self.wave_id_uni * (traits.SMEM_K_LINE_STRIDE * eb)
-                + (d * traits.SMEM_N_RPT * traits.SMEM_K_LINE_STRIDE * eb)
+                + fx.Index(traits.K_BAND_BASE[d] * eb)
+                + self.wave_id_uni * (traits.K_BAND_LINE_STRIDE[d] * eb)
             )
-            n_in_tile = self.n_in_warp * traits.NUM_WAVES + self.wave_id
-            global_d = self.d_bucket * traits.VEC_KV + (d * traits.D_128B_SIZE)
-            src_elem = self.kv_gmem_elem_offset + n_in_tile * self.stride_kv_n_v + global_d
-            self.buffer_load_lds_128(self.k_div, lds_addr, src_elem, tile_start * self.stride_kv_n_v)
+            for pas in range_constexpr(-(-slots // traits.WARP_SIZE)):
+                slot = self.lane_in_warp + fx.Index(pas * traits.WARP_SIZE)
+                n_in_tile = (slot // lanes_per_row) * traits.NUM_WAVES + self.wave_id
+                global_d = (slot % lanes_per_row) * traits.VEC_KV + traits.K_BAND_GLOBAL_D[d]
+                src_elem = self.kv_gmem_elem_offset + n_in_tile * self.stride_kv_n_v + global_d
+                lds_addr = band_base + fx.Index(pas * traits.WARP_SIZE * traits.VEC_KV * eb)
+                active = min(slots - pas * traits.WARP_SIZE, traits.WARP_SIZE)
+                if const_expr(active == traits.WARP_SIZE):
+                    self.buffer_load_lds_128(self.k_div, lds_addr, src_elem, tile_start * self.stride_kv_n_v)
+                else:
+                    self._load_k_band_partial_wave(lds_addr, src_elem, tile_start, active)
+
+    def _load_k_band_partial_wave(self, lds_addr, src_elem, tile_start, active_lanes):
+        soffset = tile_start * self.stride_kv_n_v
+        k_div = self.k_div
+
+        @flyc.jit
+        def _run():
+            if self.lane_in_warp < fx.Index(active_lanes):
+                self.buffer_load_lds_128(k_div, lds_addr, src_elem, soffset)
+
+        _run()
 
     def load_v(self, tile_start, buf_id):
         if const_expr(self.traits.FP8_PV):
@@ -4844,7 +4983,7 @@ class DualwaveFp8KvGmemToLdsLoader(DualwaveFp8KernelContext):
 
     def zero_v_fp8_lds(self):
         traits = self.traits
-        v_tile_bytes = (traits.BLOCK_N // 8) * (traits.HEAD_DIM // 16) * 128
+        v_tile_bytes = (traits.BLOCK_N // 8) * (traits.HEAD_DIM_V // 16) * 128
         total = 2 * v_tile_bytes
         aligned_base = ((self.lds_vt_base_idx + fx.Index(127)) // fx.Index(128)) * fx.Index(128)
         zero = Vec.from_elements([fx.Int32(0) for _ in range_constexpr(4)], fx.Int32)
@@ -4858,12 +4997,12 @@ class DualwaveFp8KvGmemToLdsLoader(DualwaveFp8KernelContext):
         traits = self.traits
         if const_expr(traits.VDMA):
             return self._stage_v_fp8_block_dma(tile_start, buf_id)
-        v_tile_bytes = (traits.BLOCK_N // 8) * (traits.HEAD_DIM // 16) * 128
+        v_tile_bytes = (traits.BLOCK_N // 8) * (traits.HEAD_DIM_V // 16) * 128
         buf_off = buf_id * v_tile_bytes
         n = self.wave_id * fx.Index(8) + self.lane // fx.Index(8)
         d_block = self.lane % fx.Index(8)
         src_elem = (
-            self.kv_gmem_elem_offset + n * self.stride_kv_n_v + d_block * fx.Index(16) + tile_start * self.stride_kv_n_v
+            self.v_gmem_elem_offset + n * self.stride_v_n_v + d_block * fx.Index(16) + tile_start * self.stride_v_n_v
         )
         v16 = fly.copy_atom_call_ssa(
             [Vec.make_type(4, fx.Int32)], self.load_atom_128, fx.slice(self.v_div, (None, fx.Int32(src_elem)))
@@ -4883,18 +5022,36 @@ class DualwaveFp8KvGmemToLdsLoader(DualwaveFp8KernelContext):
 
     def _stage_v_fp8_block_dma(self, tile_start, buf_id):
         traits = self.traits
-        v_tile_bytes = (traits.BLOCK_N // 8) * (traits.HEAD_DIM // 16) * 128
+        v_tile_bytes = (traits.BLOCK_N // 8) * (traits.HEAD_DIM_V // 16) * 128
         buf_off = buf_id * v_tile_bytes
         aligned_base = ((self.lds_vt_base_idx + fx.Index(127)) // fx.Index(128)) * fx.Index(128)
-        lds_addr = aligned_base + fx.Index(buf_off) + self.wave_id_uni * fx.Index(1024)
-        dest_n = fx.Int32(self.wave_id * fx.Index(8) + self.lane % fx.Index(8))
-        w16 = dest_n % fx.Int32(16)
-        c_add = (w16 >= fx.Int32(4)) & (w16 < fx.Int32(8))
-        c_sub = (w16 >= fx.Int32(8)) & (w16 < fx.Int32(12))
-        n = dest_n + c_add.select(fx.Int32(4), fx.Int32(0)) - c_sub.select(fx.Int32(4), fx.Int32(0))
-        d_block = self.lane // fx.Index(8)
-        src_elem = self.kv_gmem_elem_offset + fx.Index(n) * self.stride_kv_n_v + d_block * fx.Index(16)
-        self.buffer_load_lds_128(self.v_div, lds_addr, src_elem, tile_start * self.stride_kv_n_v)
+        groups = traits.BLOCK_N // 8
+        passes = -(-groups // traits.NUM_WAVES)
+        for pas in range_constexpr(passes):
+            grp = self.wave_id_uni + fx.Index(pas * traits.NUM_WAVES)
+            lds_addr = aligned_base + fx.Index(buf_off) + grp * fx.Index(1024)
+            dest_n = fx.Int32(grp * fx.Index(8) + self.lane % fx.Index(8))
+            w16 = dest_n % fx.Int32(16)
+            c_add = (w16 >= fx.Int32(4)) & (w16 < fx.Int32(8))
+            c_sub = (w16 >= fx.Int32(8)) & (w16 < fx.Int32(12))
+            n = dest_n + c_add.select(fx.Int32(4), fx.Int32(0)) - c_sub.select(fx.Int32(4), fx.Int32(0))
+            d_block = self.lane // fx.Index(8)
+            src_elem = self.v_gmem_elem_offset + fx.Index(n) * self.stride_v_n_v + d_block * fx.Index(16)
+            if const_expr(groups % traits.NUM_WAVES == 0 or pas < passes - 1):
+                self.buffer_load_lds_128(self.v_div, lds_addr, src_elem, tile_start * self.stride_v_n_v)
+            else:
+                self._load_v_group_if_in_tile(lds_addr, src_elem, tile_start, grp, groups)
+
+    def _load_v_group_if_in_tile(self, lds_addr, src_elem, tile_start, grp, groups):
+        soffset = tile_start * self.stride_v_n_v
+        v_div = self.v_div
+
+        @flyc.jit
+        def _run():
+            if grp < fx.Index(groups):
+                self.buffer_load_lds_128(v_div, lds_addr, src_elem, soffset)
+
+        _run()
 
     def _stage_vt_dequant_fp8(self, tile_start, buf_id):
         # Dequantize fp8 V into the exact bf16 V staging positions. The two d-iters
@@ -4905,7 +5062,7 @@ class DualwaveFp8KvGmemToLdsLoader(DualwaveFp8KernelContext):
         for d in range_constexpr(traits.SDRPT_BF):
             global_d = self.d_bucket * traits.VEC_BF + (d * traits.D128_BF)
             src_elem = (
-                self.kv_gmem_elem_offset + n_in_tile * self.stride_kv_n_v + global_d + tile_start * self.stride_kv_n_v
+                self.v_gmem_elem_offset + n_in_tile * self.stride_v_n_v + global_d + tile_start * self.stride_v_n_v
             )
             v_i32x2 = fly.copy_atom_call_ssa(
                 [self.v2i32_type], self.v_fp8_load64_atom, fx.slice(self.v_div, (None, fx.Int32(src_elem)))
@@ -4942,12 +5099,17 @@ class DualwaveFp8KvLdsToVgprLoader(DualwaveFp8KernelContext):
         n_lo = self.lane_mod_32
         n_hi = self.lane_mod_32 + 32
 
+        rows_per_line = traits.NUM_WAVES
+
         def _read_strip(key):
-            row = (key % 8) * traits.SMEM_K_LINE_STRIDE + (key // 8) * traits.D_128B_SIZE
-            return [
-                self.read_i32x8_lds(self.lds_kv_base_ptr, k_base + row + ws * 64 + d_base)
-                for ws in range_constexpr(traits.HEAD_DIM // 64)
-            ]
+            out = []
+            for ws in range_constexpr(traits.HEAD_DIM // 64):
+                b = traits.K_WS_BAND[ws]
+                line = (key % rows_per_line) * traits.K_BAND_LINE_STRIDE[b]
+                row = line + (key // rows_per_line) * traits.K_BAND_CHUNK[b]
+                addr = k_base + traits.K_BAND_BASE[b] + row + traits.K_WS_OFF[ws] + d_base
+                out.append(self.read_i32x8_lds(self.lds_kv_base_ptr, addr))
+            return out
 
         return (_read_strip(n_lo), _read_strip(n_hi))
 
@@ -4975,9 +5137,9 @@ class DualwaveFp8KvLdsToVgprLoader(DualwaveFp8KernelContext):
 
     def _load_v_fp8_block(self, buf_id):
         traits = self.traits
-        v_tile_bytes = (traits.BLOCK_N // 8) * (traits.HEAD_DIM // 16) * 128
+        v_tile_bytes = (traits.BLOCK_N // 8) * (traits.HEAD_DIM_V // 16) * 128
         buf_off = buf_id * v_tile_bytes
-        nbands = traits.HEAD_DIM // 16  # 8
+        nbands = traits.HEAD_DIM_V // 16  # 8
         rh = (self.lane % fx.Index(32)) // fx.Index(16)
         l16 = self.lane % fx.Index(16)
         lane_hi = self.lane // fx.Index(32)
@@ -5296,16 +5458,17 @@ class DualwaveFp8StoreHelper(DualwaveFp8KernelContext):
             for g in range_constexpr(2):
                 o_pack = self._packed_o_128_vec(v_o, dc, g)
                 d_col = (dc * self.traits.D_CHUNK) + (2 * g + self.lane_div_32) * 8
-                o_global = self.global_idx_q(q_row, d_col)
+                o_global = self.global_idx_o(q_row, d_col)
                 self.buffer_store_128(o_pack, o_global)
 
     def store_splitk_partial_o(self, v_o, m_row, l_row, q_row):
+        m_row = fx.Float32(m_row) * self.c_logit_scale
         split_z = self.batch_idx * self.traits.NUM_KV_SPLITS + self.split_idx
         o_part_row_base = ((split_z * self.traits.NUM_HEADS_Q + self.q_head_idx) * self.seq_len_v + q_row) * (
-            self.traits.HEAD_DIM // 2
+            self.traits.HEAD_DIM_V // 2
         )
         grid_z = fx.Index(gpu.grid_dim.z)
-        mrow_base = grid_z * self.traits.NUM_HEADS_Q * self.seq_len_v * (self.traits.HEAD_DIM // 2)
+        mrow_base = grid_z * self.traits.NUM_HEADS_Q * self.seq_len_v * (self.traits.HEAD_DIM_V // 2)
         lrow_base = mrow_base + grid_z * self.traits.NUM_HEADS_Q * self.seq_len_v
         ml_row_idx = (split_z * self.traits.NUM_HEADS_Q + self.q_head_idx) * self.seq_len_v + q_row
 
@@ -5329,10 +5492,10 @@ class DualwaveFp8StoreHelper(DualwaveFp8KernelContext):
                 q_row_e = self.q_start + self.wave_q_offset + self.lane_mod_32
                 split_z_e = self.batch_idx * self.traits.NUM_KV_SPLITS + self.split_idx
                 o_row_base_e = ((split_z_e * self.traits.NUM_HEADS_Q + self.q_head_idx) * self.seq_len_v + q_row_e) * (
-                    self.traits.HEAD_DIM // 2
+                    self.traits.HEAD_DIM_V // 2
                 )
                 grid_z_e = fx.Index(gpu.grid_dim.z)
-                mrow_base_e = grid_z_e * self.traits.NUM_HEADS_Q * self.seq_len_v * (self.traits.HEAD_DIM // 2)
+                mrow_base_e = grid_z_e * self.traits.NUM_HEADS_Q * self.seq_len_v * (self.traits.HEAD_DIM_V // 2)
                 lrow_base_e = mrow_base_e + grid_z_e * self.traits.NUM_HEADS_Q * self.seq_len_v
                 ml_row_e = (split_z_e * self.traits.NUM_HEADS_Q + self.q_head_idx) * self.seq_len_v + q_row_e
                 if q_row_e < self.seq_len_v:
@@ -5361,6 +5524,7 @@ class DualwaveSplitKCombineContext:
         stride_q_n=None,
         LSE=None,
         Sink=None,
+        CuSeqQ=None,
     ):
         if isinstance(traits_or_ctx, DualwaveSplitKCombineContext):
             self.__dict__.update(traits_or_ctx.__dict__)
@@ -5373,12 +5537,14 @@ class DualwaveSplitKCombineContext:
         self.WS = WS
         self.LSE = LSE
         self.Sink = Sink
+        self.CuSeqQ = CuSeqQ
         self.batch_size = batch_size
         self.seq_len = seq_len
         self.stride_q_n = stride_q_n
 
     def init_types_and_constants(self):
-        self.elem_dtype = dtype_to_elem_type(self.traits.DTYPE_STR)
+        self.out_dtype_str = "bf16" if self.traits.DTYPE_STR == "fp8" else self.traits.DTYPE_STR
+        self.elem_dtype = dtype_to_elem_type(self.out_dtype_str)
         self.fm_fast = fx.arith.FastMathFlags.fast
         self.c_zero_f = fx.Float32(0.0)
         self.c_zero_v4f32 = Vec.filled(4, 0.0, fx.Float32)
@@ -5405,22 +5571,32 @@ class DualwaveSplitKCombineContext:
     def init_workspace(self):
         traits = self.traits
         z_total = self.batch_size_v * traits.NUM_KV_SPLITS
-        self.ws_opart_per_split_elems = fx.Index(traits.NUM_HEADS_Q) * self.seq_len_v * fx.Index(traits.HEAD_DIM // 2)
+        self.ws_opart_per_split_elems = fx.Index(traits.NUM_HEADS_Q) * self.seq_len_v * fx.Index(traits.HEAD_DIM_V // 2)
         self.ws_ml_per_split_elems = fx.Index(traits.NUM_HEADS_Q) * self.seq_len_v
         self.ws_opart_per_split_bytes = self.ws_opart_per_split_elems * fx.Index(4)
         self.ws_ml_per_split_bytes = self.ws_ml_per_split_elems * fx.Index(4)
         self.ws_mrow_abs_bytes = z_total * self.ws_opart_per_split_bytes
         self.ws_lrow_abs_bytes = self.ws_mrow_abs_bytes + z_total * self.ws_ml_per_split_bytes
         self.local_ml_idx = self.q_head_idx * self.seq_len_v + self.seq_idx
-        self.local_o_base = (self.q_head_idx * self.seq_len_v + self.seq_idx) * fx.Index(traits.HEAD_DIM // 2)
+        self.local_o_base = (self.q_head_idx * self.seq_len_v + self.seq_idx) * fx.Index(traits.HEAD_DIM_V // 2)
         self.ws_base_i64 = fx.Int64(fx.ptrtoint(fx.get_iter(self.WS)))
 
     def init_descriptors(self):
-        per_batch_elems = self.seq_len_v * self.stride_q_n_v
-        batch_byte_off = self.batch_idx * per_batch_elems * fx.Index(2)
+        if const_expr(self.traits.VARLEN):
+            _cuq_div = fx.logical_divide(fx.rocdl.make_buffer_tensor(self.CuSeqQ), fx.make_layout(1, 1))
+            _cu_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Int32)
+            _cu_v1i32 = Vec.make_type(1, fx.Int32)
+            q_tok_base = _cu_load(_cuq_div, self.batch_idx, _cu_atom, _cu_v1i32)
+            q_tok_end = _cu_load(_cuq_div, self.batch_idx + fx.Index(1), _cu_atom, _cu_v1i32)
+            batch_byte_off = q_tok_base * self.stride_q_n_v * fx.Index(2)
+            nrec_bytes = (q_tok_end - q_tok_base) * self.stride_q_n_v * fx.Index(2)
+        else:
+            per_batch_elems = self.seq_len_v * self.stride_q_n_v
+            batch_byte_off = self.batch_idx * per_batch_elems * fx.Index(2)
+            nrec_bytes = per_batch_elems * fx.Index(2)
         self.o_rsrc = buffer_ops.create_buffer_resource_from_addr(
             as_mlir_value(fx.Int64(fx.ptrtoint(fx.get_iter(self.O))) + fx.Int64(batch_byte_off)),
-            num_records_bytes=as_mlir_value(fx.Int64(per_batch_elems * fx.Index(2))),
+            num_records_bytes=as_mlir_value(fx.Int64(nrec_bytes)),
         )
         self.load_atom_64 = fx.make_copy_atom(fx.rocdl.BufferCopy64b(), fx.Int32)
 
@@ -5535,7 +5711,7 @@ class DualwaveSplitKCombineHelper(DualwaveSplitKCombineContext):
         inv = (fx.Float32(den) > self.c_zero_f).select(inv_rcp, self.c_zero_f)
         inv4 = Vec.from_elements([fx.Float32(inv)], fx.Float32).broadcast_to(4)
         out4 = Vec(acc * inv4, (4,), fx.Float32)
-        if const_expr(self.traits.DTYPE_STR == "bf16"):
+        if const_expr(self.out_dtype_str == "bf16"):
             lo = rocdl.cvt_pk_bf16_f32(out4[0], out4[1])
             hi = rocdl.cvt_pk_bf16_f32(out4[2], out4[3])
         else:
@@ -5558,7 +5734,7 @@ class DualwaveSplitKCombineHelper(DualwaveSplitKCombineContext):
         buffer_ops.buffer_store(as_mlir_value(fx.Float32(lse_val)), lse_rsrc, as_mlir_value(fx.Int32(lse_off)))
 
     def store_output(self, o_pack):
-        o_global = self.seq_idx * self.stride_q_n_v + self.q_head_idx * self.traits.HEAD_DIM + self.col
+        o_global = self.seq_idx * self.stride_q_n_v + self.q_head_idx * self.traits.HEAD_DIM_V + self.col
         buffer_ops.buffer_store(
             o_pack.ir_value(),
             self.o_rsrc,

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -1695,7 +1695,9 @@ def run_fp8_config(
     seed=DEFAULT_SEED,
     verbose=True,
     num_kv_heads=None,
-    num_kv_splits=1,
+    # Mirror the library default so a benchmark measures what callers get; a
+    # correctness test that must not depend on the autotuner passes 1.
+    num_kv_splits=None,
     head_dim_v=None,
     seqlen_kv=None,
     varlen_seqlens_q=None,
@@ -1713,7 +1715,8 @@ def run_fp8_config(
         ``[total_q, H, D]``, K/V are ``[total_kv, Hkv, *]`` and cu_seqlens are
         derived from the per-sequence lengths. Passing only ``varlen_seqlens_q``
         makes it self-attention.
-      - ``num_kv_splits`` > 1: forwarded to the split-K path.
+      - ``num_kv_splits``: ``None`` autotunes, ``1`` pins the unsplit kernel,
+        ``> 1`` forces that many KV splits.
 
     Only configurations that can never be valid (wrong arch, indivisible head
     counts, malformed lengths) are rejected here. Anything the kernel does not
@@ -1810,8 +1813,10 @@ def run_fp8_config(
         )
         if cross:
             fp8_exec_kwargs["max_seqlen_kv"] = Skv
-    if int(num_kv_splits) > 1:
-        fp8_exec_kwargs["num_kv_splits"] = int(num_kv_splits)
+    # Forward faithfully: `None` asks the interface to autotune, `1` pins the
+    # unsplit kernel. Only forwarding `> 1` made an explicit 1 fall back to the
+    # default, i.e. to the autotuner -- the opposite of what the caller asked.
+    fp8_exec_kwargs["num_kv_splits"] = None if num_kv_splits is None else int(num_kv_splits)
 
     try:
         flydsl_flash_attn_func(
@@ -4876,6 +4881,10 @@ def test_fp8_lazy_rescale_keeps_the_running_max_monotonic():
         k_descale=k_s.reshape(1).contiguous(),
         v_descale=v_s.reshape(1).contiguous(),
         dualwave_swp_lazy_rescale=True,
+        # The subject is the main kernel's running max; leave the split
+        # autotuner out of it so the assertion cannot be answered by the
+        # combine pass instead.
+        num_kv_splits=1,
     )
     out = (out[0] if isinstance(out, (tuple, list)) else out).float()
     torch.cuda.synchronize()
@@ -5052,6 +5061,9 @@ def test_fp8_default_is_the_lazy_rescale():
         q_descale=q_s.reshape(1).contiguous(),
         k_descale=k_s.reshape(1).contiguous(),
         v_descale=v_s.reshape(1).contiguous(),
+        # This compares two rescale modes of the dense kernel; the split
+        # autotuner is free to move underneath it and is not the subject.
+        num_kv_splits=1,
     )
     qq, kk = (q / q_s).to(fp8), (k / k_s).to(fp8)
 
@@ -5093,34 +5105,45 @@ def _assert_fp8_shape(causal, batch=1, seq_len=1, head_dim=_FP8_D, head_dim_v=_F
     )
 
 
+# `num_kv_splits=None` is the shipped default and lets the autotuner pick, so a
+# test that passes nothing exercises whichever path the heuristic happens to
+# choose today. Every head-dim test below runs both: `1` pins the unsplit kernel
+# (deterministic coverage of what the test claims to be about) and `None` keeps
+# the path a caller actually gets.
+FP8_SPLIT_MODES = [pytest.param(1, id="dense"), pytest.param(None, id="autosplit")]
+
+
 @_requires_gfx950
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("batch,seq_len", [(1, 4096), (2, 4096), (3, 4096), (4, 4096), (1, 8192)])
-def test_fp8_head_dim_192_v_128_dense(causal, batch, seq_len):
+@pytest.mark.parametrize("num_kv_splits", FP8_SPLIT_MODES)
+def test_fp8_head_dim_192_v_128_dense(causal, batch, seq_len, num_kv_splits):
     """Dense self-attention with QK head_dim 192 and a 128-wide V.
 
     Q/K are [B, S, 12, 192], V is [B, S, 12, 128], and the output follows V.
     """
-    _assert_fp8_shape(causal, batch=batch, seq_len=seq_len)
+    _assert_fp8_shape(causal, batch=batch, seq_len=seq_len, num_kv_splits=num_kv_splits)
 
 
 @_requires_gfx950
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("batch", FP8_VARLEN_BATCHES)
-def test_fp8_head_dim_192_v_128_varlen(causal, batch):
+@pytest.mark.parametrize("num_kv_splits", FP8_SPLIT_MODES)
+def test_fp8_head_dim_192_v_128_varlen(causal, batch, num_kv_splits):
     """Packed varlen self-attention over 2614 tokens, batch 1..4.
 
     Q/K are [2614, 12, 192] and V is [2614, 12, 128] at every batch -- only the
     cu_seqlens partition changes (batch 2 is [0, 1024, 2614]). Q and KV share the
     per-sequence lengths, so only the V head dim differs here.
     """
-    _assert_fp8_shape(causal, varlen_seqlens_q=FP8_VARLEN_Q_SEQLENS[batch])
+    _assert_fp8_shape(causal, varlen_seqlens_q=FP8_VARLEN_Q_SEQLENS[batch], num_kv_splits=num_kv_splits)
 
 
 @_requires_gfx950
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("batch", FP8_VARLEN_BATCHES)
-def test_fp8_head_dim_192_v_128_varlen_cross_length(causal, batch):
+@pytest.mark.parametrize("num_kv_splits", FP8_SPLIT_MODES)
+def test_fp8_head_dim_192_v_128_varlen_cross_length(causal, batch, num_kv_splits):
     """Packed varlen cross-attention, batch 1..4: 2614 Q tokens vs 16384 KV tokens.
 
     Q is [2614, 12, 192], K is [16384, 12, 192] and V is [16384, 12, 128] at every
@@ -5131,6 +5154,7 @@ def test_fp8_head_dim_192_v_128_varlen_cross_length(causal, batch):
         causal,
         varlen_seqlens_q=FP8_VARLEN_Q_SEQLENS[batch],
         varlen_seqlens_kv=FP8_VARLEN_KV_SEQLENS[batch],
+        num_kv_splits=num_kv_splits,
     )
 
 
@@ -5340,11 +5364,16 @@ _NUM_CU = 256
         (8, 32, 2048, 2048, True, 256),
         (16, 32, 1024, 1024, True, 256),
         (32, 32, 512, 512, True, 256),
-        # A long KV does not on its own force the wide tile: at one workgroup
-        # per CU the narrow tile still measured 12-21% faster here.
-        (1, 8, 4096, 4096, True, 128),
-        (1, 8, 4096, 16384, True, 128),
-        # ... but a second batch fills the GPU, and then it does not.
+        # Short KV and an under-filled GPU: narrow.
+        (1, 8, 2048, 2048, True, 128),
+        # Long KV goes wide even at one workgroup per CU. Pinning block_m and
+        # letting the split count follow it, the wide tile measured 50.2us vs
+        # 56.7us here and 164.6us vs 216.3us at 4096/16384 -- the narrow tile
+        # inflates the workgroup estimate and talks the autotuner out of a split
+        # that pays. A sweep with split-K forced off says the opposite, which is
+        # why this rule must not be tuned with the two heuristics decoupled.
+        (1, 8, 4096, 4096, True, 256),
+        (1, 8, 4096, 16384, True, 256),
         (2, 8, 4096, 4096, True, 256),
     ],
 )

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -1695,8 +1695,6 @@ def run_fp8_config(
     seed=DEFAULT_SEED,
     verbose=True,
     num_kv_heads=None,
-    # Mirror the library default so a benchmark measures what callers get; a
-    # correctness test that must not depend on the autotuner passes 1.
     num_kv_splits=None,
     head_dim_v=None,
     seqlen_kv=None,
@@ -1813,9 +1811,6 @@ def run_fp8_config(
         )
         if cross:
             fp8_exec_kwargs["max_seqlen_kv"] = Skv
-    # Forward faithfully: `None` asks the interface to autotune, `1` pins the
-    # unsplit kernel. Only forwarding `> 1` made an explicit 1 fall back to the
-    # default, i.e. to the autotuner -- the opposite of what the caller asked.
     fp8_exec_kwargs["num_kv_splits"] = None if num_kv_splits is None else int(num_kv_splits)
 
     try:
@@ -4881,9 +4876,6 @@ def test_fp8_lazy_rescale_keeps_the_running_max_monotonic():
         k_descale=k_s.reshape(1).contiguous(),
         v_descale=v_s.reshape(1).contiguous(),
         dualwave_swp_lazy_rescale=True,
-        # The subject is the main kernel's running max; leave the split
-        # autotuner out of it so the assertion cannot be answered by the
-        # combine pass instead.
         num_kv_splits=1,
     )
     out = (out[0] if isinstance(out, (tuple, list)) else out).float()
@@ -5061,8 +5053,6 @@ def test_fp8_default_is_the_lazy_rescale():
         q_descale=q_s.reshape(1).contiguous(),
         k_descale=k_s.reshape(1).contiguous(),
         v_descale=v_s.reshape(1).contiguous(),
-        # This compares two rescale modes of the dense kernel; the split
-        # autotuner is free to move underneath it and is not the subject.
         num_kv_splits=1,
     )
     qq, kk = (q / q_s).to(fp8), (k / k_s).to(fp8)
@@ -5105,11 +5095,7 @@ def _assert_fp8_shape(causal, batch=1, seq_len=1, head_dim=_FP8_D, head_dim_v=_F
     )
 
 
-# `num_kv_splits=None` is the shipped default and lets the autotuner pick, so a
-# test that passes nothing exercises whichever path the heuristic happens to
-# choose today. Every head-dim test below runs both: `1` pins the unsplit kernel
-# (deterministic coverage of what the test claims to be about) and `None` keeps
-# the path a caller actually gets.
+# `1` pins the unsplit kernel, `None` is the shipped default (autotuned).
 FP8_SPLIT_MODES = [pytest.param(1, id="dense"), pytest.param(None, id="autosplit")]
 
 
@@ -5222,11 +5208,7 @@ def _fp8_combine_rows_per_block(head_dim_v):
 
 
 def _run_fp8_into_nan_out(q, k, v, head_dim_v, **kwargs):
-    """Launch fp8 attention into a NaN-filled ``out`` and return it.
-
-    A zero-initialised buffer hides rows the kernel never writes; NaN makes them
-    countable, which is the whole point of these two tests.
-    """
+    """Launch fp8 attention into a NaN-filled ``out`` so unwritten rows are countable."""
     fp8 = torch.float8_e4m3fn
     fp8_max = torch.finfo(fp8).max
     scales = [t.abs().amax().float().clamp(min=1e-12) / fp8_max for t in (q, k, v)]
@@ -5249,13 +5231,7 @@ def _run_fp8_into_nan_out(q, k, v, head_dim_v, **kwargs):
 @_requires_gfx950
 @pytest.mark.parametrize("batch,seq_len,num_heads", [(1, 4097, 1), (1, 4097, 3), (1, 2050, 7), (1, 8193, 1)])
 def test_fp8_auto_split_kv_writes_every_row(batch, seq_len, num_heads):
-    """Auto split-K must not drop the tail of the combine grid.
-
-    ``batch * num_heads * seq_len`` is deliberately not a multiple of
-    COMBINE_ROWS_PER_BLOCK (8 at head_dim_v=128), which a floor-divided combine
-    grid leaves unwritten. No ``num_kv_splits`` is passed: the point is that a
-    caller who never asked for split-K still gets every row.
-    """
+    """Auto split-K must not drop the tail of the combine grid."""
     D = 128
     assert (batch * num_heads * seq_len) % _fp8_combine_rows_per_block(D) != 0, "shape would not exercise the tail"
     torch.manual_seed(0)
@@ -5267,14 +5243,7 @@ def test_fp8_auto_split_kv_writes_every_row(batch, seq_len, num_heads):
 @_requires_gfx950
 @pytest.mark.parametrize("seq_len,num_heads,head_dim_v", [(385, 1, 128), (385, 3, 128), (1155, 1, 128), (386, 1, 64)])
 def test_fp8_varlen_split_kv_respects_batch_boundaries(seq_len, num_heads, head_dim_v):
-    """varlen + split-K must not mix batches inside a combine wave.
-
-    A buffer resource is wave-scoped. When ``(max_seqlen_q * num_heads)`` is not a
-    multiple of the rows a wave covers, a batch boundary lands mid-wave; deriving
-    the O descriptor per thread then writes the row after the boundary with the
-    previous batch's descriptor, losing that row and corrupting the previous
-    batch's row 0.
-    """
+    """varlen + split-K must not mix batches inside a combine wave."""
     rows_per_wave = 256 // head_dim_v
     assert (seq_len * num_heads) % rows_per_wave != 0, "shape would not straddle a wave"
     B, D = 8, 192
@@ -5313,16 +5282,12 @@ def test_fp8_supported_v_head_dims_run(head_dim_v):
 @pytest.mark.parametrize(
     "head_dim,head_dim_v,match",
     [
-        # D_CHUNKS < 2: `_anchor_v_o` emits a single-element inline-asm struct and
-        # LLVM aborts the process rather than failing the build.
+        # D_CHUNKS < 2 aborts LLVM; D_CHUNKS > 6 miscomputes the high chunks.
         (128, 32, "head_dim_v"),
-        # D_CHUNKS > 6: launches, but the high D_CHUNKs come back wrong.
         (128, 224, "head_dim_v"),
         (128, 256, "head_dim_v"),
-        # Fits neither the QK MFMA slicing nor a clean band split.
         (96, 96, "head_dim"),
-        # Within the head-dim rules but over the 160 KiB LDS budget. 256/256 is
-        # the shape people ask about; it trips the head_dim_v rule first.
+        # Within the head-dim rules but over the LDS budget.
         (256, 192, "LDS"),
         (320, 128, "LDS"),
         (384, 64, "LDS"),
@@ -5364,25 +5329,16 @@ _NUM_CU = 256
         (8, 32, 2048, 2048, True, 256),
         (16, 32, 1024, 1024, True, 256),
         (32, 32, 512, 512, True, 256),
-        # Short KV and an under-filled GPU: narrow.
         (1, 8, 2048, 2048, True, 128),
-        # Long KV goes wide even at one workgroup per CU. Pinning block_m and
-        # letting the split count follow it, the wide tile measured 50.2us vs
-        # 56.7us here and 164.6us vs 216.3us at 4096/16384 -- the narrow tile
-        # inflates the workgroup estimate and talks the autotuner out of a split
-        # that pays. A sweep with split-K forced off says the opposite, which is
-        # why this rule must not be tuned with the two heuristics decoupled.
+        # Long KV goes wide even at one workgroup per CU: the narrow tile inflates
+        # the workgroup estimate and talks the split autotuner out of a split.
         (1, 8, 4096, 4096, True, 256),
         (1, 8, 4096, 16384, True, 256),
         (2, 8, 4096, 4096, True, 256),
     ],
 )
 def test_fp8_auto_block_m_picks(batch, num_heads, seqlen_q, seqlen_kv, causal, expect):
-    """Pin what `_fp8_auto_block_m` chooses.
-
-    Every correctness test passes whichever tile it picks, so an inverted
-    comparison here is invisible without an assertion on the choice itself.
-    """
+    """Pin what `_fp8_auto_block_m` chooses; correctness tests pass either way."""
     got = flash_attn_interface._fp8_auto_block_m(batch, num_heads, seqlen_q, seqlen_kv, causal, _NUM_CU)
     assert got == expect
 
@@ -5441,8 +5397,6 @@ def test_fp8_num_kv_splits_none_is_auto_and_one_is_off(monkeypatch):
         return orig(**kw)
 
     monkeypatch.setattr(flash_attn_interface, "_build_dense_fp8", spy)
-    # Small enough that the autotuner still has idle CUs to fill at the tile
-    # `_fp8_auto_block_m` picks; a shape it would leave unsplit proves nothing.
     B, S, H, D = 1, 8192, 2, 128
     torch.manual_seed(0)
     q, k, v = (torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16) * 0.1 for _ in range(3))
@@ -5457,13 +5411,7 @@ def test_fp8_num_kv_splits_none_is_auto_and_one_is_off(monkeypatch):
 @_requires_gfx950
 @pytest.mark.parametrize("seq_len,num_heads,head_dim", [(4097, 1, 128), (2050, 7, 128), (1025, 1, 64)])
 def test_bf16_split_kv_writes_every_row(seq_len, num_heads, head_dim):
-    """The bf16 combine grid shares the fp8 one's rounding, and the same bug.
-
-    ``num_heads * seq_len`` is not a multiple of COMBINE_ROWS_PER_BLOCK, so a
-    floor-divided grid leaves the tail of the last block unwritten. Unlike the
-    fp8 case this needs an explicit ``num_kv_splits`` -- bf16 has no autotuner --
-    which is why it went unnoticed.
-    """
+    """The bf16 combine grid shares the fp8 one's rounding, and the same bug."""
     B = 1
     torch.manual_seed(0)
     q, k, v = (

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -152,6 +152,49 @@ EXTRA_CONFIGS = [
     [[127, 129, 255, 257], [257, 255, 129, 127], None, 64, 8, 1],
 ]
 
+FP8_VARLEN_Q_SEQLENS = {
+    1: [2614],
+    2: [1024, 1590],
+    3: [1024, 512, 1078],
+    4: [1024, 512, 256, 822],
+}
+FP8_VARLEN_KV_SEQLENS = {
+    1: [16384],
+    2: [8192, 8192],
+    3: [8192, 4096, 4096],
+    4: [8192, 4096, 2048, 2048],
+}
+FP8_VARLEN_BATCHES = (1, 2, 3, 4)
+
+FP8_SPLITKV_SPLITS = (2, 4, 8, 16)
+FP8_SPLITKV_SEQLENS = (4096, 8192, 16384, 32768)
+
+FP8_EXTRA_CONFIGS = [
+    [FP8_VARLEN_Q_SEQLENS[b], None, None, 12, 12, 1, 192, 128]
+    for b in FP8_VARLEN_BATCHES
+] + [
+    [FP8_VARLEN_Q_SEQLENS[b], FP8_VARLEN_KV_SEQLENS[b], None, 12, 12, 1, 192, 128]
+    for b in FP8_VARLEN_BATCHES
+] + [
+    [seq, seq, b, 12, 12, 1, 192, 128]
+    for seq in (4096, 8192, 16384, 32768)
+    for b in ((1, 2) if seq == 32768 else (1, 2, 3, 4))
+] + [
+    [seq, seq, 1, 12, 12, sp, 192, 128]
+    for seq, sp in zip(FP8_SPLITKV_SEQLENS, FP8_SPLITKV_SPLITS)
+] + [
+    [8192, 8192, b, 12, 12, 4, 192, 128]
+    for b in (2, 3, 4)
+] + [
+    [8192, 8192, 1, 12, 12, sp, 128, 128]
+    for sp in FP8_SPLITKV_SPLITS
+] + [
+    [512, 16384, 1, 12, 12, 8, 192, 128],
+    [2614, 16384, 1, 12, 12, 8, 192, 128],
+    [1024, 32768, 1, 12, 12, 16, 192, 128],
+    [512, 16384, 4, 12, 12, 8, 192, 128],
+]
+
 
 def _short_label(value):
     label = str(value)
@@ -159,7 +202,8 @@ def _short_label(value):
 
 
 def _extra_case_from_config(row):
-    seqlen_q, seqlen_kv, batch, nh, nh_kv, kv_splits = row
+    seqlen_q, seqlen_kv, batch, nh, nh_kv, kv_splits, *head_dims = row
+    dims = {"hd": head_dims[0], "hd_v": head_dims[1]} if head_dims else {}
     if seqlen_kv is None:
         return {
             "sq_label": _short_label(seqlen_q),
@@ -168,6 +212,7 @@ def _extra_case_from_config(row):
             "nh_kv": nh_kv,
             "kv_splits": kv_splits,
             "kwargs": {"varlen_seqlens_q": list(seqlen_q)},
+            **dims,
         }
     if batch is not None:
         return {
@@ -177,6 +222,7 @@ def _extra_case_from_config(row):
             "nh_kv": nh_kv,
             "kv_splits": kv_splits,
             "kwargs": {"batch": batch, "seqlen_q": seqlen_q, "seqlen_kv": seqlen_kv},
+            **dims,
         }
     return {
         "sq_label": _short_label(seqlen_q),
@@ -185,6 +231,7 @@ def _extra_case_from_config(row):
         "nh_kv": nh_kv,
         "kv_splits": kv_splits,
         "kwargs": {"varlen_seqlens_q": list(seqlen_q), "varlen_seqlens_kv": list(seqlen_kv)},
+        **dims,
     }
 
 
@@ -347,10 +394,11 @@ def pytorch_ref_attention_qkv_diff(q, k, v, causal=True, bias=None, alibi_slopes
         v_t = v_t.repeat_interleave(rep, dim=1)
     B, H, Sq, D = q_t.shape
     Skv = k_t.shape[2]
+    Dv = v_t.shape[3]
     delta = Skv - Sq
     scale = 1.0 / math.sqrt(D)
     k_trans = k_t.transpose(-1, -2).contiguous()
-    out = torch.empty((B, H, Sq, D), device=q_t.device, dtype=torch.float32)
+    out = torch.empty((B, H, Sq, Dv), device=q_t.device, dtype=torch.float32)
     chunk = max(1, min(Sq, (64 * 1024 * 1024) // max(B * H * Skv, 1)))
     key_idx = torch.arange(Skv, device=q_t.device).view(1, 1, 1, Skv)
     for s0 in range(0, Sq, chunk):
@@ -1102,6 +1150,11 @@ def run_attn_config(
     if splitk:
         if D not in (64, 128) or dtype_str not in ("bf16", "f16") or (seqlen_q is not None and seqlen_q < 384):
             return {"skip": True}
+        if not use_block_table and seqlen_kv is not None and seqlen_kv != seqlen_q:
+            return {
+                "skip": True,
+                "skip_reason": f"dense split-K requires seqlen_kv == seqlen_q, got {seqlen_kv} != {seqlen_q}",
+            }
 
     # ── bias addressing guard ────────────────────────────────────────────────
     if use_bias:
@@ -1618,6 +1671,26 @@ def _dequant_fp8(x_fp8, descale):
     return x_fp8.to(torch.float32) * descale.to(torch.float32)
 
 
+def _score_pairs(sq, skv, causal):
+    """(q, k) score elements actually computed for one sequence pair.
+
+    Non-causal is the full sq*skv rectangle. Causal is bottom-right aligned like
+    the kernel mask (row i attends keys [0, skv - sq + i]), so a cross-length pair
+    keeps the whole prefix. Matches sq*skv/2 when sq == skv, which is what the
+    self-attention TFLOPS numbers have always used.
+    """
+    if not causal:
+        return float(sq * skv)
+    if sq <= skv:
+        return 0.5 * sq * (2 * skv - sq)
+    return 0.5 * skv * skv
+
+
+def _fp8_flops(pairs, num_heads, head_dim, head_dim_v):
+    """FLOPs for `pairs` score elements: 2*pairs*D for QK^T plus 2*pairs*Dv for PV."""
+    return 2.0 * pairs * num_heads * (head_dim + head_dim_v)
+
+
 def run_fp8_config(
     batch,
     seq_len,
@@ -1630,30 +1703,41 @@ def run_fp8_config(
     verbose=True,
     num_kv_heads=None,
     num_kv_splits=1,
+    head_dim_v=None,
+    seqlen_kv=None,
+    varlen_seqlens_q=None,
+    varlen_seqlens_kv=None,
+    bench=True,
 ):
     """Run the FlyDSL fp8 (e4m3fn) forward path and validate vs a dequantized-input
     SDPA reference at the fixed fp8 gate (max_err < 5e-2 and min_cos > 0.98).
 
-    Unsupported fp8 configurations (non-gfx950, head_dim != 128, split-K) raise a
-    clear error that is surfaced as an ERROR row (never a silent SKIP). Returns a
-    run_config-compatible dict so it prints through the same summary table.
+    Shape options beyond dense self-attention:
+      - ``head_dim_v``: V (and therefore O) head dim, when it differs from the QK
+        ``head_dim`` -- e.g. QK D=192 with V Dv=128.
+      - ``seqlen_kv``: dense cross-attention, K/V longer or shorter than Q.
+      - ``varlen_seqlens_q`` / ``varlen_seqlens_kv``: packed varlen. Q is
+        ``[total_q, H, D]``, K/V are ``[total_kv, Hkv, *]`` and cu_seqlens are
+        derived from the per-sequence lengths. Passing only ``varlen_seqlens_q``
+        makes it self-attention.
+      - ``num_kv_splits`` > 1: forwarded to the split-K path.
+
+    Only configurations that can never be valid (wrong arch, indivisible head
+    counts, malformed lengths) are rejected here. Anything the kernel does not
+    implement yet reaches it and surfaces the launcher's own message as an ERROR
+    row -- never a silent SKIP, and never a stale gate in this harness that would
+    keep rejecting a shape after the kernel gains support for it.
+
+    Returns a run_config-compatible dict so it prints through the same summary
+    table. ``bench=False`` skips the timing pass and returns correctness only.
     """
     device = "cuda"
     results = {}
 
     if num_kv_heads is None:
         num_kv_heads = num_heads
+    Dv = head_dim if head_dim_v is None else head_dim_v
 
-    # fp8 split-K is not implemented. Reject it explicitly rather than silently
-    # running a dense fp8 forward while the config row advertises kv_sp>1 (which
-    # would validate the wrong path).
-    if int(num_kv_splits) > 1:
-        results["err"] = f"fp8 split-K (num_kv_splits={num_kv_splits}) is not implemented (dense fp8 only)"
-        return results
-
-    # fp8 forward is gfx950-only and head_dim==128 only. Reject anything else
-    # up-front with a clear, specific error (surfaced as an ERROR row) rather
-    # than a SKIP that would mask a real failure.
     try:
         gpu_arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
     except Exception:
@@ -1661,30 +1745,80 @@ def run_fp8_config(
     if not gpu_arch.startswith("gfx950"):
         results["err"] = f"fp8 requires gfx950 (got '{gpu_arch or 'unknown'}')"
         return results
-    if head_dim != 128:
-        results["err"] = f"fp8 requires head_dim == 128 (got {head_dim})"
-        return results
     if num_heads % num_kv_heads != 0:
         results["err"] = f"num_heads ({num_heads}) must be divisible by num_kv_heads ({num_kv_heads})"
         return results
-    if seq_len < 1:
-        results["err"] = f"seq_len ({seq_len}) must be >= 1"
-        return results
 
-    B, S, H, D = batch, seq_len, num_heads, head_dim
+    varlen = varlen_seqlens_q is not None
+    if varlen:
+        vl_q = list(varlen_seqlens_q)
+        vl_kv = list(varlen_seqlens_kv) if varlen_seqlens_kv is not None else list(vl_q)
+        if len(vl_kv) != len(vl_q):
+            results["err"] = f"varlen_seqlens_kv ({len(vl_kv)}) must match varlen_seqlens_q ({len(vl_q)})"
+            return results
+        if min(vl_q + vl_kv) < 1:
+            results["err"] = f"varlen seqlens must be >= 1, got q={vl_q} kv={vl_kv}"
+            return results
+    else:
+        if seq_len < 1:
+            results["err"] = f"seq_len ({seq_len}) must be >= 1"
+            return results
+        if seqlen_kv is not None and seqlen_kv < 1:
+            results["err"] = f"seqlen_kv ({seqlen_kv}) must be >= 1"
+            return results
+        vl_q = vl_kv = None
+
+    H, D = num_heads, head_dim
     H_KV = num_kv_heads
     setup_seed(seed)
 
     # Host bf16 master tensors -> per-tensor e4m3fn + shape-[1] fp32 descales.
-    q_bf16 = torch.empty(B, S, H, D, dtype=torch.bfloat16, device=device).uniform_(*UNIFORM_RANGE)
-    k_bf16 = torch.empty(B, S, H_KV, D, dtype=torch.bfloat16, device=device).uniform_(*UNIFORM_RANGE)
-    v_bf16 = torch.empty(B, S, H_KV, D, dtype=torch.bfloat16, device=device).uniform_(*UNIFORM_RANGE)
+    if varlen:
+        B = len(vl_q)
+        cuq = [0]
+        for s in vl_q:
+            cuq.append(cuq[-1] + s)
+        cukv = [0]
+        for s in vl_kv:
+            cukv.append(cukv[-1] + s)
+        total_q, total_kv = cuq[-1], cukv[-1]
+        cross = any(a != b for a, b in zip(vl_q, vl_kv))
+        cu_q_t = torch.tensor(cuq, dtype=torch.int32, device=device)
+        cu_kv_t = torch.tensor(cukv, dtype=torch.int32, device=device)
+        q_bf16 = torch.empty(total_q, H, D, dtype=torch.bfloat16, device=device).uniform_(*UNIFORM_RANGE)
+        k_bf16 = torch.empty(total_kv, H_KV, D, dtype=torch.bfloat16, device=device).uniform_(*UNIFORM_RANGE)
+        v_bf16 = torch.empty(total_kv, H_KV, Dv, dtype=torch.bfloat16, device=device).uniform_(*UNIFORM_RANGE)
+        o_shape = (total_q, H, Dv)
+        S, Skv = max(vl_q), max(vl_kv)
+        pairs = sum(_score_pairs(a, b, causal) for a, b in zip(vl_q, vl_kv))
+    else:
+        B, S = batch, seq_len
+        Skv = seq_len if seqlen_kv is None else seqlen_kv
+        cross = Skv != S
+        cu_q_t = cu_kv_t = None
+        q_bf16 = torch.empty(B, S, H, D, dtype=torch.bfloat16, device=device).uniform_(*UNIFORM_RANGE)
+        k_bf16 = torch.empty(B, Skv, H_KV, D, dtype=torch.bfloat16, device=device).uniform_(*UNIFORM_RANGE)
+        v_bf16 = torch.empty(B, Skv, H_KV, Dv, dtype=torch.bfloat16, device=device).uniform_(*UNIFORM_RANGE)
+        o_shape = (B, S, H, Dv)
+        pairs = B * _score_pairs(S, Skv, causal)
+
     q_fp8, q_descale = quantize_per_tensor_fp8(q_bf16)
     k_fp8, k_descale = quantize_per_tensor_fp8(k_bf16)
     v_fp8, v_descale = quantize_per_tensor_fp8(v_bf16)
 
-    o_bf16 = torch.zeros(B, S, H, D, dtype=torch.bfloat16, device=device)
+    o_bf16 = torch.zeros(*o_shape, dtype=torch.bfloat16, device=device)
     fp8_exec_kwargs = dict(q_descale=q_descale, k_descale=k_descale, v_descale=v_descale)
+    if varlen:
+        fp8_exec_kwargs.update(
+            cu_seqlens_q=cu_q_t,
+            cu_seqlens_kv=cu_kv_t,
+            max_seqlen_q=S,
+            cross_seqlen=cross,
+        )
+        if cross:
+            fp8_exec_kwargs["max_seqlen_kv"] = Skv
+    if int(num_kv_splits) > 1:
+        fp8_exec_kwargs["num_kv_splits"] = int(num_kv_splits)
 
     try:
         flydsl_flash_attn_func(
@@ -1709,20 +1843,30 @@ def run_fp8_config(
     o_flat = o_bf16.contiguous().view(-1)
 
     # Reference: dequantize the SAME e4m3fn Q/K/V (applying descales) and run the
-    # high-precision SDPA reference the bf16 path uses.
-    ref_4d = pytorch_ref_attention(
-        _dequant_fp8(q_fp8, q_descale),
-        _dequant_fp8(k_fp8, k_descale),
-        _dequant_fp8(v_fp8, v_descale),
-        causal=causal,
-    )
-    ref_flat = ref_4d.to(torch.float32).contiguous().view(-1)
+    q_ref = _dequant_fp8(q_fp8, q_descale)
+    k_ref = _dequant_fp8(k_fp8, k_descale)
+    v_ref = _dequant_fp8(v_fp8, v_descale)
+    if varlen:
+        ref_t = torch.empty(o_shape, dtype=torch.float32, device=device)
+        for b in range(B):
+            ref_fn = pytorch_ref_attention if (vl_q[b] == vl_kv[b] and D == Dv) else pytorch_ref_attention_qkv_diff
+            ref_t[cuq[b] : cuq[b + 1]] = ref_fn(
+                q_ref[cuq[b] : cuq[b + 1]].unsqueeze(0),
+                k_ref[cukv[b] : cukv[b + 1]].unsqueeze(0),
+                v_ref[cukv[b] : cukv[b + 1]].unsqueeze(0),
+                causal=causal,
+            ).squeeze(0)
+        ref_out = ref_t
+    else:
+        ref_fn = pytorch_ref_attention if (not cross and D == Dv) else pytorch_ref_attention_qkv_diff
+        ref_out = ref_fn(q_ref, k_ref, v_ref, causal=causal)
+    ref_flat = ref_out.to(torch.float32).contiguous().view(-1)
 
     o_f32 = o_flat.float()
     ref_f32 = ref_flat.float()
     max_err = (o_f32 - ref_f32).abs().max().item()
     mean_err = (o_f32 - ref_f32).abs().mean().item()
-    cos_sim = F.cosine_similarity(o_f32.reshape(-1, D), ref_f32.reshape(-1, D), dim=1)
+    cos_sim = F.cosine_similarity(o_f32.reshape(-1, Dv), ref_f32.reshape(-1, Dv), dim=1)
     min_cos = cos_sim.min().item()
     results["max_err"] = max_err
     results["mean_err"] = mean_err
@@ -1730,12 +1874,16 @@ def run_fp8_config(
     results["passed"] = max_err < FP8_MAX_ERR and min_cos > FP8_MIN_COS
 
     if verbose:
-        tag = f"B={B} S={S} H={H} D={D} fp8"
-        print(f"  [{tag}] --- compare_arrays ---")
+        shape_tag = f"varlen q={vl_q} kv={vl_kv}" if varlen else f"B={B} S={S} Skv={Skv}"
+        d_tag = f"D={D}" if D == Dv else f"D={D} Dv={Dv}"
+        print(f"  [{shape_tag} H={H} {d_tag} kv_sp={num_kv_splits} fp8] --- compare_arrays ---")
         compare_arrays(
             o_f32.detach().cpu().numpy(),
             ref_f32.detach().cpu().numpy(),
         )
+
+    if not bench:
+        return results
 
     try:
 
@@ -1768,10 +1916,8 @@ def run_fp8_config(
             torch.cuda.synchronize()
 
         _, us = run_perftest(kernel_fn, num_iters=iters, num_warmup=warmup)
-        s_eff = S / 2.0 if causal else float(S)
-        flops = 4.0 * S * s_eff * D * H * B
         results["us"] = us
-        results["tflops"] = flops / (us * 1e-6) / 1e12
+        results["tflops"] = _fp8_flops(pairs, H, D, Dv) / (us * 1e-6) / 1e12
     except Exception as e:
         # A failed timing path must not be reportable as a clean PASS-with-N/A row.
         # Keep the correctness numbers visible but mark the row not-passed so the
@@ -2508,13 +2654,13 @@ def _fmt_normal_row(cfg, path, status, r):
 
 
 _EXTRA_HDR = (
-    f"  {'Sq':<24} {'Skv':<24} {'H':>4} {'Hkv':>4} {'D':>4} " f"{'dtype':>6} {'causal':>8} {'Path':<{_PATH_W}s}"
+    f"  {'Sq':<24} {'Skv':<24} {'H':>4} {'Hkv':>4} {'D':>7} " f"{'dtype':>6} {'causal':>8} {'Path':<{_PATH_W}s}"
 )
 _EXTRA_W = len(_EXTRA_HDR)
 
 
 def _fmt_extra_prefix(sq, skv, nh, nh_kv, hd, dtype_key, causal_tag, path=""):
-    return f"  {sq:<24} {skv:<24} {nh:>4} {nh_kv:>4} {hd:>4} " f"{dtype_key:>6} {causal_tag:>8} {path:<{_PATH_W}s}"
+    return f"  {sq:<24} {skv:<24} {nh:>4} {nh_kv:>4} {hd:>7} " f"{dtype_key:>6} {causal_tag:>8} {path:<{_PATH_W}s}"
 
 
 def _fmt_extra_cmp_row(sq, skv, nh, nh_kv, hd, dtype_key, causal_tag, path, fly_r, ck_r):
@@ -2782,12 +2928,21 @@ def main():
     extra_cases = (
         [_extra_case_from_config(row) for row in EXTRA_CONFIGS] if args.extra and configs is DEFAULT_CONFIGS else []
     )
+    fp8_extra_cases = (
+        [_extra_case_from_config(row) for row in FP8_EXTRA_CONFIGS]
+        if args.extra and configs is DEFAULT_CONFIGS and "fp8" in dtypes_to_test
+        else []
+    )
+    if args.compare and fp8_extra_cases:
+        print("  note: fp8 extra shapes (D/Dv, varlen, split-K) run in normal mode only; skipped under --compare")
+        fp8_extra_cases = []
     run_configs = [
         (batch, seq_len, nh, nh_kv_default, hd, cfg_kv_splits)
         for batch, seq_len, nh, nh_kv_default, cfg_kv_splits in configs
         for hd in head_dims_to_test
     ]
     extra_run_cases = [(case, hd) for case in extra_cases for hd in head_dims_to_test]
+    extra_run_cases += [(case, case["hd"]) for case in fp8_extra_cases]
     paged_kv_paths = [(None, "")]
     if args.block_table:
         paged_kv_paths = [
@@ -3420,13 +3575,15 @@ def main():
                         nh_kv_eff = args.num_kv_heads if args.num_kv_heads is not None else case["nh_kv"]
                         kv_splits = case.get("kv_splits", 1)
                         kwargs = dict(case["kwargs"])
+                        hd_v = case.get("hd_v", hd)
+                        hd_label = hd if hd_v == hd else f"{hd}/{hd_v}"
                         for kv_cache_layout, path in paged_kv_paths:
                             pre = _fmt_extra_prefix(
                                 case["sq_label"],
                                 case["skv_label"],
                                 nh,
                                 nh_kv_eff,
-                                hd,
+                                hd_label,
                                 dtype_key,
                                 ctag,
                                 path=path,
@@ -3462,7 +3619,7 @@ def main():
                                                 case["skv_label"],
                                                 nh,
                                                 nh_kv_eff,
-                                                hd,
+                                                hd_label,
                                                 dtype_key,
                                                 ctag,
                                                 path,
@@ -3489,6 +3646,10 @@ def main():
                                         verbose=False,
                                         num_kv_heads=nh_kv_eff,
                                         num_kv_splits=kv_splits,
+                                        head_dim_v=hd_v,
+                                        seqlen_kv=kwargs.get("seqlen_kv"),
+                                        varlen_seqlens_q=kwargs.get("varlen_seqlens_q"),
+                                        varlen_seqlens_kv=kwargs.get("varlen_seqlens_kv"),
                                     )
                                 else:
                                     r = run_attn_config(
@@ -3523,7 +3684,7 @@ def main():
                                         case["skv_label"],
                                         nh,
                                         nh_kv_eff,
-                                        hd,
+                                        hd_label,
                                         dtype_key,
                                         ctag,
                                         path,
@@ -3541,7 +3702,7 @@ def main():
                                         case["skv_label"],
                                         nh,
                                         nh_kv_eff,
-                                        hd,
+                                        hd_label,
                                         dtype_key,
                                         ctag,
                                         path,
@@ -3559,7 +3720,7 @@ def main():
                                         case["skv_label"],
                                         nh,
                                         nh_kv_eff,
-                                        hd,
+                                        hd_label,
                                         dtype_key,
                                         ctag,
                                         path,
@@ -3582,7 +3743,7 @@ def main():
                                     case["skv_label"],
                                     nh,
                                     nh_kv_eff,
-                                    hd,
+                                    hd_label,
                                     dtype_key,
                                     ctag,
                                     path,
@@ -4598,6 +4759,27 @@ def test_sink_splitk_counted_once(num_kv_splits):
 
 
 @_requires_gfx950
+@pytest.mark.parametrize("Sq,Skv", [(512, 4096), (4096, 512)])
+@pytest.mark.parametrize("causal", [False, True])
+def test_splitk_rejects_cross_length_kv(Sq, Skv, causal):
+    """Dense split-K is self-attention only, and it used to fail without saying so.
+
+    `_build_splitk` never passes cross_seqlen, so the kernel derives its KV extent
+    from Sq: Sq=512/Skv=4096 returned garbage (cosine ~0.23 -- only the first Sq
+    keys are read) and Sq=4096/Skv=512 read past the KV buffer and faulted the GPU.
+    Both directions must now raise before any launch.
+    """
+    dtype = torch.bfloat16
+    B, H, D = 1, 8, 128
+    setup_seed(DEFAULT_SEED)
+    q = torch.empty(B, Sq, H, D, dtype=dtype, device="cuda").uniform_(*UNIFORM_RANGE)
+    k = torch.empty(B, Skv, H, D, dtype=dtype, device="cuda").uniform_(*UNIFORM_RANGE)
+    v = torch.empty(B, Skv, H, D, dtype=dtype, device="cuda").uniform_(*UNIFORM_RANGE)
+    with pytest.raises(ValueError, match="seq_len_kv == seq_len_q"):
+        flydsl_flash_attn_func(q, k, v, causal=causal, num_kv_splits=4)
+
+
+@_requires_gfx950
 @pytest.mark.parametrize("Sq,Skv", [(512, 128), (512, 160)])
 def test_sink_lse_cross_attn_skipped_blocks(Sq, Skv):
     """Causal cross-attention with Skv < Sq skips whole q blocks that see no key.
@@ -4887,3 +5069,130 @@ def test_fp8_default_is_the_lazy_rescale():
     lazy = (lazy[0] if isinstance(lazy, (tuple, list)) else lazy).float()
 
     torch.testing.assert_close(default, lazy, rtol=0, atol=0)
+
+
+
+_FP8_HEADS = 12
+_FP8_D, _FP8_DV = 192, 128
+
+
+def _assert_fp8_shape(causal, batch=1, seq_len=1, head_dim=_FP8_D, head_dim_v=_FP8_DV, **kwargs):
+    """Correctness-only run of one fp8 shape, asserted against the fp8 gate.
+
+    bench=False keeps the profiler and timing loop out of the unit run; the
+    benchmark numbers for these shapes come from the CLI harness.
+    """
+    r = run_fp8_config(
+        batch,
+        seq_len,
+        _FP8_HEADS,
+        head_dim,
+        causal,
+        warmup=0,
+        iters=1,
+        verbose=False,
+        bench=False,
+        head_dim_v=head_dim_v,
+        **kwargs,
+    )
+    assert "err" not in r, r["err"]
+    assert r["passed"], (
+        f"fp8 gate: max_err={r['max_err']:.3e} (< {FP8_MAX_ERR}), "
+        f"min_cos={r['min_cos']:.5f} (> {FP8_MIN_COS})"
+    )
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("batch,seq_len", [(1, 4096), (2, 4096), (3, 4096), (4, 4096), (1, 8192)])
+def test_fp8_head_dim_192_v_128_dense(causal, batch, seq_len):
+    """Dense self-attention with QK head_dim 192 and a 128-wide V.
+
+    Q/K are [B, S, 12, 192], V is [B, S, 12, 128], and the output follows V.
+    """
+    _assert_fp8_shape(causal, batch=batch, seq_len=seq_len)
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("batch", FP8_VARLEN_BATCHES)
+def test_fp8_head_dim_192_v_128_varlen(causal, batch):
+    """Packed varlen self-attention over 2614 tokens, batch 1..4.
+
+    Q/K are [2614, 12, 192] and V is [2614, 12, 128] at every batch -- only the
+    cu_seqlens partition changes (batch 2 is [0, 1024, 2614]). Q and KV share the
+    per-sequence lengths, so only the V head dim differs here.
+    """
+    _assert_fp8_shape(causal, varlen_seqlens_q=FP8_VARLEN_Q_SEQLENS[batch])
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("batch", FP8_VARLEN_BATCHES)
+def test_fp8_head_dim_192_v_128_varlen_cross_length(causal, batch):
+    """Packed varlen cross-attention, batch 1..4: 2614 Q tokens vs 16384 KV tokens.
+
+    Q is [2614, 12, 192], K is [16384, 12, 192] and V is [16384, 12, 128] at every
+    batch; batch 2 is cu_seqlens_q [0, 1024, 2614] / cu_seqlens_kv [0, 8192, 16384].
+    Causal here is bottom-right aligned, which is what the reference applies too.
+    """
+    _assert_fp8_shape(
+        causal,
+        varlen_seqlens_q=FP8_VARLEN_Q_SEQLENS[batch],
+        varlen_seqlens_kv=FP8_VARLEN_KV_SEQLENS[batch],
+    )
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("num_kv_splits", FP8_SPLITKV_SPLITS)
+@pytest.mark.parametrize("head_dim,head_dim_v", [(128, 128), (192, 128)])
+def test_fp8_split_kv(causal, num_kv_splits, head_dim, head_dim_v):
+    """fp8 split-KV: the KV dimension split across workgroups plus a combine pass.
+
+    The 128/128 pair isolates the split from the new head-dim pair, so a failure
+    points at one feature or the other rather than both at once.
+    """
+    _assert_fp8_shape(
+        causal,
+        batch=1,
+        seq_len=8192,
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        num_kv_splits=num_kv_splits,
+    )
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("batch", (1, 2, 3, 4))
+def test_fp8_split_kv_batched(causal, batch):
+    """Split-KV over batches: the grid is B * num_kv_splits deep, so the batch is
+    what decides whether splitting still fills the GPU."""
+    _assert_fp8_shape(causal, batch=batch, seq_len=8192, num_kv_splits=4)
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("seq_len,seqlen_kv,num_kv_splits", [(512, 16384, 8), (2614, 16384, 8), (1024, 32768, 16)])
+def test_fp8_split_kv_cross_length(causal, seq_len, seqlen_kv, num_kv_splits):
+    """Split-KV with short Q against long KV -- the shape split-KV exists for.
+
+    Sq < Skv in every case on purpose: with num_kv_splits > 1 the kernel ignores
+    cross_seqlen today, and Sq > Skv reads past the KV buffer (the bf16 path
+    faults the GPU), so that direction is left out rather than tested.
+    """
+    _assert_fp8_shape(causal, batch=1, seq_len=seq_len, seqlen_kv=seqlen_kv, num_kv_splits=num_kv_splits)
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("seq_len,num_kv_splits", list(zip(FP8_SPLITKV_SEQLENS, FP8_SPLITKV_SPLITS)))
+def test_fp8_split_kv_long_sequence(causal, seq_len, num_kv_splits):
+    """Split count scaled with the KV length, 4k/2 through 32k/16.
+
+    32k also crosses the fp8 long-sequence bound where the rescale threshold
+    drops from 6 to 4 (see test_fp8_rescale_threshold_drops_past_the_long_sequence_bound),
+    so the split path is covered on both sides of that build variant.
+    """
+    _assert_fp8_shape(causal, batch=1, seq_len=seq_len, num_kv_splits=num_kv_splits)

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -169,31 +169,24 @@ FP8_VARLEN_BATCHES = (1, 2, 3, 4)
 FP8_SPLITKV_SPLITS = (2, 4, 8, 16)
 FP8_SPLITKV_SEQLENS = (4096, 8192, 16384, 32768)
 
-FP8_EXTRA_CONFIGS = [
-    [FP8_VARLEN_Q_SEQLENS[b], None, None, 12, 12, 1, 192, 128]
-    for b in FP8_VARLEN_BATCHES
-] + [
-    [FP8_VARLEN_Q_SEQLENS[b], FP8_VARLEN_KV_SEQLENS[b], None, 12, 12, 1, 192, 128]
-    for b in FP8_VARLEN_BATCHES
-] + [
-    [seq, seq, b, 12, 12, 1, 192, 128]
-    for seq in (4096, 8192, 16384, 32768)
-    for b in ((1, 2) if seq == 32768 else (1, 2, 3, 4))
-] + [
-    [seq, seq, 1, 12, 12, sp, 192, 128]
-    for seq, sp in zip(FP8_SPLITKV_SEQLENS, FP8_SPLITKV_SPLITS)
-] + [
-    [8192, 8192, b, 12, 12, 4, 192, 128]
-    for b in (2, 3, 4)
-] + [
-    [8192, 8192, 1, 12, 12, sp, 128, 128]
-    for sp in FP8_SPLITKV_SPLITS
-] + [
-    [512, 16384, 1, 12, 12, 8, 192, 128],
-    [2614, 16384, 1, 12, 12, 8, 192, 128],
-    [1024, 32768, 1, 12, 12, 16, 192, 128],
-    [512, 16384, 4, 12, 12, 8, 192, 128],
-]
+FP8_EXTRA_CONFIGS = (
+    [[FP8_VARLEN_Q_SEQLENS[b], None, None, 12, 12, 1, 192, 128] for b in FP8_VARLEN_BATCHES]
+    + [[FP8_VARLEN_Q_SEQLENS[b], FP8_VARLEN_KV_SEQLENS[b], None, 12, 12, 1, 192, 128] for b in FP8_VARLEN_BATCHES]
+    + [
+        [seq, seq, b, 12, 12, 1, 192, 128]
+        for seq in (4096, 8192, 16384, 32768)
+        for b in ((1, 2) if seq == 32768 else (1, 2, 3, 4))
+    ]
+    + [[seq, seq, 1, 12, 12, sp, 192, 128] for seq, sp in zip(FP8_SPLITKV_SEQLENS, FP8_SPLITKV_SPLITS)]
+    + [[8192, 8192, b, 12, 12, 4, 192, 128] for b in (2, 3, 4)]
+    + [[8192, 8192, 1, 12, 12, sp, 128, 128] for sp in FP8_SPLITKV_SPLITS]
+    + [
+        [512, 16384, 1, 12, 12, 8, 192, 128],
+        [2614, 16384, 1, 12, 12, 8, 192, 128],
+        [1024, 32768, 1, 12, 12, 16, 192, 128],
+        [512, 16384, 4, 12, 12, 8, 192, 128],
+    ]
+)
 
 
 def _short_label(value):
@@ -5071,7 +5064,6 @@ def test_fp8_default_is_the_lazy_rescale():
     torch.testing.assert_close(default, lazy, rtol=0, atol=0)
 
 
-
 _FP8_HEADS = 12
 _FP8_D, _FP8_DV = 192, 128
 
@@ -5097,8 +5089,7 @@ def _assert_fp8_shape(causal, batch=1, seq_len=1, head_dim=_FP8_D, head_dim_v=_F
     )
     assert "err" not in r, r["err"]
     assert r["passed"], (
-        f"fp8 gate: max_err={r['max_err']:.3e} (< {FP8_MAX_ERR}), "
-        f"min_cos={r['min_cos']:.5f} (> {FP8_MIN_COS})"
+        f"fp8 gate: max_err={r['max_err']:.3e} (< {FP8_MAX_ERR}), " f"min_cos={r['min_cos']:.5f} (> {FP8_MIN_COS})"
     )
 
 

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -5095,7 +5095,6 @@ def _assert_fp8_shape(causal, batch=1, seq_len=1, head_dim=_FP8_D, head_dim_v=_F
     )
 
 
-# `1` pins the unsplit kernel, `None` is the shipped default (autotuned).
 FP8_SPLIT_MODES = [pytest.param(1, id="dense"), pytest.param(None, id="autosplit")]
 
 
@@ -5199,14 +5198,6 @@ def test_fp8_split_kv_long_sequence(causal, seq_len, num_kv_splits):
     _assert_fp8_shape(causal, batch=1, seq_len=seq_len, num_kv_splits=num_kv_splits)
 
 
-# ── regressions for the split-K combine row mapping ─────────────────────────
-
-
-def _fp8_combine_rows_per_block(head_dim_v):
-    """Output rows one combine workgroup covers: 256 threads / (head_dim_v/4) lanes."""
-    return 256 // (head_dim_v // 4)
-
-
 def _run_fp8_into_nan_out(q, k, v, head_dim_v, **kwargs):
     """Launch fp8 attention into a NaN-filled ``out`` so unwritten rows are countable."""
     fp8 = torch.float8_e4m3fn
@@ -5233,7 +5224,7 @@ def _run_fp8_into_nan_out(q, k, v, head_dim_v, **kwargs):
 def test_fp8_auto_split_kv_writes_every_row(batch, seq_len, num_heads):
     """Auto split-K must not drop the tail of the combine grid."""
     D = 128
-    assert (batch * num_heads * seq_len) % _fp8_combine_rows_per_block(D) != 0, "shape would not exercise the tail"
+    assert (batch * num_heads * seq_len) % (256 // (D // 4)) != 0, "shape would not exercise the tail"
     torch.manual_seed(0)
     q, k, v = (torch.randn(batch, seq_len, num_heads, D, device="cuda", dtype=torch.bfloat16) * 0.1 for _ in range(3))
     out = _run_fp8_into_nan_out(q, k, v, D, causal=False, num_kv_heads=num_heads)
@@ -5268,9 +5259,6 @@ def test_fp8_varlen_split_kv_respects_batch_boundaries(seq_len, num_heads, head_
     torch.testing.assert_close(split.float(), unsplit.float(), rtol=2e-2, atol=2e-2)
 
 
-# ── head-dim validation ────────────────────────────────────────────────────
-
-
 @_requires_gfx950
 @pytest.mark.parametrize("head_dim_v", [64, 96, 128, 160, 192])
 def test_fp8_supported_v_head_dims_run(head_dim_v):
@@ -5287,7 +5275,6 @@ def test_fp8_supported_v_head_dims_run(head_dim_v):
         (128, 224, "head_dim_v"),
         (128, 256, "head_dim_v"),
         (96, 96, "head_dim"),
-        # Within the head-dim rules but over the LDS budget.
         (256, 192, "LDS"),
         (320, 128, "LDS"),
         (384, 64, "LDS"),
@@ -5311,27 +5298,19 @@ def test_fp8_dense_ragged_seq_lens(seq_len):
     _assert_fp8_shape(True, batch=2, seq_len=seq_len, num_heads=4, head_dim=192, head_dim_v=128)
 
 
-# ── what the auto-heuristics pick ──────────────────────────────────────────
-
-
 _NUM_CU = 256
 
 
 @pytest.mark.parametrize(
     "batch,num_heads,seqlen_q,seqlen_kv,causal,expect",
     [
-        # Narrow only while the 128-row tile still fits the GPU in one round.
         (1, 8, 512, 512, True, 128),
         (1, 8, 2048, 2048, True, 128),
         (1, 8, 2048, 2048, False, 128),
-        # Same rule for causal and non-causal: once the GPU is full, stay wide.
-        # An inverted causal rule picks 128 for these three and loses ~20%.
         (8, 32, 2048, 2048, True, 256),
         (16, 32, 1024, 1024, True, 256),
         (32, 32, 512, 512, True, 256),
         (1, 8, 2048, 2048, True, 128),
-        # Long KV goes wide even at one workgroup per CU: the narrow tile inflates
-        # the workgroup estimate and talks the split autotuner out of a split.
         (1, 8, 4096, 4096, True, 256),
         (1, 8, 4096, 16384, True, 256),
         (2, 8, 4096, 4096, True, 256),
@@ -5356,11 +5335,8 @@ def test_fp8_auto_block_m_rule_does_not_depend_on_causal():
 @pytest.mark.parametrize(
     "batch,num_heads,seqlen,causal,expect",
     [
-        # Too few KV tiles per split to amortise the fixed per-workgroup cost.
         (1, 8, 512, False, 1),
-        # An under-filled GPU with enough KV tiles to share out.
         (1, 8, 4096, False, 2),
-        # The GPU is already full, so splitting only adds a combine pass.
         (32, 32, 8192, False, 1),
     ],
 )
@@ -5373,7 +5349,6 @@ def test_fp8_auto_kv_splits_picks(batch, num_heads, seqlen, causal, expect):
     "batch,causal,cross,num_kv_splits,expect",
     [
         (2, True, False, 1, 2),
-        # An odd batch cannot be folded 2-at-a-time; the kernel would drop one.
         (3, True, False, 1, 1),
         (2, False, False, 1, 1),
         (2, True, True, 1, 1),

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -1716,12 +1716,6 @@ def run_fp8_config(
       - ``num_kv_splits``: ``None`` autotunes, ``1`` pins the unsplit kernel,
         ``> 1`` forces that many KV splits.
 
-    Only configurations that can never be valid (wrong arch, indivisible head
-    counts, malformed lengths) are rejected here. Anything the kernel does not
-    implement yet reaches it and surfaces the launcher's own message as an ERROR
-    row -- never a silent SKIP, and never a stale gate in this harness that would
-    keep rejecting a shape after the kernel gains support for it.
-
     Returns a run_config-compatible dict so it prints through the same summary
     table. ``bench=False`` skips the timing pass and returns correctness only.
     """
@@ -4755,13 +4749,7 @@ def test_sink_splitk_counted_once(num_kv_splits):
 @pytest.mark.parametrize("Sq,Skv", [(512, 4096), (4096, 512)])
 @pytest.mark.parametrize("causal", [False, True])
 def test_splitk_rejects_cross_length_kv(Sq, Skv, causal):
-    """Dense split-K is self-attention only, and it used to fail without saying so.
-
-    `_build_splitk` never passes cross_seqlen, so the kernel derives its KV extent
-    from Sq: Sq=512/Skv=4096 returned garbage (cosine ~0.23 -- only the first Sq
-    keys are read) and Sq=4096/Skv=512 read past the KV buffer and faulted the GPU.
-    Both directions must now raise before any launch.
-    """
+    """Dense split-K is self-attention only, and it used to fail without saying so."""
     dtype = torch.bfloat16
     B, H, D = 1, 8, 128
     setup_seed(DEFAULT_SEED)
@@ -5129,12 +5117,7 @@ def test_fp8_head_dim_192_v_128_varlen(causal, batch, num_kv_splits):
 @pytest.mark.parametrize("batch", FP8_VARLEN_BATCHES)
 @pytest.mark.parametrize("num_kv_splits", FP8_SPLIT_MODES)
 def test_fp8_head_dim_192_v_128_varlen_cross_length(causal, batch, num_kv_splits):
-    """Packed varlen cross-attention, batch 1..4: 2614 Q tokens vs 16384 KV tokens.
-
-    Q is [2614, 12, 192], K is [16384, 12, 192] and V is [16384, 12, 128] at every
-    batch; batch 2 is cu_seqlens_q [0, 1024, 2614] / cu_seqlens_kv [0, 8192, 16384].
-    Causal here is bottom-right aligned, which is what the reference applies too.
-    """
+    """Packed varlen cross-attention, batch 1..4: 2614 Q tokens vs 16384 KV tokens."""
     _assert_fp8_shape(
         causal,
         varlen_seqlens_q=FP8_VARLEN_Q_SEQLENS[batch],
@@ -5176,12 +5159,7 @@ def test_fp8_split_kv_batched(causal, batch):
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("seq_len,seqlen_kv,num_kv_splits", [(512, 16384, 8), (2614, 16384, 8), (1024, 32768, 16)])
 def test_fp8_split_kv_cross_length(causal, seq_len, seqlen_kv, num_kv_splits):
-    """Split-KV with short Q against long KV -- the shape split-KV exists for.
-
-    Sq < Skv in every case on purpose: with num_kv_splits > 1 the kernel ignores
-    cross_seqlen today, and Sq > Skv reads past the KV buffer (the bf16 path
-    faults the GPU), so that direction is left out rather than tested.
-    """
+    """Split-KV with short Q against long KV -- the shape split-KV exists for."""
     _assert_fp8_shape(causal, batch=1, seq_len=seq_len, seqlen_kv=seqlen_kv, num_kv_splits=num_kv_splits)
 
 
@@ -5189,12 +5167,7 @@ def test_fp8_split_kv_cross_length(causal, seq_len, seqlen_kv, num_kv_splits):
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("seq_len,num_kv_splits", list(zip(FP8_SPLITKV_SEQLENS, FP8_SPLITKV_SPLITS)))
 def test_fp8_split_kv_long_sequence(causal, seq_len, num_kv_splits):
-    """Split count scaled with the KV length, 4k/2 through 32k/16.
-
-    32k also crosses the fp8 long-sequence bound where the rescale threshold
-    drops from 6 to 4 (see test_fp8_rescale_threshold_drops_past_the_long_sequence_bound),
-    so the split path is covered on both sides of that build variant.
-    """
+    """Split count scaled with the KV length, 4k/2 through 32k/16."""
     _assert_fp8_shape(causal, batch=1, seq_len=seq_len, num_kv_splits=num_kv_splits)
 
 

--- a/tests/kernels/test_flash_attn_fwd.py
+++ b/tests/kernels/test_flash_attn_fwd.py
@@ -5068,7 +5068,7 @@ _FP8_HEADS = 12
 _FP8_D, _FP8_DV = 192, 128
 
 
-def _assert_fp8_shape(causal, batch=1, seq_len=1, head_dim=_FP8_D, head_dim_v=_FP8_DV, **kwargs):
+def _assert_fp8_shape(causal, batch=1, seq_len=1, head_dim=_FP8_D, head_dim_v=_FP8_DV, num_heads=_FP8_HEADS, **kwargs):
     """Correctness-only run of one fp8 shape, asserted against the fp8 gate.
 
     bench=False keeps the profiler and timing loop out of the unit run; the
@@ -5077,7 +5077,7 @@ def _assert_fp8_shape(causal, batch=1, seq_len=1, head_dim=_FP8_D, head_dim_v=_F
     r = run_fp8_config(
         batch,
         seq_len,
-        _FP8_HEADS,
+        num_heads,
         head_dim,
         causal,
         warmup=0,
@@ -5187,3 +5187,263 @@ def test_fp8_split_kv_long_sequence(causal, seq_len, num_kv_splits):
     so the split path is covered on both sides of that build variant.
     """
     _assert_fp8_shape(causal, batch=1, seq_len=seq_len, num_kv_splits=num_kv_splits)
+
+
+# ── regressions for the split-K combine row mapping ─────────────────────────
+
+
+def _fp8_combine_rows_per_block(head_dim_v):
+    """Output rows one combine workgroup covers: 256 threads / (head_dim_v/4) lanes."""
+    return 256 // (head_dim_v // 4)
+
+
+def _run_fp8_into_nan_out(q, k, v, head_dim_v, **kwargs):
+    """Launch fp8 attention into a NaN-filled ``out`` and return it.
+
+    A zero-initialised buffer hides rows the kernel never writes; NaN makes them
+    countable, which is the whole point of these two tests.
+    """
+    fp8 = torch.float8_e4m3fn
+    fp8_max = torch.finfo(fp8).max
+    scales = [t.abs().amax().float().clamp(min=1e-12) / fp8_max for t in (q, k, v)]
+    qq, kq, vq = ((t.float() / s).to(fp8).contiguous() for t, s in zip((q, k, v), scales))
+    descales = [s.reshape(1).contiguous() for s in scales]
+    out = torch.full(q.shape[:-1] + (head_dim_v,), float("nan"), device=q.device, dtype=torch.bfloat16)
+    flydsl_flash_attn_func(
+        qq,
+        kq,
+        vq,
+        out=out,
+        q_descale=descales[0],
+        k_descale=descales[1],
+        v_descale=descales[2],
+        **kwargs,
+    )
+    return out
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("batch,seq_len,num_heads", [(1, 4097, 1), (1, 4097, 3), (1, 2050, 7), (1, 8193, 1)])
+def test_fp8_auto_split_kv_writes_every_row(batch, seq_len, num_heads):
+    """Auto split-K must not drop the tail of the combine grid.
+
+    ``batch * num_heads * seq_len`` is deliberately not a multiple of
+    COMBINE_ROWS_PER_BLOCK (8 at head_dim_v=128), which a floor-divided combine
+    grid leaves unwritten. No ``num_kv_splits`` is passed: the point is that a
+    caller who never asked for split-K still gets every row.
+    """
+    D = 128
+    assert (batch * num_heads * seq_len) % _fp8_combine_rows_per_block(D) != 0, "shape would not exercise the tail"
+    torch.manual_seed(0)
+    q, k, v = (torch.randn(batch, seq_len, num_heads, D, device="cuda", dtype=torch.bfloat16) * 0.1 for _ in range(3))
+    out = _run_fp8_into_nan_out(q, k, v, D, causal=False, num_kv_heads=num_heads)
+    assert not torch.isnan(out).any(), f"{int(torch.isnan(out).any(-1).sum())} output rows were never written"
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("seq_len,num_heads,head_dim_v", [(385, 1, 128), (385, 3, 128), (1155, 1, 128), (386, 1, 64)])
+def test_fp8_varlen_split_kv_respects_batch_boundaries(seq_len, num_heads, head_dim_v):
+    """varlen + split-K must not mix batches inside a combine wave.
+
+    A buffer resource is wave-scoped. When ``(max_seqlen_q * num_heads)`` is not a
+    multiple of the rows a wave covers, a batch boundary lands mid-wave; deriving
+    the O descriptor per thread then writes the row after the boundary with the
+    previous batch's descriptor, losing that row and corrupting the previous
+    batch's row 0.
+    """
+    rows_per_wave = 256 // head_dim_v
+    assert (seq_len * num_heads) % rows_per_wave != 0, "shape would not straddle a wave"
+    B, D = 8, 192
+    torch.manual_seed(0)
+    cu = torch.arange(0, (B + 1) * seq_len, seq_len, device="cuda", dtype=torch.int32)
+    total = B * seq_len
+    q = torch.randn(total, num_heads, D, device="cuda", dtype=torch.bfloat16) * 0.1
+    k = torch.randn(total, num_heads, D, device="cuda", dtype=torch.bfloat16) * 0.1
+    v = torch.randn(total, num_heads, head_dim_v, device="cuda", dtype=torch.bfloat16) * 0.1
+    kw = dict(
+        causal=False,
+        num_kv_heads=num_heads,
+        cu_seqlens_q=cu,
+        cu_seqlens_kv=cu,
+        max_seqlen_q=seq_len,
+        max_seqlen_kv=seq_len,
+        cross_seqlen=False,
+    )
+    split = _run_fp8_into_nan_out(q, k, v, head_dim_v, num_kv_splits=2, **kw)
+    assert not torch.isnan(split).any(), f"{int(torch.isnan(split).any(-1).sum())} output rows were never written"
+    unsplit = _run_fp8_into_nan_out(q, k, v, head_dim_v, num_kv_splits=1, **kw)
+    torch.testing.assert_close(split.float(), unsplit.float(), rtol=2e-2, atol=2e-2)
+
+
+# ── head-dim validation ────────────────────────────────────────────────────
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("head_dim_v", [64, 96, 128, 160, 192])
+def test_fp8_supported_v_head_dims_run(head_dim_v):
+    """Every head_dim_v the guard admits has to actually produce the right answer."""
+    _assert_fp8_shape(False, batch=1, seq_len=512, num_heads=4, head_dim=128, head_dim_v=head_dim_v)
+
+
+@_requires_gfx950
+@pytest.mark.parametrize(
+    "head_dim,head_dim_v,match",
+    [
+        # D_CHUNKS < 2: `_anchor_v_o` emits a single-element inline-asm struct and
+        # LLVM aborts the process rather than failing the build.
+        (128, 32, "head_dim_v"),
+        # D_CHUNKS > 6: launches, but the high D_CHUNKs come back wrong.
+        (128, 224, "head_dim_v"),
+        (128, 256, "head_dim_v"),
+        # Fits neither the QK MFMA slicing nor a clean band split.
+        (96, 96, "head_dim"),
+        # Within the head-dim rules but over the 160 KiB LDS budget. 256/256 is
+        # the shape people ask about; it trips the head_dim_v rule first.
+        (256, 192, "LDS"),
+        (320, 128, "LDS"),
+        (384, 64, "LDS"),
+    ],
+)
+def test_fp8_rejected_head_dims_raise_before_launch(head_dim, head_dim_v, match):
+    """Unsupported head dims must name the shape, not abort or fault the GPU."""
+    B, S, H = 1, 512, 4
+    torch.manual_seed(0)
+    q = torch.randn(B, S, H, head_dim, device="cuda", dtype=torch.bfloat16) * 0.1
+    k = torch.randn(B, S, H, head_dim, device="cuda", dtype=torch.bfloat16) * 0.1
+    v = torch.randn(B, S, H, head_dim_v, device="cuda", dtype=torch.bfloat16) * 0.1
+    with pytest.raises((RuntimeError, ValueError), match=match):
+        _run_fp8_into_nan_out(q, k, v, head_dim_v, causal=False, num_kv_heads=H)
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("seq_len", [1, 385, 1000, 4097])
+def test_fp8_dense_ragged_seq_lens(seq_len):
+    """Dense fp8 on sequence lengths that are not multiples of the tile."""
+    _assert_fp8_shape(True, batch=2, seq_len=seq_len, num_heads=4, head_dim=192, head_dim_v=128)
+
+
+# ── what the auto-heuristics pick ──────────────────────────────────────────
+
+
+_NUM_CU = 256
+
+
+@pytest.mark.parametrize(
+    "batch,num_heads,seqlen_q,seqlen_kv,causal,expect",
+    [
+        # Narrow only while the 128-row tile still fits the GPU in one round.
+        (1, 8, 512, 512, True, 128),
+        (1, 8, 2048, 2048, True, 128),
+        (1, 8, 2048, 2048, False, 128),
+        # Same rule for causal and non-causal: once the GPU is full, stay wide.
+        # An inverted causal rule picks 128 for these three and loses ~20%.
+        (8, 32, 2048, 2048, True, 256),
+        (16, 32, 1024, 1024, True, 256),
+        (32, 32, 512, 512, True, 256),
+        # A long KV does not on its own force the wide tile: at one workgroup
+        # per CU the narrow tile still measured 12-21% faster here.
+        (1, 8, 4096, 4096, True, 128),
+        (1, 8, 4096, 16384, True, 128),
+        # ... but a second batch fills the GPU, and then it does not.
+        (2, 8, 4096, 4096, True, 256),
+    ],
+)
+def test_fp8_auto_block_m_picks(batch, num_heads, seqlen_q, seqlen_kv, causal, expect):
+    """Pin what `_fp8_auto_block_m` chooses.
+
+    Every correctness test passes whichever tile it picks, so an inverted
+    comparison here is invisible without an assertion on the choice itself.
+    """
+    got = flash_attn_interface._fp8_auto_block_m(batch, num_heads, seqlen_q, seqlen_kv, causal, _NUM_CU)
+    assert got == expect
+
+
+def test_fp8_auto_block_m_rule_does_not_depend_on_causal():
+    """The two mask modes share one rule; splitting them is what regressed before."""
+    for batch in (1, 2, 4, 8, 16, 32):
+        for num_heads in (8, 16, 32):
+            for seqlen in (512, 1024, 2048, 4096):
+                assert flash_attn_interface._fp8_auto_block_m(
+                    batch, num_heads, seqlen, seqlen, True, _NUM_CU
+                ) == flash_attn_interface._fp8_auto_block_m(batch, num_heads, seqlen, seqlen, False, _NUM_CU)
+
+
+@pytest.mark.parametrize(
+    "batch,num_heads,seqlen,causal,expect",
+    [
+        # Too few KV tiles per split to amortise the fixed per-workgroup cost.
+        (1, 8, 512, False, 1),
+        # An under-filled GPU with enough KV tiles to share out.
+        (1, 8, 4096, False, 2),
+        # The GPU is already full, so splitting only adds a combine pass.
+        (32, 32, 8192, False, 1),
+    ],
+)
+def test_fp8_auto_kv_splits_picks(batch, num_heads, seqlen, causal, expect):
+    got = flash_attn_interface._fp8_auto_kv_splits(batch, num_heads, seqlen, seqlen, causal, _NUM_CU)
+    assert got == expect
+
+
+@pytest.mark.parametrize(
+    "batch,causal,cross,num_kv_splits,expect",
+    [
+        (2, True, False, 1, 2),
+        # An odd batch cannot be folded 2-at-a-time; the kernel would drop one.
+        (3, True, False, 1, 1),
+        (2, False, False, 1, 1),
+        (2, True, True, 1, 1),
+        (2, True, False, 4, 1),
+    ],
+)
+def test_fp8_batch_interleave_group_picks(batch, causal, cross, num_kv_splits, expect):
+    got = flash_attn_interface._fp8_batch_interleave_group(batch, causal, cross, num_kv_splits)
+    assert got == expect
+
+
+def test_fp8_num_kv_splits_none_is_auto_and_one_is_off(monkeypatch):
+    """``None`` opts into the autotuner; an explicit ``1`` keeps the kernel unsplit."""
+    if get_rocm_arch() != "gfx950":
+        pytest.skip("dense fp8 attention is gfx950-only")
+    seen = []
+    orig = flash_attn_interface._build_dense_fp8
+
+    def spy(**kw):
+        seen.append(kw["num_kv_splits"])
+        return orig(**kw)
+
+    monkeypatch.setattr(flash_attn_interface, "_build_dense_fp8", spy)
+    # Small enough that the autotuner still has idle CUs to fill at the tile
+    # `_fp8_auto_block_m` picks; a shape it would leave unsplit proves nothing.
+    B, S, H, D = 1, 8192, 2, 128
+    torch.manual_seed(0)
+    q, k, v = (torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16) * 0.1 for _ in range(3))
+    for kwargs in ({}, {"num_kv_splits": 1}, {"num_kv_splits": 4}):
+        _run_fp8_into_nan_out(q, k, v, D, causal=True, num_kv_heads=H, **kwargs)
+    auto, off, pinned = seen
+    assert auto > 1, "the default should reach the autotuner"
+    assert off == 1, "an explicit num_kv_splits=1 must stay unsplit"
+    assert pinned == 4
+
+
+@_requires_gfx950
+@pytest.mark.parametrize("seq_len,num_heads,head_dim", [(4097, 1, 128), (2050, 7, 128), (1025, 1, 64)])
+def test_bf16_split_kv_writes_every_row(seq_len, num_heads, head_dim):
+    """The bf16 combine grid shares the fp8 one's rounding, and the same bug.
+
+    ``num_heads * seq_len`` is not a multiple of COMBINE_ROWS_PER_BLOCK, so a
+    floor-divided grid leaves the tail of the last block unwritten. Unlike the
+    fp8 case this needs an explicit ``num_kv_splits`` -- bf16 has no autotuner --
+    which is why it went unnoticed.
+    """
+    B = 1
+    torch.manual_seed(0)
+    q, k, v = (
+        torch.randn(B, seq_len, num_heads, head_dim, device="cuda", dtype=torch.bfloat16) * 0.1 for _ in range(3)
+    )
+    out = torch.full_like(q, float("nan"))
+    flydsl_flash_attn_func(q, k, v, causal=False, num_kv_heads=num_heads, out=out, num_kv_splits=2)
+    assert not torch.isnan(out).any(), f"{int(torch.isnan(out).any(-1).sum())} output rows were never written"
+    unsplit = flydsl_flash_attn_func(q, k, v, causal=False, num_kv_heads=num_heads, num_kv_splits=1)
+    if isinstance(unsplit, (tuple, list)):
+        unsplit = unsplit[0]
+    torch.testing.assert_close(out.float(), unsplit.float(), rtol=2e-3, atol=2e-3)


### PR DESCRIPTION
## Motivation

FlashAttention FP8: Added support for asymmetric head dimensions, variable sequence lengths (varlen), and KV splitting

Perf: MI355X, B=1, H=16, Hkv=1, causal, Skv = 2*Sq


<img width="871" height="446" alt="image" src="https://github.com/user-attachments/assets/54eb2cf4-1aba-46f2-8e6c-d28212718f67" />


