### PR TITLE
[DSL] Support per-launcher ROCm wave-size hints

### DIFF
--- a/docs/api/compiler.rst
+++ b/docs/api/compiler.rst
@@ -96,6 +96,32 @@ descriptors with layout metadata:
    )
    launch(tA, B, n, stream=torch.cuda.Stream())
 
+Explicit ROCm wave size
+----------------------
+
+An explicitly wave64-authored RDNA kernel can select its code-generation mode
+without changing process-global backend functions:
+
+.. code-block:: python
+
+   launch.compile_hints["wave_size"] = 64
+   executable = flyc.compile(launch, *args)
+
+The hint accepts integer ``32`` or ``64``. CDNA targets reject wave32. An omitted
+hint preserves the architecture default. Both GPU module target annotations and
+the final lowering pipeline use the same mode; the hint is included in the JIT
+cache identity and its compilation context is thread-local.
+
+The ROCm backend exposes ``supports_wave_size_hint = True`` for callers that
+must remain compatible with older compiler versions without this hint.
+
+This is a module-wide code-generation choice, not an automatic layout rewrite.
+Every kernel in the launcher must be authored for the selected wave size. In
+particular, the existing high-level RDNA4 ``WMMA`` atom describes wave32 operands;
+wave64 WMMA experiments must supply the matching low-level ROCDL operand and
+accumulator types instead. The architecture's default layout helpers are not
+changed by this hint.
+
 ROCDL operations
 -----------------
 

--- a/python/flydsl/compiler/backends/rocm.py
+++ b/python/flydsl/compiler/backends/rocm.py
@@ -11,6 +11,8 @@ from .base import BaseBackend, GPUTarget
 class RocmBackend(BaseBackend):
     """ROCm / AMDGPU compile backend (HIP runtime, ROCDL lowering)."""
 
+    supports_wave_size_hint = True
+
     @staticmethod
     def supports_target(target: GPUTarget) -> bool:
         return target.backend == "rocm"
@@ -47,10 +49,25 @@ class RocmBackend(BaseBackend):
         """Format {key: value, ...} as 'key=value key2=value2' for MLIR pass options."""
         return " ".join(f"{k}={v}" for k, v in opts.items())
 
+    def _wave_options(self, compile_hints: dict) -> Tuple[int, str]:
+        default = get_warp_size(self.target.arch)
+        wave_size = compile_hints.get("wave_size", default)
+        if isinstance(wave_size, bool) or not isinstance(wave_size, int):
+            raise TypeError(f"wave_size must be 32 or 64, got {wave_size!r}")
+        if wave_size not in (32, 64):
+            raise ValueError(f"wave_size must be 32 or 64, got {wave_size}")
+        if wave_size != default and not self.target.arch.startswith(("gfx10", "gfx11", "gfx12")):
+            raise ValueError(f"{self.target.arch} does not support wave_size={wave_size}")
+        if "wave_size" not in compile_hints:
+            return wave_size, ""
+        other_size = 64 if wave_size == 32 else 32
+        return wave_size, f"+wavefrontsize{wave_size},-wavefrontsize{other_size}"
+
     def _pipeline_parts(self, *, compile_hints: dict) -> Tuple[List[str], str]:
         chip = self.target.arch
         waves_per_eu = compile_hints.get("waves_per_eu")
         maxnreg = compile_hints.get("maxnreg")
+        wave_size, wave_features = self._wave_options(compile_hints)
 
         bin_cli_opts = []
         if env.debug.enable_debug_info:
@@ -67,12 +84,12 @@ class RocmBackend(BaseBackend):
             "correct-sqrt": "true",
             "daz": "false",
             "fast": "true" if compile_hints.get("fast_fp_math") else "false",
-            "features": "",
+            "features": wave_features,
             "finite-only": "false",
             "module": "",
             "triple": "amdgcn-amd-amdhsa",
             "unsafe-math": "true" if compile_hints.get("unsafe_fp_math") else "false",
-            "wave64": "true" if get_warp_size(chip) == 64 else "false",
+            "wave64": "true" if wave_size == 64 else "false",
         }
 
         pre_binary_fragments = [
@@ -135,7 +152,12 @@ class RocmBackend(BaseBackend):
                 func_op.attributes["rocdl.waves_per_eu"] = wpe_attr
 
     def gpu_module_targets(self) -> List[str]:
+        from ..kernel_function import CompilationContext
+
         chip = self.target.arch
+        _, features = self._wave_options(CompilationContext.get_compile_hints())
+        if features:
+            return [f'#rocdl.target<chip = "{chip}", features = "{features}">']
         return [f'#rocdl.target<chip = "{chip}">']
 
     # -- cache / fingerprint ---------------------------------------------

--- a/tests/unit/test_compile_backends.py
+++ b/tests/unit/test_compile_backends.py
@@ -72,3 +72,59 @@ def test_registering_extra_backend_does_not_change_default(monkeypatch):
     assert backends.compile_backend_name() == "rocm"
     assert backends.get_backend(arch="gfx942").target.backend == "rocm"
     assert backends.get_backend("dummy", arch="dummy0").target.backend == "dummy"
+
+
+@pytest.mark.parametrize("wave_size", [32, 64])
+def test_rocm_wave_hint_matches_both_module_targets(monkeypatch, wave_size):
+    backends = _load_backends(monkeypatch)
+    from flydsl.compiler.kernel_function import CompilationContext
+
+    backend = backends.get_backend(arch="gfx1201")
+    assert backend.supports_wave_size_hint
+    hints = {"wave_size": wave_size}
+    with CompilationContext.compile_hints(hints):
+        targets = backend.gpu_module_targets()
+        pipeline = backend.pipeline_fragments(compile_hints=hints)
+    features = f"+wavefrontsize{wave_size},-wavefrontsize{96 - wave_size}"
+    assert features in targets[0]
+    attach = next(part for part in pipeline if part.startswith("rocdl-attach-target"))
+    assert f"features={features}" in attach
+    assert f"wave64={'true' if wave_size == 64 else 'false'}" in attach
+    assert backend.gpu_module_targets() == ['#rocdl.target<chip = "gfx1201">']
+
+
+@pytest.mark.parametrize("wave_size", [True, False, "64", 64.0, 0, 16, 128])
+def test_rocm_rejects_invalid_wave_hint(monkeypatch, wave_size):
+    backends = _load_backends(monkeypatch)
+    backend = backends.get_backend(arch="gfx1201")
+    with pytest.raises((TypeError, ValueError), match="wave_size"):
+        backend.pipeline_fragments(compile_hints={"wave_size": wave_size})
+
+
+def test_cdna_rejects_wave32(monkeypatch):
+    backends = _load_backends(monkeypatch)
+    backend = backends.get_backend(arch="gfx942")
+    with pytest.raises(ValueError, match="does not support wave_size=32"):
+        backend.pipeline_fragments(compile_hints={"wave_size": 32})
+
+
+def test_rocm_wave_hints_do_not_leak_between_threads(monkeypatch):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    backends = _load_backends(monkeypatch)
+    from flydsl.compiler.kernel_function import CompilationContext
+
+    backend = backends.get_backend(arch="gfx1201")
+    ready = Barrier(2)
+
+    def targets(wave_size):
+        with CompilationContext.compile_hints({"wave_size": wave_size}):
+            ready.wait(timeout=10)
+            return backend.gpu_module_targets()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        wave32, wave64 = list(pool.map(targets, [32, 64]))
+    assert "+wavefrontsize32,-wavefrontsize64" in wave32[0]
+    assert "+wavefrontsize64,-wavefrontsize32" in wave64[0]
+    assert backend.gpu_module_targets() == ['#rocdl.target<chip = "gfx1201">']


### PR DESCRIPTION
## Summary

Add an explicit per-launcher ROCm `wave_size` compile hint (32 or 64). This branch contains only the backend implementation, documentation, and focused tests: three files, 106 insertions and two deletions.

- Keep GPU-module target features and final lowering wave mode consistent.
- Preserve architecture defaults when the hint is absent.
- Reject invalid values and unsupported wave32 requests on CDNA.
- Expose `RocmBackend.supports_wave_size_hint` for downstream capability detection.
- Reuse the existing thread-local compilation context and hint-aware JIT cache; no process-global wave-size override.

This is a code-generation selection, **not automatic layout conversion**. Kernels must be authored for the chosen wave size. Existing RDNA4 high-level WMMA layouts remain wave32; explicitly authored wave64 kernels use matching low-level operands.

## Motivation and scope

The optimized follow-up to https://github.com/vllm-project/vllm/pull/56005 uses both wave32 and wave64 block-scaled FP8 GEMMs. Without this capability it selects a correct wave32 prefill fallback. This patch enables its wave64 routes without global backend monkeypatching.

Based directly on upstream main `65e5d8efac9e8732e28f3b412d5cd868f2361258`; patch commit `879f5e61021e57bf9921c445018fd929fc873b13`. No memory-primitives, scalar FP8 conversion, or LLVM true16 patches are included. No new dependencies. Searched open FlyDSL PRs for wave, wave_size, and wavefront support; no duplicate per-launcher wave-size change was found.

## Quick downstream performance check

AMD Radeon AI PRO R9700, gfx1201, HIP device 2 / PCI bus 0x83. Compared actual upstream-main Python sources against the same main plus this patch, using the same existing MLIR/LLVM binaries and identical vLLM kernel sources. This is not a fresh LLVM rebuild.

18 route-covering shapes; graph timing; 15 interleaved Triton/FlyDSL samples per mode; 32 calls for hot-cache measurement; at least 256 MiB rotating weight/scale pools; 50 ms active warmup. Main and patched compiler runs were sequential. All outputs passed the harness's full-output comparison against Triton and sampled independent reference checks.

**Important provenance:** downstream numbers use the optimized vLLM follow-up, now published as squashed commit [`c5ba4054`](https://github.com/vllm-project/vllm/pull/56005/commits/c5ba4054cabc674df3d9f7e1bb059feb781018e3). Router SHA256: `147cdd39afa6d65b588fcbc426e03381d0fa0d1c7dd12bea7a203c91b7db6705`. They are motivation/spot-check results, not a full model-shape sweep or end-to-end serving measurement.

- Seven affected routes: patch speedup **1.438x hot / 1.489x rotating** (main-only latency approximately **44% / 49% higher**).
- Eleven unchanged routes: patch/main speed ratio **0.980x / 0.995x**; retain this run-to-run difference rather than claiming exact timing parity.
- All 18: patch speedup **1.137x / 1.164x** over main-only.
- Both configurations beat their same-run Triton baseline in all 18 cases. No claim of universal wins.
- Large-prefill examples M1024 and M8192 show approximately 26–33% higher latency without the patch.

| M | N | K | Main hot (µs) | +patch hot (µs) | Main rotating (µs) | +patch rotating (µs) |
|---:|---:|---:|---:|---:|---:|---:|
| 128 | 1536 | 2048 | 19.03 | 10.20 | 21.34 | 11.54 |
| 128 | 1536 | 4096 | 35.12 | 15.70 | 45.50 | 18.68 |
| 256 | 8192 | 5120 | 129.04 | 110.00 | 151.31 | 113.54 |
| 512 | 1536 | 4096 | 53.15 | 36.94 | 55.04 | 36.36 |
| 523 | 5120 | 8704 | 306.99 | 277.83 | 298.73 | 280.41 |
| 1024 | 8192 | 5120 | 492.11 | 386.82 | 475.14 | 376.18 |
| 8192 | 8192 | 28672 | 22928.30 | 17868.79 | 22485.95 | 16956.94 |

The current working compiler is assumed equivalent to main plus this patch for interpretation, as agreed with the downstream author; no fresh three-way comparison is claimed. No end-to-end serving latency benchmark was run in this check.

## Testing

- `PYTHONPATH=$PWD/python python -m pytest tests/unit/test_compile_backends.py -q`: **13 passed** (CPU-only, empty HIP/ROCR visibility, gfx1201 compile target).
- vLLM `python -m pytest tests/kernels/quantization/test_block_fp8.py -k rdna4 -q`: **109 passed with plain main; 109 passed with main + patch**.
- Black 26.5.1 and Ruff 0.16.6 checks passed on both changed Python files.
- All configured pre-commit hooks passed on the three changed files.
- `git diff --check` passed.
- GPU execution tested on gfx1201 only; CDNA rejection is covered by unit tests, not a CDNA hardware run.

Exact local benchmark entry point: `HIP_VISIBLE_DEVICES=2 .../.venv/bin/python /app/rdna4-optimization-reference/flydsl-sync/run_perf.py --output-dir <main-only-or-main-wave>`, selecting the corresponding compiler's `python/` directory via PYTHONPATH. This archived harness and the optimized downstream source are local follow-up artifacts; the table above discloses the affected shapes and measurements.

## Review / AI assistance

Draft for human review. OpenAI Codex assisted with implementation, tests, benchmarking, and this description. The human submitter remains responsible for reviewing and approving the change.

