### PR TITLE
Reject global->LDS direct loads on gfx11

### DIFF
--- a/python/flydsl/expr/rocdl/__init__.py
+++ b/python/flydsl/expr/rocdl/__init__.py
@@ -23,6 +23,7 @@ from . import rdna3 as rdna3
 from . import rdna4 as rdna4
 from .enum import SyncScope as SyncScope
 from .universal import *
+from .utils import require_lds_dma_support
 
 __all__ = [
     # Targets
@@ -812,6 +813,7 @@ def raw_ptr_buffer_load_lds(rsrc, lds_ptr, size, voffset, soffset, offset, aux=N
     from ..._mlir import ir as _ir
     from ..._mlir.dialects.rocdl import raw_ptr_buffer_load_lds as _op
 
+    require_lds_dma_support("raw_ptr_buffer_load_lds")
     if aux is not None and not isinstance(aux, _ir.Attribute):
         if isinstance(aux, int):
             aux = _ir.IntegerAttr.get(_ir.IntegerType.get_signless(32), aux)

--- a/python/flydsl/expr/rocdl/universal.py
+++ b/python/flydsl/expr/rocdl/universal.py
@@ -32,7 +32,7 @@ from ..typing import (
     is_target_address_space,
 )
 from . import cdna3, rdna3, rdna4
-from .utils import normalize_s_waitcnt_field
+from .utils import normalize_s_waitcnt_field, require_lds_dma_support
 
 
 @dsl_loc_tracing
@@ -108,11 +108,12 @@ def BufferCopyLDS(bit_size):
     - `soffset` (`i32`), default zero
     - `imm_offset` (`i32`), default zero
     """
+    require_lds_dma_support(f"BufferCopyLDS({bit_size})")
     return CopyOpCDNA3BufferCopyLDSType.get(bit_size)
 
 
-BufferCopyLDS32b = lambda: CopyOpCDNA3BufferCopyLDSType.get(32)
-BufferCopyLDS128b = lambda: CopyOpCDNA3BufferCopyLDSType.get(128)
+BufferCopyLDS32b = lambda: BufferCopyLDS(32)
+BufferCopyLDS128b = lambda: BufferCopyLDS(128)
 
 
 def BufferCopyLDS64b():

--- a/python/flydsl/expr/rocdl/utils.py
+++ b/python/flydsl/expr/rocdl/utils.py
@@ -2,7 +2,30 @@
 # Copyright (c) 2026 FlyDSL Project Contributors
 
 from ..._mlir import ir
+from ...runtime.device import get_rocm_arch
+from ...utils import env
 from ..numeric import Numeric
+
+
+def require_lds_dma_support(what):
+    """Reject global -> LDS direct loads (``buffer_load_* ... lds``) on gfx11.
+
+    RDNA3 / RDNA3.5 dropped the VMEM -> LDS hardware path that gfx9 and gfx10
+    expose. Emitting the intrinsic anyway passes MLIR verification and then
+    aborts the whole process in LLVM instruction selection with "Do not know
+    how to expand this operator's operand!", so reject it while a Python
+    traceback still points at the kernel line that asked for it.
+    """
+    # `ARCH` picks the compile target in RocmBackend.detect_target(), so gate on the arch actually
+    # being compiled for rather than on the installed device.
+    arch = env.compile.arch or get_rocm_arch()
+    if not arch or not arch.startswith("gfx11"):
+        return
+    raise ValueError(
+        f"{what} is not supported on target arch {arch!r}: gfx11 (RDNA3 / RDNA3.5) has no "
+        "global -> LDS direct-load hardware. Use a buffer load into registers followed by "
+        "ds_write instead."
+    )
 
 
 def normalize_s_waitcnt_field(name, value, maximum):

--- a/tests/unit/test_lds_dma_arch_gate.py
+++ b/tests/unit/test_lds_dma_arch_gate.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""gfx11 has no global -> LDS direct-load (``buffer_load_* ... lds``) hardware.
+
+The intrinsic passes MLIR verification there and then aborts the process in LLVM
+instruction selection, so the entry points that emit it must reject gfx11 up
+front. The gate keys off ``ARCH``, so these run without a device.
+
+Scope is gfx11 only; gfx12 is deliberately left alone.
+"""
+
+import pytest
+
+import flydsl.expr as fx
+from flydsl.compiler.jit_function import _create_mlir_context
+from flydsl.expr.rocdl.utils import require_lds_dma_support
+
+pytestmark = [pytest.mark.l1b_target_dialect, pytest.mark.rocm_lower]
+
+NO_LDS_DMA = ["gfx1100", "gfx1101", "gfx1151"]
+HAS_LDS_DMA = ["gfx942", "gfx950", "gfx1030"]
+
+
+@pytest.mark.parametrize("arch", HAS_LDS_DMA)
+def test_lds_dma_accepted(monkeypatch, arch):
+    monkeypatch.setenv("ARCH", arch)
+    require_lds_dma_support("raw_ptr_buffer_load_lds")
+
+
+@pytest.mark.parametrize("arch", NO_LDS_DMA)
+def test_buffer_copy_lds_atom_rejected(monkeypatch, arch):
+    monkeypatch.setenv("ARCH", arch)
+    for make_atom in (fx.rocdl.BufferCopyLDS32b, fx.rocdl.BufferCopyLDS128b):
+        with pytest.raises(ValueError, match=f"not supported on target arch '{arch}'"):
+            make_atom()
+
+
+@pytest.mark.parametrize("arch", NO_LDS_DMA)
+def test_raw_ptr_buffer_load_lds_rejected(monkeypatch, arch):
+    monkeypatch.setenv("ARCH", arch)
+    with _create_mlir_context():
+        with pytest.raises(ValueError, match="no global -> LDS direct-load hardware"):
+            # Rejected before any operand is touched, so the arguments do not matter.
+            fx.rocdl.raw_ptr_buffer_load_lds(None, None, 4, 0, 0, 0)


### PR DESCRIPTION
## Problem

`rocdl.raw.ptr.buffer.load.lds` lowers to `buffer_load_* ... lds`, which has no hardware backing on gfx11 (RDNA3 / RDNA3.5). Emitting it there passes MLIR verification and then aborts the whole process in LLVM instruction selection:

```
ExpandIntegerOperand Op #2: t171: ch = llvm.amdgcn.raw.ptr.buffer.load.lds<
  (dereferenceable load (s128) from %ir.92, align 1, addrspace 8),
  (dereferenceable store (s4096) into %ir.185, align 1, addrspace 3)> ...

LLVM ERROR: Do not know how to expand this operator's operand!
```

`LLVM ERROR` is `report_fatal_error` → `abort()` inside the in-process JIT, so the Python interpreter dies with SIGABRT.

This is reachable today: `aiter/ops/flydsl/kernels/splitk_hgemm.py` selects the async global→LDS path for every arch except gfx942 (`ASYNC_COPY = GPU_ARCH != "gfx942"`), so running its test on a Strix Halo (gfx1151) kills the interpreter.

## Fix

Gate the two entry points that emit the op, so the failure surfaces as a `ValueError` while a Python traceback still points at the kernel line:

```
ValueError: raw_ptr_buffer_load_lds is not supported on target arch 'gfx1151': gfx11
(RDNA3 / RDNA3.5) has no global -> LDS direct-load hardware. Use a buffer load into
registers followed by ds_write instead.
```

Wording follows the existing `s_waitcnt` "is not supported on target arch …" idiom in the same package, and the precedent set by `BufferCopyLDS64b()`, which already raises for the same class of bug (verifies, then silently fails instruction selection).