### PR TITLE
[DO NOT MERGE] Add MegaMoE engineering skill

### DIFF
--- a/.claude/skills/megamoe-engineering/SKILL.md
+++ b/.claude/skills/megamoe-engineering/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: megamoe-engineering
+description: >
+  Develop, review, debug, validate, and tune AITER/FlyDSL MegaMoE on AMD
+  multi-GPU EP systems. Use for MegaMoE or MegaMoEV2 architecture, MTPR,
+  fixed-slot/compact dispatch, fused prepare/quant, payload dedup/fanout,
+  Stage1/Stage2, A8W4/A4W4/SmoothQuant paths, AOT/JIT, 8-GPU correctness,
+  CUDA Graph hangs, ATT traces, or ATOM/SGLang end-to-end performance. Do not
+  use for an ordinary non-Mega fused_moe/GEMM task.
+allowed-tools: Read Edit Bash Grep Glob Agent WebFetch WebSearch
+---
+
+# MegaMoE Engineering
+
+Use this skill as a decision system, not as permission to replay old commands.
+MegaMoE spans AITER, FlyDSL, MORI and serving-framework code; stale source,
+runtime or routing assumptions can produce plausible but invalid results.
+
+## Start every task here
+
+1. Read the active repository's `CLAUDE.md` and locate any `AGENTS.md` that
+   governs files in scope.
+2. Classify the task and read only the matching references below.
+3. Resolve the current source, branch, commit, dirty state, imported Python
+   files, FlyDSL build, PyTorch/HIP, MORI and GPU model. Never infer these from
+   a directory name or an earlier report.
+4. Use a clean, isolated worktree based on the requested branch. Preserve
+   unrelated dirty work; never copy a historical source tree over current
+   code.
+5. Read the current implementation and tests before treating any historical
+   document as truth. A dated result is evidence for its recorded stack only.
+6. Before using an eight-GPU node, identify every `/dev/kfd` holder and its
+   container/job owner. Do not stop another workload without fresh authority
+   in the current conversation.
+
+The read-only helper [scripts/preflight.sh](scripts/preflight.sh) records most
+of the provenance needed in steps 3 and 6.
+
+## Reference router
+
+| Task | Read |
+|---|---|
+| Understand or change the algorithm, buffers, dispatch or quant path | [architecture-and-protocol.md](references/architecture-and-protocol.md) |
+| Find the authoritative source, tests, configs, framework hooks or local evidence | [repository-map.md](references/repository-map.md) |
+| Build a node/container, select a runtime, inspect GPU ownership or diagnose apparent compilation hangs | [environment-and-safety.md](references/environment-and-safety.md) |
+| Prove correctness, CUDA Graph safety, AOT coverage, CI reachability or whole-model health | [validation.md](references/validation.md) |
+| Establish baselines, interpret Stage1/Stage2/E2E time, capture ATT/PMC or tune a shape | [performance-and-tracing.md](references/performance-and-tracing.md) |
+| Diagnose a hang, race, silent error, buffer overflow or cross-rank protocol mismatch | [correctness-and-debugging.md](references/correctness-and-debugging.md) |
+| Add a model/network or reason about V4-Pro, M13, GLM-5.2 or Kimi-K3 geometry | [models-and-shapes.md](references/models-and-shapes.md) |
+| Locate prior runbooks, performance tables, traces, reviews and incident reports | [evidence-index.md](references/evidence-index.md) |
+
+For a PR review, read architecture, validation, correctness and the evidence
+index. For performance tuning, read architecture, validation, performance and
+the relevant model section. For a serving regression, also read environment
+and repository map.
+
+## Source-of-truth order
+
+When sources disagree, use this order:
+
+1. current checked-out production source and its tests;
+2. the exact serving image/runtime and import-path evidence;
+3. artifacts from a run with recorded commits, command and raw logs;
+4. a dated design/review document;
+5. remembered behavior or an unversioned performance number.
+
+Stop and resolve a disagreement at levels 1-3. Do not average incompatible
+results or describe a workaround as a root-cause fix.
+
+## Non-negotiable engineering rules
+
+- Correctness precedes performance. A candidate is not tunable until eager
+  output, eight-rank reference comparison and CUDA Graph replay pass.
+- Preserve the exact mathematical order of quantization, routing, GEMM,
+  routing-weight application and combine. A faster non-equivalent pipeline is
+  a correctness bug.
+- Cross-rank wire fields must be derived from rank-invariant inputs. Local
+  token buckets may select compute geometry, but may not silently select a
+  different payload layout, ready protocol or P2P dtype.
+- A zero-token rank must still enter the collective protocol when peers have
+  work. Returning early can strand the EP group.
+- A ready flag does not make prior P2P writes visible. Audit release, publish,
+  wait and acquire as one protocol.
+- CUDA Graph and long queued chains are separate gates from one synchronized
+  eager call. Test back-to-back launches and the framework's real layer count.
+- Treat `max_tok_per_rank`/MTPR as an ABI and capacity choice, not only a tune
+  hint. Validate runtime tokens, source encoding, buffer sizes and the
+  fixed/compact boundary.
+- Do not claim AOT from a warm JIT cache. Build the declared profile and prove
+  a fresh process succeeds with run-only/cache-miss enforcement.
+- Do not add Stage1 and Stage2 event times and call the result E2E. Kernels,
+  streams and ranks can overlap; measure the graph span and report rank mean
+  and rank max separately.
+- Compare candidates on the same machine, container, runtime, weights, route,
+  MTPR and timing path. Re-run the baseline adjacent to the candidate when the
+  expected gain is near run-to-run noise.
+- A normal non-fatbin JIT specialization should finish in seconds on the known
+  setup. Minutes of silence require process/GPU/port/cache inspection; do not
+  label it "still compiling" without compiler activity or a new artifact.
+- Tune from trace evidence. First name the critical stage and instruction or
+  resource bottleneck, then change the smallest relevant knob or code path.
+- Keep production defaults free of experimental environment switches and dead
+  configurations. Use temporary overrides only to establish causality, then
+  either encode a validated selector rule or remove the experiment.
+
+## Standard work loops
+
+### Functional or protocol change
+
+1. Draw the before/after dataflow and list every producer, consumer, buffer,
+   epoch/ready flag and compile-key field affected.
+2. Add a CPU/config invariant test where possible.
+3. Compile representative fixed and compact variants with cache isolation.
+4. Run the focused eight-rank accuracy/Graph/stress matrix.
+5. Re-run the performance anchors and serving cases affected by the change.
+6. Review the final diff against the entire MegaMoE call chain, not only the
+   edited function.
+
+### Performance tuning
+
+1. Freeze source and environment; record a fresh paired baseline.
+2. Collect synchronized per-rank kernel timing and identify the critical rank.
+3. Capture ATT for the dominant kernel; use PMC when bandwidth, occupancy or
+   cache behavior is the unresolved question.
+4. Form one measurable hypothesis. Change one code path or a bounded config
+   family.
+5. Run the cheap correctness gate, then paired perf. Reject noisy/non-general
+   wins.
+6. Repeat until the requested target or an evidenced hardware/protocol limit.
+7. Full-scan all supported buckets and both MTPR modes before cleanup.
+
+### Hang investigation
+
+1. Confirm whether the active GPU kernel is prepare, Stage1, Stage2, combine or
+   an unrelated framework kernel. Capture dispatch traces; do not infer it from
+   the last host log line.
+2. Reproduce with a watchdog and an owned-process cleanup trap.
+3. Preserve asymmetric rank tokens, routing and queued launch depth while
+   bisecting one protocol phase at a time.
+4. Record progress counters from a non-blocking/pinned path where possible;
+   ordinary D2H copies can wait behind a wedged persistent kernel.
+5. Prove the exact unsatisfied wait or missing visibility edge. A timeout,
+   extra synchronization or relaxed comparison alone is not a fix.
+
+## Definition of done
+
+A completed change reports:
+
+- repo/branch/full commit and diff scope;
+- image/runtime/FlyDSL/AITER/MORI/PyTorch/HIP/GPU provenance;
+- exact command and raw-log location;
+- functional matrix with eager, reference error, Graph replay and stress;
+- Stage1, Stage2/combine and E2E rank-mean/rank-max data;
+- base-versus-candidate delta for every requested shape;
+- AOT/JIT and serving results when those paths are affected;
+- cleanup status, known limitations and processes/artifacts left behind.
+
+Use a Markdown table for final comparisons. Keep raw logs and traces outside
+the repository; commit only durable instructions or small curated baselines.
+
+## Knowledge freshness
+
+This skill intentionally records durable invariants and routes to dated
+evidence. It cannot make old performance numbers current. When a task reveals
+a new validated invariant, incident root cause, model geometry or canonical
+runner, update the relevant reference in a dedicated documentation change.
+Record the validating commit and date. Never promote an unverified experiment
+or an active worktree path into a universal rule.

--- a/.claude/skills/megamoe-engineering/references/architecture-and-protocol.md
+++ b/.claude/skills/megamoe-engineering/references/architecture-and-protocol.md
@@ -1,0 +1,281 @@
+# MegaMoE architecture and protocol
+
+This reference captures durable reasoning and a dated architecture snapshot.
+Always inspect the current source before relying on a launch boundary or tune
+default.
+
+## Mathematical contract
+
+For source token `t`, router slot `s`, selected global expert `e(t,s)` and
+routing weight `p(t,s)`, MegaMoE must compute the standard routed-MoE result:
+
+```text
+u(t,s) = W2[e] (SwiGLU(W1[e] x[t]))
+y[t]   = sum_s p(t,s) * u(t,s)
+```
+
+The fused implementation may change layouts, quantize intermediate values,
+overlap communication with GEMMs and scatter results directly to the source
+rank. It may not change which activation is quantized, which expert owns a
+route, where the routing weight is applied or which slots are combined.
+
+At the operator boundary each rank owns some tokens with the complete hidden
+dimension. Router IDs are global expert IDs. An expert owner is normally:
+
+```text
+owner_rank  = global_expert // experts_per_rank
+local_expert = global_expert % experts_per_rank
+```
+
+The result must return in the original source-rank/token order. A source map
+therefore needs source rank, source token and top-k slot even when payload rows
+are deduplicated.
+
+## Production AITER snapshot
+
+As of 2026-09-09, AITER main contains the architecture restored by AITER #5346
+(the corrected successor of #5001). Verify the current tree under
+`aiter/ops/flydsl/kernels/mega_moe/` before changing it.
+
+The logical pipeline is:
+
+```text
+BF16 input
+  -> fixed-slot: standalone 1x32 MXFP8 quant
+     compact: prepare kernel fuses 1x32 MXFP8 quant with count/group/plan
+  -> Stage1: P2P dispatch + expert-major FP8xFP4 GEMM1
+             + SwiGLU + 1x32 MXFP8 requant
+  -> Stage2: FP8xFP4 GEMM2 + routing weight + P2P scatter
+  -> terminal combine: sum top-k slots, dequantizing FP8 P2P payload if used
+```
+
+The host wrapper may call Stage2 and combine as one logical operation while
+they remain distinct GPU kernels. Confirm launch count and overlap from the
+trace rather than from the Python function name.
+
+Current production concepts include:
+
+- paired Stage1/Stage2 bundle selection and AOT preload;
+- compact prepare outside the high-LDS GEMM1 kernel;
+- BF16-to-MXFP8 quant work fused into compact prepare;
+- deterministic runtime fanout/payload dedup metadata;
+- producer CTAs followed by oversubscribed consumers;
+- fixed-slot direct dispatch for small MTPR;
+- compact group-major dispatch for larger capacities;
+- ready-tile order for sufficiently skewed compact workloads;
+- source-indexed payload storage at the largest capacity;
+- zero-token-rank participation and generic top-k support currently bounded by
+  the implementation.
+
+These are related protocol pieces, not independent flags. Moving only one part
+between branches can create a build that compiles but has mismatched buffer or
+ready semantics.
+
+## Customer FlyDSL-universe paths
+
+The ByteDance branch `ghu/mega_moe_v1_copy` is a distinct product fork. Its
+delivered code must not be assumed identical to AITER main.
+
+The important paths are:
+
+| Path | Activation flow | Notes |
+|---|---|---|
+| Native MX A8W4 | BF16 -> 1x32 MXFP8/E8M0 -> dispatch/GEMM1 | Decode was originally restricted and tuned through TPR 512; prefill enablement/tuning is separate work. |
+| SmoothQuant A8W4 | BF16 -> SmoothQuant to INT8 -> dispatch/GEMM1 | Customer-specific. The delivered design keeps SmoothQuant before Stage1; do not silently move quantization after BF16 dispatch. |
+| A8W8 smooth prefill | customer-specific quant/communication path | Treat separately; do not infer its transport from native MX A8W4. |
+
+At the 2026-09-09 delivered Byte head `5846a600`, native M13 A8W4 explicitly
+accepted only `tokens=MTPR` through 512. Larger MTPR support therefore needs
+protocol/capacity validation before tuning. This commit is historical evidence,
+not a promise about the latest branch.
+
+The abandoned experiment that embedded SmoothQuant inside Stage1 was not the
+final customer baseline. It increased register pressure and degraded many
+shapes. Preserve the delivered pre-Stage1 semantics unless a new trace-backed,
+fully equivalent design wins the complete matrix.
+
+## Fixed-slot and compact
+
+The exact threshold belongs to the current selector. In the #5346 AITER
+snapshot, `FIXED_SLOT_MAX_MTPR=255`; the Byte fork can use different boundaries.
+
+Fixed-slot:
+
+- derives destination slots from fixed capacity;
+- avoids the complete compact prefix/packing plan;
+- targets small CUDA Graph decode capacities;
+- has direct-dispatch constraints, including the supported experts/rank range;
+- still needs all ranks to participate, including zero-token ranks.
+
+Compact:
+
+- counts routes, groups them and builds expert-major row ranges;
+- returns destination-owned bases to sources;
+- allocates rows for actual traffic plus alignment rather than every fixed slot;
+- is the normal large-MTPR/prefill path;
+- can use chunk/tile readiness and fanout metadata.
+
+`MTPR=tokens` and `MTPR=MAX` exercise different capacity, protocol and buffer
+costs for the same actual token count. Always scan both when the deployment can
+use both.
+
+## Prepare, Stage1 and role scheduling
+
+Separating compact prepare from GEMM1 is deliberate:
+
+- count/group/plan needs modest LDS but serialized cross-rank decisions;
+- GEMM1 needs substantial LDS/VGPR and benefits from a compute-focused grid;
+- quant can run as independent specialist CTAs in the prepare launch;
+- prepare publishes a complete layout before Stage1 consumes it.
+
+Current Stage1 assigns producer/consumer work according to the current source
+implementation. Do not rely on remembered claims such as "no atomics" or
+"static work". At the #5346 snapshot, compact/fixed consumer paths still use
+sharded atomic work heads, while arrival tickets and oversubscription ensure
+required roles can become resident. A future static assignment is valid only
+if it proves load balance, producer residency and every supported shape.
+
+The forward-progress question is more important than the exact role count:
+
+1. Can every required producer become resident while consumers wait?
+2. Do producer/owner CTAs retire or join useful compute after finite role work?
+3. Can queued consumers backfill released CUs?
+4. Does any persistent consumer wait on work that only a non-resident producer
+   can publish?
+
+## Fanout and payload dedup
+
+"Fanout" means one transmitted activation payload can feed more than one
+selected expert at the same destination. The current pair specialization:
+
+1. selects a pair of local expert IDs for each destination at runtime;
+2. detects tokens whose routed top-k contains both experts;
+3. emits one canonical shared segment instead of two activation payload rows;
+4. preserves the two routing weights, source slots and expert identities;
+5. computes/scatters both expert results with aligned-pair or residual Stage2
+   work.
+
+The runtime pair table is double-buffered by parity and kept out of the compile
+key so one AOT artifact can serve different routing distributions. Expert IDs,
+not only a 64-bit bitmap, are required when a destination owns more than 64
+experts. Top-k grouping width and metadata encoding remain explicit limits.
+
+Dedup saves the large activation+scale payload; it does not permit dropping
+per-route weights or return mappings. Audit the non-deduplicated fallback and
+mixed pair/non-pair routes.
+
+## Stage1 payload readiness
+
+A compact plan creates expert/tile metadata and producer tasks. A producer
+typically writes:
+
+- quantized activation row;
+- 1x32 activation scales;
+- routing weight;
+- source map or route metadata.
+
+Correct P2P publication is:
+
+```text
+remote payload stores
+  -> wait for stores as required
+  -> system release fence
+  -> system-scope ready publication
+
+consumer wait
+  -> observe expected epoch/count
+  -> system acquire fence
+  -> all consuming waves converge
+  -> load payload / execute GEMM
+```
+
+Plan-ready, pair-order-ready, payload-ready, tile-ready, ready-queue epoch and
+launch-ready have different meanings. Reusing one as another needs a proof.
+
+Payload chunks can release tiles before a source-to-expert transfer is fully
+complete. The planner must compute each tile's exact expected publisher count;
+the final publisher may enqueue that tile. Any layout transition must reset
+ready state in the same coherence domain used by publishers.
+
+## Stage1 GEMM1 and epilogue
+
+The destination consumes expert-major rows:
+
+```text
+FP8 activation [M,H] x MXFP4 W1 [expert,H,2I]
+  -> FP32 accumulators
+  -> optional bounded SwiGLU semantics
+  -> [M,I]
+  -> 1x32 MXFP8/E8M0 requant for Stage2
+```
+
+Compile invariants include the MFMA fragment geometry, tile-N per wave,
+Stage1 SBM, tile-K, LDS layout and output-buffer addressing. Validate these in
+the selector before launching. A selector that returns `NUM_ACC_N=1` to a
+kernel requiring an even accumulator count is a functional failure, not a tune
+miss.
+
+## Stage2 and combine
+
+Stage2 maps `(M block, N block, expert)` work, performs GEMM2, applies the
+routing weight and scatters to the source rank/token/top-k slot. Persistent,
+strided/skew and aligned-pair variants are scheduling choices; the source map
+and scatter wire format are common contracts.
+
+Large-MTPR paths can quantize P2P Stage2 output to FP8 blockwise 1x32 plus E8M0
+scales. Smaller paths can scatter BF16. This choice must be identical across
+ranks for the operator instance and included in Stage2/bundle identity.
+
+The final result is the sum of top-k slots. When timing, distinguish:
+
+- Stage2 GEMM/scatter kernel;
+- combine kernel;
+- the host helper that may include both;
+- the full first-to-last graph span.
+
+## Capacity and addressing invariants
+
+Check these from current code for every new profile:
+
+- `experts % world_size == 0`;
+- MTPR is supported, normally a positive power of two;
+- every rank's actual tokens are `<= MTPR`;
+- source rank/token/top-k encoding has enough bits;
+- route/fanout segment encoding admits the global expert count and extra group
+  segments;
+- Stage2 block-M divides Stage1 sort-block-M;
+- quant group dimensions are divisible by 32 where required;
+- local and symmetric buffers cover worst-case routing and padding;
+- a buffer-resource descriptor never addresses beyond its byte limit;
+- offsets crossing 2/4 GiB are computed and rebased with 64-bit arithmetic;
+- bundle identity contains every dtype/layout/protocol/geometry value that can
+  change generated code or ABI.
+
+At MTPR 32768, activation receive storage can exceed 4 GiB. The safe pattern is
+to compute row/tile bases in 64 bits and create a local descriptor at the
+rebased address, rather than issue one descriptor with a huge element offset.
+
+## AOT and preload
+
+Disk AOT and module preload solve different costs:
+
+1. AOT creates compiled artifacts at image/build time.
+2. Preload materializes the artifact and HIP module before the first request.
+
+A build that contains artifacts can still show `hipModuleLoadData` on the first
+request if it was not preloaded. Conversely, calling the real communication
+kernel on dummy pointers is not a safe preload strategy.
+
+Production AOT should reuse the exact runtime wrapper, selector and compile
+kwargs. Bundle/job identity must include rank, EPR, world size, model shape,
+top-k, MTPR, quant dtype/layout, wire format and all code-generating options.
+Validate by building a fresh cache and starting a second process with strict
+run-only mode. Missing artifacts must fail rather than silently JIT.
+
+## Concurrency contract
+
+Historically, one `MegaMoEV2` instance supports one ordered in-flight launch.
+The instance owns mutable parity, counters, buffers and ready state. Do not
+enable concurrent multi-stream/TBO re-entry unless the current implementation
+has independent per-ubatch state, deterministic cross-rank launch order and a
+dedicated multi-stream Graph test.

--- a/.claude/skills/megamoe-engineering/references/correctness-and-debugging.md
+++ b/.claude/skills/megamoe-engineering/references/correctness-and-debugging.md
@@ -1,0 +1,198 @@
+# Correctness, hang and race debugging
+
+MegaMoE bugs often present as a hang on one rank and a harmless-looking wait
+on seven peers. Diagnose the first violated invariant, not the last printed
+line.
+
+## Failure classification
+
+Classify the observation before changing code:
+
+| Symptom | First questions |
+|---|---|
+| All ranks idle on host | rendezvous, Python exception, compiler/cache lock, framework barrier? |
+| One rank exited, peers busy | what failed first on the missing rank? |
+| GPUs busy indefinitely | which kernel is resident, and which ready/counter value cannot advance? |
+| Finite but wrong output | route/source map, quant scale, routing weight, epoch reuse, uninitialized padding? |
+| Graph-only failure | captured pointer/state mutation, epoch reset, queued reuse, hidden host operation? |
+| Large-MTPR-only failure | buffer capacity, address width, epoch wrap, source encoding, selector boundary? |
+| Mixed-rank-only failure | rank-dependent wire/config choice, zero-token early return, unequal collective path? |
+| AOT-only failure | missing job, incomplete cache key, changed constructor/API, synthetic merge mismatch? |
+
+Preserve the first failing logs, process list, active kernel and source commit.
+A clean rerun after killing everything is not a diagnosis.
+
+## Minimal reproducible ladder
+
+Keep the failing semantic axis while reducing cost:
+
+1. reproduce the exact eight-rank case with a watchdog;
+2. reduce queued iterations/layers, not rank asymmetry or route skew;
+3. identify prepare, Stage1, Stage2 or combine as the resident/failing phase;
+4. reduce tokens while retaining the same fixed/compact mode and MTPR;
+5. isolate the phase with inputs captured from a passing full operator;
+6. add progress counters or invariant traps outside the performance build;
+7. prove one missing write, invalid state transition or memory overlap.
+
+If the failure disappears when synchronizing, treat that as evidence of a
+race/visibility/lifetime defect. Do not ship the synchronization unless it is
+part of the intended protocol and its performance is accepted.
+
+## Distributed protocol audit
+
+For every shared field, write down:
+
+```text
+owner rank/wave
+allocation and reset point
+epoch or generation
+writer(s)
+release/fence operation
+published ready/counter value
+reader(s)
+wait predicate
+acquire/invalidate operation
+reuse condition
+capacity and address type
+```
+
+Then verify these invariants:
+
+- one semantic object has one owner or a proven atomic multi-writer protocol;
+- payload and metadata become visible before readiness is published;
+- readers acquire visibility after observing readiness;
+- epoch/generation prevents a later launch from satisfying an earlier wait;
+- a slot is not reused until all readers that require it are finished;
+- all ranks choose the same wire layout, P2P dtype and ready protocol;
+- local compute geometry does not change the cross-rank ABI;
+- padding/sentinel entries cannot be interpreted as real routes;
+- zero-token ranks still publish/participate as required;
+- address arithmetic cannot wrap at supported maximum capacity.
+
+Equality waits such as `counter == expected` deserve special scrutiny. If a
+producer can advance past the expected value before a delayed consumer loads
+it, equality can wait forever. Use a proven monotonic/generation protocol;
+changing `==` to `>=` without analyzing reuse and wraparound can accept stale
+work.
+
+## Known high-value failure patterns
+
+These are diagnostic patterns, not assumptions that the current source still
+contains the bug.
+
+### Rank-local selector changes a wire field
+
+Local token count selects a different SBM, P2P dtype, packet shape or ready
+layout on different ranks. Equal-token tests pass; variable local tokens hang
+or corrupt. Separate rank-invariant wire configuration from rank-local compute
+tuning and add an exhaustive invariant test.
+
+### Zero-token rank returns early
+
+The empty rank skips dispatch/ready publication while peers send to or wait on
+it. Keep collective/protocol participation; only skip local arithmetic that is
+provably irrelevant.
+
+### Cross-wave LDS slot overwrite
+
+A dynamic Stage1 queue reuses one LDS work descriptor while another wave still
+consumes it. This can duplicate/skip GEMM tiles and is a correctness race even
+if it first appears as variable performance. Give each live consumer a stable
+slot or prove handoff with release/acquire and non-overlapping lifetime.
+
+### Counter/epoch backpressure race
+
+A persistent producer or consumer observes a value from the next iteration,
+or overwrites a slot before the previous generation retires. Reproduce with
+queued launches and many graph replays; a single synchronized eager call is
+insufficient.
+
+### Buffer-resource or address-width limit
+
+Legacy raw buffer resources can impose a 4-GiB addressing window or truncate
+byte offsets. Large MTPR/top-k/hidden sizes expose this. Prefer current tensor
+buffer APIs and prove 64-bit capacity arithmetic; do not retain a private raw
+pointer compatibility branch indefinitely.
+
+### Quantization-order drift
+
+Moving SmoothQuant into a different stage can quantize after dispatch instead
+of before it, change scale granularity or increase Stage1 register pressure.
+Draw the exact BF16 -> smooth scale -> INT8/MX payload -> GEMM sequence and
+compare against the delivered reference. Algebraic similarity is not enough
+when rounding points move.
+
+### Stage1/Stage2 contract mismatch
+
+An isolated Stage2 wrapper chooses a default SBM/config instead of consuming
+the active Stage1 contract. This can pass a narrow shape and fail AOT or a new
+model. Make cross-stage fields explicit and include them in bundle/cache
+identity.
+
+### AOT API drift
+
+An AOT generator calls a selector with an obsolete signature or omits a new
+keyword such as EP size. JIT tests pass because runtime supplies it. Test the
+real AOT enumeration in a fresh cache and the synthetic merge result used by
+CI; require the expected job count and zero `produced no kernel` results.
+
+### Stale binary or import-path split
+
+Python comes from one checkout while FlyDSL bindings or an AITER extension
+come from another Torch/ROCm ABI. Print `module.__file__`, inspect loaded
+libraries and rebuild against the active venv. Do not modify kernel protocol to
+compensate for an ABI failure.
+
+### One rank fails before a collective
+
+Peers appear wedged in MegaMoE or a barrier, but the root error is an OOM,
+assert or Python exception on another rank. Inspect every rank log and preserve
+the earliest timestamped error.
+
+## Progress instrumentation
+
+Temporary debug state should be monotonic and low-risk:
+
+- per-rank phase ID and epoch;
+- per-producer sent/retired count;
+- per-consumer acquired/completed tile count;
+- per-destination published/observed ready count;
+- last expert/source/tile identifier;
+- overflow or invalid-route flag.
+
+Prefer host-visible pinned or independently readable state. A normal D2H copy
+on the same stream may sit behind the hung persistent kernel and reveal
+nothing. Remove instrumentation and its buffers from the production diff after
+the root cause is proven.
+
+## CUDA Graph and re-entry audit
+
+Check all captured state:
+
+- device pointers are stable for the graph's lifetime;
+- counters/epochs reset in device-visible order;
+- host scalars are not read dynamically during replay;
+- route/fanout metadata can change only where the graph contract permits;
+- one operator instance is not entered concurrently on unsupported streams;
+- preload/AOT creates no request-path compilation or allocation;
+- back-to-back layer launches cannot reuse scratch before retirement.
+
+If multi-stream/TBO is required, either allocate independent state per in-flight
+instance or implement an explicit ownership protocol. Same-stream ordering is
+not proof of multi-stream safety.
+
+## Proving a fix
+
+A fix report must name:
+
+1. the violated invariant;
+2. the precise producer/consumer interleaving or invalid value;
+3. why the patch prevents that interleaving for all supported generations;
+4. a focused regression that failed before and passes after;
+5. eight-rank eager, Graph replay and queued-stress results;
+6. performance impact on fixed and compact anchors;
+7. whether the defect was introduced by the PR or already present on its base.
+
+To decide new versus pre-existing, run the same reproducer and environment on
+the merge base. Do not infer ancestry from where the suspicious line first
+caught attention.

--- a/.claude/skills/megamoe-engineering/references/environment-and-safety.md
+++ b/.claude/skills/megamoe-engineering/references/environment-and-safety.md
@@ -1,0 +1,198 @@
+# Environment and execution safety
+
+MegaMoE failures are often caused by a mixed source/runtime stack, a stale
+cache, an occupied GPU, a rendezvous collision or insufficient symmetric heap.
+Prove the environment before interpreting a kernel result.
+
+## Read-only node preflight
+
+On the target host, run the skill's non-initializing helper twice before
+starting:
+
+```bash
+.claude/skills/megamoe-engineering/scripts/preflight.sh \
+  --aiter <aiter-worktree> \
+  --flydsl <flydsl-worktree> \
+  --runner <runner> \
+  --python <python>
+```
+
+It uses package metadata and sysfs rather than importing Torch or invoking a
+GPU management runtime. That distinction matters on an unhealthy/shared node:
+even a nominally read-only `torch.cuda.device_count()` or `rocm-smi` call can
+enter an uninterruptible driver wait. Use runtime imports only as a separate,
+bounded build smoke after ownership is established.
+
+Map every holder to a container or scheduler job. GPU utilization at zero is
+not enough: a process can hold memory or a context while idle. A busy GPU is
+not necessarily an unrelated process: verify ownership, comm name and cgroup.
+Inspect full command lines only when needed and avoid copying credentials from
+process arguments into reports.
+
+Do not inherit a previous conversation's permission to kill processes. Only
+stop PIDs started by the current runner or targets explicitly authorized in the
+current task. Prefer a runner that records child PIDs and cleans only those.
+
+## Known machine profiles
+
+Historical work used eight-MI355X nodes referred to as host46 and host47, with
+containers such as `guoliang_stage1` and `guoliang_eplb_main47`. These names are
+discovery hints only. Containers can be recreated, stopped or repurposed.
+
+Before use, record:
+
+```bash
+podman ps -a
+podman inspect <container> --format '{{.ImageName}} {{.Image}}'
+podman top <container> pid,user,etime,args
+```
+
+Confirm that the container has all eight `/dev/dri` devices and `/dev/kfd`, uses
+host networking/IPC when required by MORI, and mounts the requested code/model
+paths. Do not start or reconfigure a shared container without checking its
+owner.
+
+## Canonical Python and library composition
+
+One validated customer profile used:
+
+```bash
+VERIFY_ROOT=/home/ghu/opus_verify_46
+UNIVERSE_ROOT=/home/ghu/FlyDSL_universe
+TORCH_LIB=/opt/venv/lib/python3.12/site-packages/torch/lib
+
+export PYTHONPATH="$VERIFY_ROOT:$UNIVERSE_ROOT/build-fly/python_packages:/home/ghu/mori/python:/home/ghu/aiter_universe/aiter"
+export LD_LIBRARY_PATH="$UNIVERSE_ROOT/build-fly/python_packages/flydsl/_mlir/_mlir_libs:$TORCH_LIB"
+export FLYDSL_RUNTIME_ENABLE_CACHE=0
+export MORI_SHMEM_HEAP_SIZE=64G
+export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export WORLD_SIZE=8 MASTER_ADDR=127.0.0.1
+```
+
+Use `/opt/venv/bin/python` for that profile. The Torch library directory is
+required so AITER extensions can resolve symbols such as `c10`. Paths differ on
+host47 and newer images; derive them from the actual environment.
+
+Never trust `PYTHONPATH` order without proving imports:
+
+```bash
+/opt/venv/bin/python - <<'PY'
+import aiter
+import flydsl
+import torch
+
+print("aiter", aiter.__file__)
+print("flydsl", flydsl.__file__)
+print("torch", torch.__version__, torch.version.hip)
+PY
+```
+
+Also print the exact MegaMoE Stage1, dispatch and test modules. A source edit has
+no meaning if Python imports a different checkout or generated package.
+
+## Build compatibility
+
+FlyDSL Python sources, generated dialect bindings and shared libraries form one
+ABI set. Do not combine an arbitrary source checkout with an unrelated
+`build-fly/python_packages` merely because imports succeed. Validate signatures
+for any API changed between revisions, then run a real compile/lower smoke.
+
+AITER binary extensions must match the active Torch/ROCm ABI. A historical
+`module_quant.so` failure was fixed by rebuilding it against the active venv.
+If the container is replaced, reproduce the build rather than copying the old
+`.so` blindly.
+
+Check shared-library resolution when symbols are missing:
+
+```bash
+ldd <extension.so>
+```
+
+Do not dismiss ROCm differences wholesale. A pure generated kernel can have the
+same ISA, but runtime, compiler, profiler, MORI and module ABI differences can
+change execution or measurement. Compare ISA only after source and compile keys
+are controlled.
+
+## JIT cache modes
+
+Use a rank-private cache directory. Concurrent ranks sharing one cache can
+create lock contention or make a fresh compile look like a hit.
+
+- For source/debug experiments: set `FLYDSL_RUNTIME_ENABLE_CACHE=0`, or create a
+  fresh rank-specific directory.
+- For cache-reuse validation: preserve the artifact manifest and mtimes between
+  runs.
+- For AOT validation: build into an empty directory, then launch a fresh process
+  with `FLYDSL_RUNTIME_RUN_ONLY=1`.
+- Do not combine run-only with settings that require JIT IR dumping.
+
+An in-memory compiled-function cache survives within a process even when disk
+cache is disabled. Use a new process when proving compilation or cache-key
+behavior.
+
+## Distinguishing compile, wait and hang
+
+Normal non-fatbin specialization on the known setup is usually seconds, not
+minutes. If a run is silent:
+
+1. inspect CPU command lines and child compiler processes;
+2. inspect GPU holders, utilization and memory;
+3. inspect cache files, lock files and mtimes;
+4. inspect rank logs independently;
+5. check rendezvous port ownership;
+6. determine whether one rank exited while peers wait at a collective;
+7. identify the active GPU kernel before changing code.
+
+Evidence of real compilation includes an active compiler/lowering process or a
+growing/new artifact. Eight GPUs at 100% with stable logs and no compiler is a
+device wait/hang, not compilation.
+
+Use a unique `MASTER_PORT` below the default ephemeral range when practical.
+After a failed rank, terminate only the sibling PIDs recorded by the runner so
+they do not keep the port and GPU contexts.
+
+## Symmetric heap and memory
+
+MORI symmetric workspace is outside the framework's ordinary model/KV memory
+budget. Size it for the exact MTPR, model dimension, top-k, payload dtype and
+dedup scheme. Historical profiles required 16-64 GiB depending on path.
+
+Do not blindly raise the heap:
+
+- compute the expected dispatch/combine allocations;
+- leave headroom for model weights, AITER workspaces and CUDA Graph capture;
+- record the value in every comparison;
+- understand that changing it can affect whether the server starts and how
+  much HBM remains for scheduling.
+
+## Safe runner pattern
+
+A multi-rank runner should:
+
+1. choose a unique port and rank-private caches;
+2. print source/build/import provenance before launch;
+3. record each child PID;
+4. redirect one log per rank;
+5. stop peers immediately if one rank fails before joining collectives;
+6. install an EXIT/INT/TERM trap that signals only recorded children;
+7. wait for all ranks and propagate a nonzero exit code;
+8. print rank0 gates plus enough tails from every failed rank.
+
+Avoid an unconditional `pkill -f` in a reusable runner. It can kill a colleague
+whose command contains the same test filename.
+
+## End-of-run audit
+
+Before declaring a task clean:
+
+```text
+all child ranks exited
+rendezvous port released
+no task-owned /dev/kfd holder
+no task-owned server/client/watchdog process
+cache/log/trace locations recorded
+unrelated process list unchanged
+```
+
+If material files or processes were removed, state exactly what and whether it
+was recoverable.

--- a/.claude/skills/megamoe-engineering/references/evidence-index.md
+++ b/.claude/skills/megamoe-engineering/references/evidence-index.md
@@ -1,0 +1,141 @@
+# Evidence index and historical lessons
+
+This file routes agents to prior evidence available in the established
+workspace. These artifacts are not shipped with FlyDSL and may not exist on a
+different machine. Their dates, branches and environments bound every claim.
+
+## How to consume historical evidence
+
+1. Read the artifact's provenance and command before its conclusion.
+2. Resolve the referenced commit; distinguish PR head, merge result, reverted
+   history and later corrected PR.
+3. Verify that imported code/build paths matched the named checkout.
+4. Treat a table without raw logs and environment as a lead, not a baseline.
+5. Re-run the baseline adjacent to the candidate for any current decision.
+6. Extract durable invariants into this skill only after current-source review
+   and a reproducer confirm them.
+
+## Architecture and implementation records
+
+| Artifact | Use | Caveat |
+|---|---|---|
+| `/data/ghu/MEGA_MOE_V2_IMPLEMENTATION.md` | Historical end-to-end algorithm, data structures and kernel roles. | Predates later #5346 production changes; never use as current launch-boundary truth. |
+| `/data/ghu/megamoe_aot_design.md` | AOT bundle/preload goals and cache reasoning. | Verify current AOT registry, job signatures and deployment profiles. |
+| `/data/ghu/MEGA_V2_DEADLOCK_REPORT.md` | Deadlock investigation patterns and counter protocol evidence. | Confirm the exact commit before claiming the same root cause. |
+| `/data/ghu/MEGA_V2_CUDAGRAPH_DEADLOCK_EXPERIMENTS.md` | CUDA Graph/queued-launch experiments. | Experiments include rejected mitigations; a passing workaround is not necessarily the fix. |
+
+## Runbooks and environment records
+
+| Artifact | Use | Caveat |
+|---|---|---|
+| `/data/ghu/run_book_hgl.md` | ATOM whole-model command history and operational checks. | Pin image, ATOM and AITER anew; do not paste an old command blindly. |
+| `/data/ghu/MEGAMOE_RUNBOOK.md` | SGLang fixed-length/AgentX workflow history. | Confirm the current AMD MegaMoE backend flags in SGLang source. |
+| `/data/ghu/host47_megamoe_env_setup_20260826.md` | Known M13/FlyDSL-universe Python and library setup. | Host/container builds can be replaced; verify imports and ABI. |
+| `/data/ghu/hgl_0822_final_patch.md` | Prior ATOM concurrency commands and standard performance reference. | Historical stack only; useful for reproducer construction, not a current claim. |
+
+## Performance records
+
+| Artifact | Use | Caveat |
+|---|---|---|
+| `/data/ghu/mega_moe_v2_perf_compare_20260824.md` | Curated MTPR=MAX and MTPR=tokens comparison. | Confirm which prepare/quant architecture and commits produced it. |
+| `/data/ghu/mega_moe_v2_perf_compare_20260824.full_backup.md` | Longer optimization diary and early fused-prepare evidence. | Contains intermediate/rejected states; do not quote the last-looking number without provenance. |
+| `/data/ghu/mega_moe_v2_v4_pro_performance_host46.md` | V4-Pro microbenchmark reference. | Host46 environment and contention changed repeatedly. |
+| `/data/ghu/m13_smooth_fullscan_compare_20260827.md` | Byte M13 SmoothQuant full-scan comparison. | Check labels and commits: experimental fused variants sometimes regressed most buckets. |
+| `/data/ghu/m13_mx_a8w4_prefill_tuning_20260909.md` | Active M13 MX A8W4 1024-32768 tuning log. | Work in progress until final full scan, accuracy and Graph gates are recorded. |
+| `/data/ghu/tmp.md` | PR performance table and historical SGLang fixed/AgentX results. | Convenience summary; use linked/raw runbook evidence for PR claims. |
+
+## Reviews and compatibility records
+
+| Artifact | Use | Caveat |
+|---|---|---|
+| `/data/ghu/flydsl_universe_megamoe_review_20260826.md` | Review of customer MegaMoE fork and protocol risks. | Re-check current branch; some findings were fixed or bypassed later. |
+| `/data/ghu/flydsl_pr972_review_20260831.md` | A4W4 PR review, including Stage1 queue race and A8W4 interaction analysis. | Tie every finding to its reviewed revision. |
+| `/data/ghu/aiter_pr4980_review_20260909.md` | Independent AITER PR review and MegaMoE compatibility notes. | Draft evidence until review commit and reproducer are recorded. |
+
+## Trace helpers and raw traces
+
+Useful local helpers:
+
+```text
+/data/ghu/parse_megamoe_trace.py
+/data/ghu/analyze_megamoe_kernel_trace.py
+/data/ghu/run_universe_a8w4m13_8_att_flexible_20260828.sh
+```
+
+Example raw trace directory:
+
+```text
+/data/ghu/0825_c4096_trace
+```
+
+The directory name was later identified as a concurrency-512 capture despite
+the `c4096` label. This is a standing lesson: derive graph batch, shapes and
+kernel calls from trace metadata, not filenames.
+
+## Relevant upstream history
+
+| Link | Interpretation |
+|---|---|
+| AITER PR `#5001` | Large MegaMoE optimization effort; merged then reverted. Use for design/perf archaeology, not as production head. |
+| AITER PR `#5346` | Corrected/reopened production line containing the MegaMoE work. Verify current main ancestry. |
+| AITER issue `#5322` | GLM-5.2 support request and expected geometry/integration context. |
+| AITER PR `#4980` | Separately reviewed AITER change; assess interaction against its exact revision. |
+| FlyDSL PR `#972` | A4W4-focused change reviewed for shared MegaMoE/A8W4 regressions. |
+| FlyDSL PR `#1098` | Cooperative scan/reduce extension API migration reference. |
+
+Use GitHub or the local git object database to resolve exact SHAs. PR numbers
+are identifiers, not immutable source snapshots.
+
+## Durable lessons extracted from the evidence
+
+- A clean microbenchmark can coexist with a large whole-model regression when
+  launch order, AOT, MTPR padding or graph overlap changes.
+- The historical best architecture for one path is not automatically correct
+  for SmoothQuant: quantization order and Stage1 register pressure matter.
+- A `produced no kernel` AOT summary can be the downstream symptom of a host
+  selector/API exception; preserve the earliest exception.
+- Equal local token counts hide rank-dependent wire decisions and zero-token
+  protocol failures.
+- Stage1/Stage2 times overlap; tables that appear not to add up can still be
+  correct if E2E is measured over the overlapped graph.
+- A raw trace filename, branch name or directory suffix is not provenance.
+- Killing all GPU processes may make a run pass while destroying root-cause
+  evidence and another user's job; ownership-aware cleanup is mandatory.
+
+## Evidence record template
+
+Create a task report with this minimum header:
+
+```markdown
+# <task and date>
+
+## Provenance
+- Host/GPU:
+- Image digest:
+- AITER/FlyDSL/MORI/framework commits:
+- Dirty state and imported module paths:
+- Python/Torch/HIP:
+- Cache/AOT mode:
+
+## Workload
+- Model geometry and quant path:
+- Rank tokens / MTPR / route / seed:
+- Exact command:
+- Raw logs/traces:
+
+## Correctness
+- Eager/reference error:
+- CUDA Graph replay:
+- Stress/variable-rank/AOT:
+
+## Performance
+| Shape | Base rank max | Candidate rank max | Delta | Config |
+|---|---:|---:|---:|---|
+
+## Root cause or conclusion
+<evidence, limitations and remaining work>
+```
+
+If a new artifact supersedes an old one, keep the old row but mark the scope
+and link the successor. Silent replacement erases the history needed to debug
+regressions.

--- a/.claude/skills/megamoe-engineering/references/models-and-shapes.md
+++ b/.claude/skills/megamoe-engineering/references/models-and-shapes.md
@@ -1,0 +1,173 @@
+# Models, geometry and shape onboarding
+
+Model names are convenient labels, not compile contracts. Store explicit
+geometry and verify it against the exact model revision and serving stack.
+
+## Dated geometry anchors
+
+The following values are working anchors collected during 2026 MegaMoE work.
+Re-check official config/model code before adding production support.
+
+| Model/path | Hidden | Per-expert intermediate | Routed experts | Top-k | EP | Experts/rank | Important semantics |
+|---|---:|---:|---:|---:|---:|---:|---|
+| DeepSeek V4-Pro | 7168 | 3072 | 384 | 6 | 8 | 48 | SwiGLU limit historically 10; production AITER/ATOM anchor. |
+| ByteDance M13 | 3584 | 1280 | 384 | 8 | 8 | 48 | Native MX A8W4 and customer SmoothQuant A8W4 are distinct input/scale paths. |
+| GLM-5.2 routed MoE | 6144 | 2048 | 256 | 8 | 8 | 32 | Shared expert is outside the routed MegaMoE result and must be integrated separately. |
+| Kimi-K3 routing anchor | 3584 | 512 | 896 | 16 | 8 | 112 | Top-k and EPR exceed older bitmap/fixed assumptions; activation/integration must be verified. |
+
+Do not call a shape supported because the selector compiles. Routing semantics,
+activation/clamp, shared experts, scale layout, weight format and framework
+combine behavior are part of support.
+
+## Canonical shape tuple
+
+Record at least:
+
+```text
+(hidden, intermediate, num_routed_experts, topk, ep_size,
+ experts_per_rank, activation, activation_limit,
+ input_dtype, weight_dtype, input_scale_layout, weight_scale_layout,
+ route_weight_dtype, output_dtype, tokens_per_rank, MTPR)
+```
+
+Also record whether dimensions are logical or already account for gated
+activations. Never infer `experts_per_rank` with integer division unless the
+model/framework guarantees even placement.
+
+## Onboarding a model
+
+### 1. Establish authoritative semantics
+
+Use the exact Hugging Face/config revision or framework model implementation.
+Verify:
+
+- routed expert count and top-k;
+- hidden and routed intermediate dimensions;
+- activation, gate/up packing and any clamp/limit;
+- shared-expert count, dimensions and fusion location;
+- router score normalization and routing-weight application;
+- expert placement and EP group size;
+- input/weight/output quantization and scale shapes;
+- padding, noaux/top-k grouping or expert-bias behavior.
+
+Save the source URL/revision in the task report. Model repositories can update;
+do not turn an unpinned web lookup into an undated table entry.
+
+### 2. Derive distributed geometry
+
+Compute and validate:
+
+```text
+experts_per_rank
+maximum routed assignments = MTPR * EP * topk
+per-destination payload capacity
+source-token/slot encoding range
+fanout/dedup ID range
+dispatch and combine buffer bytes
+Stage1 and Stage2 tile divisibility/tails
+```
+
+Top-k greater than six and EPR greater than 64 are deliberate stress axes.
+Audit every packed bitfield, bitmap and fixed-slot assertion. Do not add a
+model-name exception around an insufficient encoding.
+
+### 3. Add every config layer
+
+Update together:
+
+1. network/test registry;
+2. Stage1 geometry selector;
+3. Stage2 geometry selector;
+4. terminal combine table or CSV;
+5. AOT profile/job enumeration and cache key;
+6. framework model/backend enablement;
+7. focused and exhaustive selector tests.
+
+Print resolved configs in the benchmark. A missing combine CSV entry may
+silently choose a generic kernel and make a MegaMoE-versus-MORI comparison
+invalid.
+
+### 4. Validate semantic composition
+
+When the framework computes a shared expert separately, compare:
+
+```text
+framework_output = routed_megamoe_output + shared_expert_output
+```
+
+against the framework reference at the same point. A test that feeds only the
+routed experts should not claim full-layer model correctness.
+
+For SmoothQuant, compare against the delivered customer implementation and
+record the exact order of smoothing, per-token quantization, dispatch and
+GEMM. For native MX A8W4, record the MX scale format/granularity used by the
+active AITER implementation; do not label it generic INT8.
+
+### 5. Tune by deployment regime
+
+At minimum scan:
+
+```text
+tokens/rank: 1,4,8,16,32,64,128,256,512,
+             1024,2048,4096,8192,16384,32768
+MTPR:        tokens and each fixed deployment capacity
+routes:      uniform, hot, mixed skew, unequal rank tokens, zero-token rank
+```
+
+The exact upper bound is deployment-specific. Decode selectors should not
+silently activate a prefill load-balancing path; prefill support must not
+regress small-token fixed-slot behavior.
+
+## Historical model-specific cautions
+
+### V4-Pro
+
+This is the primary whole-model ATOM regression anchor. A common isolated shape
+is `7168x3072`, EPR48, top-k6. Verify both fixed and compact modes and the
+serving concurrency matrix; microbenchmark improvements can lose overlap in a
+61-layer graph.
+
+### ByteDance M13
+
+Keep three labels distinct in reports:
+
+```text
+smoothquant a8w4
+smoothquant a8w4 optimized
+mx a8w4
+```
+
+Native MX A8W4 and SmoothQuant A8W4 may share dispatch/GEMM infrastructure but
+do not share the same preprocessing or scale semantics. The delivered
+`ghu/mega_moe_v1_copy` history covered decode through token 512; later prefill
+tuning must be reported with the exact new commit and cannot be back-attributed
+to the delivered baseline.
+
+### GLM-5.2
+
+Issue-driven support must include EPR32/top-k8 selectors, combine geometry and
+AOT jobs. Verify the framework's shared-expert path and SwiGLU behavior. Do not
+reuse a V4-Pro activation limit merely because hidden/intermediate tiles
+compile.
+
+### Kimi-K3
+
+Top-k16 and EPR112 invalidate assumptions tailored to top-k6/EPR48. Runtime
+pair IDs/fanout metadata should be range-checked end to end. A routing-only
+microbenchmark is useful for protocol coverage but does not establish complete
+model activation or quantization support.
+
+## Model-support acceptance record
+
+For each added model, retain:
+
+```text
+authoritative model revision and extracted fields
+derived capacity/address calculations
+selector boundary-test result
+AOT expected/actual job count and run-only result
+8-rank eager/reference/Graph/stress matrix
+full token/MTPR performance table
+framework integration result including shared experts
+known unsupported modes
+```

--- a/.claude/skills/megamoe-engineering/references/performance-and-tracing.md
+++ b/.claude/skills/megamoe-engineering/references/performance-and-tracing.md
@@ -1,0 +1,204 @@
+# Performance and trace workflow
+
+MegaMoE performance is a distributed pipeline result. A headline kernel time
+without rank, launch path, route and capacity provenance is not actionable.
+
+## Establish a paired baseline
+
+Freeze these before changing code:
+
+```text
+host/GPU and ownership window
+container image and immutable digest
+AITER, FlyDSL, MORI and framework commits
+actual imported Python modules and loaded shared objects
+JIT/AOT mode and cache directory
+model geometry, dtype path and activation semantics
+tokens per rank and the complete rank-token vector
+MTPR, route distribution and seed
+Graph/eager timing method, warmup and iteration count
+heap size, environment switches and resolved tune config
+```
+
+Run base and candidate adjacent in time. Alternate their order when contention
+or thermal drift is plausible. Use at least three paired samples for a change
+near noise; report median plus range. A ten-iteration inner loop is normally
+enough for a broad shape scan after the candidate has passed correctness.
+
+Do not compare an eager baseline with a CUDA Graph candidate, prequantized
+input with BF16 input, or `MTPR=tokens` with a fixed deployment MTPR.
+
+## Timing semantics
+
+Collect both rank-local detail and the distributed critical path:
+
+| Metric | Meaning |
+|---|---|
+| prepare/quant | Serial work before Stage1, including route plan and input quantization when present. |
+| Stage1 | Dispatch producer plus GEMM1 consumers for the current architecture. |
+| Stage2 | GEMM2, return communication and any work included by the measured wrapper. |
+| combine | Terminal top-k reduction when it is not included in Stage2. |
+| operator E2E | First operator launch to completion on one rank. |
+| distributed E2E | Earliest relevant launch to latest completion across all ranks. |
+
+Stage kernels, streams and ranks overlap. Therefore:
+
+```text
+Stage1_us + Stage2_us != E2E_us in general
+```
+
+Record rank mean, rank maximum and the identity of the critical rank. A rank0
+number alone can hide load imbalance. Synchronize only where required by the
+declared timing method; adding synchronization can destroy the overlap being
+measured.
+
+Use the framework's CUDA Graph/event timing path for decode whenever possible.
+An ATT/profile trace is for attribution, not automatically a replacement for
+the acceptance timing path.
+
+## Decompose bytes before changing CU counts
+
+For each stage, estimate bytes that must cross each interface:
+
+```text
+input activation and input scale reads
+routed payload and metadata P2P writes/reads
+W1/W2 and weight-scale reads
+intermediate activation and scale writes/reads
+returned output and route-weight traffic
+ready/counter/control traffic
+```
+
+Then calculate an effective rate with the measured critical-span time:
+
+```text
+effective_bandwidth = required_bytes / critical_time
+```
+
+State whether the byte count is logical or physical. Fanout/dedup, padding,
+cache reuse, coalescing and protocol retries can make the two differ. Compare
+against current GPU HBM/XGMI counters or authoritative specifications; do not
+hard-code a remembered peak bandwidth as the achieved denominator.
+
+A low dispatch CU count can be optimal: enough producers can saturate XGMI
+while leaving CUs for GEMM consumers. Conversely, reducing producers below the
+latency/bandwidth knee starves consumers. Measure producer bandwidth and
+consumer idle gaps before assigning more CUs.
+
+## Trace ladder
+
+Escalate only as far as needed to falsify the current hypothesis.
+
+### 1. Graph/profile trace
+
+Capture every rank and identify:
+
+- exact kernel names and launch order;
+- first launch, last completion and idle gaps;
+- prepare/quant serialization;
+- Stage1 producer/consumer overlap;
+- Stage2 and terminal combine relationship;
+- unexpected module loads, compilation or host gaps;
+- rank that defines the distributed critical path.
+
+Match a trace kernel to the current source and resolved config before tuning.
+Generated names can encode tile shapes, but verify the mapping rather than
+decoding by memory.
+
+### 2. ATT instruction trace
+
+Capture the dominant kernel on the critical rank, then inspect:
+
+- wave issue timeline and CU role distribution;
+- VMEM/LDS/MFMA issue gaps;
+- waits on ready flags or work queues;
+- producer retirement and consumer replacement;
+- atomic contention and cache-line serialization;
+- occupancy, VGPR/SGPR/LDS limits;
+- tail tiles and expert/rank imbalance;
+- whether communication and compute actually overlap.
+
+Use a narrow kernel/rank/CU filter first. A full eight-rank ATT capture can be
+too large and perturb the workload.
+
+### 3. PMC passes
+
+When ATT cannot distinguish causes, collect a small number of counter passes
+for HBM/XGMI/L2/LDS, instruction mix, MFMA utilization, stalls and occupancy.
+Keep the workload and seed identical across passes. Counters from different
+runs are not cycle-aligned; use them as aggregate evidence.
+
+### 4. ISA/resource comparison
+
+For a source/API refactor, compare generated ISA, code-object metadata,
+VGPR/SGPR/LDS use and launch geometry. Identical high-level Python does not
+prove identical ISA; identical ISA does not prove identical distributed launch
+behavior.
+
+Historical local helpers that may accelerate this workflow include:
+
+```text
+/data/ghu/parse_megamoe_trace.py
+/data/ghu/analyze_megamoe_kernel_trace.py
+/data/ghu/run_universe_a8w4m13_8_att_flexible_20260828.sh
+```
+
+Inspect and copy them into a task-owned directory before use. They are evidence
+artifacts, not repository APIs.
+
+## Bottleneck taxonomy
+
+Classify the dominant loss before editing:
+
+| Class | Typical evidence | Candidate levers |
+|---|---|---|
+| Host/JIT/AOT | launch gap, module load, cache miss | preload/bundle coverage, cache identity, remove request-path compile |
+| Prepare/quant | long serial kernel before Stage1 | fuse only semantically compatible work, vectorize, reduce scans, tune prepare CUs |
+| Dispatch producer | XGMI below attainable rate or queue starvation | producer CUs, packet width, dedup/fanout, coalescing, ready granularity |
+| Stage1 GEMM | low MFMA issue, poor occupancy, consumer idle | tile geometry, wave count, preshuffle, producer retirement/consumer assignment |
+| Dynamic scheduling | atomic hot spot, duplicate/skipped work risk | static assignment where valid, sharded heads, monotonic ownership protocol |
+| Stage2/GEMM2 | weight traffic or small-M inefficiency | block-M/N/K, persistent CU count, skew/tail strategy, aligned-pair path |
+| Combine | top-k reduction dominates tiny tokens | vector width, cooperative reduction, layout, separate/fused boundary |
+| Load imbalance | one rank/expert extends tail | route-aware work distribution, bounded over-subscription, tail handling |
+| Protocol wait | long ready polling despite available work | publish granularity, epoch reuse, visibility/fence audit |
+
+Do not introduce a permanent environment switch for each experiment. Use a
+temporary override to establish causality, encode the winning bounded selector
+rule, then delete the switch and dead branches.
+
+## Shape tuning discipline
+
+Tune all requested token buckets, not only token 128. Treat small decode,
+medium decode and prefill as different regimes. For each regime:
+
+1. print the selected prepare, Stage1, Stage2 and combine configs;
+2. test a bounded grid around the current geometry;
+3. reject any candidate that fails accuracy, Graph replay or a neighboring
+   bucket;
+4. encode a deterministic selector with exhaustive boundary tests;
+5. rerun without command-line overrides or experimental environment flags.
+
+Always scan both `MTPR=tokens` and the fixed deployment MTPR requested by the
+serving stack. A selector that keys on runtime tokens while changing a wire
+field is invalid even when every equal-token microbenchmark passes.
+
+## Interpreting a claimed win
+
+A credible performance conclusion includes:
+
+```text
+base and candidate full commits
+same-stack paired commands
+raw per-rank samples
+median/range and rank max
+exact resolved config
+accuracy and Graph gate for the measured binary
+trace evidence explaining the delta
+neighboring bucket/full-scan result
+whole-model result when launch/protocol/AOT behavior changed
+```
+
+If a microbenchmark improves but the serving workload regresses, preserve both
+facts and trace the framework case. MegaMoE exists to overlap communication and
+compute across the real graph; the smallest isolated kernel time is not the
+sole objective.

--- a/.claude/skills/megamoe-engineering/references/repository-map.md
+++ b/.claude/skills/megamoe-engineering/references/repository-map.md
@@ -1,0 +1,202 @@
+# Repository and source map
+
+MegaMoE is not implemented in one repository. Resolve the active stack before
+editing or benchmarking.
+
+## Repository roles
+
+| Repository | Responsibility |
+|---|---|
+| AITER | Production `MegaMoEV2`, config selection, AOT jobs, MORI integration, operator tests and benchmark. |
+| FlyDSL | DSL/compiler/runtime, extension collectives, buffer tensor API, JIT/AOT/preload behavior and kernel-authoring standards. |
+| FlyDSL_universe | Customer/experimental kernel tree, including ByteDance native and SmoothQuant variants. It can intentionally diverge from AITER. |
+| MORI | Symmetric-memory allocation, P2P pointers, barriers and the comparison EP dispatch/combine implementation. |
+| ATOM | Production serving integration, CUDA Graph, EPLB, continuous batching and end-to-end benchmark. |
+| SGLang | Independent serving integration and fixed-length/AgentX validation. |
+
+Do not infer that a similarly named MegaMoE in a framework uses AITER/FlyDSL.
+Confirm the imported module and environment switch in the exact framework
+commit.
+
+## AITER production map
+
+Locate the current tree with:
+
+```bash
+rg --files aiter/ops/flydsl/kernels/mega_moe aiter/aot/flydsl \
+  op_tests/multigpu_tests op_tests/flydsl_tests | sort
+```
+
+As of the #5346 snapshot, the principal files are:
+
+```text
+aiter/ops/flydsl/kernels/mega_moe/
+  __init__.py
+  mega_moe_v2.py
+  mega_moe_config.py
+  mega_moe_prepare.py
+  dispatch.py
+  mega_moe_stage1.py
+  gemm1.py
+  gemm_util.py
+  mega_moe_stage2.py
+  mega_moe_stage2_aligned_pair.py
+  gemm2.py
+  quant.py
+
+aiter/aot/flydsl/mega_moe.py
+op_tests/multigpu_tests/test_mega_moe_v2.py
+op_tests/multigpu_tests/bench_mega_moe_v2.py
+op_tests/flydsl_tests/test_mega_moe_config.py
+```
+
+Related code can live outside the directory:
+
+- dispatch/combine host and kernel implementation;
+- `communication_ops_utils.py` for system/agent atomics and fences;
+- `tensor_shim.py` for `ptr_buf_tensor`, compiled launch and preload helpers;
+- AOT registry/common driver;
+- fused-MoE CSV selectors used by the MORI comparison;
+- serving hooks in ATOM/SGLang.
+
+Search by public type and protocol names, not a memorized path:
+
+```bash
+rg -n "MegaMoEV2|DispatchSlot|build_mega_moe_bundle_plan|preload_aot_bundles"
+rg -n "MORI_EP_LAUNCH_CONFIG_MODE|AITER_MEGA_MOE|FLYDSL_RUNTIME_RUN_ONLY"
+```
+
+## FlyDSL map
+
+MegaMoE consumes current FlyDSL APIs. Before carrying code between commits,
+inspect:
+
+```text
+python/flydsl/compiler/
+python/flydsl/expr/
+python/flydsl/extension/
+kernels/common/
+.claude/skills/kernel-code-cleanup/SKILL.md
+.claude/skills/kernel-trace-analysis/SKILL.md
+.claude/skills/capture-kernel-trace/SKILL.md
+```
+
+The #1098 FlyDSL API migration replaced private warp scan/reduce helpers with
+the public cooperative extension. Current forms include:
+
+```python
+fx.coop.warp_reduce(value, fx.ReductionOp.MAX, width=64)
+fx.coop.warp_scan_with_aggregate(value, fx.ReductionOp.ADD, width=64)
+fx.coop.warp_exclusive_scan(value, fx.ReductionOp.ADD, width=64)
+```
+
+Preserve invalid-lane zeroing, chunk carry and aggregate semantics when moving
+MegaMoE. A textual helper rename is not proof of equivalence.
+
+Use the current layout/buffer surface. `buffer_ops` and raw MLIR compatibility
+can be stale even when an old kernel still compiles against a private build.
+
+## ByteDance FlyDSL-universe map
+
+The customer branch has historically lived at:
+
+```text
+repository: /home/ghu/FlyDSL_universe
+branch:     ghu/mega_moe_v1_copy
+kernel:     kernels/mega_moe/
+tests:      tests/kernels/test_mega_moe_v2.py
+            tests/kernels/test_mega_moe_int8.py
+unit:       tests/unit/test_mega_moe_config.py
+```
+
+These are discovery hints, not permission to modify that checkout. It has often
+contained valuable uncommitted work. Fetch the requested remote head and create
+an independent worktree. Record both the remote commit and the original dirty
+status without changing it.
+
+Important runner candidates on the known machines include:
+
+```text
+/home/ghu/opus_verify_46/run8.sh
+/home/ghu/opus_verify_47/run_universe_a8w4m13_8.sh
+/data/ghu/run_universe_a8w4m13_8.sh
+/data/ghu/run_m13_mx_a8w4_prefill_matrix_20260909.sh
+```
+
+Inspect the runner before each use. Test flags and import paths evolve.
+
+## Framework map
+
+For ATOM, locate the current MegaMoE backend rather than copying an old server
+command:
+
+```bash
+rg -n "moe-backend.*mega|MegaMoE|AITER_MEGA_MOE|MTPR|enable-tbo" .
+```
+
+For SGLang, distinguish AMD FlyDSL MegaMoE from the unrelated CUDA/DeepGEMM
+backend with the same name. Search the exact integration switch and public
+wrapper. Historical switches included `SGLANG_AMD_USE_FLYDSL_MEGA_MOE` and
+`SGLANG_AMD_FLYDSL_MEGA_MOE_MTPR`; verify current spelling in source.
+
+## Configuration sources
+
+MegaMoE production geometry is primarily rule-selected in
+`mega_moe_config.py`, not an offline JSON tuner. The baseline MORI/fused-MoE
+comparison can use AITER model CSVs. Always print the resolved config and file
+path from the benchmark; otherwise a comparison can silently use a generic or
+wrong-model entry.
+
+When adding a model, inspect all of:
+
+1. network/test shape registry;
+2. Stage1 selector;
+3. Stage2 selector;
+4. terminal combine geometry table/CSV;
+5. AOT deployment profiles and cache identity;
+6. framework-side shared-expert and activation semantics.
+
+## Branch and worktree discipline
+
+Use a clean worktree instead of stashing someone else's work:
+
+```bash
+git fetch origin main
+git worktree add -b <task-branch> <new-path> origin/main
+git -C <new-path> status --short --branch
+```
+
+Before claiming a PR is "main plus this patch":
+
+```bash
+git merge-base --is-ancestor origin/main HEAD
+git diff --check origin/main..HEAD
+git diff --name-only origin/main..HEAD
+```
+
+If unrelated attention, TopK, GEMM or framework files appear, do not use the
+branch for a controlled MegaMoE comparison.
+
+For two large MegaMoE PRs, run a real merge simulation and review every
+conflicting protocol field. Never resolve Stage1/Stage2/config/AOT conflicts by
+blindly taking `ours` or `theirs`.
+
+## Provenance that must accompany a result
+
+Record:
+
+```text
+date/time and timezone
+host GPU model and count
+image name and immutable digest
+repository full commits and dirty status
+actual imported module paths
+Python, PyTorch, HIP/ROCm, FlyDSL and MORI versions
+FLYDSL build/library path
+JIT cache mode and directory
+MTPR, tokens/rank, rank-token vector, route distribution and random seed
+exact command, raw log directory and trace directory
+```
+
+Directory names such as `main`, `final`, `optimized` or `delivered` are not
+provenance.

--- a/.claude/skills/megamoe-engineering/references/validation.md
+++ b/.claude/skills/megamoe-engineering/references/validation.md
@@ -1,0 +1,263 @@
+# Validation strategy
+
+MegaMoE needs layered validation because a single synchronized call misses
+cross-rank drift, CUDA Graph reuse, AOT cache gaps and serving integration.
+Use the cheapest gate that can falsify the candidate, then advance.
+
+## Gate 0: provenance and diff scope
+
+Before execution:
+
+```bash
+git status --short --branch
+git rev-parse HEAD
+git diff --check <base>...HEAD
+git diff --name-status <base>...HEAD
+```
+
+Print imported module paths and runtime versions. Confirm the candidate changes
+only expected files. For a refactor, save the base command and output before
+editing.
+
+## Gate 1: static and CPU invariants
+
+Run project style, compile and focused unit checks. For AITER this normally
+includes:
+
+```bash
+python -m compileall -q aiter/ops/flydsl/kernels/mega_moe
+python -m pytest -q op_tests/flydsl_tests/test_mega_moe_config.py
+```
+
+Add an exhaustive selector test when changing configuration. Sweep every model,
+EPR, supported MTPR and token bucket, plus boundary values between buckets.
+Validate at least:
+
+- Stage1 MFMA geometry (`tile_n`, waves and accumulator fragments);
+- Stage2 block-M divides Stage1 sort-block-M;
+- dispatch CU/group divisibility and non-empty consumer capacity;
+- fixed-slot expert limits;
+- source/top-k/fanout bit encodings;
+- cross-rank wire tuple is invariant over different local token buckets;
+- buffer capacity and 32-/64-bit address ranges;
+- every code-generating value is present in cache/bundle identity;
+- zero-token rank resolves to a participating variant.
+
+Compile/lower representative Stage1, Stage2, prepare, quant and combine variants
+without launching P2P kernels where a CPU dummy path is supported.
+
+## Gate 2: focused eight-rank correctness
+
+The production AITER runner is
+`op_tests/multigpu_tests/test_mega_moe_v2.py`. Inspect `--help` at the tested
+commit; do not rely on a copied flag list.
+
+A typical launch is:
+
+```bash
+MORI_SHMEM_HEAP_SIZE=40G \
+python -m torch.distributed.run --standalone --nproc_per_node=8 \
+  op_tests/multigpu_tests/test_mega_moe_v2.py \
+  --network v4_pro \
+  --bs-list 1,4,8,16,32,64,128,256,512 \
+  --max-tok-per-rank 512 \
+  --iters 10
+```
+
+Use the current exact parser. A passing gate should include:
+
+- all eight ranks complete;
+- distributed FP32/reference error within the declared threshold;
+- eager result is finite;
+- CUDA Graph capture and repeated replay complete;
+- replay output is exactly stable when inputs/state are unchanged;
+- no rank reports overflow, invalid address or a different protocol/config;
+- task-owned processes exit.
+
+Do not use `--skip-acc` for a functional gate. It is allowed only after the same
+candidate/shape has passed accuracy.
+
+## Required shape axes
+
+For a change to shared production code, cover the intersection of supported
+values rather than one headline point.
+
+### Token buckets
+
+```text
+1, 4, 8, 16, 32, 64, 128, 256, 512,
+1024, 2048, 4096, 8192, 16384, 32768
+```
+
+Add boundary tokens around selector transitions, such as one below/above the
+midpoint used by nearest-bucket logic.
+
+### Capacity modes
+
+- `MTPR=tokens`: per-shape instance, exposing fixed/bounded/large transitions.
+- fixed deployment MTPR (commonly 256, 8192 or 32768): actual tokens vary while
+  buffer/wire protocol remains fixed.
+
+### Routing and rank distribution
+
+- uniform/random;
+- hot expert/hot destination;
+- rank-balanced hotspot;
+- mixed skew;
+- different local token counts on all eight ranks;
+- one or more zero-token ranks;
+- invalid/padding sentinel IDs where supported;
+- fanout pair present, absent and changing between replays.
+
+Route distribution and rank-token distribution are different axes. A
+`rank-mixed-skew` route generator does not prove support for unequal tensor
+lengths.
+
+### Model geometry
+
+At minimum retain anchors for V4-Pro and every newly supported model. Shared
+Stage1/Stage2 edits should also exercise top-k 8/EPR32 and, when supported,
+top-k 16/EPR above 64.
+
+## Variable local-token reference
+
+An accuracy reference based on `all_gather` of equal-shape tensors does not
+support unequal rank token counts. Pad to the maximum, gather token counts and
+slice by per-rank prefix offsets. A burst test that only checks completion is a
+hang gate, not an accuracy proof.
+
+Every rank must agree whether to enter reference collectives. Reduce a local
+"can run reference" flag before branching.
+
+## Stage-specific checks
+
+Run isolated Stage1/Stage2 only after a full operator pass establishes their
+inputs and metadata are valid.
+
+- Stage1 reference: validate compact/fixed row layout, expert IDs, source maps,
+  quantized output/scales and padding.
+- Stage2 reference: pass the active Stage1 config/wire contract explicitly;
+  validate routing weights, destination slot and P2P dequantization.
+- Combine: validate all top-k slots and zero/padding behavior.
+
+An isolated Stage2 call that omits the active config can benchmark a different
+SBM/P2P protocol than the preceding Stage1.
+
+## CUDA Graph and queued-chain stress
+
+Capture/replay is mandatory for decode. In addition to one replay, test:
+
+- 20 or more identical replays for ordinary gates;
+- alternating supported token buckets if the framework creates separate graph
+  buckets;
+- a chain matching the production MoE layer count (historically 61 for
+  V4-Pro);
+- multiple consecutive forward steps without host synchronization;
+- asymmetric rank tokens and zero-token ranks;
+- runtime fanout metadata changes across epochs;
+- same-stream ordered reuse of the same operator instance.
+
+If concurrent multi-stream/TBO use is intended, it needs its own test with
+independent state. A same-stream pass does not authorize multi-stream re-entry.
+
+Use a watchdog with a finite timeout. Preserve per-rank logs and the active
+kernel when it fires; do not just kill and rerun with added synchronizations.
+
+## ByteDance customer-path gates
+
+Known runner families include:
+
+```text
+/home/ghu/opus_verify_47/run_universe_a8w4m13_8.sh
+/home/ghu/opus_verify_46/run8.sh
+```
+
+For native M13 MX A8W4, use `network=m13`, `quant=a8w4` and explicitly record
+`tokens`, `MTPR` and whether input is BF16 or prequantized. For the delivered
+SmoothQuant path, use `tests/kernels/test_mega_moe_int8.py` with the exact
+`mode` and dispatch-quant choice from the branch runner.
+
+The historical environment used `/opt/venv/bin/python`, eight one-rank
+processes, a 64-GiB MORI heap and cache disabled for source experiments. Verify
+the current runner because host46 and host47 have used different FlyDSL builds
+and Torch/ROCm versions.
+
+Customer-path acceptance requires comparison with the delivered baseline's
+accuracy, not merely a broad `rtol`. If a purportedly algebraic refactor should
+be bitwise equivalent, require zero eager difference and exact Graph replay.
+
+## AOT gates
+
+AOT changes require all of:
+
+1. enumerate the deployment profiles and expected jobs;
+2. compile into a new empty cache using the production AOT entry point;
+3. require zero failed/no-kernel jobs;
+4. save an artifact manifest;
+5. start a fresh process with `FLYDSL_RUNTIME_RUN_ONLY=1`;
+6. run eight-rank accuracy/Graph across every bundled token bucket;
+7. prove no request-path `hipModuleLoadData` in a serving trace;
+8. test a deliberate missing artifact and confirm it fails.
+
+Do not test only the PR head if CI will merge it with a newer base. A prior AOT
+failure escaped because head CI did not exercise the synthetic merge state and
+a later API required `ep_size`. Reproduce both head and merge-result semantics
+when interfaces changed on main.
+
+## CI reachability
+
+Reading a new case arm is not proof CI executes it. Trace the driver from file
+discovery through skip lists, mode guards and shell `continue` statements.
+Run the driver locally with an explicit target and verify the command appears in
+the log. A script that prints `Skipping test` and exits zero provides no
+coverage.
+
+When adding a GPU case, verify the workflow actually has the requested GPU
+count/label and sufficient heap/time. Keep a cheap CPU selector/invariant gate
+so obvious geometry failures do not depend on scarce eight-GPU CI.
+
+## Performance validation after correctness
+
+Use the same graph/event timing path as the baseline. Ten timed iterations are
+appropriate for a full shape scan in the known customer runner; increase paired
+repetitions for changes near noise. Report rank mean/max, not rank0 alone.
+
+After per-shape tuning, run the complete matrix again from clean processes and
+without ad-hoc overrides. Regressions at untuned buckets must be addressed or
+explicitly excluded by a production selector rule.
+
+## Whole-model gates
+
+Kernel tests do not prove framework behavior. For changes to protocol, MTPR,
+AOT, launch order or performance-sensitive defaults, run the production
+framework with pinned versions.
+
+ATOM's established V4-Pro matrix uses:
+
+| Total concurrency | Random range ratio |
+|---:|---:|
+| 512 | 1.0 |
+| 512 | 0.8 |
+| 4096 | 1.0 |
+| 4096 | 0.8 |
+
+Record completed requests, errors, throughput, input/output length range, EPLB
+events, server health and whether TBO/speculation are enabled. Compare against
+the standard baseline, not only a favorable historical patch.
+
+For SGLang, keep fixed-length and AgentX/variable-length as separate workloads.
+A fixed 8192-token input can hide full-MTPR padding that dominates a broad
+variable-ISL corpus.
+
+## Final review gate
+
+After tests pass:
+
+```text
+review full diff and generated config identities
+remove temporary env gates and debug counters
+run cleanup/style/static checks
+repeat key accuracy and performance anchors from clean processes
+confirm no task-owned GPU/server process remains
+archive raw logs and write a provenance-rich Markdown result
+```

--- a/.claude/skills/megamoe-engineering/scripts/preflight.sh
+++ b/.claude/skills/megamoe-engineering/scripts/preflight.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Read-only MegaMoE environment/provenance preflight.
+set -u
+
+usage() {
+  printf '%s\n' \
+    "Usage: $0 [--aiter PATH] [--flydsl PATH] [--runner PATH] [--python PATH]" \
+    "Prints repository, import, runtime, GPU, process and runner provenance." \
+    "It does not build, launch, kill, clean, reset or modify repositories."
+}
+
+aiter_path=""
+flydsl_path=""
+runner_path=""
+python_path="python3"
+
+while (($#)); do
+  case "$1" in
+    --aiter)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      aiter_path=$2
+      shift 2
+      ;;
+    --flydsl)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      flydsl_path=$2
+      shift 2
+      ;;
+    --runner)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      runner_path=$2
+      shift 2
+      ;;
+    --python)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      python_path=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+section() {
+  printf '\n[%s]\n' "$1"
+}
+
+repo_info() {
+  local label=$1
+  local path=$2
+  section "$label repository"
+  if [[ -z "$path" ]]; then
+    printf 'not specified\n'
+    return
+  fi
+  if ! git -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    printf 'not a git worktree: %s\n' "$path"
+    return
+  fi
+  printf 'path=%s\n' "$(cd "$path" && pwd -P)"
+  printf 'head=%s\n' "$(git -C "$path" rev-parse HEAD 2>/dev/null || true)"
+  printf 'branch=%s\n' "$(git -C "$path" branch --show-current 2>/dev/null || true)"
+  printf 'describe=%s\n' "$(git -C "$path" describe --always --dirty --tags 2>/dev/null || true)"
+  printf 'status:\n'
+  git -C "$path" status --short --branch 2>&1 || true
+  printf 'remotes:\n'
+  git -C "$path" remote -v 2>&1 | sed -E 's#(https?://)[^/@]+@#\1<redacted>@#g' || true
+}
+
+section "timestamp and host"
+printf 'utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf 'hostname=%s\n' "$(hostname 2>/dev/null || true)"
+uname -a 2>&1 || true
+
+repo_info "AITER" "$aiter_path"
+repo_info "FlyDSL" "$flydsl_path"
+
+section "selected environment"
+for name in \
+  HIP_VISIBLE_DEVICES \
+  WORLD_SIZE \
+  MASTER_ADDR \
+  MASTER_PORT \
+  MORI_SHMEM_HEAP_SIZE \
+  FLYDSL_RUNTIME_ENABLE_CACHE \
+  FLYDSL_RUNTIME_CACHE_DIR \
+  FLYDSL_RUNTIME_RUN_ONLY \
+  PYTHONPATH \
+  LD_LIBRARY_PATH; do
+  if [[ -v $name ]]; then
+    printf '%s=%s\n' "$name" "${!name}"
+  else
+    printf '%s=<unset>\n' "$name"
+  fi
+done
+
+section "Python paths and distributions"
+printf 'requested_python=%s\n' "$python_path"
+if command -v "$python_path" >/dev/null 2>&1 || [[ -x "$python_path" ]]; then
+  "$python_path" - <<'PY' 2>&1 || true
+import importlib.metadata
+import importlib.util
+import platform
+import sys
+
+print(f"executable={sys.executable}")
+print(f"python={platform.python_version()}")
+for name in ("torch", "flydsl", "aiter", "mori"):
+    try:
+        spec = importlib.util.find_spec(name)
+        print(f"{name}.origin={None if spec is None else spec.origin}")
+    except Exception as exc:
+        print(f"{name}.origin_error={type(exc).__name__}: {exc}")
+    try:
+        print(f"{name}.distribution_version={importlib.metadata.version(name)}")
+    except importlib.metadata.PackageNotFoundError:
+        print(f"{name}.distribution_version=<not installed as a distribution>")
+PY
+else
+  printf 'python executable not found\n'
+fi
+
+section "GPU inventory"
+gpu_count=0
+for device_path in /sys/class/drm/card*/device; do
+  [[ -r "$device_path/product_name" ]] || continue
+  card_path=${device_path%/device}
+  card_name=${card_path##*/}
+  gpu_count=$((gpu_count + 1))
+  printf '%s' "$card_name"
+  for field_name in product_name product_number unique_id mem_info_vram_total mem_info_vram_used; do
+    if [[ -r "$device_path/$field_name" ]]; then
+      IFS= read -r field_value < "$device_path/$field_name" || field_value='<unreadable>'
+      printf ' %s=%s' "$field_name" "$field_value"
+    fi
+  done
+  printf '\n'
+done
+printf 'gpu_count=%s (sysfs only; no GPU runtime initialization)\n' "$gpu_count"
+
+section "/dev/kfd holders"
+if [[ -e /dev/kfd ]]; then
+  holder_count=0
+  for proc_path in /proc/[0-9]*; do
+    pid=${proc_path##*/}
+    [[ -r "$proc_path/status" ]] || continue
+    for fd_path in "$proc_path"/fd/*; do
+      fd_target=$(readlink "$fd_path" 2>/dev/null || true)
+      [[ "$fd_target" == /dev/kfd ]] || continue
+      holder_count=$((holder_count + 1))
+      holder_user=$(stat -c '%U' "$proc_path" 2>/dev/null || printf '?')
+      holder_comm=$(tr -d '\000' < "$proc_path/comm" 2>/dev/null || printf '?')
+      holder_cgroup=$(sed -n '1p' "$proc_path/cgroup" 2>/dev/null || true)
+      printf 'pid=%s user=%s comm=%s cgroup=%s\n' "$pid" "$holder_user" "$holder_comm" "$holder_cgroup"
+      break
+    done
+  done
+  printf 'holder_count=%s (resolved through /proc/*/fd)\n' "$holder_count"
+else
+  printf '/dev/kfd unavailable\n'
+fi
+
+section "GPU-related processes"
+ps -eo user=,pid=,ppid=,etimes=,stat=,comm= 2>&1 \
+  | awk 'BEGIN { IGNORECASE=1 } /torchrun|torch\.distributed|test_mega_moe|bench_mega_moe|sglang|atom|vllm|rocprof|rocprofv3/ { print }' \
+  || true
+
+section "runner"
+if [[ -z "$runner_path" ]]; then
+  printf 'not specified\n'
+elif [[ ! -f "$runner_path" ]]; then
+  printf 'not found: %s\n' "$runner_path"
+else
+  printf 'path=%s\n' "$(cd "$(dirname "$runner_path")" && pwd -P)/$(basename "$runner_path")"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$runner_path" 2>&1 || true
+  fi
+  stat -c 'mode=%A owner=%U:%G size=%s mtime=%y' "$runner_path" 2>&1 || true
+fi
+
+section "preflight conclusion"
+printf '%s\n' \
+  'This report is descriptive. Verify process ownership before cleanup and' \
+  'record the exact benchmark command, model geometry, route, MTPR and raw logs.'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ FlyDSL/
 | CuTe layout reference | [`docs/cute_layout_algebra_guide.md`](docs/cute_layout_algebra_guide.md) | Mathematical background and FlyDSL mapping of CuTe concepts |
 | Kernel authoring | [`docs/kernel_authoring_guide.md`](docs/kernel_authoring_guide.md) | `@flyc.kernel`, `@flyc.jit`, launch config, LDS, tiled copy/MMA |
 | Kernel tuning | [`docs/kernel_tuning_guide.md`](docs/kernel_tuning_guide.md) | Tiling, LDS double-buffer/swizzle, prefetch, MFMA scheduling, occupancy, ATT/PMC profiling |
+| MegaMoE engineering | [`.claude/skills/megamoe-engineering/SKILL.md`](.claude/skills/megamoe-engineering/SKILL.md) | Multi-repository architecture, protocol safety, 8-GPU/AOT/Graph validation, trace-led tuning, serving regressions and evidence routing |
 | Pre-built kernels | [`docs/prebuilt_kernels_guide.md`](docs/prebuilt_kernels_guide.md) | Norm, Softmax, GEMM, MoE, attention, dtype/config notes |
 | External bitcode integration | [`docs/extern_integration_guide.md`](docs/extern_integration_guide.md) | `ffi` + `link_extern`: plug pre-compiled LLVM bitcode into the JIT pipeline (`python/flydsl/expr/extern.py`, `compiler/extern_link.py`) |
 | Testing & benchmarking | [`docs/testing_benchmarking_guide.md`](docs/testing_benchmarking_guide.md) | Test categories, benchmark harness, performance comparisons |


### PR DESCRIPTION
> [!IMPORTANT]
> Personal reference PR for agent reuse. Please do not merge.

## Motivation

Preserve the MegaMoE architecture, validation, debugging, performance-tuning,
environment, and historical-evidence knowledge needed to work safely across
FlyDSL, AITER, MORI, ATOM, SGLang, and the customer FlyDSL_universe branch.

## Technical Details

- Add a progressively disclosed `megamoe-engineering` skill with task-based
  routing to focused references.
- Capture protocol invariants for fixed/compact dispatch, quant/prepare,
  Stage1/Stage2, fanout/dedup, readiness, AOT/preload, CUDA Graph, and capacity.
- Add trace-led tuning and root-cause workflows, 8-GPU/AOT/serving validation
  gates, model geometry/onboarding guidance, and a dated evidence index.
- Add a read-only preflight helper that reports source/runtime/GPU ownership
  provenance without initializing the GPU runtime.
- Link the skill from `CLAUDE.md` for repository-local discovery.

## Test Plan

- Run the repository agent-document/API checks.
- Run the skill validator.
- Syntax-check and execute the read-only preflight helper.

## Test Result

- `python3 scripts/check_repo.py`: PASS
- `python3 scripts/check_docs_api.py --all`: PASS
- `quick_validate.py .claude/skills/megamoe-engineering`: PASS
- `bash -n .../scripts/preflight.sh`: PASS
- Preflight end-to-end smoke: PASS
