### PR TITLE
[Bugfix] Detach requires_grad tensors before DLPack export

### DIFF
--- a/python/flydsl/compiler/jit_argument.py
+++ b/python/flydsl/compiler/jit_argument.py
@@ -421,6 +421,18 @@ class MemRefJitArg(abc.ABC):
         return self
 
 
+def _detach_if_requires_grad(obj):
+    """Drop autograd before DLPack export.
+
+    ``tensor.__dlpack__()`` raises ``BufferError`` when ``requires_grad`` is
+    set. FlyDSL kernels are forward-only; ``detach()`` shares storage.
+    """
+    if not getattr(obj, "requires_grad", False):
+        return obj
+    detach = getattr(obj, "detach", None)
+    return detach() if detach is not None else obj
+
+
 class DLTensorJitArg(MemRefJitArg):
     """Generic dlpack-backed memref arg: works with *any* ``__dlpack__`` object
     (torch, numpy, jax, cupy, ...) through the DLPack protocol alone.
@@ -441,6 +453,7 @@ class DLTensorJitArg(MemRefJitArg):
         use_32bit_stride: bool = False,
         dynamic_layout: bool = True,
     ):
+        dltensor = _detach_if_requires_grad(dltensor)
         self.dltensor = dltensor
         try:
             dl = dltensor.__dlpack__(stream=-1)
@@ -474,6 +487,7 @@ class DLTensorJitArg(MemRefJitArg):
             if ad is not None:
                 return ad
             t = a.dltensor if hasattr(a, "dltensor") else a
+            t = _detach_if_requires_grad(t)
             return DLTensorAdaptor(t.__dlpack__(stream=-1) if with_stream else t.__dlpack__())
 
         if not self.is_layout_dynamic:
@@ -550,6 +564,7 @@ class TorchTensorJitArg(MemRefJitArg):
         use_32bit_stride: bool = False,
         dynamic_layout: bool = True,
     ):
+        tensor = _detach_if_requires_grad(tensor)
         self.torch_tensor = tensor
         super().__init__(
             element_bits=tensor.element_size() * 8,
@@ -641,7 +656,12 @@ def from_dlpack(
     assumed_align: Optional[int] = None,
     use_32bit_stride: bool = False,
 ) -> DLTensorJitArg:
-    return DLTensorJitArg(tensor, assumed_align, use_32bit_stride, dynamic_layout=False)
+    return DLTensorJitArg(
+        _detach_if_requires_grad(tensor),
+        assumed_align,
+        use_32bit_stride,
+        dynamic_layout=False,
+    )
 
 
 def from_torch_tensor(
@@ -650,7 +670,12 @@ def from_torch_tensor(
     assumed_align: Optional[int] = None,
     use_32bit_stride: bool = False,
 ) -> TorchTensorJitArg:
-    return TorchTensorJitArg(tensor, assumed_align, use_32bit_stride, dynamic_layout=False)
+    return TorchTensorJitArg(
+        _detach_if_requires_grad(tensor),
+        assumed_align,
+        use_32bit_stride,
+        dynamic_layout=False,
+    )
 
 
 def from_c_void_p(

--- a/tests/unit/test_jit_stream_param.py
+++ b/tests/unit/test_jit_stream_param.py
@@ -205,3 +205,23 @@ class TestKernelParameter:
         _vecadd(w, b, c, SIZE, BLOCK_DIM, VEC_WIDTH)
         torch.cuda.synchronize()
         assert torch.allclose(c, w.detach() + b, atol=1e-5)
+
+    def test_from_dlpack_parameter_requires_grad_forward_only(self):
+        """aiter wraps with flyc.from_dlpack, which must export Parameter."""
+        w = torch.nn.Parameter(
+            torch.randn(SIZE, device="cuda", dtype=torch.float32),
+            requires_grad=True,
+        )
+        b = torch.randn(SIZE, device="cuda", dtype=torch.float32)
+        c = torch.empty_like(b)
+        _vecadd(
+            flyc.from_dlpack(w).mark_layout_dynamic(leading_dim=0, divisibility=VEC_WIDTH),
+            flyc.from_dlpack(b).mark_layout_dynamic(leading_dim=0, divisibility=VEC_WIDTH),
+            flyc.from_dlpack(c).mark_layout_dynamic(leading_dim=0, divisibility=VEC_WIDTH),
+            SIZE,
+            BLOCK_DIM,
+            VEC_WIDTH,
+        )
+        torch.cuda.synchronize()
+        assert torch.allclose(c, w.detach() + b, atol=1e-5)
+        assert w.requires_grad

--- a/tests/unit/test_requires_grad_export.py
+++ b/tests/unit/test_requires_grad_export.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""requires_grad tensors must wrap through from_dlpack / from_torch_tensor.
+
+PyTorch refuses ``tensor.__dlpack__()`` when ``requires_grad`` is set
+(``BufferError``). FlyDSL kernels are forward-only, so the wrap path detaches
+(same storage, no copy) before export. aiter calls ``flyc.from_dlpack``
+directly and never hits the ``@jit`` auto-adapt path.
+"""
+
+import pytest
+import torch
+
+import flydsl.compiler as flyc
+from flydsl.compiler.jit_argument import TorchTensorJitArg
+
+pytestmark = pytest.mark.l0_backend_agnostic
+
+
+def _parameter():
+    return torch.nn.Parameter(torch.empty(8, dtype=torch.float32), requires_grad=True)
+
+
+def _fill_data_ptr(arg, live):
+    ctype, fill = arg.__c_abi_spec__()[0]
+    slot = ctype()
+    fill(live, slot)
+    return int(slot.value)
+
+
+def test_from_dlpack_parameter_requires_grad_shares_storage():
+    p = _parameter()
+    arg = flyc.from_dlpack(p)
+    assert not arg.dltensor.requires_grad
+    assert arg.dltensor.data_ptr() == p.data_ptr()
+    assert p.requires_grad
+
+
+def test_from_dlpack_launch_fill_accepts_requires_grad_tensor():
+    """Compiled kernels may receive a live Parameter, not the wrap-time object."""
+    template = flyc.from_dlpack(torch.empty(8, dtype=torch.float32)).mark_layout_dynamic(leading_dim=0)
+    live = _parameter()
+    assert _fill_data_ptr(template, live) == live.data_ptr()
+    assert live.requires_grad
+
+
+def test_from_torch_tensor_parameter_requires_grad_shares_storage():
+    p = _parameter()
+    arg = flyc.from_torch_tensor(p)
+    assert not arg.torch_tensor.requires_grad
+    assert arg.torch_tensor.data_ptr() == p.data_ptr()
+    assert p.requires_grad
+
+
+def test_auto_adapt_parameter_requires_grad_shares_storage():
+    p = _parameter()
+    arg = TorchTensorJitArg(p)
+    assert not arg.torch_tensor.requires_grad
+    assert arg.torch_tensor.data_ptr() == p.data_ptr()
+    assert p.requires_grad


### PR DESCRIPTION
## Summary
PyTorch refuses `tensor.__dlpack__()` when `requires_grad` is set (`BufferError: Can't export tensors that require gradient`). FlyDSL kernels are forward-only, so detach (same storage, no copy) before export.

`@jit` auto-adapt of a raw `torch.Tensor` already avoided this by using `data_ptr()`. aiter and similar callers go through `flyc.from_dlpack(t)` instead, which always calls `__dlpack__()` — `nn.Parameter` and CUDA-graph activations still have `requires_grad=True` even under `no_grad` / `eval()`. That is the gpt-oss gfx950 capture crash.

## Change
Detach in the actual export paths:
- `flyc.from_dlpack` / `DLTensorJitArg.__init__` (wrap-time `__dlpack__`)
- `DLTensorJitArg` launch fill (live tensor may not be the wrap-time object)
- `flyc.from_torch_tensor` / `TorchTensorJitArg` for the same contract

The original Parameter is unchanged.
