### PR TITLE
[LLVM] Fix true16 lowering for packed FP8 conversions

### DIFF
--- a/.github/workflows/build-custom-llvm-tools.yaml
+++ b/.github/workflows/build-custom-llvm-tools.yaml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: mlir_install.tgz
-          key: mlir-tools-${{ steps.llvm-ref.outputs.safe_ref }}-${{ hashFiles('flydsl/scripts/build_llvm.sh') }}
+          key: mlir-tools-${{ steps.llvm-ref.outputs.safe_ref }}-${{ hashFiles('flydsl/thirdparty/llvm-*.patch', 'flydsl/scripts/build_llvm.sh') }}
 
       - name: Use cached MLIR install tarball
         if: steps.mlir-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/build-whl.yaml
+++ b/.github/workflows/build-whl.yaml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: mlir_install.tgz
-          key: mlir-install-manylinux228-${{ hashFiles('flydsl/thirdparty/llvm-build-info.json', 'flydsl/scripts/build_llvm.sh', 'flydsl/CMakeLists.txt') }}
+          key: mlir-install-manylinux228-${{ hashFiles('flydsl/thirdparty/llvm-build-info.json', 'flydsl/thirdparty/llvm-*.patch', 'flydsl/scripts/build_llvm.sh', 'flydsl/CMakeLists.txt') }}
 
       - name: Use cached MLIR install tarball
         if: steps.mlir-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -182,16 +182,21 @@ jobs:
             echo "pin_changed=false" >>"${GITHUB_OUTPUT}"
             exit 0
           fi
-          for f in thirdparty/llvm-build-info.json thirdparty/llvm-rocdl-lld-argv0.patch scripts/build_llvm.sh; do
+          changed=false
+          for f in thirdparty/llvm-build-info.json thirdparty/llvm-rocdl-lld-argv0.patch thirdparty/llvm-amdgpu-cvt-pk-f32-f8-true16.patch scripts/build_llvm.sh; do
             if ! git -C flydsl-test show "FETCH_HEAD:${f}" >"base-pin/${f}"; then
-              echo "Base commit has no ${f}; treating LLVM pin as unchanged."
-              echo "pin_changed=false" >>"${GITHUB_OUTPUT}"
-              exit 0
+              if [ "${f}" = "thirdparty/llvm-build-info.json" ]; then
+                echo "Base commit has no ${f}; treating LLVM pin as unchanged."
+                echo "pin_changed=false" >>"${GITHUB_OUTPUT}"
+                exit 0
+              fi
+              echo "LLVM input is new relative to base: ${f}"
+              rm -f "base-pin/${f}"
+              changed=true
             fi
           done
-          changed=false
-          for f in thirdparty/llvm-build-info.json thirdparty/llvm-rocdl-lld-argv0.patch scripts/build_llvm.sh; do
-            if ! diff -q "flydsl-test/${f}" "base-pin/${f}" >/dev/null; then
+          for f in thirdparty/llvm-build-info.json thirdparty/llvm-rocdl-lld-argv0.patch thirdparty/llvm-amdgpu-cvt-pk-f32-f8-true16.patch scripts/build_llvm.sh; do
+            if [ ! -f "base-pin/${f}" ] || ! diff -q "flydsl-test/${f}" "base-pin/${f}" >/dev/null; then
               echo "LLVM input differs from base: ${f}"
               changed=true
             fi

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -17,7 +17,10 @@ LLVM_PACKAGE_INSTALL="${LLVM_PACKAGE_INSTALL:-1}"
 LLVM_BUILD_INFO="${REPO_ROOT}/thirdparty/llvm-build-info.json"
 LLVM_COMMIT_DEFAULT=$(python3 -c "import json; print(json.load(open('${LLVM_BUILD_INFO}'))['upstream']['llvm_hash'])")
 LLVM_REF="${LLVM_REF:-${LLVM_COMMIT:-$LLVM_COMMIT_DEFAULT}}"
-LLVM_PATCH="${REPO_ROOT}/thirdparty/llvm-rocdl-lld-argv0.patch"
+LLVM_PATCHES=(
+    "${REPO_ROOT}/thirdparty/llvm-rocdl-lld-argv0.patch"
+    "${REPO_ROOT}/thirdparty/llvm-amdgpu-cvt-pk-f32-f8-true16.patch"
+)
 LLVM_BUILD_PROFILE="${LLVM_BUILD_PROFILE:-full}"
 
 case "${LLVM_BUILD_PROFILE}" in
@@ -93,13 +96,15 @@ else
     git checkout FETCH_HEAD
 fi
 
-if git apply --reverse --check "${LLVM_PATCH}" >/dev/null 2>&1; then
-    echo "LLVM patch already applied: ${LLVM_PATCH}"
-else
-    echo "Applying LLVM patch: ${LLVM_PATCH}"
-    git apply --check "${LLVM_PATCH}"
-    git apply "${LLVM_PATCH}"
-fi
+for LLVM_PATCH in "${LLVM_PATCHES[@]}"; do
+    if git apply --reverse --check "${LLVM_PATCH}" >/dev/null 2>&1; then
+        echo "LLVM patch already applied: ${LLVM_PATCH}"
+    else
+        echo "Applying LLVM patch: ${LLVM_PATCH}"
+        git apply --check "${LLVM_PATCH}"
+        git apply "${LLVM_PATCH}"
+    fi
+done
 
 LLVM_COMMIT_RESOLVED=$(git rev-parse HEAD)
 popd

--- a/scripts/ci_mlir_cache_key.sh
+++ b/scripts/ci_mlir_cache_key.sh
@@ -20,6 +20,7 @@ TREE_ROOT="${1:?usage: ci_mlir_cache_key.sh <tree-root>}"
 INPUTS=(
   thirdparty/llvm-build-info.json
   thirdparty/llvm-rocdl-lld-argv0.patch
+  thirdparty/llvm-amdgpu-cvt-pk-f32-f8-true16.patch
   scripts/build_llvm.sh
 )
 

--- a/thirdparty/llvm-amdgpu-cvt-pk-f32-f8-true16.patch
+++ b/thirdparty/llvm-amdgpu-cvt-pk-f32-f8-true16.patch
@@ -1,0 +1,104 @@
+diff --git a/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.cpp b/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.cpp
+index 3f0fb64be..37a3db3d4 100644
+--- a/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.cpp
++++ b/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.cpp
+@@ -16,6 +16,7 @@
+ #include "AMDGPU.h"
+ #include "AMDGPUAsmPrinter.h"
+ #include "AMDGPUMachineFunctionInfo.h"
++#include "GCNSubtarget.h"
+ #include "MCTargetDesc/AMDGPUInstPrinter.h"
+ #include "MCTargetDesc/AMDGPUMCExpr.h"
+ #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
+@@ -262 +263,17 @@ void AMDGPUMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) const {
++  // These packed-conversion patterns use an i32 fake16 pseudo because the
++  // intrinsic carries two selectable 16-bit words. Select the real true16
++  // opcode explicitly on subtargets which require it.
++  const bool LowerPackedCvtAsTrue16 =
++      static_cast<const GCNSubtarget &>(ST).useRealTrue16Insts() &&
++      (Opcode == AMDGPU::V_CVT_PK_F32_BF8_fake16_e32 ||
++       Opcode == AMDGPU::V_CVT_PK_F32_FP8_fake16_e32);
++  if (LowerPackedCvtAsTrue16) {
++    const unsigned True16Opcode = Opcode == AMDGPU::V_CVT_PK_F32_BF8_fake16_e32
++                                      ? AMDGPU::V_CVT_PK_F32_BF8_t16_e32
++                                      : AMDGPU::V_CVT_PK_F32_FP8_t16_e32;
++    MCOpcode = TII->pseudoToMCOpcode(True16Opcode);
++    assert(MCOpcode != -1 &&
++           "True16 packed conversion has no target-specific version");
++  }
++
+   OutMI.setOpcode(MCOpcode);
+@@ -264,5 +280,23 @@ void AMDGPUMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) const {
++  // The cvt.pk.f32.{bf8,fp8} intrinsic carries a packed i32 source, so its
++  // SelectionDAG pattern intentionally uses the fake16 pseudo. When that
++  // pseudo maps to a real true16 e32 encoding, a VGPR source must name its low
++  // half explicitly. SGPR and immediate sources retain their regular spelling.
++  const bool NarrowPackedCvtSource = LowerPackedCvtAsTrue16;
++  const int Src0Idx =
++      NarrowPackedCvtSource
++          ? AMDGPU::getNamedOperandIdx(Opcode, AMDGPU::OpName::src0)
++          : -1;
++  const SIRegisterInfo &TRI = TII->getRegisterInfo();
++
++  int OperandIdx = 0;
+   for (const MachineOperand &MO : MI->explicit_operands()) {
+     MCOperand MCOp;
+-    lowerOperand(MO, MCOp);
++    if (OperandIdx == Src0Idx && MO.isReg() && TRI.isVGPRPhysReg(MO.getReg())) {
++      Register LoReg = TRI.getSubReg(MO.getReg(), AMDGPU::lo16);
++      MCOp = MCOperand::createReg(AMDGPU::getMCReg(LoReg, ST));
++    } else {
++      lowerOperand(MO, MCOp);
++    }
+     OutMI.addOperand(MCOp);
++    ++OperandIdx;
+   }
+diff --git a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.cvt.fp8.ll b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.cvt.fp8.ll
+index 7f3dd0400..372b44d81 100644
+--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.cvt.fp8.ll
++++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.cvt.fp8.ll
+@@ -310,3 +310,4 @@ define <2 x float> @test_cvt_pk_f32_bf8_word0(i32 %a) {
+ ; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+ ; GFX1170-NEXT:    v_cvt_pk_f32_bf8_e32 v[0:1], v0
++; GFX1170-TRUE16-SAME: .l
+ ; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+@@ -320,3 +321,4 @@ define <2 x float> @test_cvt_pk_f32_bf8_word0(i32 %a) {
+ ; GFX12-NEXT:    s_wait_kmcnt 0x0
+ ; GFX12-NEXT:    v_cvt_pk_f32_bf8_e32 v[0:1], v0
++; GFX12-TRUE16-SAME: .l
+ ; GFX12-NEXT:    s_setpc_b64 s[30:31]
+@@ -327,3 +329,4 @@ define <2 x float> @test_cvt_pk_f32_bf8_word0(i32 %a) {
+ ; GFX1250-NEXT:    s_wait_kmcnt 0x0
+ ; GFX1250-NEXT:    v_cvt_pk_f32_bf8_e32 v[0:1], v0
++; GFX1250-TRUE16-SAME: .l
+ ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
+@@ -376,3 +379,4 @@ define <2 x float> @test_cvt_pk_f32_fp8_word0(i32 %a) {
+ ; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+ ; GFX1170-NEXT:    v_cvt_pk_f32_fp8_e32 v[0:1], v0
++; GFX1170-TRUE16-SAME: .l
+ ; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+@@ -386,3 +390,4 @@ define <2 x float> @test_cvt_pk_f32_fp8_word0(i32 %a) {
+ ; GFX12-NEXT:    s_wait_kmcnt 0x0
+ ; GFX12-NEXT:    v_cvt_pk_f32_fp8_e32 v[0:1], v0
++; GFX12-TRUE16-SAME: .l
+ ; GFX12-NEXT:    s_setpc_b64 s[30:31]
+@@ -393,3 +398,4 @@ define <2 x float> @test_cvt_pk_f32_fp8_word0(i32 %a) {
+ ; GFX1250-NEXT:    s_wait_kmcnt 0x0
+ ; GFX1250-NEXT:    v_cvt_pk_f32_fp8_e32 v[0:1], v0
++; GFX1250-TRUE16-SAME: .l
+ ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
+@@ -1288,3 +1294,4 @@ define <2 x float> @test_sext_cvt_pk_f32_fp8_word0(i16 %a) {
+ ; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+ ; GFX1170-NEXT:    v_cvt_pk_f32_fp8_e32 v[0:1], v0
++; GFX1170-TRUE16-SAME: .l
+ ; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+@@ -1300,3 +1307,4 @@ define <2 x float> @test_sext_cvt_pk_f32_fp8_word0(i16 %a) {
+ ; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+ ; GFX12-NEXT:    v_cvt_pk_f32_fp8_e32 v[0:1], v0
++; GFX12-TRUE16-SAME: .l
+ ; GFX12-NEXT:    s_setpc_b64 s[30:31]
+@@ -1309,3 +1317,4 @@ define <2 x float> @test_sext_cvt_pk_f32_fp8_word0(i16 %a) {
+ ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+ ; GFX1250-NEXT:    v_cvt_pk_f32_fp8_e32 v[0:1], v0
++; GFX1250-TRUE16-SAME: .l
+ ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]


### PR DESCRIPTION
## Summary

- patch the pinned LLVM AMDGPU MC lowering to select real true16 opcodes for packed FP8/BF8 conversions
- select the low 16-bit VGPR half required by the true16 encoding while preserving SGPR and immediate operands
- add gfx1170, gfx12, and gfx1250 code-generation checks
- apply the LLVM patches idempotently and include every patch input in local and CI cache keys

## Motivation

`llvm.amdgcn.cvt.pk.f32.{fp8,bf8}` is selected through a fake16 pseudo because the intrinsic carries two selectable 16-bit words. On targets using real true16 instructions, the MC lowering must explicitly select the true16 opcode and spell a VGPR source as its low half. Without this, packed conversion lowering can produce an invalid or incorrectly encoded instruction.

This PR is independent of the FlyDSL scalar `cvt_f32_fp8` API addition and is based directly on `main` for focused review.

## Validation

- both FlyDSL LLVM patches pass `git apply --check` against the pinned LLVM revision `e2a39f504fee836e4def9581bed817ecc327b9dc`
- `llvm-lit -v llvm/test/CodeGen/AMDGPU/llvm.amdgcn.cvt.fp8.ll` passes
- `git clang-format --diff` reports no LLVM source formatting changes
- shell syntax, workflow YAML parsing, cache-key generation, and FlyDSL style checks pass
