### PR TITLE
[Bugfix][Benchmark] Fix compiler API usage in Softmax and RMSNorm benchmarks

### DIFF
--- a/tests/kernels/benchmark_common.py
+++ b/tests/kernels/benchmark_common.py
@@ -172,11 +172,11 @@ def _bench_flydsl_torch(*, op: str, M: int, N: int, dtype: str, warmup: int, ite
     """Build + compile FlyDSL kernel, then benchmark via torch CUDA events.
 
     This intentionally avoids hip-python / HIP driver calls, aligning with the
-    style used by other tests (flydsl.compile + torch timing).
+    style used by other tests (flydsl.compiler.compile + torch timing).
     """
     import torch
 
-    import flydsl
+    import flydsl.compiler as flyc
 
     if not torch.cuda.is_available():
         return None
@@ -188,15 +188,14 @@ def _bench_flydsl_torch(*, op: str, M: int, N: int, dtype: str, warmup: int, ite
         from kernels.norm.softmax_kernel import build_softmax_module
 
         # M is runtime; module construction uses a dummy M.
-        # `flydsl.compile()` already has its own cache.
+        # `flyc.compile()` already has its own cache.
         m = build_softmax_module(1, N, dtype)
-        exe = flydsl.compile(m)
+        exe = flyc.compile(m)
         x = torch.randn((M, N), device="cuda", dtype=torch_dtype)
         y = torch.empty((M, N), device="cuda", dtype=torch_dtype)
         return bench_gpu_us_torch(lambda: exe(x, y, M), warmup=warmup, iters=iters)
 
     if op == "layernorm":
-        import flydsl.compiler as flyc
         import flydsl.expr as fx
         from kernels.norm.layernorm_kernel import build_layernorm_module
 
@@ -226,7 +225,7 @@ def _bench_flydsl_torch(*, op: str, M: int, N: int, dtype: str, warmup: int, ite
         from kernels.norm.rmsnorm_kernel import build_rmsnorm_module
 
         m = build_rmsnorm_module(N, dtype)
-        exe = flydsl.compile(m)
+        exe = flyc.compile(m)
         x = torch.randn((M, N), device="cuda", dtype=torch_dtype)
         gamma = torch.randn((N,), device="cuda", dtype=torch_dtype)
         y = torch.empty((M, N), device="cuda", dtype=torch_dtype)


### PR DESCRIPTION
## Motivation

The shared comparison sweep does not report FlyDSL timing results for Softmax and RMSNorm.

Both paths call the removed top-level `flydsl.compile` API. The resulting `AttributeError` is caught by `run_compare_sweep`, which records `flydsl_gpu_us=None`, so the failure appears as a missing `-` result instead of an explicit error.

## Technical Details

- Import `flydsl.compiler` as `flyc`.
- Use `flyc.compile` for the Softmax and RMSNorm benchmark paths.
- Reuse the same compiler import in the LayerNorm path.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
