### PR TITLE
[Perf][Dialect] Fold redundant index cast pairs in layout lowering

### DIFF
--- a/lib/Dialect/Fly/Transforms/LayoutLowering.cpp
+++ b/lib/Dialect/Fly/Transforms/LayoutLowering.cpp
@@ -14,6 +14,7 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/InferIntRangeInterface.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/CSE.h"
@@ -21,7 +22,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/MathExtras.h"
 
 #include <optional>
@@ -50,22 +50,6 @@ namespace {
 
 /// Depth limit for the narrow-value proof walk; layout index chains are short.
 constexpr unsigned kMaxNarrowProofDepth = 16;
-
-/// Fallback bounds on launch coordinates when no compile-time geometry is known.
-///
-/// These are only reached when the op carries no `upper_bound` and the enclosing
-/// kernel declares no launch geometry; `launchCoordinateBound` prefers either of
-/// those when present.  They are deliberately generous, because a bound that is
-/// too small is unsound rather than merely imprecise: it would let a value that
-/// really does exceed i32 be folded through an i32 round trip.
-///
-/// Workgroup-relative coordinates are bounded by the largest workgroup any
-/// supported target can launch.  HIP caps a workgroup at 1024 work items, so
-/// 2^16 leaves several doublings of headroom while staying far enough below
-/// 2^31 that ordinary scaling of a thread id still folds.  Grid-relative ones
-/// get the full HIP grid limit of 2^31-1.
-constexpr uint64_t kMaxWorkgroupCoordinate = 1u << 16;
-constexpr uint64_t kMaxGridCoordinate = (uint64_t(1) << 31) - 1;
 
 Value castPrintfArg(PatternRewriter &rewriter, Location loc, Value value, std::string &format) {
   Type type = value.getType();
@@ -2970,31 +2954,22 @@ static std::optional<uint64_t> narrowUpperBound(Value v, unsigned depth,
     return std::nullopt;
   auto pop = llvm::make_scope_exit([&] { visited.erase(def); });
 
-  // Launch coordinates are bounded by the launch geometry.  Workgroup-relative
-  // ones stay small; grid-relative ones can reach the grid limit.  An op that
-  // declares its own `upper_bound` is believed over either fallback: the
-  // attribute is a promise from the producer that exceeding it is undefined
-  // behaviour, and it is the only bound that stays correct if the launch
-  // configuration outgrows the constants above.
-  if (isa<gpu::ThreadIdOp, gpu::BlockDimOp, gpu::LaneIdOp, gpu::BlockIdOp, gpu::GridDimOp>(def)) {
-    if (auto declared = def->getAttrOfType<IntegerAttr>("upper_bound"))
-      return declared.getValue().getZExtValue();
-    bool isGrid = isa<gpu::BlockIdOp, gpu::GridDimOp>(def);
-    // The kernel's declared launch geometry is exact where it exists.  Upstream
-    // checks an enclosing gpu.launch, the gpu.func itself, then any
-    // `gpu.known_*_size` on the surrounding function.  `gpu.lane_id` names no
-    // axis, so it keeps the fallback.
-    std::optional<gpu::Dimension> dim =
-        llvm::TypeSwitch<Operation *, std::optional<gpu::Dimension>>(def)
-            .Case<gpu::ThreadIdOp, gpu::BlockDimOp, gpu::BlockIdOp, gpu::GridDimOp>(
-                [](auto indexOp) { return indexOp.getDimension(); })
-            .Default([](Operation *) { return std::nullopt; });
-    if (dim) {
-      auto kind = isGrid ? gpu::DimensionKind::Grid : gpu::DimensionKind::Block;
-      if (auto known = gpu::getKnownDimensionSizeAround(def, kind, *dim))
-        return *known;
+  // Launch coordinates: ask the op for its own range.  Every gpu index op
+  // implements InferIntRangeInterface, and that implementation already prefers
+  // an explicit `upper_bound` attribute, then the launch geometry declared by an
+  // enclosing gpu.launch / gpu.func / `gpu.known_*_size`, and only then its own
+  // implicit maximum (kMaxDim, i.e. uint32_t::max).  Deferring to it keeps this
+  // analysis in step with upstream instead of restating the ordering here.
+  if (auto inferrable = dyn_cast<InferIntRangeInterface>(def)) {
+    if (def->getNumOperands() == 0 && def->getNumResults() == 1) {
+      std::optional<uint64_t> inferred;
+      inferrable.inferResultRanges({}, [&](Value v, const ConstantIntRanges &range) {
+        if (v == def->getResult(0))
+          inferred = range.umax().getZExtValue();
+      });
+      if (inferred)
+        return inferred;
     }
-    return isGrid ? kMaxGridCoordinate : kMaxWorkgroupCoordinate;
   }
 
   auto operandBound = [&](unsigned i) {
@@ -3057,22 +3032,27 @@ static std::optional<uint64_t> narrowUpperBound(Value v, unsigned depth,
     return std::nullopt;
   }
 
-  // Casts narrow or widen, and a signed narrowing can turn a small non-negative
-  // value into a negative one that reads as huge unsigned (index -> i8 -> index
-  // takes 128 to 2^64-128).  Only pass a bound through when it provably
-  // survives: it must fit the destination with the sign bit clear.  An unsigned
-  // cast has no sign bit to flip, so it only has to fit.
+  // Casts narrow or widen, and for the signed form either direction can turn a
+  // small non-negative value into a negative one that reads as huge unsigned.
+  // Narrowing does it by truncating (index -> i8 keeps 128 as -128); widening
+  // does it by sign-extending whatever the narrow type already held (i8 -> index
+  // takes that -128 to 2^64-128).  Both are governed by the *narrower* of the
+  // two types, so check the bound against that one: it must fit with the sign
+  // bit clear.  An unsigned cast has no sign bit to flip and only has to fit.
   if (isa<arith::IndexCastOp, arith::IndexCastUIOp>(def)) {
     auto srcBound = operandBound(0);
     if (!srcBound)
       return std::nullopt;
-    unsigned dstBits = 64;
-    if (auto intTy = dyn_cast<IntegerType>(getElementTypeOrSelf(def->getResult(0).getType())))
-      dstBits = intTy.getWidth();
-    if (dstBits >= 64)
+    auto intWidth = [](Type t) -> unsigned {
+      auto intTy = dyn_cast<IntegerType>(getElementTypeOrSelf(t));
+      return intTy ? intTy.getWidth() : 64; // `index` occupies its full storage
+    };
+    unsigned narrowBits =
+        std::min(intWidth(def->getOperand(0).getType()), intWidth(def->getResult(0).getType()));
+    if (narrowBits >= 64)
       return srcBound;
-    uint64_t limit =
-        isa<arith::IndexCastUIOp>(def) ? (uint64_t(1) << dstBits) : (uint64_t(1) << (dstBits - 1));
+    uint64_t limit = isa<arith::IndexCastUIOp>(def) ? (uint64_t(1) << narrowBits)
+                                                    : (uint64_t(1) << (narrowBits - 1));
     return *srcBound < limit ? srcBound : std::nullopt;
   }
 
@@ -3094,6 +3074,10 @@ static bool isProvablyNarrow(Value v, unsigned bits) {
   std::optional<uint64_t> bound = narrowUpperBound(v, 0, visited);
   if (!bound)
     return false;
+  // An intermediate at least as wide as `index` cannot lose anything, and the
+  // shift below would be undefined for it.
+  if (bits >= 64)
+    return true;
   // Signed casts, so the usable range is one bit smaller.
   return *bound < (uint64_t(1) << (bits - 1));
 }

--- a/lib/Dialect/Fly/Transforms/LayoutLowering.cpp
+++ b/lib/Dialect/Fly/Transforms/LayoutLowering.cpp
@@ -19,7 +19,12 @@
 #include "mlir/Transforms/CSE.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/MathExtras.h"
+
+#include <optional>
 
 #include "flydsl/Dialect/Fly/IR/FlyDialect.h"
 #include "flydsl/Dialect/Fly/Transforms/Passes.h"
@@ -42,6 +47,25 @@ namespace fly {
 } // namespace mlir
 
 namespace {
+
+/// Depth limit for the narrow-value proof walk; layout index chains are short.
+constexpr unsigned kMaxNarrowProofDepth = 16;
+
+/// Fallback bounds on launch coordinates when no compile-time geometry is known.
+///
+/// These are only reached when the op carries no `upper_bound` and the enclosing
+/// kernel declares no launch geometry; `launchCoordinateBound` prefers either of
+/// those when present.  They are deliberately generous, because a bound that is
+/// too small is unsound rather than merely imprecise: it would let a value that
+/// really does exceed i32 be folded through an i32 round trip.
+///
+/// Workgroup-relative coordinates are bounded by the largest workgroup any
+/// supported target can launch.  HIP caps a workgroup at 1024 work items, so
+/// 2^16 leaves several doublings of headroom while staying far enough below
+/// 2^31 that ordinary scaling of a thread id still folds.  Grid-relative ones
+/// get the full HIP grid limit of 2^31-1.
+constexpr uint64_t kMaxWorkgroupCoordinate = 1u << 16;
+constexpr uint64_t kMaxGridCoordinate = (uint64_t(1) << 31) - 1;
 
 Value castPrintfArg(PatternRewriter &rewriter, Location loc, Value value, std::string &format) {
   Type type = value.getType();
@@ -2905,6 +2929,243 @@ public:
 /// moves the static offset strictly outward (swap), and the resulting
 /// `dyn -> static` form is rejected by the already-canonical check, so the
 /// pattern cannot loop.
+/// Conservative upper bound on |v|, or nullopt when it cannot be established.
+///
+/// The fold below is only sound when the value survives a trip through i32, and
+/// the type system cannot say that: an `index` is 64-bit.  Estimating a bound
+/// instead of answering a yes/no question matters, because "built from bounded
+/// roots" is not the same as "stays small": `tid * tid * tid * tid` is made
+/// entirely of launch coordinates and still reaches 2^40.
+///
+/// Roots are launch coordinates (bounded by the block/grid geometry) and
+/// constants (bounded by their own value).  Every operator combines its
+/// operands' bounds the way the operation combines values, and any step that
+/// would overflow the estimate itself gives up.  Anything unrecognised -- a
+/// kernel argument, a load, an op not on the list -- is unknown.
+///
+/// This is the value-range knowledge upstream deliberately does not assume, and
+/// the only reason FlyDSL may re-fold what `arith` no longer does.
+static std::optional<uint64_t> narrowUpperBound(Value v, unsigned depth,
+                                                llvm::SmallPtrSetImpl<Operation *> &visited) {
+  if (depth > kMaxNarrowProofDepth)
+    return std::nullopt;
+
+  // A non-negative constant bounds itself.  Negative values are rejected
+  // outright: every rule below reasons about unsigned magnitudes, and a
+  // negative operand reads as a huge unsigned value there, so an
+  // absolute-value bound would understate it.
+  APInt cst;
+  if (matchPattern(v, m_ConstantInt(&cst))) {
+    if (cst.isNegative())
+      return std::nullopt;
+    return cst.getLimitedValue();
+  }
+
+  Operation *def = v.getDefiningOp();
+  if (!def)
+    return std::nullopt; // block/function argument: unknown range
+
+  // A value reached twice on one walk (cyclic chain) cannot be bounded here.
+  if (!visited.insert(def).second)
+    return std::nullopt;
+  auto pop = llvm::make_scope_exit([&] { visited.erase(def); });
+
+  // Launch coordinates are bounded by the launch geometry.  Workgroup-relative
+  // ones stay small; grid-relative ones can reach the grid limit.  An op that
+  // declares its own `upper_bound` is believed over either fallback: the
+  // attribute is a promise from the producer that exceeding it is undefined
+  // behaviour, and it is the only bound that stays correct if the launch
+  // configuration outgrows the constants above.
+  if (isa<gpu::ThreadIdOp, gpu::BlockDimOp, gpu::LaneIdOp, gpu::BlockIdOp, gpu::GridDimOp>(def)) {
+    if (auto declared = def->getAttrOfType<IntegerAttr>("upper_bound"))
+      return declared.getValue().getZExtValue();
+    bool isGrid = isa<gpu::BlockIdOp, gpu::GridDimOp>(def);
+    // The kernel's declared launch geometry is exact where it exists.  Upstream
+    // checks an enclosing gpu.launch, the gpu.func itself, then any
+    // `gpu.known_*_size` on the surrounding function.  `gpu.lane_id` names no
+    // axis, so it keeps the fallback.
+    std::optional<gpu::Dimension> dim =
+        llvm::TypeSwitch<Operation *, std::optional<gpu::Dimension>>(def)
+            .Case<gpu::ThreadIdOp, gpu::BlockDimOp, gpu::BlockIdOp, gpu::GridDimOp>(
+                [](auto indexOp) { return indexOp.getDimension(); })
+            .Default([](Operation *) { return std::nullopt; });
+    if (dim) {
+      auto kind = isGrid ? gpu::DimensionKind::Grid : gpu::DimensionKind::Block;
+      if (auto known = gpu::getKnownDimensionSizeAround(def, kind, *dim))
+        return *known;
+    }
+    return isGrid ? kMaxGridCoordinate : kMaxWorkgroupCoordinate;
+  }
+
+  auto operandBound = [&](unsigned i) {
+    return narrowUpperBound(def->getOperand(i), depth + 1, visited);
+  };
+
+  auto checkedAdd = [](uint64_t a, uint64_t b) -> std::optional<uint64_t> {
+    uint64_t r;
+    return __builtin_add_overflow(a, b, &r) ? std::nullopt : std::optional<uint64_t>(r);
+  };
+  auto checkedMul = [](uint64_t a, uint64_t b) -> std::optional<uint64_t> {
+    uint64_t r;
+    return __builtin_mul_overflow(a, b, &r) ? std::nullopt : std::optional<uint64_t>(r);
+  };
+
+  // Binary ops: combine the operand bounds the way the operation combines values.
+  if (def->getNumOperands() == 2) {
+    auto lhs = operandBound(0);
+    auto rhs = operandBound(1);
+
+    // `and`, `rem` and `min` are bounded by one operand alone, so an unknown
+    // other side is tolerable.
+    if (isa<arith::AndIOp, arith::RemUIOp, arith::MinUIOp>(def)) {
+      if (!lhs && !rhs)
+        return std::nullopt;
+      if (!lhs)
+        return rhs;
+      if (!rhs)
+        return lhs;
+      return std::min(*lhs, *rhs);
+    }
+    // Shifting right and dividing only shrink the left operand.  Both read
+    // their operands as unsigned, which is sound here because every value this
+    // function can bound is non-negative: the sources are non-negative
+    // constants and launch coordinates, and no rule below can turn those into a
+    // negative result.
+    if (isa<arith::ShRUIOp, arith::DivUIOp>(def))
+      return lhs;
+
+    if (!lhs || !rhs)
+      return std::nullopt;
+
+    if (isa<arith::AddIOp>(def))
+      return checkedAdd(*lhs, *rhs);
+    // Subtraction is deliberately absent: with unsigned reasoning `a - b` wraps
+    // to a huge value whenever b > a, which no bound on a and b rules out.
+    if (isa<arith::MulIOp>(def))
+      return checkedMul(*lhs, *rhs);
+    if (isa<arith::ShLIOp>(def)) {
+      if (*rhs >= 64)
+        return std::nullopt;
+      return checkedMul(*lhs, uint64_t(1) << *rhs);
+    }
+    if (isa<arith::OrIOp, arith::XOrIOp, arith::MaxUIOp>(def)) {
+      // Bit-wise or/xor cannot exceed the next power of two above either side.
+      uint64_t m = std::max(*lhs, *rhs);
+      return m == UINT64_MAX ? std::nullopt
+                             : std::optional<uint64_t>(m == 0 ? 0 : llvm::NextPowerOf2(m) - 1);
+    }
+    return std::nullopt;
+  }
+
+  // Casts narrow or widen, and a signed narrowing can turn a small non-negative
+  // value into a negative one that reads as huge unsigned (index -> i8 -> index
+  // takes 128 to 2^64-128).  Only pass a bound through when it provably
+  // survives: it must fit the destination with the sign bit clear.  An unsigned
+  // cast has no sign bit to flip, so it only has to fit.
+  if (isa<arith::IndexCastOp, arith::IndexCastUIOp>(def)) {
+    auto srcBound = operandBound(0);
+    if (!srcBound)
+      return std::nullopt;
+    unsigned dstBits = 64;
+    if (auto intTy = dyn_cast<IntegerType>(getElementTypeOrSelf(def->getResult(0).getType())))
+      dstBits = intTy.getWidth();
+    if (dstBits >= 64)
+      return srcBound;
+    uint64_t limit =
+        isa<arith::IndexCastUIOp>(def) ? (uint64_t(1) << dstBits) : (uint64_t(1) << (dstBits - 1));
+    return *srcBound < limit ? srcBound : std::nullopt;
+  }
+
+  // select: either arm may be taken.
+  if (isa<arith::SelectOp>(def)) {
+    auto t = operandBound(1);
+    auto f = operandBound(2);
+    if (!t || !f)
+      return std::nullopt;
+    return std::max(*t, *f);
+  }
+
+  return std::nullopt;
+}
+
+/// Is \p v provably small enough to survive a round trip through \p bits?
+static bool isProvablyNarrow(Value v, unsigned bits) {
+  llvm::SmallPtrSet<Operation *, 16> visited;
+  std::optional<uint64_t> bound = narrowUpperBound(v, 0, visited);
+  if (!bound)
+    return false;
+  // Signed casts, so the usable range is one bit smaller.
+  return *bound < (uint64_t(1) << (bits - 1));
+}
+
+/// Fold `cast(cast(x : index -> iN) : iN -> index)` back to `x`.
+///
+/// Only the signed form (`arith.index_cast`) is handled.  The pattern is a
+/// template so the unsigned form could be added, but nothing in tree emits
+/// `arith.index_castui`, and `isProvablyNarrow` reserves the sign bit, so
+/// instantiating it would add an untested path for no benefit.
+///
+/// Upstream MLIR used to fold this in `arith`'s canonicalizer, but the pattern
+/// was unsound in general and was removed in llvm/llvm-project@8c81064169c5: for
+/// a narrow intermediate such as i8 the inner cast truncates, so the round trip
+/// loses bits and must be preserved.  The check upstream now applies is purely
+/// type-based -- an `index` is assumed to occupy its full 64-bit internal
+/// storage -- so `index -> i32 -> index` is rejected as lossy even where it is
+/// not.
+///
+/// FlyDSL emits exactly that shape when layout arithmetic crosses between
+/// `index` and i32, and `isProvablyNarrow` supplies the value-range knowledge
+/// upstream deliberately does not assume.  Re-folding removes 42 redundant cast
+/// pairs from a MoE stage1 kernel, which after lowering would otherwise become
+/// `trunc`/`sext` pairs inside the MFMA loop (measured: vgpr_spill_count
+/// 147 -> 19).
+///
+/// Both casts must be the same op: mixing signed and unsigned changes the
+/// meaning of the round trip, and the template parameter enforces that.
+/// Scalars and vectors are both handled -- for a vector the element types carry
+/// the index/integer distinction, and requiring the outer result type to equal
+/// the innermost source type keeps the shapes in step.
+///
+/// Convergence: each rewrite replaces one op with an existing value and adds
+/// nothing, so the pattern cannot loop.
+template <typename CastOp> class RedundantIndexCastPairImpl : public OpRewritePattern<CastOp> {
+public:
+  using OpRewritePattern<CastOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(CastOp op, PatternRewriter &rewriter) const override {
+    // Outer cast must land back on `index` (element type, so vectors work too).
+    if (!isa<IndexType>(getElementTypeOrSelf(op.getType())))
+      return failure();
+
+    auto inner = op.getIn().template getDefiningOp<CastOp>();
+    if (!inner)
+      return failure();
+
+    // Innermost source must be exactly what we are returning to; for vectors
+    // this also pins the shape.
+    Value orig = inner.getIn();
+    if (orig.getType() != op.getType())
+      return failure();
+
+    // The intermediate must be wide enough to hold the value.  Anything
+    // narrower than 32 bits is genuinely lossy and is left alone.
+    auto midTy = dyn_cast<IntegerType>(getElementTypeOrSelf(inner.getType()));
+    if (!midTy || midTy.getWidth() < 32)
+      return failure();
+
+    // Type width alone does not make the round trip lossless: an `index` is
+    // 64-bit, so a value above 2^31 would not survive it.  Only fold when the
+    // value is provably narrow.
+    if (!isProvablyNarrow(orig, midTy.getWidth()))
+      return failure();
+
+    rewriter.replaceOp(op, orig);
+    return success();
+  }
+};
+
+using RedundantIndexCastPair = RedundantIndexCastPairImpl<arith::IndexCastOp>;
+
 class AddOffsetCanonicalization : public OpRewritePattern<AddOffsetOp> {
 public:
   using OpRewritePattern<AddOffsetOp>::OpRewritePattern;
@@ -3058,6 +3319,7 @@ public:
     patterns.add<MemRefLoadVecOpLowering, MemRefStoreVecOpLowering>(context);
     patterns.add<MemRefAllocaOpLowering>(context);
     patterns.add<AddOffsetCanonicalization>(context);
+    patterns.add<RedundantIndexCastPair>(context);
 
     // Utility ops
     patterns.add<PrintOpLowering>(context);

--- a/tests/mlir/Transforms/redundant_index_cast_pair.mlir
+++ b/tests/mlir/Transforms/redundant_index_cast_pair.mlir
@@ -1,0 +1,353 @@
+// RUN: %fly-opt %s --fly-layout-lowering | FileCheck %s
+
+// A round trip through an intermediate at least 32 bits wide is redundant --
+// but only when the value is provably narrow enough to survive it.  Values
+// derived from launch coordinates and constants qualify.
+
+// CHECK-LABEL: func.func @fold_from_thread_id
+// CHECK-NOT:     arith.index_cast
+// CHECK:         return
+func.func @fold_from_thread_id() -> index {
+  %tid = gpu.thread_id x
+  %c63 = arith.constant 63 : index
+  %m = arith.andi %tid, %c63 : index
+  %0 = arith.index_cast %m : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// A chain of workgroup-relative coordinates stays small and folds.
+
+// CHECK-LABEL: func.func @fold_arith_chain
+// CHECK-NOT:     arith.index_cast
+// CHECK:         return
+func.func @fold_arith_chain() -> index {
+  %tid = gpu.thread_id x
+  %dim = gpu.block_dim x
+  %c4 = arith.constant 4 : index
+  %a = arith.muli %dim, %c4 : index
+  %b = arith.addi %a, %tid : index
+  %s = arith.shrui %b, %c4 : index
+  %0 = arith.index_cast %s : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// A grid-relative coordinate carries the grid limit (2^31-1), so scaling it
+// leaves i32 range and the pair must be kept.  A bare `block_id` still folds,
+// because the limit itself fits in a signed i32.
+
+// CHECK-LABEL: func.func @fold_bare_block_id
+// CHECK-NOT:     arith.index_cast
+// CHECK:         return
+func.func @fold_bare_block_id() -> index {
+  %bid = gpu.block_id x
+  %0 = arith.index_cast %bid : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// CHECK-LABEL: func.func @keep_scaled_block_id
+// CHECK:         arith.index_cast
+// CHECK:         arith.index_cast
+func.func @keep_scaled_block_id() -> index {
+  %bid = gpu.block_id x
+  %c4 = arith.constant 4 : index
+  %s = arith.muli %bid, %c4 : index
+  %0 = arith.index_cast %s : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// CHECK-LABEL: func.func @fold_i64_intermediate
+// CHECK-NOT:     arith.index_cast
+// CHECK:         return
+func.func @fold_i64_intermediate() -> index {
+  %tid = gpu.thread_id x
+  %0 = arith.index_cast %tid : index to i64
+  %1 = arith.index_cast %0 : i64 to index
+  return %1 : index
+}
+
+// A value of unknown range must NOT be folded: an `index` is 64-bit, so a
+// value above 2^31 would not survive the trip through i32.  This is the
+// unsoundness llvm/llvm-project@8c81064169c5 fixed upstream.
+
+// CHECK-LABEL: func.func @keep_unknown_arg
+// CHECK:         arith.index_cast %arg0 : index to i32
+// CHECK:         arith.index_cast %{{.*}} : i32 to index
+func.func @keep_unknown_arg(%a: index) -> index {
+  %0 = arith.index_cast %a : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// Likewise when an unknown value enters the arithmetic chain.
+
+// CHECK-LABEL: func.func @keep_tainted_chain
+// CHECK:         arith.index_cast
+// CHECK:         arith.index_cast
+func.func @keep_tainted_chain(%a: index) -> index {
+  %tid = gpu.thread_id x
+  %b = arith.addi %tid, %a : index
+  %0 = arith.index_cast %b : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// A narrow intermediate truncates even a bounded value, so it is never folded.
+
+// CHECK-LABEL: func.func @keep_i8
+// CHECK:         arith.index_cast %{{.*}} : index to i8
+// CHECK:         arith.index_cast %{{.*}} : i8 to index
+func.func @keep_i8() -> index {
+  %tid = gpu.thread_id x
+  %0 = arith.index_cast %tid : index to i8
+  %1 = arith.index_cast %0 : i8 to index
+  return %1 : index
+}
+
+// CHECK-LABEL: func.func @keep_i16
+// CHECK:         arith.index_cast %{{.*}} : index to i16
+// CHECK:         arith.index_cast %{{.*}} : i16 to index
+func.func @keep_i16() -> index {
+  %tid = gpu.thread_id x
+  %0 = arith.index_cast %tid : index to i16
+  %1 = arith.index_cast %0 : i16 to index
+  return %1 : index
+}
+
+// The unsigned round trip is left alone: the pattern is only instantiated for
+// arith.index_cast, so index_castui is never rewritten even when the value is
+// provably narrow.
+
+// CHECK-LABEL: func.func @keep_unsigned_narrow
+// CHECK:         arith.index_castui
+// CHECK:         arith.index_castui
+func.func @keep_unsigned_narrow() -> index {
+  %tid = gpu.thread_id x
+  %0 = arith.index_castui %tid : index to i32
+  %1 = arith.index_castui %0 : i32 to index
+  return %1 : index
+}
+
+// Vectors are handled through their element types.
+
+// CHECK-LABEL: func.func @fold_vector
+// CHECK-NOT:     arith.index_cast
+// CHECK:         return
+func.func @fold_vector() -> vector<4xindex> {
+  %v = arith.constant dense<[1, 2, 3, 4]> : vector<4xindex>
+  %0 = arith.index_cast %v : vector<4xindex> to vector<4xi32>
+  %1 = arith.index_cast %0 : vector<4xi32> to vector<4xindex>
+  return %1 : vector<4xindex>
+}
+
+// A mixed signed/unsigned pair is not a round trip at all, and the outer
+// index_cast must not treat the inner index_castui as its own inverse.
+
+// CHECK-LABEL: func.func @keep_mixed_signedness
+// CHECK:         arith.index_castui
+// CHECK:         arith.index_cast
+func.func @keep_mixed_signedness() -> index {
+  %tid = gpu.thread_id x
+  %0 = arith.index_castui %tid : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// Unsigned casts are never folded, bounded operand or not.
+
+// CHECK-LABEL: func.func @keep_unsigned_unknown
+// CHECK:         arith.index_castui %arg0
+// CHECK:         arith.index_castui
+func.func @keep_unsigned_unknown(%a: index) -> index {
+  %0 = arith.index_castui %a : index to i32
+  %1 = arith.index_castui %0 : i32 to index
+  return %1 : index
+}
+
+// Bounded roots are not enough on their own: arithmetic can carry a small value
+// out of i32 range, and then the round trip is lossy again.
+
+// CHECK-LABEL: func.func @keep_large_constant
+// CHECK:         arith.index_cast
+// CHECK:         arith.index_cast
+func.func @keep_large_constant() -> index {
+  %big = arith.constant 1099511627776 : index
+  %tid = gpu.thread_id x
+  %s = arith.addi %big, %tid : index
+  %0 = arith.index_cast %s : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// CHECK-LABEL: func.func @keep_mul_overflow
+// CHECK:         arith.index_cast
+// CHECK:         arith.index_cast
+func.func @keep_mul_overflow() -> index {
+  %t = gpu.thread_id x
+  %a = arith.muli %t, %t : index
+  %b = arith.muli %a, %t : index
+  %c = arith.muli %b, %t : index
+  %0 = arith.index_cast %c : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// CHECK-LABEL: func.func @keep_shift_overflow
+// CHECK:         arith.index_cast
+// CHECK:         arith.index_cast
+func.func @keep_shift_overflow() -> index {
+  %t = gpu.thread_id x
+  %c40 = arith.constant 40 : index
+  %s = arith.shli %t, %c40 : index
+  %0 = arith.index_cast %s : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// Shrinking operations keep a value in range, so these still fold.
+
+// CHECK-LABEL: func.func @fold_masked
+// CHECK-NOT:     arith.index_cast
+// CHECK:         return
+func.func @fold_masked() -> index {
+  %t = gpu.thread_id x
+  %c63 = arith.constant 63 : index
+  %big = arith.constant 1099511627776 : index
+  %m = arith.andi %big, %c63 : index
+  %s = arith.addi %m, %t : index
+  %0 = arith.index_cast %s : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// A negative constant is not a narrow value: every bound rule reads its
+// operands as unsigned, where -1 is UINT64_MAX rather than 1.  The select
+// keeps the constant from being folded away before the pattern runs.
+
+// CHECK-LABEL: func.func @keep_negative_constant
+// CHECK:         arith.index_cast
+// CHECK:         arith.index_cast
+func.func @keep_negative_constant(%p: i1) -> index {
+  %cneg = arith.constant -1 : index
+  %c1 = arith.constant 1 : index
+  %c = arith.select %p, %cneg, %c1 : index
+  %0 = arith.index_cast %c : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// Subtraction is not bounded by its operands: read unsigned, `tid - 1` wraps to
+// UINT64_MAX when tid is 0, even though both sides are tiny.
+
+// CHECK-LABEL: func.func @keep_subtraction
+// CHECK:         arith.index_cast
+// CHECK:         arith.index_cast
+func.func @keep_subtraction() -> index {
+  %c0 = gpu.thread_id x
+  %c1 = arith.constant 1 : index
+  %d = arith.subi %c0, %c1 : index
+  %0 = arith.index_cast %d : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// A shift-right whose left operand came from a subtraction inherits that
+// unknown range instead of the shift narrowing it.
+
+// CHECK-LABEL: func.func @keep_shift_of_subtraction
+// CHECK:         arith.index_cast
+// CHECK:         arith.index_cast
+func.func @keep_shift_of_subtraction(%a: index) -> index {
+  %c1 = arith.constant 1 : index
+  %d = arith.subi %c1, %a : index
+  %s = arith.shrui %d, %c1 : index
+  %0 = arith.index_cast %s : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// A declared upper_bound is believed over the built-in fallback, so a thread id
+// scaled past what the fallback would allow still folds when the launch
+// geometry says it is small.
+
+// CHECK-LABEL: func.func @fold_declared_upper_bound
+// CHECK-NOT:     arith.index_cast
+// CHECK:         return
+func.func @fold_declared_upper_bound() -> index {
+  %tid = gpu.thread_id x upper_bound 256
+  %c = arith.constant 65536 : index
+  %m = arith.muli %tid, %c : index
+  %0 = arith.index_cast %m : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// The same scaling is refused without the attribute: the fallback bound has to
+// assume a far larger workgroup, and the product leaves i32 range.
+
+// CHECK-LABEL: func.func @keep_scaled_without_bound
+// CHECK:         arith.index_cast
+// CHECK:         arith.index_cast
+func.func @keep_scaled_without_bound() -> index {
+  %tid = gpu.thread_id x
+  %c = arith.constant 65536 : index
+  %m = arith.muli %tid, %c : index
+  %0 = arith.index_cast %m : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// A block id with a declared bound is likewise trusted over the grid fallback.
+
+// CHECK-LABEL: func.func @fold_block_id_upper_bound
+// CHECK-NOT:     arith.index_cast
+// CHECK:         return
+func.func @fold_block_id_upper_bound() -> index {
+  %bid = gpu.block_id x upper_bound 1024
+  %c = arith.constant 1024 : index
+  %m = arith.muli %bid, %c : index
+  %0 = arith.index_cast %m : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// The kernel's declared launch geometry is exact, and beats the fallback: with
+// known_block_size the thread id is at most 256, so scaling by 2^20 stays well
+// inside i32 even though the fallback bound would refuse it.
+
+// CHECK-LABEL: gpu.func @fold_known_block_size
+// CHECK-NOT:     arith.index_cast
+// CHECK:         gpu.return
+gpu.module @m {
+  gpu.func @fold_known_block_size(%out: memref<?xindex>) kernel
+      attributes {known_block_size = array<i32: 256, 1, 1>} {
+    %tid = gpu.thread_id x
+    %c = arith.constant 1048576 : index
+    %z = arith.constant 0 : index
+    %m = arith.muli %tid, %c : index
+    %0 = arith.index_cast %m : index to i32
+    %1 = arith.index_cast %0 : i32 to index
+    memref.store %1, %out[%z] : memref<?xindex>
+    gpu.return
+  }
+
+  // Without the attribute the same kernel keeps the casts: the fallback has to
+  // assume a workgroup far larger than 256, and the product leaves i32 range.
+
+  // CHECK-LABEL: gpu.func @keep_without_known_block_size
+  // CHECK:         arith.index_cast
+  // CHECK:         arith.index_cast
+  gpu.func @keep_without_known_block_size(%out: memref<?xindex>) kernel {
+    %tid = gpu.thread_id x
+    %c = arith.constant 1048576 : index
+    %z = arith.constant 0 : index
+    %m = arith.muli %tid, %c : index
+    %0 = arith.index_cast %m : index to i32
+    %1 = arith.index_cast %0 : i32 to index
+    memref.store %1, %out[%z] : memref<?xindex>
+    gpu.return
+  }
+}

--- a/tests/mlir/Transforms/redundant_index_cast_pair.mlir
+++ b/tests/mlir/Transforms/redundant_index_cast_pair.mlir
@@ -18,33 +18,43 @@ func.func @fold_from_thread_id() -> index {
 
 // A chain of workgroup-relative coordinates stays small and folds.
 
-// CHECK-LABEL: func.func @fold_arith_chain
+// CHECK-LABEL: gpu.func @fold_arith_chain
 // CHECK-NOT:     arith.index_cast
-// CHECK:         return
-func.func @fold_arith_chain() -> index {
-  %tid = gpu.thread_id x
-  %dim = gpu.block_dim x
-  %c4 = arith.constant 4 : index
-  %a = arith.muli %dim, %c4 : index
-  %b = arith.addi %a, %tid : index
-  %s = arith.shrui %b, %c4 : index
-  %0 = arith.index_cast %s : index to i32
-  %1 = arith.index_cast %0 : i32 to index
-  return %1 : index
+// CHECK:         gpu.return
+gpu.module @arith_chain {
+  gpu.func @fold_arith_chain(%out: memref<?xindex>) kernel
+      attributes {known_block_size = array<i32: 256, 1, 1>} {
+    %tid = gpu.thread_id x
+    %dim = gpu.block_dim x
+    %c4 = arith.constant 4 : index
+    %z = arith.constant 0 : index
+    %a = arith.muli %dim, %c4 : index
+    %b = arith.addi %a, %tid : index
+    %s = arith.shrui %b, %c4 : index
+    %0 = arith.index_cast %s : index to i32
+    %1 = arith.index_cast %0 : i32 to index
+    memref.store %1, %out[%z] : memref<?xindex>
+    gpu.return
+  }
 }
 
 // A grid-relative coordinate carries the grid limit (2^31-1), so scaling it
 // leaves i32 range and the pair must be kept.  A bare `block_id` still folds,
 // because the limit itself fits in a signed i32.
 
-// CHECK-LABEL: func.func @fold_bare_block_id
+// CHECK-LABEL: gpu.func @fold_bare_block_id
 // CHECK-NOT:     arith.index_cast
-// CHECK:         return
-func.func @fold_bare_block_id() -> index {
-  %bid = gpu.block_id x
-  %0 = arith.index_cast %bid : index to i32
-  %1 = arith.index_cast %0 : i32 to index
-  return %1 : index
+// CHECK:         gpu.return
+gpu.module @bare_block_id {
+  gpu.func @fold_bare_block_id(%out: memref<?xindex>) kernel
+      attributes {known_grid_size = array<i32: 1024, 1, 1>} {
+    %bid = gpu.block_id x
+    %z = arith.constant 0 : index
+    %0 = arith.index_cast %bid : index to i32
+    %1 = arith.index_cast %0 : i32 to index
+    memref.store %1, %out[%z] : memref<?xindex>
+    gpu.return
+  }
 }
 
 // CHECK-LABEL: func.func @keep_scaled_block_id
@@ -209,18 +219,23 @@ func.func @keep_shift_overflow() -> index {
 
 // Shrinking operations keep a value in range, so these still fold.
 
-// CHECK-LABEL: func.func @fold_masked
+// CHECK-LABEL: gpu.func @fold_masked
 // CHECK-NOT:     arith.index_cast
-// CHECK:         return
-func.func @fold_masked() -> index {
-  %t = gpu.thread_id x
-  %c63 = arith.constant 63 : index
-  %big = arith.constant 1099511627776 : index
-  %m = arith.andi %big, %c63 : index
-  %s = arith.addi %m, %t : index
-  %0 = arith.index_cast %s : index to i32
-  %1 = arith.index_cast %0 : i32 to index
-  return %1 : index
+// CHECK:         gpu.return
+gpu.module @masked {
+  gpu.func @fold_masked(%out: memref<?xindex>) kernel
+      attributes {known_block_size = array<i32: 256, 1, 1>} {
+    %t = gpu.thread_id x
+    %c63 = arith.constant 63 : index
+    %big = arith.constant 1099511627776 : index
+    %z = arith.constant 0 : index
+    %m = arith.andi %big, %c63 : index
+    %s = arith.addi %m, %t : index
+    %0 = arith.index_cast %s : index to i32
+    %1 = arith.index_cast %0 : i32 to index
+    memref.store %1, %out[%z] : memref<?xindex>
+    gpu.return
+  }
 }
 
 // A negative constant is not a narrow value: every bound rule reads its
@@ -350,4 +365,94 @@ gpu.module @m {
     memref.store %1, %out[%z] : memref<?xindex>
     gpu.return
   }
+}
+
+// Widening is as dangerous as narrowing for the signed cast: whatever the
+// narrow type already holds gets sign-extended, so a value that overflowed i8
+// between the two casts comes back as a huge unsigned one.  The bound has to be
+// checked against the narrower of the two types, not just the destination.
+
+// CHECK-LABEL: func.func @keep_widening_after_i8_overflow
+// CHECK:         arith.index_cast %{{.*}} : index to i32
+// CHECK:         arith.index_cast %{{.*}} : i32 to index
+func.func @keep_widening_after_i8_overflow() -> index {
+  %tid = gpu.thread_id x
+  %c127 = arith.constant 127 : index
+  %m = arith.andi %tid, %c127 : index
+  %b = arith.index_cast %m : index to i8
+  %c100 = arith.constant 100 : i8
+  %w = arith.addi %b, %c100 : i8
+  %x = arith.index_cast %w : i8 to index
+  %c1 = arith.constant 1 : index
+  %s = arith.shrui %x, %c1 : index
+  %0 = arith.index_cast %s : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// The same taint reaching divui, and the one-unknown-side rules: each of these
+// would take the bound from the tainted operand alone.
+
+// CHECK-LABEL: func.func @keep_divui_of_widened
+// CHECK:         arith.index_cast %{{.*}} : index to i32
+// CHECK:         arith.index_cast %{{.*}} : i32 to index
+func.func @keep_divui_of_widened() -> index {
+  %tid = gpu.thread_id x
+  %c127 = arith.constant 127 : index
+  %m = arith.andi %tid, %c127 : index
+  %b = arith.index_cast %m : index to i8
+  %c100 = arith.constant 100 : i8
+  %w = arith.addi %b, %c100 : i8
+  %x = arith.index_cast %w : i8 to index
+  %c2 = arith.constant 2 : index
+  %d = arith.divui %x, %c2 : index
+  %0 = arith.index_cast %d : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// CHECK-LABEL: func.func @keep_minui_of_widened
+// CHECK:         arith.index_cast %{{.*}} : index to i32
+// CHECK:         arith.index_cast %{{.*}} : i32 to index
+func.func @keep_minui_of_widened(%u: index) -> index {
+  %tid = gpu.thread_id x
+  %c127 = arith.constant 127 : index
+  %m = arith.andi %tid, %c127 : index
+  %b = arith.index_cast %m : index to i8
+  %c100 = arith.constant 100 : i8
+  %w = arith.addi %b, %c100 : i8
+  %x = arith.index_cast %w : i8 to index
+  %mn = arith.minui %u, %x : index
+  %0 = arith.index_cast %mn : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// A value that stays inside i8's signed range survives the widening, so the
+// round trip through i32 is still redundant.
+
+// CHECK-LABEL: func.func @fold_widening_within_i8
+// CHECK-NOT:     arith.index_cast %{{.*}} : index to i32
+// CHECK:         return
+func.func @fold_widening_within_i8() -> index {
+  %tid = gpu.thread_id x
+  %c63 = arith.constant 63 : index
+  %m = arith.andi %tid, %c63 : index
+  %b = arith.index_cast %m : index to i8
+  %x = arith.index_cast %b : i8 to index
+  %0 = arith.index_cast %x : index to i32
+  %1 = arith.index_cast %0 : i32 to index
+  return %1 : index
+}
+
+// A 64-bit-or-wider intermediate cannot lose anything, and must not trip the
+// shift that computes the narrowness threshold.
+
+// CHECK-LABEL: func.func @fold_i128_intermediate
+// CHECK-NOT:     arith.index_cast
+// CHECK:         return
+func.func @fold_i128_intermediate(%a: index) -> index {
+  %0 = arith.index_cast %a : index to i128
+  %1 = arith.index_cast %0 : i128 to index
+  return %1 : index
 }


### PR DESCRIPTION
## Problem

`flydsl` 0.3.0 → 0.3.1 regressed MiniMax-M3-MXFP8 throughput on MI355X by ~3.6%,
traced to one MoE stage1 kernel spilling heavily:

    mfma_moe1_silu_mul_afp8_wfp8_fp8_t128x256x256_pm1_fp8q_sort_async_gui_xcd4_swiglu_v32
    vgpr_spill_count: 28 -> 143,  114 of them inside the MFMA loop

The cause is upstream, in the LLVM pin the release moved to
(`7f77ca0dbda4` -> `e2a39f504fee`): llvm/llvm-project@8c81064169c5 stopped folding
`index_cast(index_cast(x : index -> iN) : iN -> index)`.

That commit is correct -- the fold is unsound in general, since a narrow
intermediate truncates (`i64 -> index -> i8 -> index` silently drops 56 bits).
But the check it applies is purely type-based: an `index` counts as 64-bit, so
`index -> i32 -> index` is rejected as lossy even where it is not.

FlyDSL emits exactly that shape when layout arithmetic crosses between `index`
and i32. 92 redundant casts now survive canonicalization, become 46
`trunc`/`sext` pairs after lowering, and push a kernel already at
512 VGPR + 256 AGPR over the edge.

## Fix

Re-fold the pair in `fly-layout-lowering`, guarded by a bound on the *value*
rather than on the type -- the value-range knowledge upstream deliberately does
not assume, but FlyDSL has: these are tile and lane coordinates bounded by
launch geometry.

`narrowUpperBound()` walks the definition chain and combines operand bounds the
way each op combines values, checking for overflow of the estimate itself. Roots
are launch coordinates and constants; anything unrecognised is unknown and
rejected.

Two subtleties the guard has to get right, both covered by tests:

- **Reachability from bounded roots is not enough.** `tid * tid * tid * tid`
  is built entirely of launch coordinates and still reaches 2^40, and a large
  `arith.constant` is a bounded root by itself.
- **Grid coordinates need the grid limit.** HIP allows a grid dimension up to
  2^31-1, so `block_id`/`grid_dim` carry that bound. A workgroup-sized bound
  would understate `block_id * 4`, whose real maximum is 2^33, and fold a pair
  that actually truncates.

Signed and unsigned casts are handled via a template, which also keeps a mixed
`index_cast`/`index_castui` pair from folding. Vectors go through their element
types.

## Results

On the affected kernel:

| | before | after |
|---|---|---|
| `arith.index_cast` after layout lowering | 1292 | 1208 (42 of 46 pairs folded) |
| `vgpr_spill_count` | 147 | **19** |
| throughput at ISL 8192 (c=8/16/32) | baseline | **+5.2% / +4.7% / +3.1%** |

The four remaining pairs trace back to a kernel argument and are correctly left
alone. The other four stage1 kernels carry the same redundancy without spilling;
they lose 14-44 pairs each and are otherwise unchanged.
