### PR TITLE
[Bugfix][Kernel] Fix fused RoPE for head dimension 96

### DIFF
--- a/kernels/attention/fused_rope_cache_kernel.py
+++ b/kernels/attention/fused_rope_cache_kernel.py
@@ -73,12 +73,19 @@ def build_fused_rope_cache_module(
         raise ValueError(f"dtype_str must be 'bf16' or 'f16', got {dtype_str!r}")
     half_dim = rotary_dim // 2
 
-    # VEC_WIDTH: elements per thread. Use ceil division so vecs_per_head never
-    # exceeds WARP_SIZE for the fixed one-thread-per-vector mapping below.
-    # For D=64:  VEC_WIDTH=1 -> vecs_per_head=64 (full wavefront, 16-bit loads).
-    # For D=96:  VEC_WIDTH=2 -> vecs_per_head=48 (fits within one wavefront).
-    # For D=128: VEC_WIDTH=2 -> vecs_per_head=64 (32-bit loads, unchanged).
-    VEC_WIDTH = max(1, (head_dim + WARP_SIZE - 1) // WARP_SIZE)
+    # Select the smallest native copy width that fits one head in a wave and
+    # evenly divides each NeoX half. On wave32 this maps D=64/96/128/256 to
+    # VEC_WIDTH=2/4/4/8; on wave64 it maps them to 1/2/2/4.
+    VEC_WIDTH = next(
+        (
+            width
+            for width in (1, 2, 4, 8)
+            if head_dim % width == 0 and half_dim % width == 0 and head_dim // width <= WARP_SIZE
+        ),
+        None,
+    )
+    if VEC_WIDTH is None:
+        raise ValueError(f"unsupported head_dim={head_dim} for wave{WARP_SIZE}")
 
     vecs_per_half = half_dim // VEC_WIDTH
     vecs_per_head = head_dim // VEC_WIDTH
@@ -149,10 +156,8 @@ def build_fused_rope_cache_module(
             fx.copy(atom or copy_atom, r, fx.slice(div_tensor, (None, idx)))
 
         # Helper: get the rotary-pair element via ds_bpermute (LDS cross-lane shuffle).
-        # For NeoX RoPE, the pair of thread tid is tid XOR vecs_per_half.
         # ds_bpermute: thread tid reads the VGPR value held by thread (pair_byte_addr/4).
-        # pair_byte_addr = (tid XOR vecs_per_half) * 4.
-        # Handles VEC_WIDTH=1 (vector<1xbf16/f16>, 16-bit) and VEC_WIDTH=2 (vector<2xbf16/f16>, 32-bit).
+        # Handles native vectors from one to eight bf16/f16 elements.
         def ds_bpermute_pair(vec_val, pair_byte_addr):
             """Return the copy of vec_val held by the rotary-pair thread, via ds_bpermute."""
             if const_expr(VEC_WIDTH == 1):
@@ -190,9 +195,14 @@ def build_fused_rope_cache_module(
             is_first_half = tid < vecs_per_half
             cos_vec_idx = tid % vecs_per_half if reuse_freqs_front_part else tid
 
-            # Pair lane for ds_bpermute: tid XOR vecs_per_half (symmetric, works for both halves).
+            # XOR is the cheapest symmetric mapping when the half-wave span is
+            # a power of two. Other spans, such as D=96 on wave32 (12 lanes per
+            # half), require explicit addition/subtraction.
+            if const_expr((vecs_per_half & (vecs_per_half - 1)) == 0):
+                pair_lane = tid ^ vecs_per_half
+            else:
+                pair_lane = is_first_half.select(tid + vecs_per_half, tid - vecs_per_half)
             # pair_byte_addr = pair_lane * 4 (ds_bpermute address unit is bytes, VGPR = 4 bytes).
-            pair_lane = tid ^ vecs_per_half
             pair_byte_addr = pair_lane * 4
 
             # --- Shared cos/sin (loaded once, used by both Q and K) ---

--- a/tests/kernels/test_fused_rope_cache.py
+++ b/tests/kernels/test_fused_rope_cache.py
@@ -626,6 +626,26 @@ def test_f16(num_tokens, flash_layout):
 
 
 # ===========================================================================
+# Category 4b: Non-power-of-two head dimension
+# ===========================================================================
+
+
+@pytest.mark.parametrize("dtype_str", ["bf16", "f16"])
+@pytest.mark.parametrize("flash_layout", [True, False], ids=["flash", "nonflash"])
+def test_head_dim_96(dtype_str, flash_layout):
+    """D=96 exercises a non-power-of-two NeoX half-wave span."""
+    passed, errs = run_test(
+        num_tokens=32,
+        head_dim=96,
+        num_q_heads=32,
+        num_kv_heads=32,
+        flash_layout=flash_layout,
+        dtype_str=dtype_str,
+    )
+    assert passed, f"FAILED (dtype={dtype_str} flash={flash_layout}): {errs}"
+
+
+# ===========================================================================
 # Category 5: pos_dtype — i32 vs i64 (stride-2 indexing)
 # ===========================================================================
 


### PR DESCRIPTION
## Motivation

The fused RoPE + KV cache kernel currently fails to compile for `head_dim=96` on wave32.

The previous vector-width calculation selects `VEC_WIDTH=3`. The `ds_bpermute_b32` path handles the vector as 32-bit chunks and reconstructs only two BF16/FP16 elements, which causes:

```text
ValueError: cannot broadcast shapes (2,) and (3,)
```

This is a real model configuration used by the Phi-3 Mini family. The existing comments also describe D=96 as a supported configuration.

## Technical Details

- Select the smallest copy width from `1/2/4/8` that divides both the complete head and each NeoX half while fitting the head into one wave.
- On wave32, D=96 now uses `VEC_WIDTH=4` and 24 active lanes.
- Keep the existing XOR lane mapping when `vecs_per_half` is a power of two.
- Use explicit addition/subtraction to pair the two NeoX halves for other lane spans, such as 12 lanes per half for D=96 on wave32.
- Add D=96 correctness tests for BF16/FP16 and flash/non-flash KV cache layouts.

The D=64, D=128, and D=256 paths retain their existing vector widths and XOR mapping.

## Test Plan

Run the fused RoPE + KV cache test suite:

```bash
PYTHONPATH=. python3 -m pytest tests/kernels/test_fused_rope_cache.py -q
```

The change was tested on an AMD Radeon 8060S using native `gfx1151` wave32 execution.

In addition to correctness testing, compare the generated ISA and CUDA Graph performance of the existing D=64/128/256 paths against `origin/main`.

## Test Result

```text
74 passed, 248 skipped
```

All four newly added D=96 combinations passed, and Q, K, key cache, and value cache matched the PyTorch reference.

The final gfx1151 ISA for D=64, D=128, and D=256 is byte-for-byte identical to `origin/main`. Interleaved CUDA Graph measurements showed no performance regression in those existing paths.

Representative D=96 CUDA Graph replay results for BF16, `QH=KH=32`:

| Tokens | Latency |
| ---: | ---: |
| 1 | 4.025 us |
| 128 | 10.637 us |
| 512 | 35.252 us |
| 2048 | 456.657 us |
| 4096 | 909.765 us |

The generated D=96 kernel uses 35 VGPRs, 26 SGPRs, no LDS, no scratch, and no register spills.

A direct D=96 comparison is unavailable because AITER's public Triton fused kernel currently rejects non-power-of-two head dimensions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
