### PR TITLE
[CI] Use host networking for manylinux image builds

### DIFF
--- a/.github/workflows/Dockerfile.manylinux_2_28
+++ b/.github/workflows/Dockerfile.manylinux_2_28
@@ -8,7 +8,7 @@
 #   Merge:   Python toolchains + ROCm + build deps in one image
 #
 # Build:
-#   docker build \
+#   docker build --network=host \
 #     --build-arg ROCM_VERSION=7.2 \
 #     -t flydsl/manylinux_2_28:rocm7.2 \
 #     - < .github/workflows/Dockerfile.manylinux_2_28

--- a/.github/workflows/build-custom-llvm-tools.yaml
+++ b/.github/workflows/build-custom-llvm-tools.yaml
@@ -33,7 +33,8 @@ jobs:
           ROCM_VERSION=7.2
           IMAGE="ghcr.io/rocm/flydsl-manylinux_2_28:rocm${ROCM_VERSION}-a3c082a2ac9c"
           if ! docker pull "${IMAGE}"; then
-            docker build \
+            # Use the runner's network for dnf/pip during the build, too.
+            docker build --network=host \
               --build-arg ROCM_VERSION="${ROCM_VERSION}" \
               -t "${IMAGE}" \
               - < flydsl/.github/workflows/Dockerfile.manylinux_2_28

--- a/.github/workflows/build-whl.yaml
+++ b/.github/workflows/build-whl.yaml
@@ -42,7 +42,8 @@ jobs:
           IMAGE="ghcr.io/rocm/flydsl-manylinux_2_28:rocm${ROCM_VERSION}-cp310-cp314"
           if ! docker pull "${IMAGE}"; then
             # The Dockerfile is self-contained, so avoid sending the full repo as build context.
-            docker build \
+            # Use the runner's network for dnf/pip during the build, too.
+            docker build --network=host \
               --build-arg ROCM_VERSION="${ROCM_VERSION}" \
               -t "${IMAGE}" \
               - < flydsl/.github/workflows/Dockerfile.manylinux_2_28

--- a/.github/workflows/flydsl.yaml
+++ b/.github/workflows/flydsl.yaml
@@ -296,7 +296,8 @@ jobs:
           ROCM_VERSION=7.2
           IMAGE="ghcr.io/rocm/flydsl-manylinux_2_28:rocm${ROCM_VERSION}-cp310-cp314"
           if ! docker pull "${IMAGE}"; then
-            docker build \
+            # Use the runner's network for dnf/pip during the build, too.
+            docker build --network=host \
               --build-arg ROCM_VERSION="${ROCM_VERSION}" \
               -t "${IMAGE}" \
               - < flydsl-test/.github/workflows/Dockerfile.manylinux_2_28


### PR DESCRIPTION
The manylinux image fallback intermittently fails while DNF resolves the required AlmaLinux BaseOS mirrorlist. This stopped both [prepare-mlir](https://github.com/ROCm/FlyDSL/actions/runs/34459592706/job/102814434281) and [wheel publishing](https://github.com/ROCm/FlyDSL/actions/runs/34489347899/job/102912301448) after roughly eight minutes with `Resolving timed out after 30000 milliseconds`.

Use `docker build --network=host` in all three manylinux build entry points: test preparation, wheel publishing, and custom LLVM tools. Their runtime containers already use host networking, but that setting does not apply to Dockerfile `RUN` instructions. This makes DNF and pip use the runner network during image construction as well. Update the Dockerfile's build example to match.

Follow-up to #1115: the unused `amdgpu` and `ROCm` repositories remain disabled. BaseOS must stay enabled because the successful rerun installed `libffi-devel`, `openssl-devel`, and their dependencies from it. Required dependency installation still fails on error.

Validation:

- All three workflows pass `actionlint` (custom runner labels excluded; ShellCheck unavailable).
- YAML parsing and `bash -n` pass for all 67 shell steps in the affected workflows.
- `python3 scripts/check_repo.py` and `git diff --check` pass.
- [CPU-runner prepare-mlir](https://github.com/ROCm/FlyDSL/actions/runs/34526885255/job/103038378036) passed at commit `2354e515c1108f30d8985a0233c40888196c5384`. Its log confirms the fallback executed `docker build --network=host`; DNF completed in 55 seconds and pip in 3.7 seconds. Both PR/base wheels built, passed checksum verification, and were uploaded successfully.
- Python/C++ style checks, CodeQL, and documentation builds passed. The downstream GPU matrix is still pending/in progress; wheel-publishing and custom-LLVM workflows were checked statically rather than dispatched.

The original SHA's [second attempt](https://github.com/ROCm/FlyDSL/actions/runs/34459592706/job/102902290896) succeeded without this patch, confirming that the DNS failure is intermittent. The logs establish the failed DNS request, but do not isolate the underlying bridge/cluster DNS fault; this change fixes the build/runtime networking mismatch.
