### PR TITLE
[CI] Avoid unused ROCm repository refresh in manylinux build

### DIFF
--- a/.github/workflows/Dockerfile.manylinux_2_28
+++ b/.github/workflows/Dockerfile.manylinux_2_28
@@ -34,9 +34,9 @@ COPY --from=python-source /opt/python /opt/python
 # Copy patchelf binary (statically linked, required by auditwheel)
 COPY --from=python-source /usr/local/bin/patchelf /usr/local/bin/patchelf
 
-# Install build dependencies. ROCm is already in the base image; skip the amdgpu
-# repo so dnf does not hit flaky repo.radeon.com metadata fetches on CI.
-RUN dnf install -y --disablerepo=amdgpu \
+# ROCm is already in the base image. These build dependencies come from the OS
+# repos; disable both vendor repos to avoid unnecessary repo.radeon.com requests.
+RUN dnf install -y --disablerepo=amdgpu,ROCm \
       ninja-build \
       gcc \
       gcc-c++ \


### PR DESCRIPTION
The manylinux builder installs generic build dependencies from the OS
repositories, while the base image already provides the ROCm SDK. The existing
command disables `amdgpu` but still refreshes the `ROCm` vendor repository, so an
unrelated `repo.radeon.com` metadata outage can stop image preparation.

Disable both vendor repositories for that transaction. The installed package list
and ROCm SDK remain unchanged.

The failure reproduced in
[prepare-mlir](https://github.com/ROCm/FlyDSL/actions/runs/34439021827/job/102750177050):
`dnf` timed out resolving the unused `ROCm` repository. The same Dockerfile change
then completed the manylinux image step in
[the follow-up job](https://github.com/ROCm/FlyDSL/actions/runs/34443874091/job/102764752944).

This change was split from [#1047](https://github.com/ROCm/FlyDSL/pull/1047) so
the review-check skill remains limited to its own implementation and tests.
