### PR TITLE
[Perf] Reduce small-batch TopK selection overhead on gfx950

### DIFF
--- a/kernels/moe/topk_gating_softmax_kernel.py
+++ b/kernels/moe/topk_gating_softmax_kernel.py
@@ -399,6 +399,7 @@ def _build_topk_gating_softmax_module(
     renormalize: bool = True,
     *,
     max_vpt: int = 16,
+    ballot_argmax: bool = False,
 ):
     """Build a fused TopK gating softmax kernel.
 
@@ -421,6 +422,7 @@ def _build_topk_gating_softmax_module(
     ATOM_BITS = layout["ATOM_BITS"]
     ELEMS_PER_ATOM = layout["ELEMS_PER_ATOM"]
     ATOMS_PER_THREAD = layout["ATOMS_PER_THREAD"]
+    USE_DPP = max_vpt == 8 and ballot_argmax
 
     # No shared memory used — every reduction stays inside a sub-warp lane group.
 
@@ -469,8 +471,18 @@ def _build_topk_gating_softmax_module(
             width_i32 = c_tpt
             w = x
             for _sh in range_constexpr(int(math.log2(THREADS_PER_TOKEN))):
-                off = fx.Int32(THREADS_PER_TOKEN // (2 << _sh))
-                peer = w.shuffle_xor(off, width_i32)
+                offset = THREADS_PER_TOKEN // (2 << _sh)
+                off = fx.Int32(offset)
+                peer = w
+                if USE_DPP and offset in (1, 2):
+                    # Quad permutations preserve the fixed XOR1/2 lane map
+                    # without a DS instruction and its dependency wait.
+                    ctrl = 0xB1 if offset == 1 else 0x4E
+                    bits = fx.Float32(w).bitcast(fx.Int32)
+                    peer_bits = fx.rocdl.update_dpp(T.i32, as_ir_value(bits), as_ir_value(bits), ctrl, 0xF, 0xF, True)
+                    peer = fx.Int32(peer_bits).bitcast(fx.Float32)
+                else:
+                    peer = w.shuffle_xor(off, width_i32)
                 if mode == "max":
                     w = fx.max(w, peer)
                 else:
@@ -478,24 +490,32 @@ def _build_topk_gating_softmax_module(
             return w
 
         def group_reduce_argmax(val, idx):
-            """Butterfly argmax within a THREADS_PER_TOKEN sub-warp group.
-
-            All lanes in the group end with the same (max_val, max_idx).
-            Ties are broken by the lower expert index.
-            """
-            width_i32 = c_tpt
-            wv, wi = val, idx
-            for _sh in range_constexpr(int(math.log2(THREADS_PER_TOKEN))):
-                off = fx.Int32(THREADS_PER_TOKEN // (2 << _sh))
-                peer_v = wv.shuffle_xor(off, width_i32)
-                peer_i = wi.shuffle_xor(off, width_i32)
-                is_greater = peer_v > wv
-                is_equal = ArithValue(peer_v) == ArithValue(wv)
-                peer_lower_idx = peer_i < wi
-                take_peer = is_greater | (is_equal & peer_lower_idx)
-                wv = take_peer.select(peer_v, wv)
-                wi = take_peer.select(peer_i, wi)
-            return wv, wi
+            """Reduce probability, then identify its lowest-index lane."""
+            winner_val, winner_idx = val, idx
+            if ballot_argmax:
+                # A lane owns a contiguous, increasing expert interval. The
+                # lowest lane among equal maxima therefore owns the lowest
+                # expert index, including ties caused by probability underflow.
+                winner_val = group_reduce(val, "max")
+                contenders = fx.Int64(fx.rocdl.ballot(T.i64, ArithValue(val) == ArithValue(winner_val)))
+                group_base = lane - expert_lane
+                group_bits = contenders.shrui(fx.Int64(group_base)) & fx.Int64((1 << THREADS_PER_TOKEN) - 1)
+                winner_lane = group_base + fx.Int32(fx.cttz(group_bits))
+                winner_idx = fx.gpu.shuffle_idx(idx, winner_lane, c_warp)
+            else:
+                width_i32 = c_tpt
+                winner_val, winner_idx = val, idx
+                for _sh in range_constexpr(int(math.log2(THREADS_PER_TOKEN))):
+                    off = fx.Int32(THREADS_PER_TOKEN // (2 << _sh))
+                    peer_v = winner_val.shuffle_xor(off, width_i32)
+                    peer_i = winner_idx.shuffle_xor(off, width_i32)
+                    is_greater = peer_v > winner_val
+                    is_equal = ArithValue(peer_v) == ArithValue(winner_val)
+                    peer_lower_idx = peer_i < winner_idx
+                    take_peer = is_greater | (is_equal & peer_lower_idx)
+                    winner_val = take_peer.select(peer_v, winner_val)
+                    winner_idx = take_peer.select(peer_i, winner_idx)
+            return winner_val, winner_idx
 
         # ── Buffer-backed views ──────────────────────────────────────────
         GatingOutput_buf = fx.rocdl.make_buffer_tensor(GatingOutput)
@@ -609,15 +629,29 @@ def _build_topk_gating_softmax_module(
         selected_sum = c_zero_f
 
         for k_idx in range_constexpr(topk):
-            # Per-thread argmax over its VPT slots.
+            # A balanced local tournament shortens the dependent compare /
+            # select chain. Equal probabilities retain the left (lower-index)
+            # leaf, exactly like the original increasing-index linear scan.
             thread_best_val = c_neg_inf
             thread_best_idx = fx.Int32(-1)
-            for v in range_constexpr(VPT):
-                pv = prob_list[v]
-                ci = col_idx_list[v]
-                is_better = pv > thread_best_val
-                thread_best_val = is_better.select(pv, thread_best_val)
-                thread_best_idx = is_better.select(ci, thread_best_idx)
+            if ballot_argmax:
+                best_vals = list(prob_list)
+                best_indices = list(col_idx_list)
+                for level in range_constexpr(int(math.log2(VPT))):
+                    stride = 1 << level
+                    for v in range_constexpr(0, VPT, 2 * stride):
+                        take_right = best_vals[v + stride] > best_vals[v]
+                        best_vals[v] = take_right.select(best_vals[v + stride], best_vals[v])
+                        best_indices[v] = take_right.select(best_indices[v + stride], best_indices[v])
+                thread_best_val = best_vals[0]
+                thread_best_idx = best_indices[0]
+            else:
+                for v in range_constexpr(VPT):
+                    pv = prob_list[v]
+                    ci = col_idx_list[v]
+                    is_better = pv > thread_best_val
+                    thread_best_val = is_better.select(pv, thread_best_val)
+                    thread_best_idx = is_better.select(ci, thread_best_idx)
 
             # Sub-warp argmax → all THREADS_PER_TOKEN lanes hold the winner.
             global_best_val, global_best_idx = group_reduce_argmax(thread_best_val, thread_best_idx)
@@ -709,7 +743,7 @@ def build_topk_gating_softmax_module(
     wide = _build_topk_gating_softmax_module(num_experts, topk, dtype_str, renormalize)
     if not get_rocm_arch().startswith("gfx95") or num_experts not in (128, 256) or topk not in (4, 6, 8):
         return wide
-    narrow = _build_topk_gating_softmax_module(num_experts, topk, dtype_str, renormalize, max_vpt=8)
+    narrow = _build_topk_gating_softmax_module(num_experts, topk, dtype_str, renormalize, max_vpt=8, ballot_argmax=True)
 
     @flyc.jit
     def launch_topk_gating_softmax(

--- a/kernels/moe/topk_gating_softmax_kernel.py
+++ b/kernels/moe/topk_gating_softmax_kernel.py
@@ -30,6 +30,7 @@ from flydsl._mlir.dialects import vector
 from flydsl.expr import arith, as_ir_value, range_constexpr
 from flydsl.expr.arith import ArithValue
 from flydsl.expr.typing import Int32, T
+from flydsl.runtime.device import get_rocm_arch
 from kernels.common.kernels_common import dtype_to_elem_type, get_warp_size
 
 KERNEL_NAME = "topk_gating_softmax_kernel"
@@ -39,18 +40,20 @@ WARPS_PER_BLOCK = 4
 BLOCK_THREADS = WARPS_PER_BLOCK * WARP_SIZE  # 256 on gfx95x
 
 
-def _pick_layout(num_experts: int):
+def _pick_layout(num_experts: int, max_vpt: int = 16):
     """Pick (VPT, THREADS_PER_TOKEN) for the multi-token-per-block fast path.
 
     Constraints:
       - ``VPT`` is a power of 2 in [1, 16]
       - ``THREADS_PER_TOKEN = num_experts // VPT`` is a power of 2 <= WARP_SIZE
-      - prefer the largest ``VPT`` (fewest loads, widest atom)
+      - prefer the largest ``VPT <= max_vpt`` (fewest loads, widest atom)
 
     For ``num_experts=128`` on a 64-wide wave this picks ``(VPT=16, TPT=8)``
     (TOKENS_PER_BLOCK=32). vLLM's ``topkGatingSoftmax`` uses VPT=8 / TPT=16
     """
     for vpt in [16, 8, 4, 2, 1]:
+        if vpt > max_vpt:
+            continue
         if num_experts % vpt != 0:
             continue
         tpt = num_experts // vpt
@@ -62,18 +65,18 @@ def _pick_layout(num_experts: int):
     return None, None
 
 
-def _compute_topk_gating_layout(num_experts: int, topk: int, dtype_str: str):
+def _compute_topk_gating_layout(num_experts: int, topk: int, dtype_str: str, *, max_vpt: int = 16):
     """Resolve the full layout dict (VPT, THREADS_PER_TOKEN, TOKENS_PER_BLOCK,
     ATOM_BITS, ELEMS_PER_ATOM, ATOMS_PER_THREAD, elem_bits) for the multi-
     token-per-block gating softmax kernel.
 
-    Shared by the standalone kernel in this module and the fused oneshot
-    kernel in ``kernels/moe_sorting_kernel.py`` so the two paths can never
-    disagree on the layout.
+    Shared by the standalone kernel and the fused oneshot sorting kernel.
+    The default preserves the fused layout; standalone small-batch dispatch
+    can request a lower ``max_vpt`` without changing the fused path.
     """
     elem_bits = 32 if dtype_str == "f32" else 16
 
-    VPT, THREADS_PER_TOKEN = _pick_layout(num_experts)
+    VPT, THREADS_PER_TOKEN = _pick_layout(num_experts, max_vpt)
     if VPT is None:
         raise ValueError(
             f"num_experts={num_experts} is not supported by the multi-token-per-block "
@@ -389,11 +392,13 @@ def _emit_topk_gating_softmax_body(
                 _store_scalar_i32(tei_div, Int32(k_idx), tei_val)
 
 
-def build_topk_gating_softmax_module(
+def _build_topk_gating_softmax_module(
     num_experts: int,
     topk: int,
     dtype_str: str = "bf16",
     renormalize: bool = True,
+    *,
+    max_vpt: int = 16,
 ):
     """Build a fused TopK gating softmax kernel.
 
@@ -407,7 +412,7 @@ def build_topk_gating_softmax_module(
         A @flyc.jit launcher function with signature
         ``(gating, weights, indices, tei, num_tokens, *, stream)``.
     """
-    layout = _compute_topk_gating_layout(num_experts, topk, dtype_str)
+    layout = _compute_topk_gating_layout(num_experts, topk, dtype_str, max_vpt=max_vpt)
     elem_bits = layout["elem_bits"]
     VPT = layout["VPT"]
     THREADS_PER_TOKEN = layout["THREADS_PER_TOKEN"]
@@ -682,5 +687,42 @@ def build_topk_gating_softmax_module(
             block=(BLOCK_THREADS, 1, 1),
             stream=stream,
         )
+
+    return launch_topk_gating_softmax
+
+
+def build_topk_gating_softmax_module(
+    num_experts: int,
+    topk: int,
+    dtype_str: str = "bf16",
+    renormalize: bool = True,
+):
+    """Build fused softmax + top-K selection with optional renormalization.
+
+    Returns a JIT launcher accepting gating logits, weights, expert indices,
+    token-expert indices, token count, and stream. For gfx95, 128/256 experts,
+    and top-K in {4, 6, 8}, batches of at most 2048 tokens use eight values per
+    thread to shorten the serial selection chain. Larger batches retain the
+    wider layout to avoid increasing total wave work. The token count remains
+    dynamic: the same compiled launcher supports both layouts.
+    """
+    wide = _build_topk_gating_softmax_module(num_experts, topk, dtype_str, renormalize)
+    if not get_rocm_arch().startswith("gfx95") or num_experts not in (128, 256) or topk not in (4, 6, 8):
+        return wide
+    narrow = _build_topk_gating_softmax_module(num_experts, topk, dtype_str, renormalize, max_vpt=8)
+
+    @flyc.jit
+    def launch_topk_gating_softmax(
+        GatingOutput: fx.Tensor,
+        TopkWeights: fx.Tensor,
+        TopkIndices: fx.Tensor,
+        TokenExpertIndices: fx.Tensor,
+        num_tokens_in: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        if num_tokens_in <= fx.Int32(2048):
+            narrow(GatingOutput, TopkWeights, TopkIndices, TokenExpertIndices, num_tokens_in, stream)
+        else:
+            wide(GatingOutput, TopkWeights, TopkIndices, TokenExpertIndices, num_tokens_in, stream)
 
     return launch_topk_gating_softmax

--- a/tests/kernels/test_topk_gating_softmax.py
+++ b/tests/kernels/test_topk_gating_softmax.py
@@ -211,8 +211,9 @@ def run_test(num_tokens, num_experts, topk, dtype_str, renormalize=True):
 
 def _dispatch_contract_input(capacity, num_experts, dtype):
     """Exactly representable logits with ties across both 8- and 16-value lanes."""
-    rows = torch.arange(capacity, dtype=torch.int64)[:, None]
-    cols = torch.arange(num_experts, dtype=torch.int64)[None, :]
+    # Other test modules set the default device to CUDA during collection.
+    rows = torch.arange(capacity, dtype=torch.int64, device="cpu")[:, None]
+    cols = torch.arange(num_experts, dtype=torch.int64, device="cpu")[None, :]
     logits = ((rows * 17 + cols * 7) % 13 - 6).to(torch.float32)
     logits[0::6] = 0  # Every expert ties: the first K indices must win.
     logits[1::6] = -4
@@ -224,7 +225,7 @@ def _dispatch_contract_input(capacity, num_experts, dtype):
     logits[2::6, -1] = 0
     # All eight winners can belong to the final lane, including lane 63.
     logits[4::6] = -4
-    logits[4::6, -8:] = torch.arange(1, 9, dtype=torch.float32)
+    logits[4::6, -8:] = torch.arange(1, 9, dtype=torch.float32, device="cpu")
     # Distinct f32 logits round to equal softmax probabilities. Selecting
     # logits instead would incorrectly reverse the lowest-index tie order.
     logits[5::6] = cols.to(torch.float32) * 1e-10
@@ -280,8 +281,8 @@ def test_topk_runtime_dispatch_contract(num_experts, topk, dtype_str, renormaliz
         torch.testing.assert_close(got_weights[:num_tokens], expected_weights[:num_tokens], atol=2e-6, rtol=2e-5)
         assert torch.equal(got_indices[:num_tokens], expected_indices[:num_tokens]), "expert order/ties differ"
         expected_tei = (
-            torch.arange(topk, dtype=torch.int32)[None, :] * num_tokens
-            + torch.arange(num_tokens, dtype=torch.int32)[:, None]
+            torch.arange(topk, dtype=torch.int32, device="cpu")[None, :] * num_tokens
+            + torch.arange(num_tokens, dtype=torch.int32, device="cpu")[:, None]
         )
         assert torch.equal(got_tei[:num_tokens], expected_tei)
         # The dynamic token count can be smaller than the allocated tensor.
@@ -304,6 +305,12 @@ def test_topk_runtime_dispatch_contract(num_experts, topk, dtype_str, renormaliz
         poison_outputs()
         graph.replay()
         check_outputs(num_tokens)
+
+
+def test_topk_contract_with_cuda_default_device():
+    """Exercise the full-suite device context even when this module runs alone."""
+    with torch.device("cuda"):
+        test_topk_runtime_dispatch_contract(128, 6, "bf16", True)
 
 
 def test_all():

--- a/tests/kernels/test_topk_gating_softmax.py
+++ b/tests/kernels/test_topk_gating_softmax.py
@@ -214,14 +214,20 @@ def _dispatch_contract_input(capacity, num_experts, dtype):
     rows = torch.arange(capacity, dtype=torch.int64)[:, None]
     cols = torch.arange(num_experts, dtype=torch.int64)[None, :]
     logits = ((rows * 17 + cols * 7) % 13 - 6).to(torch.float32)
-    logits[0::4] = 0  # Every expert ties: the first K indices must win.
-    logits[1::4] = -4
+    logits[0::6] = 0  # Every expert ties: the first K indices must win.
+    logits[1::6] = -4
     boundary_experts = [i for i in (7, 8, 15, 16, 31, 32, 63, 64, 127, 128, 255) if i < num_experts]
-    logits[1::4, boundary_experts] = 4
+    logits[1::6, boundary_experts] = 4
     # The kernel selects after f32 softmax. All but the final expert underflow
     # to zero, so the remaining winners must be the lowest unused indices.
-    logits[2::4] = -1000
-    logits[2::4, -1] = 0
+    logits[2::6] = cols.to(torch.float32) - 1000
+    logits[2::6, -1] = 0
+    # All eight winners can belong to the final lane, including lane 63.
+    logits[4::6] = -4
+    logits[4::6, -8:] = torch.arange(1, 9, dtype=torch.float32)
+    # Distinct f32 logits round to equal softmax probabilities. Selecting
+    # logits instead would incorrectly reverse the lowest-index tie order.
+    logits[5::6] = cols.to(torch.float32) * 1e-10
     return logits.to(dtype)
 
 

--- a/tests/kernels/test_topk_gating_softmax.py
+++ b/tests/kernels/test_topk_gating_softmax.py
@@ -209,6 +209,97 @@ def run_test(num_tokens, num_experts, topk, dtype_str, renormalize=True):
     return passed, flydsl_gpu_us
 
 
+def _dispatch_contract_input(capacity, num_experts, dtype):
+    """Exactly representable logits with ties across both 8- and 16-value lanes."""
+    rows = torch.arange(capacity, dtype=torch.int64)[:, None]
+    cols = torch.arange(num_experts, dtype=torch.int64)[None, :]
+    logits = ((rows * 17 + cols * 7) % 13 - 6).to(torch.float32)
+    logits[0::4] = 0  # Every expert ties: the first K indices must win.
+    logits[1::4] = -4
+    boundary_experts = [i for i in (7, 8, 15, 16, 31, 32, 63, 64, 127, 128, 255) if i < num_experts]
+    logits[1::4, boundary_experts] = 4
+    # The kernel selects after f32 softmax. All but the final expert underflow
+    # to zero, so the remaining winners must be the lowest unused indices.
+    logits[2::4] = -1000
+    logits[2::4, -1] = 0
+    return logits.to(dtype)
+
+
+_DISPATCH_CONTRACT_CONFIGS = [
+    (num_experts, topk, dtype_str, (e_idx + k_idx + d_idx) % 2 == 0)
+    for e_idx, num_experts in enumerate((128, 256))
+    for k_idx, topk in enumerate((4, 6, 8))
+    for d_idx, dtype_str in enumerate(("bf16", "f16", "f32"))
+]
+
+
+@pytest.mark.parametrize("num_experts,topk,dtype_str,renormalize", _DISPATCH_CONTRACT_CONFIGS)
+def test_topk_runtime_dispatch_contract(num_experts, topk, dtype_str, renormalize):
+    """Keep the public launcher correct across its runtime batch boundary.
+
+    Reuse one launcher and identically shaped tensors while changing the token
+    count. This catches stale specialization of the runtime scalar, including
+    switching back to the short-batch path. No performance loop is involved.
+    """
+    capacity = 2049
+    quantized_input = _dispatch_contract_input(capacity, num_experts, _torch_dtype(dtype_str))
+    # Stable sorting expresses the kernel's explicit lowest-index tie rule.
+    # The discrete inputs avoid ambiguous approximate-exp boundary rankings.
+    probabilities = torch.softmax(quantized_input.float(), dim=-1)
+    expected_indices = torch.argsort(probabilities, dim=-1, descending=True, stable=True)[:, :topk]
+    expected_weights = probabilities.gather(1, expected_indices)
+    if renormalize:
+        expected_weights /= expected_weights.sum(dim=-1, keepdim=True).clamp_min(1e-20)
+    expected_indices = expected_indices.to(torch.int32)
+
+    gating = quantized_input.to(device="cuda")
+    frozen_input = gating.clone()
+    weights = torch.empty((capacity, topk), dtype=torch.float32, device="cuda")
+    indices = torch.empty((capacity, topk), dtype=torch.int32, device="cuda")
+    tei = torch.empty((capacity, topk), dtype=torch.int32, device="cuda")
+    launch_fn = build_topk_gating_softmax_module(num_experts, topk, dtype_str, renormalize)
+
+    def launch(num_tokens):
+        launch_fn(gating, weights, indices, tei, num_tokens, stream=torch.cuda.current_stream())
+
+    def poison_outputs():
+        weights.fill_(float("nan"))
+        indices.fill_(-1)
+        tei.fill_(-1)
+
+    def check_outputs(num_tokens):
+        torch.cuda.synchronize()
+        assert torch.equal(gating, frozen_input), "gating input was modified"
+        got_weights, got_indices, got_tei = (tensor.cpu() for tensor in (weights, indices, tei))
+        torch.testing.assert_close(got_weights[:num_tokens], expected_weights[:num_tokens], atol=2e-6, rtol=2e-5)
+        assert torch.equal(got_indices[:num_tokens], expected_indices[:num_tokens]), "expert order/ties differ"
+        expected_tei = (
+            torch.arange(topk, dtype=torch.int32)[None, :] * num_tokens
+            + torch.arange(num_tokens, dtype=torch.int32)[:, None]
+        )
+        assert torch.equal(got_tei[:num_tokens], expected_tei)
+        # The dynamic token count can be smaller than the allocated tensor.
+        assert bool(torch.isnan(got_weights[num_tokens:]).all()), "wrote weights beyond num_tokens"
+        assert bool((got_indices[num_tokens:] == -1).all()), "wrote indices beyond num_tokens"
+        assert bool((got_tei[num_tokens:] == -1).all()), "wrote TEI beyond num_tokens"
+
+    for num_tokens in (1, 17, 2048, 2049, 2048):
+        poison_outputs()
+        launch(num_tokens)
+        check_outputs(num_tokens)
+
+    # torch.cuda.graph selects a capture stream. A launch on a stale/default
+    # stream produces an empty or invalid graph; poisoning after capture makes
+    # this observable instead of accepting the output of the eager warmup.
+    for num_tokens in (2048, 2049):
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            launch(num_tokens)
+        poison_outputs()
+        graph.replay()
+        check_outputs(num_tokens)
+
+
 def test_all():
     print("=" * 80)
     print("Running TopK Gating Softmax Tests")


### PR DESCRIPTION
## Motivation

Small-batch MoE TopK gating spends substantial work in repeated local and subgroup argmax. On MI355X/gfx950, this change provides **1.22–1.41× kernel speedup** across 18 combinations of T=1024, E=128/256, K=4/6/8 and bf16/f16/f32. GPU latency for the actual routing API, including sorting and clearing, falls by **7.15% / 8.74%** for bf16 E128/K6 and E256/K8.

Related: #708 (small-token MoE latency; this change covers routing).

## Technical Details

All standalone layouts use a balanced local argmax. For the gfx95 architecture family, E=128/256, K=4/6/8 and runtime T<=2048 additionally use VPT=8, max+ballot with one winner-index gather, and quad DPP for fixed XOR1/XOR2 exchanges. Other shapes, architectures and large batches retain the original layout and subgroup argmax path; the shared fused-oneshot helper is unchanged.

Selection remains over the original computed softmax probabilities, preserving lower-index ties including underflow/rounded-probability ties. The probability arithmetic, renormalization, public launcher ABI and stream behavior remain unchanged.

Actual rocprofv3 ATT/source mapping confirms the selected path: E128/K6/T1024 has 574 executable ISA entries versus 1062 in the baseline, with 22 `ds_bpermute` and 16 quad-DPP instructions. Relative to the initial VPT=8 version, bpermutes fall from 56 to 22. Independent ablations tested the local tournament, ballot and DPP changes. The final ATT capture maps 99.8% of the code; all eight sampled waves execute the complete target instruction sequence. Not every stall category falls, and sampled full-wave duration is slightly longer than the intermediate tournament-plus-ballot version. Profiled durations are not used as benchmark timings.

## Test Plan

The baseline passed the original 19-test TopK suite; the final head passes the expanded 25-test suite. Both pass 16 existing `moe_softmax_sort` integration tests. Extended testing covers 144 configurations against the stable reference: E=128/256, K=4/6/8, all three dtypes, both renormalization modes and T=1/17/2048/2049. Fixtures include exact, rounded and underflow ties, and concentrated last-lane winners. The committed tests exercise the same launcher across runtime boundaries, input/tail invariance and real graph replay after output poisoning, plus non-ballot VPT=1/2/4/8/16 layouts; the smaller widths cover K>VPT after a lane is fully masked.

Black/Ruff, the Linux repository style wrapper, typed-arithmetic and agent-doc checks pass. Tested on one MI355X/gfx950, ROCm 7.2 and PyTorch 2.9.1, using baseline `39b271c562923b737631546ec61aa168fef804ad` and the same compiler/runtime build.

## Test Result

Standalone measurements use an unprofiled resident-buffer HIP graph: T=1024, renormalize=True, 200 kernel calls per graph, three replays per sample and 15 alternating paired samples. The bf16 subset is:

| E | K | dtype | Baseline µs | Final µs | Paired speedup |
|---:|---:|---|---:|---:|---:|
| 128 | 4 | bf16 | 3.399 | 2.770 | 1.227× |
| 128 | 6 | bf16 | 4.229 | 3.289 | 1.286× |
| 128 | 8 | bf16 | 5.146 | 3.779 | 1.361× |
| 256 | 4 | bf16 | 3.681 | 3.019 | 1.218× |
| 256 | 6 | bf16 | 4.595 | 3.454 | 1.331× |
| 256 | 8 | bf16 | 5.534 | 4.190 | 1.319× |

Routing uses separate-process ABBA order, 100 API calls per graph, three replays per sample and 15 samples per process, including gating, sorting and `moe_buf` clearing; model_dim=4096 and dtype=bf16. The table reports the mean of the two process medians:

| T,E,K | Baseline µs | Final µs | Latency reduction |
|---|---:|---:|---:|
| 16,128,6 | 8.180 | 8.178 | 0.03% |
| 17,128,6 | 9.656 | 8.585 | 11.08% |
| 1024,128,6 | 13.709 | 12.729 | 7.15% |
| 1024,256,8 | 16.167 | 14.755 | 8.74% |

T=16 uses the unchanged fused path. T=2049/65536 controls retain the original layout. These measurements do not establish whole-model serving throughput. Independent `torch.profiler` and rocprofv3 traces verify the actual routing dispatch chain; sorting remains 69–71% of summed kernel duration in the final instrumented routing captures. Event completeness and ordering pass for six rocprofv3 traces (3600 dispatches) and 14 valid torch traces (420 GPU events). An incomplete long-graph Kineto capture was rejected; small-graph torch diagnostics synchronize each iteration. Small rocprofv3 timestamp overlaps remain, so these captures do not establish precise inter-kernel gaps. Performance comes from the separate unprofiled runs above.

To reproduce, build the pinned baseline and this branch with the same compiler/ROCm environment; set CHECKOUT and FLY_RUNTIME for each worktree, reserve an idle GPU, run correctness first, then alternate worktree order:

```bash
export HIP_VISIBLE_DEVICES=0
export CHECKOUT=/path/to/worktree
export FLY_RUNTIME=/path/to/build-fly/python_packages
PYTHONPATH="$FLY_RUNTIME" python - <<'PY'
import os, statistics, sys
sys.path.insert(0, os.environ['CHECKOUT'])
import torch
from kernels.moe import topk_gating_softmax_kernel as kernel
T, E, K = 1024, 128, 6
torch.manual_seed(20260910)
x = (torch.rand((T, E), device='cuda') * 4 - 2).to(torch.bfloat16)
w = torch.empty((T, K), device='cuda', dtype=torch.float32)
i = torch.empty((T, K), device='cuda', dtype=torch.int32)
t = torch.empty_like(i)
fn = kernel.build_topk_gating_softmax_module(E, K, 'bf16', True)
def run():
    fn(x, w, i, t, T, stream=torch.cuda.current_stream())
for _ in range(20):
    run()
torch.cuda.synchronize()
g = torch.cuda.CUDAGraph()
with torch.cuda.graph(g):
    for _ in range(200):
        run()
w.fill_(float('nan'))
g.replay()
torch.cuda.synchronize()
assert torch.isfinite(w).all().item(), 'graph must actually execute the kernel'
for _ in range(10):
    g.replay()
torch.cuda.synchronize()
samples = []
for _ in range(15):
    a, b = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
    a.record()
    for _ in range(3):
        g.replay()
    b.record()
    b.synchronize()
    samples.append(a.elapsed_time(b) * 1000 / 600)
print(kernel.__file__, 'median_us=', statistics.median(samples), 'samples_us=', samples)
PY
```

Run the relevant correctness tests from each worktree before timing:

```bash
python -m pytest tests/kernels/test_topk_gating_softmax.py -q
python -m pytest tests/kernels/test_moe_sorting.py -k moe_softmax_sort -q
```

## Submission Checklist

- [x] Reviewed the [ROCm contribution guidelines](https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md#pull-requests).
- [x] Added regression coverage and ran relevant GPU tests and style checks.
- [x] Included hardware, baseline, correctness, benchmark method and measured results.
- [x] Signed off commits with DCO.
