### PR TITLE
[Skills] Add deterministic preflight to the review runner

### DIFF
--- a/.claude/skills/flydsl-code-review/SKILL.md
+++ b/.claude/skills/flydsl-code-review/SKILL.md
@@ -3,8 +3,8 @@ name: flydsl-code-review
 description: >
   Review a FlyDSL diff, branch, commit range, or PR for correctness bugs and
   convention violations using the repository's existing skills and policy docs.
-  Uses one resumable runner to pin the reviewed tree, run nine independent review
-  angles, verify every candidate, and preserve the evidence in a structured result.
+  Uses one resumable runner to pin the reviewed tree, run deterministic checks
+  and nine independent review angles, verify every candidate, and preserve the evidence.
   Pass --comment to publish a completed PR review. Use when asked to review a diff,
   review a PR, or check changes before pushing.
 allowed-tools: Read Bash
@@ -14,7 +14,7 @@ allowed-tools: Read Bash
 
 Find real defects in a change, then prove each one before reporting it.
 
-The sole execution entry is `.claude/skills/flydsl-code-review/scripts/run_review.py`. It runs independent finders,
+The sole execution entry is `.claude/skills/flydsl-code-review/scripts/run_review.py`. It runs a deterministic preflight, independent finders,
 one verifier per candidate, a challenger for every CONFIRMED, and a fresh sweep.
 Code constructs the final ranked report directly from those records. The sections
 below supply its review method; they are not an alternative manual execution path.
@@ -63,14 +63,47 @@ Defaults are 3 concurrent agents, 600 seconds per agent and 1800 seconds per
 phase including queue time. Override with `--concurrency`, `--agent-timeout` and
 `--phase-timeout`. Ctrl-C/SIGTERM cancels child process groups. Completed stages
 and all attempt logs are checkpointed in `state.json`; `--resume` retries only
-incomplete stages with the saved scope, model and configuration. Changed runner
-or skill content requires a new run. Model and effort use the CLI defaults unless
+incomplete stages with the saved scope, model and configuration. Changed runner,
+scanner or skill content requires a new run. Model and effort use the CLI defaults unless
 the user supplies `--model`/`--effort`; do not silently select a different model.
 
 Read `result.json` after the runner exits. Exit 0 means COMPLETE; exit 1 means
 INCOMPLETE. A missing result, running process, task notification or partial
 transcript is not a completed review. Preserve the run directory when reporting
 an interruption so the user can resume it.
+
+## Deterministic preflight
+
+After pinning a nonempty diff, the runner runs two source scanners from its own
+`scripts/` directory against that diff and checkout. Both are required stages:
+exit `0` means no leads in the supported scope, `1` means leads need inspection,
+and any error or timeout makes the review INCOMPLETE. The artifact retains each
+scanner's output, exit status and run history; resume reuses completed checks.
+Neither scanner executes or imports the reviewed code.
+
+- **Angle G:** `scan_legacy_spelling.py` checks added `kernels/**/*.py` lines,
+  excluding `kernels/common/buffer_ops.py`, for raw IR/unwraps, SCF builders,
+  `buffer_ops.*`, `SmemAllocator` and `make_ptr`. It filters visible comments,
+  string literals and imports, but does not resolve API identity. Ordinary
+  pointer construction and raw IR at implementation boundaries can be valid.
+- **Angle I:** `scan_unreachable_tests.py` matches added test definition lines
+  against the head AST, follows direct local calls from `__main__`, and recognizes
+  unfiltered `pytest.main([__file__])` with common aliases. Before reporting a gap,
+  identify the actual test or benchmark command: pytest coverage and a script's
+  direct call path are different contracts.
+
+The corresponding finder receives the full raw output. Inspect the complete
+source and the applicable policy at the reviewed revision before promoting a
+lead to a candidate. Group repeated spellings with the same corrective action;
+the six-candidate limit applies to the resulting defect candidates. Raw leads
+are retained for inspection, not individually certified as bugs or as clean.
+All promoted candidates go through the same independent verifier and challenge
+rules as other candidates. An empty scan never skips the semantic review.
+
+Aliases, partial diff lexical context, dynamic dispatch, runtime branches,
+pytest selectors, fixtures, decorators and plugins can require manual review.
+See [preflight-evidence.md](references/preflight-evidence.md) for the selection
+evidence and its limits; these checks do not establish review precision or recall.
 
 ## Reusing existing skills
 

--- a/.claude/skills/flydsl-code-review/references/preflight-evidence.md
+++ b/.claude/skills/flydsl-code-review/references/preflight-evidence.md
@@ -1,0 +1,26 @@
+# Why these two checks
+
+The scanners and their CPU regressions are adapted from
+[PR #1047 at `2480f877`](https://github.com/ROCm/FlyDSL/tree/2480f877aa7f74a24d1ce857b48ba92ff0699cf5/.claude/skills/flydsl-review-checks).
+They supplement the existing review runner; their output is evidence to inspect,
+not an independent review verdict or another skill entry point.
+
+That PR's [selection record](https://github.com/ROCm/FlyDSL/blob/2480f877aa7f74a24d1ce857b48ba92ff0699cf5/.claude/skills/flydsl-review-checks/references/review-evidence.md)
+reports two useful signals:
+
+- Legacy API spellings were recurring maintainer feedback, and prompt-only
+  reviewers did not reliably surface the same candidates.
+- In a small seeded comparison the baseline caught four of five candidate
+  families. Checking script entry paths supplied the missing family. A replay
+  of [#481](https://github.com/ROCm/FlyDSL/pull/481) at
+  `7e117e29c9c4582158aed33da4ee6dfe14d2c76e` identified three added fused/quant
+  tests omitted from the file's script path.
+
+Those are historical and seeded selection results, not held-out precision,
+recall, or proof of incremental benefit over this runner. Other proposed rule
+families already had baseline coverage in that experiment, so they are not
+duplicated here. Existing technical skills continue to own their semantic rules.
+
+A new deterministic check should have a reproducible positive case, a clean
+control, and evidence of coverage beyond the existing reviewer. Preserve the
+inputs and outputs before claiming a review-quality improvement.

--- a/.claude/skills/flydsl-code-review/scripts/review_common.py
+++ b/.claude/skills/flydsl-code-review/scripts/review_common.py
@@ -12,7 +12,7 @@ import math
 import posixpath
 import re
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 PER_ANGLE = 6
 SWEEP_MAX = 8
 MAX_FINDINGS = 12
@@ -26,6 +26,10 @@ ANGLES = (
     ("conventions", "convention", "Angle G — repo conventions and API stability"),
     ("reuse", "convention", "Angle H — reuse, simplification, and altitude"),
     ("test-doc", "convention", "Angle I — test and documentation contract"),
+)
+PREFLIGHTS = (
+    ("preflight:conventions", "scan_legacy_spelling.py"),
+    ("preflight:test-doc", "scan_unreachable_tests.py"),
 )
 VERDICTS = ("CONFIRMED", "PLAUSIBLE", "REFUTED")
 SEVERITIES = ("P0", "P1", "P2", "P3")
@@ -85,6 +89,14 @@ def validate_output(output: dict, *, candidate_limit: int | None = None, snapsho
 def stage_output(stages: dict, label: str) -> dict | None:
     stage = stages.get(label, {})
     return stage.get("output") if stage.get("status") == "COMPLETE" else None
+
+
+def validate_preflight(output: dict) -> dict:
+    if not isinstance(output, dict) or type(output.get("exit_code")) is not int or output["exit_code"] not in (0, 1):
+        raise ValueError("completed preflight must have scanner exit code 0 or 1")
+    if not all(isinstance(output.get(key), str) for key in ("stdout", "stderr")):
+        raise ValueError("completed preflight must retain scanner stdout and stderr")
+    return output
 
 
 def collect_candidates(stages: dict) -> list[dict]:
@@ -152,6 +164,7 @@ def rank_findings(candidates: list[dict]) -> list[dict]:
 def required_stages(scope: dict | None, candidates: list[dict]) -> list[str]:
     labels = ["scope"]
     if scope and scope.get("files"):
+        labels += [label for label, _ in PREFLIGHTS]
         labels += ["find:" + label for label, _, _ in ANGLES]
         labels += ["verify:" + c["id"] for c in candidates]
         labels += [
@@ -195,6 +208,13 @@ def build_report(state: dict) -> dict:
         for label in required
         if stage_output(stages, label) is None
     ]
+    for label, _ in PREFLIGHTS:
+        output = stage_output(stages, label)
+        if label in required and output is not None:
+            try:
+                validate_preflight(output)
+            except ValueError as exc:
+                failed.append({"stage": label, "reason": str(exc)})
     # Integrity checks and cancellation can fail outside an agent stage.
     failed += [
         {"stage": label, "reason": stage.get("error", "stage failed")}

--- a/.claude/skills/flydsl-code-review/scripts/run_review.py
+++ b/.claude/skills/flydsl-code-review/scripts/run_review.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from review_common import (
     ANGLES,
     PER_ANGLE,
+    PREFLIGHTS,
     SCHEMA_VERSION,
     SEVERITIES,
     SWEEP_MAX,
@@ -49,6 +50,7 @@ from review_common import (
     normalize_path,
     stage_output,
     validate_output,
+    validate_preflight,
 )
 
 SCRIPTS = Path(__file__).resolve().parent
@@ -65,13 +67,13 @@ def atomic_json(path: Path, value: dict) -> None:
     temporary.replace(path)
 
 
-def command(
+def command_result(
     *argv: str,
     cwd: Path,
     stdin: str | None = None,
     deadline: float | None = None,
     cancelled: threading.Event | None = None,
-) -> str:
+) -> subprocess.CompletedProcess:
     deadline = min(deadline or float("inf"), time.monotonic() + 120)
     if (cancelled and cancelled.is_set()) or time.monotonic() >= deadline:
         raise TimeoutError("command cancelled or phase deadline exceeded")
@@ -96,9 +98,14 @@ def command(
                 first = False
     finally:
         stop_process(process)
-    if process.returncode:
-        raise RuntimeError(f"{shlex.join(argv)}: {stderr.strip()}")
-    return stdout
+    return subprocess.CompletedProcess(argv, process.returncode, stdout, stderr)
+
+
+def command(*argv: str, **options) -> str:
+    result = command_result(*argv, **options)
+    if result.returncode:
+        raise RuntimeError(f"{shlex.join(argv)}: {result.stderr.strip()}")
+    return result.stdout
 
 
 def git(root: Path, *args: str, **options) -> str:
@@ -255,6 +262,8 @@ def check_snapshot(run_dir: Path, scope: dict, **control) -> None:
     )
     if hashlib.sha256(diff.encode()).hexdigest() != scope["diff_sha256"]:
         raise ValueError("pinned diff hash changed")
+    if hashlib.sha256((run_dir / "diff.patch").read_bytes()).hexdigest() != scope["diff_sha256"]:
+        raise ValueError("saved diff.patch does not match the pinned diff")
 
 
 def section(text: str, title: str) -> str:
@@ -366,6 +375,17 @@ def cli_agent(
                 # Also reap tool descendants if the CLI exited without waiting for them.
                 stop_process(process)
         envelope = json.loads(stdout_path.read_text())
+        # Verbose CLI settings emit a transcript array instead of one result.
+        # The last result owns the verdict and usage, including a failed result.
+        if isinstance(envelope, list):
+            envelope = next(
+                (
+                    record
+                    for record in reversed(envelope)
+                    if isinstance(record, dict) and record.get("type") == "result"
+                ),
+                None,
+            )
         if not isinstance(envelope, dict) or envelope.get("type") != "result":
             raise ValueError("CLI returned no terminal result record")
         attempt["usage"] = {
@@ -433,6 +453,61 @@ class ReviewRun:
 
     def task(self, label: str, prompt: str, limit: int | None = None) -> dict:
         return {"label": label, "prompt": self.context() + prompt, "limit": limit, "schema": output_schema(limit)}
+
+    def preflight(self) -> bool:
+        """Run trusted scanners over the pinned data; their matches are only leads."""
+        stages = self.state["stages"]
+        scope = self.state["scope"]
+        deadline = time.monotonic() + self.config["phase_timeout"]
+        for label, script in PREFLIGHTS:
+            fingerprint = digest(
+                {"head": scope["head_oid"], "diff": scope["diff_sha256"], "script": (SCRIPTS / script).read_text()}
+            )
+            stage = stages.setdefault(label, {"runs": []})
+            if stage.get("status") == "COMPLETE":
+                validate_preflight(stage.get("output"))
+                if stage.get("input_sha256") != fingerprint:
+                    raise ValueError(f"cached input changed for {label}; start a new run")
+                continue
+            for prior in stage["runs"]:
+                if prior["status"] == "RUNNING":
+                    prior.update(status="INCOMPLETE", error="parent stopped before recording the scanner result")
+            stage.update(status="RUNNING", output=None, input_sha256=fingerprint)
+            stage.pop("error", None)
+            record = {"status": "RUNNING"}
+            stage["runs"].append(record)
+            self.save()
+            argv = [sys.executable, str(SCRIPTS / script), "--diff", str(self.run_dir / "diff.patch")]
+            if label == "preflight:test-doc":
+                argv += ["--head", str(self.snapshot)]
+            print(f"{label}: scanning pinned diff", file=sys.stderr, flush=True)
+            started = time.monotonic()
+            try:
+                result = command_result(*argv, cwd=self.snapshot, deadline=deadline, cancelled=self.cancelled)
+                record.update(exit_code=result.returncode, stdout=result.stdout, stderr=result.stderr)
+                if result.returncode not in (0, 1):
+                    raise ValueError(f"scanner exited {result.returncode}: {result.stderr.strip()}")
+                record["status"] = "COMPLETE"
+                stage["output"] = {key: record[key] for key in ("exit_code", "stdout", "stderr")}
+            except (OSError, ValueError, TimeoutError) as exc:
+                record.update(status="INCOMPLETE", error=str(exc))
+                stage["error"] = str(exc)
+            record["wall_time_seconds"] = time.monotonic() - started
+            stage["status"] = record["status"]
+            self.save()
+        return all(stage_output(stages, label) is not None for label, _ in PREFLIGHTS)
+
+    def preflight_context(self, angle: str) -> str:
+        output = stage_output(self.state["stages"], "preflight:" + angle)
+        if output is None:
+            return ""
+        return (
+            "\nDeterministic preflight observations (unverified leads, not findings):\n"
+            + canonical(output)
+            + "\n"
+            + section(self.skill, "Deterministic preflight")
+            + "\n"
+        )
 
     def phase(self, name: str, tasks: list[dict]) -> bool:
         print(f"{name}: {len(tasks)} stage(s)", file=sys.stderr, flush=True)
@@ -555,11 +630,14 @@ class ReviewRun:
             cancelled=self.cancelled,
         )
         if self.state["scope"]["files"]:
+            if not self.preflight():
+                return
             finders = [
                 self.task(
                     "find:" + label,
                     "Review only this angle:\n"
                     + section(self.skill, title)
+                    + self.preflight_context(label)
                     + f"\nReturn up to {PER_ANGLE} candidates with a specific mechanism/root cause, "
                     "severity (P0 critical, P1 high, P2 normal, P3 low), exact file/line and failure scenario. "
                     "Pass every candidate with a nameable failure scenario to independent verification. "
@@ -570,7 +648,7 @@ class ReviewRun:
             ]
             if not self.phase("Find", finders):
                 return
-            # No completion-order admission and no verification budget: verify all <=54 candidates.
+            # No completion-order admission or verification budget: verify every finder candidate.
             candidates = collect_candidates({k: v for k, v in stages.items() if k != "sweep"})
             if not self.verify(candidates):
                 return
@@ -616,7 +694,8 @@ class ReviewRun:
 
 
 def implementation_hash() -> str:
-    return digest([p.read_text() for p in (Path(__file__), SCRIPTS / "review_common.py", SKILL)])
+    paths = [Path(__file__), SCRIPTS / "review_common.py", SKILL, *(SCRIPTS / script for _, script in PREFLIGHTS)]
+    return digest([p.read_text() for p in paths])
 
 
 def positive(value: str) -> int:

--- a/.claude/skills/flydsl-code-review/scripts/scan_legacy_spelling.py
+++ b/.claude/skills/flydsl-code-review/scripts/scan_legacy_spelling.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""List legacy-spelling review candidates on added kernel consumer lines.
+
+Only kernels/**/*.py is checked, excluding kernels/common/buffer_ops.py. These
+spelling matches require source review; in particular, ordinary make_ptr pointer
+construction is valid. Comments, strings, and imports visible in each diff hunk
+are ignored. A hunk starting inside a string or import whose opening is omitted
+does not provide enough lexical context; check the full source in those cases.
+
+Exit status: 0 = no candidates, 1 = candidates, 2 = input or tool failure.
+"""
+
+import argparse
+import io
+import re
+import sys
+import tokenize
+from pathlib import Path
+
+RULES = [
+    (
+        "raw ir.* / ArithValue",
+        r"(?<![\w.])ir\.[A-Za-z_]|\b_mlir\.|\bArithValue\b|\barith\.unwrap\b|\bas_ir_value\b",
+        "check whether typed fx values (fx.Float32 / fx.Int32, expr/numeric.py) can replace raw IR values",
+        "coderfeli #202 #250 #300 #326 #426 #850",
+    ),
+    (
+        "scf.* control flow",
+        r"(?<![\w.])scf\.(?:If|For|While|Yield)(?:Op)?\b",
+        "prefer ordinary Python if/for inside the kernel; scf.* is a lowering detail",
+        "coderfeli #33 #433 #540 #582",
+    ),
+    (
+        "buffer_ops.*",
+        r"(?<![\w.])buffer_ops\.",
+        "check whether fx.copy / a copy atom can express this kernel memory operation",
+        "coderfeli #404 #416 #894 #1032",
+    ),
+    (
+        "SmemAllocator",
+        r"\bSmemAllocator\b",
+        "prefer SharedAllocator for new kernels",
+        "sjfeng1999 #549 #567",
+    ),
+    (
+        "make_ptr (check retyping)",
+        r"\bmake_ptr\s*\(",
+        "if this only retypes an existing pointer, use recast_iter; ordinary pointer construction is valid",
+        "sjfeng1999 #288 #745",
+    ),
+]
+HUNK = re.compile(r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$")
+STRING_TOKENS = {tokenize.STRING} | {
+    getattr(tokenize, name) for name in ("FSTRING_START", "FSTRING_MIDDLE", "FSTRING_END") if hasattr(tokenize, name)
+}
+
+
+def kernel_hunks(diff):
+    """Yield new-side hunk rows as (line number, is added, source)."""
+    path = None
+    rows = []
+    old_left = new_left = 0
+    next_line = None
+    saw_header = False
+    have_new_header = False
+    for diff_line, line in enumerate(diff.splitlines(), 1):
+        if line == r"\ No newline at end of file":
+            continue
+        if old_left or new_left:
+            prefix = line[:1]
+            if prefix not in {" ", "+", "-"}:
+                raise ValueError(f"invalid or truncated hunk at diff line {diff_line}")
+            if prefix in {" ", "-"}:
+                old_left -= 1
+            if prefix in {" ", "+"}:
+                new_left -= 1
+                rows.append((next_line, prefix == "+", line[1:]))
+                next_line += 1
+            if old_left < 0 or new_left < 0:
+                raise ValueError(f"hunk line count mismatch at diff line {diff_line}")
+            if not old_left and not new_left:
+                if path and path.startswith("kernels/") and path.endswith(".py"):
+                    if path != "kernels/common/buffer_ops.py":
+                        yield path, rows
+                rows = []
+            continue
+        if line.startswith("diff --git ") or line.startswith("--- "):
+            path = None
+            saw_header = True
+            have_new_header = False
+        elif line.startswith("+++ "):
+            new_path = line[4:].split("\t", 1)[0]
+            if new_path.startswith('"'):
+                raise ValueError("quoted git paths are not supported; provide a diff with unquoted paths")
+            if not new_path.startswith("b/") and new_path != "/dev/null":
+                raise ValueError(f"expected a b/ path or /dev/null at diff line {diff_line}")
+            path = new_path[2:] if new_path.startswith("b/") else None
+            saw_header = True
+            have_new_header = True
+        elif line.startswith("@@"):
+            match = HUNK.fullmatch(line)
+            if match is None or not have_new_header:
+                raise ValueError(f"invalid hunk header at diff line {diff_line}")
+            old_left = int(match.group(2) or "1")
+            next_line = int(match.group(3))
+            new_left = int(match.group(4) or "1")
+        elif line.startswith("+"):
+            raise ValueError(f"added line outside a hunk at diff line {diff_line}")
+    if old_left or new_left:
+        raise ValueError("truncated diff hunk")
+    if diff.strip() and not saw_header:
+        raise ValueError("expected a unified git diff")
+
+
+def code_lines(rows):
+    """Keep code tokens; hunk fragments need not be complete Python statements."""
+    # Indentation is irrelevant to spelling matches, and a hunk can start midway
+    # through a block. Removing it avoids unrelated tokenizer indentation errors.
+    source = [row[2].lstrip() for row in rows]
+    visible = [[" "] * len(line) for line in source]
+    statement_start = True
+    importing = False
+    try:
+        for token in tokenize.generate_tokens(io.StringIO("\n".join(source) + "\n").readline):
+            if token.type in {tokenize.INDENT, tokenize.DEDENT, tokenize.NL, tokenize.ENDMARKER}:
+                continue
+            if token.type == tokenize.NEWLINE or (token.type == tokenize.OP and token.string == ";"):
+                statement_start = True
+                importing = False
+                continue
+            if token.type == tokenize.COMMENT:
+                continue
+            if statement_start and token.type == tokenize.NAME and token.string in {"from", "import"}:
+                importing = True
+            statement_start = False
+            if importing or token.type in STRING_TOKENS:
+                continue
+            line, start = token.start
+            _, end = token.end
+            visible[line - 1][start:end] = token.string
+    except tokenize.TokenError:
+        # Partial statements and strings are normal at the end of a diff hunk.
+        # A string token is emitted only when closed, so its contents stay blank.
+        pass
+    return ["".join(line) for line in visible]
+
+
+def scan(diff):
+    hits = []
+    for path, rows in kernel_hunks(diff):
+        for (line, added, original), code in zip(rows, code_lines(rows)):
+            if not added:
+                continue
+            for name, pattern, advice, provenance in RULES:
+                if re.search(pattern, code):
+                    hits.append((path, line, name, original.strip()[:100], advice, provenance))
+    return hits
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--diff", required=True, type=Path, metavar="FILE")
+    args = parser.parse_args(argv)
+
+    try:
+        hits = scan(args.diff.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if not hits:
+        print("no legacy spelling candidates on added kernel lines")
+        return 0
+    print(f"== legacy spelling candidates on added kernel lines: {len(hits)} ==")
+    groups = {}
+    for hit in hits:
+        groups.setdefault((hit[0], hit[2]), []).append(hit)
+    for matches in groups.values():
+        path, line, name, code, advice, provenance = matches[0]
+        print(
+            f"  {path}:{line}: {name} x{len(matches)}\n      {advice}\n      e.g. {code}\n      maintainers: {provenance}"
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/flydsl-code-review/scripts/scan_unreachable_tests.py
+++ b/.claude/skills/flydsl-code-review/scripts/scan_unreachable_tests.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Find added tests without a statically visible script entry path.
+
+Read the head source and a unified diff; never import or execute reviewed code.
+Check module-level test_* definitions and methods in Test* classes whose def
+line is added by the diff, using qualified names and line numbers. Signature
+edits can therefore produce candidates; edits only to an existing body do not.
+Follow direct calls to unambiguous
+module functions from an exact ``__name__ == "__main__"`` guard, and recognize
+pytest.main([__file__]) (including import aliases and harmless reporting flags).
+
+This is a review aid, not a Python interpreter: dynamic dispatch, pytest
+selectors/unknown arguments, runtime branches, decorators, configuration and
+plugins need review. A visible path does not guarantee runtime execution.
+Exit 0: no candidates; 1: coverage candidates/manual review; 2: invalid input.
+
+usage: scan_unreachable_tests.py --diff <diff-file> --head <worktree-root>
+"""
+
+import argparse
+import ast
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+_HUNK = re.compile(r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+_FUNCTIONS = (ast.FunctionDef, ast.AsyncFunctionDef)
+_REPORTING_FLAGS = {
+    "-q",
+    "-qq",
+    "--quiet",
+    "-v",
+    "-vv",
+    "--verbose",
+    "-s",
+    "-ra",
+    "-rA",
+    "--disable-warnings",
+    "--tb=short",
+    "--tb=long",
+    "--tb=no",
+    "--color=yes",
+    "--color=no",
+    "--color=auto",
+    "--capture=no",
+}
+
+
+def added_lines_from_diff(diff):
+    """Map Python head paths to (added line numbers, expected head lines)."""
+    files = {}
+    path = None
+    old_left = new_left = 0
+    next_line = None
+    saw_header = False
+    has_head = False
+    for line in diff.splitlines():
+        if old_left or new_left:
+            prefix = line[:1]
+            if line == "\\ No newline at end of file":
+                continue
+            if prefix not in {"+", "-", " "}:
+                raise ValueError("incomplete or malformed diff hunk")
+            if prefix != "+":
+                old_left -= 1
+            if prefix != "-":
+                new_left -= 1
+                if path is not None:
+                    added, expected = files[path]
+                    expected[next_line] = line[1:]
+                    if prefix == "+":
+                        added.add(next_line)
+                next_line += 1
+            if old_left < 0 or new_left < 0:
+                raise ValueError("diff hunk exceeds its declared line counts")
+            continue
+        if line.startswith("diff --git "):
+            path = None
+            saw_header = True
+            has_head = False
+        elif line.startswith("+++ "):
+            name = line[4:].split("\t", 1)[0]
+            saw_header = True
+            has_head = True
+            if name == "/dev/null":
+                path = None
+            elif name.startswith("b/"):
+                candidate = Path(name[2:])
+                if candidate.is_absolute() or ".." in candidate.parts:
+                    raise ValueError(f"unsafe head path: {name}")
+                path = candidate if candidate.suffix == ".py" else None
+                if path is not None:
+                    files.setdefault(path, (set(), {}))
+            else:
+                raise ValueError(f"expected unquoted b/ head path, got: {name}")
+        elif line.startswith("@@"):
+            match = _HUNK.match(line)
+            if not match or not has_head:
+                raise ValueError("malformed unified diff hunk header")
+            old_left = int(match[2]) if match[2] is not None else 1
+            next_line = int(match[3])
+            new_left = int(match[4]) if match[4] is not None else 1
+        elif line.startswith("--- ") or line == "\\ No newline at end of file":
+            continue
+        elif line.startswith(("+", "-", " ")):
+            raise ValueError("diff content outside a hunk")
+    if old_left or new_left:
+        raise ValueError("incomplete diff hunk")
+    if diff.strip() and not saw_header:
+        raise ValueError("expected a unified diff")
+    return files
+
+
+def scope_nodes(statements):
+    """Walk one scope, without treating uncalled nested definitions as calls."""
+    for node in statements:
+        yield node
+        if isinstance(node, ast.GeneratorExp):
+            # Creation evaluates only the outer iterable; the body needs consumption.
+            yield from scope_nodes([node.generators[0].iter])
+        elif not isinstance(node, (*_FUNCTIONS, ast.ClassDef, ast.Lambda)):
+            yield from scope_nodes(ast.iter_child_nodes(node))
+
+
+def bound_names(nodes, include_functions=True):
+    names = set()
+    for node in nodes:
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            names.add(node.id)
+        elif isinstance(node, ast.ClassDef) or include_functions and isinstance(node, _FUNCTIONS):
+            names.add(node.name)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                names.add(alias.asname or alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            names.add(node.name)
+        elif isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name:
+            names.add(node.name)
+        elif isinstance(node, ast.MatchMapping) and node.rest:
+            names.add(node.rest)
+    return names
+
+
+def pytest_aliases(nodes, inherited=None, parameters=()):
+    aliases = dict(inherited or {})
+    imports = {}
+    non_imports = [node for node in nodes if not isinstance(node, (ast.Import, ast.ImportFrom))]
+    shadowed = bound_names(non_imports) | set(parameters)
+    for node in nodes:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "pytest":
+                    imports[alias.asname or "pytest"] = "module"
+                else:
+                    shadowed.add(alias.asname or alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if node.module == "pytest" and not node.level and alias.name == "main":
+                    imports[alias.asname or "main"] = "main"
+                else:
+                    shadowed.add(alias.asname or alias.name)
+    # Assignments/parameters/other imports cannot be assumed to retain an alias.
+    for name in bound_names(nodes) | set(parameters):
+        aliases.pop(name, None)
+    aliases.update({name: kind for name, kind in imports.items() if name not in shadowed})
+    return aliases
+
+
+def is_main_guard(node):
+    if not isinstance(node, ast.If) or not isinstance(node.test, ast.Compare):
+        return False
+    test = node.test
+    if len(test.ops) != 1 or not isinstance(test.ops[0], ast.Eq):
+        return False
+    left, right = test.left, test.comparators[0]
+    return any(
+        isinstance(name, ast.Name)
+        and name.id == "__name__"
+        and isinstance(value, ast.Constant)
+        and value.value == "__main__"
+        for name, value in ((left, right), (right, left))
+    )
+
+
+def test_definitions(body, prefix="", *, unambiguous=False):
+    if unambiguous:
+        definitions = (*_FUNCTIONS, ast.ClassDef)
+        counts = Counter(node.name for node in body if isinstance(node, definitions))
+        rebound = bound_names(node for node in scope_nodes(body) if not isinstance(node, definitions))
+    for node in body:
+        if unambiguous and isinstance(node, (*_FUNCTIONS, ast.ClassDef)):
+            if counts[node.name] != 1 or node.name in rebound:
+                continue
+        if isinstance(node, _FUNCTIONS) and node.name.startswith("test_"):
+            yield (prefix + node.name, node.lineno)
+        elif isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+            yield from test_definitions(node.body, prefix + node.name + ".", unambiguous=unambiguous)
+
+
+def full_file_pytest(call):
+    """Accept an explicit whole-file target with only known reporting flags."""
+    if len(call.args) == 1 and not call.keywords:
+        args = call.args[0]
+    elif not call.args and len(call.keywords) == 1 and call.keywords[0].arg == "args":
+        args = call.keywords[0].value
+    else:
+        return False
+    if not isinstance(args, (ast.List, ast.Tuple)):
+        return False
+    file_count = 0
+    for arg in args.elts:
+        if isinstance(arg, ast.Name) and arg.id == "__file__":
+            file_count += 1
+        elif not isinstance(arg, ast.Constant) or arg.value not in _REPORTING_FLAGS:
+            return False
+    return file_count == 1
+
+
+def analyse(tree):
+    tests = set(test_definitions(tree.body))
+    pytest_tests = set(test_definitions(tree.body, unambiguous=True))
+    main_body = [stmt for node in tree.body if is_main_guard(node) for stmt in node.body]
+    if not main_body:
+        return tests, set(), False, False
+
+    module_nodes = list(scope_nodes(tree.body))
+    definitions = [node for node in tree.body if isinstance(node, _FUNCTIONS)]
+    counts = Counter(node.name for node in definitions)
+    rebound = bound_names(module_nodes, include_functions=False)
+    funcs = {node.name: node for node in definitions if counts[node.name] == 1 and node.name not in rebound}
+    module_aliases = pytest_aliases(module_nodes)
+    reached, visited = set(), set()
+    unknown_pytest = False
+    pending = [(main_body, ())]
+    while pending:
+        body, parameters = pending.pop()
+        nodes = list(scope_nodes(body))
+        shadowed = bound_names(nodes) | set(parameters)
+        aliases = pytest_aliases(nodes, module_aliases, parameters)
+        for node in nodes:
+            if not isinstance(node, ast.Call):
+                continue
+            target = node.func
+            is_pytest = (
+                isinstance(target, ast.Name)
+                and aliases.get(target.id) == "main"
+                or isinstance(target, ast.Attribute)
+                and target.attr == "main"
+                and isinstance(target.value, ast.Name)
+                and aliases.get(target.value.id) == "module"
+            )
+            if is_pytest:
+                if full_file_pytest(node) and "__file__" not in rebound | shadowed:
+                    reached.update(pytest_tests)
+                else:
+                    unknown_pytest = True
+            if not isinstance(target, ast.Name) or target.id in shadowed or target.id not in funcs:
+                continue
+            func = funcs[target.id]
+            # Calling async/generator functions does not execute their bodies.
+            # Await/iteration is outside the direct synchronous call graph.
+            if (
+                isinstance(func, ast.AsyncFunctionDef)
+                or func.name in visited
+                or any(isinstance(n, (ast.Yield, ast.YieldFrom)) for n in scope_nodes(func.body))
+            ):
+                continue
+            visited.add(func.name)
+            reached.add((func.name, func.lineno))
+            args = func.args
+            parameters = [a.arg for a in (*args.posonlyargs, *args.args, *args.kwonlyargs)]
+            parameters += [a.arg for a in (args.vararg, args.kwarg) if a is not None]
+            pending.append((func.body, parameters))
+    return tests, reached, True, unknown_pytest
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--diff", required=True, type=Path)
+    parser.add_argument("--head", required=True, type=Path, metavar="DIR")
+    args = parser.parse_args(argv)
+    try:
+        root = args.head.resolve(strict=True)
+        if not root.is_dir():
+            raise ValueError(f"worktree root is not a directory: {root}")
+        files = added_lines_from_diff(args.diff.read_text())
+        results = []
+        for rel, (added, expected) in files.items():
+            path = (root / rel).resolve(strict=True)
+            if not path.is_relative_to(root):
+                raise ValueError(f"head path is outside worktree root: {rel}")
+            source = path.read_text()
+            lines = source.splitlines()
+            for line, content in expected.items():
+                if line < 1 or line > len(lines) or lines[line - 1] != content:
+                    raise ValueError(f"{rel}:{line}: diff does not match head source")
+            tests, reached, dual_entry, unknown = analyse(ast.parse(source, filename=str(rel)))
+            new_tests = {test for test in tests if test[1] in added}
+            if new_tests:
+                results.append((rel, new_tests, reached, dual_entry, unknown))
+    except (OSError, UnicodeError, SyntaxError, ValueError) as error:
+        print(f"  input error: {error}", file=sys.stderr)
+        return 2
+
+    flagged = False
+    for rel, new_tests, reached, dual_entry, unknown in results:
+        if not dual_entry:
+            print(f"  {rel}: no supported __main__ guard; script coverage not assessed")
+            continue
+        missing = new_tests - reached
+        if not missing:
+            print(f"  {rel}: {len(new_tests)} added test definition line(s) have a statically visible __main__ path")
+            continue
+        flagged = True
+        print(f"  {rel}: {len(missing)} of {len(new_tests)} ADDED test definition line(s) need manual review")
+        for name, line in sorted(missing, key=lambda test: test[1]):
+            print(f"      {name}:{line}: no statically supported entry path found")
+        if unknown:
+            print("      pytest invocation uses selectors or unknown arguments; whole-file coverage is unknown")
+        print("      -> Check script wiring or identify the pytest job that exercises these tests.")
+    if not results:
+        print("  no test definitions added by this diff")
+    return 1 if flagged else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_code_review_runner.py
+++ b/tests/unit/test_code_review_runner.py
@@ -338,8 +338,11 @@ def install_fake_cli(tmp_path, monkeypatch, body):
     monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ["PATH"])
 
 
-@pytest.mark.parametrize("mode", ["success", "no_footer", "denied", "null_output"])
-def test_cli_requires_success_footer_and_no_permission_denials(tmp_path, monkeypatch, mode):
+@pytest.mark.parametrize("shape", ["object", "transcript"])
+@pytest.mark.parametrize(
+    "mode", ["success", "no_footer", "invalid_json", "denied", "null_output", "error", "bad_subtype", "nonzero_exit"]
+)
+def test_cli_requires_success_footer_and_no_permission_denials(tmp_path, monkeypatch, mode, shape):
     envelope = {
         "type": "result",
         "subtype": "success",
@@ -353,16 +356,40 @@ def test_cli_requires_success_footer_and_no_permission_denials(tmp_path, monkeyp
         envelope["permission_denials"] = [{"tool_name": "Bash"}]
     if mode == "null_output":
         envelope["structured_output"] = None
+    if mode == "error":
+        envelope["is_error"] = True
+    if mode == "bad_subtype":
+        envelope["subtype"] = "error_max_turns"
+    payload = {"type": "assistant", "message": "No terminal result"} if mode == "no_footer" else envelope
+    if shape == "transcript":
+        messages = [{"type": "system", "subtype": "init"}]
+        if mode != "no_footer":
+            # An earlier successful record must not hide the final result's
+            # failure, denial, malformed output, or usage.
+            messages.append(
+                {
+                    **envelope,
+                    "subtype": "success",
+                    "is_error": False,
+                    "permission_denials": [],
+                    "structured_output": found(),
+                    "total_cost_usd": 99,
+                }
+            )
+        payload = [*messages, payload, {"type": "assistant", "message": "Trailing transcript message"}]
+    stdout = "" if mode == "invalid_json" else json.dumps(payload)
     install_fake_cli(
-        tmp_path, monkeypatch, "print(" + repr("" if mode == "no_footer" else json.dumps(envelope)) + ")\n"
+        tmp_path, monkeypatch, f"import sys\nprint({stdout!r})\nsys.exit({1 if mode == 'nonzero_exit' else 0})\n"
     )
     task = {"prompt": "test", "schema": runner.output_schema(6), "limit": 6}
     attempt = runner.cli_agent(
         task, configuration(), tmp_path, tmp_path / "attempt", time.monotonic() + 3, threading.Event()
     )
     assert attempt["status"] == ("COMPLETE" if mode == "success" else "INCOMPLETE")
-    if mode != "no_footer":
+    if mode not in {"no_footer", "invalid_json"}:
         assert attempt["usage"]["total_cost_usd"] == 0.25
+    else:
+        assert attempt["usage"] == {}
 
 
 def test_timeout_cancels_agent_and_its_tool_process(tmp_path, monkeypatch):
@@ -437,6 +464,7 @@ def complete_report():
         "files": ["kernel.py"],
     }
     stages = {"scope": done(scope), "sweep": done(found()), "synthesize": done({})}
+    stages.update({label: done({"exit_code": 0, "stdout": "", "stderr": ""}) for label, _ in common.PREFLIGHTS})
     stages.update({"find:" + label: done(found()) for label, _, _ in common.ANGLES})
     stages["find:trace-time"] = done(
         found(candidate(10), candidate(90, "second defect"), candidate(11, "uncertain race"))
@@ -526,6 +554,121 @@ def test_publisher_rejects_changed_provenance(complete_report, field):
     report["findings"][0][field] = "tampered"
     with pytest.raises(ValueError, match="verified records"):
         common.validate_report(report)
+
+
+def test_preflight_routes_raw_leads_without_promoting_them(tmp_path, source_repo):
+    root, base, _ = source_repo
+    (root / "kernels").mkdir()
+    (root / "kernels/example.py").write_text("scratch = SmemAllocator()\n")
+    (root / "test_example.py").write_text('def test_unwired():\n    pass\n\nif __name__ == "__main__":\n    pass\n')
+    runner.git(root, "add", ".")
+    runner.git(root, "commit", "--quiet", "-m", "add preflight leads")
+    prompts = {}
+
+    def backend(task, *_):
+        prompts[task["label"]] = task["prompt"]
+        return {**done(found()), "usage": {"total_cost_usd": 0}}
+
+    review = new_run(tmp_path, (root, base, runner.revision(root, "HEAD")), backend)
+    report = review.run()
+    assert report["status"] == "COMPLETE"
+    for label, _ in common.PREFLIGHTS:
+        assert report["stages"][label]["output"]["exit_code"] == 1
+        assert len(report["stages"][label]["runs"]) == 1
+    assert "kernels/example.py:1" in prompts["find:conventions"]
+    assert "test_unwired:1" in prompts["find:test-doc"]
+    assert "test_unwired:1" not in prompts["find:conventions"]
+    assert "kernels/example.py:1" not in prompts["find:addressing"]
+    assert report["findings"] == report["risks"] == report["candidates"] == []
+    assert report["metrics"]["agent_attempts"] == 10
+    assert report["metrics"]["cost_is_complete"] is True
+    common.validate_report(report)
+
+
+@pytest.mark.parametrize("failure", [2, 17, "timeout"])
+def test_preflight_failure_is_incomplete_and_resume_retries_only_failed_scanner(
+    tmp_path, source_repo, monkeypatch, failure
+):
+    command_result = runner.command_result
+
+    def failed_scanner(*argv, **options):
+        if len(argv) > 1 and Path(argv[1]).name == "scan_legacy_spelling.py":
+            if failure == "timeout":
+                raise TimeoutError("scanner deadline exceeded")
+            return subprocess.CompletedProcess(argv, failure, "partial scanner output", "scanner input error")
+        return command_result(*argv, **options)
+
+    monkeypatch.setattr(runner, "command_result", failed_scanner)
+    backend = Backend()
+    review = new_run(tmp_path, source_repo, backend)
+    report = review.run()
+    assert report["status"] == "INCOMPLETE"
+    assert report["findings"] == []
+    assert backend.calls == []
+    assert report["stages"]["preflight:conventions"]["status"] == "INCOMPLETE"
+    assert report["stages"]["preflight:test-doc"]["status"] == "COMPLETE"
+    if failure != "timeout":
+        attempt = report["stages"]["preflight:conventions"]["runs"][0]
+        assert attempt["exit_code"] == failure
+        assert attempt["stdout"] == "partial scanner output"
+        assert attempt["stderr"] == "scanner input error"
+    with pytest.raises(ValueError, match="INCOMPLETE"):
+        publisher.publish(report, dry_run=False)
+
+    monkeypatch.setattr(runner, "command_result", command_result)
+    state = json.loads((review.run_dir / "state.json").read_text())
+    resumed = runner.ReviewRun(review.run_dir, state, backend).run()
+    assert resumed["status"] == "COMPLETE"
+    assert len(resumed["stages"]["preflight:conventions"]["runs"]) == 2
+    assert len(resumed["stages"]["preflight:test-doc"]["runs"]) == 1
+    assert resumed["metrics"]["cost_is_complete"] is True
+
+
+def test_saved_diff_cannot_diverge_from_agent_scope_on_resume(tmp_path, source_repo):
+    backend = Backend()
+    review = new_run(tmp_path, source_repo, backend)
+    assert review.run()["status"] == "COMPLETE"
+    (review.run_dir / "diff.patch").write_text("")
+    calls = len(backend.calls)
+    state = json.loads((review.run_dir / "state.json").read_text())
+    resumed = runner.ReviewRun(review.run_dir, state, backend).run()
+    assert resumed["status"] == "INCOMPLETE"
+    assert "saved diff.patch" in resumed["stages"]["run"]["error"]
+    assert len(backend.calls) == calls
+
+
+@pytest.mark.parametrize("label", [label for label, _ in common.PREFLIGHTS])
+def test_publisher_requires_both_preflight_stages(complete_report, label):
+    del complete_report["stages"][label]
+    with pytest.raises(ValueError, match="required stages"):
+        common.validate_report(complete_report)
+
+
+def test_publisher_requires_current_preflight_artifact_version(complete_report):
+    complete_report["schema_version"] = 1
+    with pytest.raises(ValueError, match="versioned runner result"):
+        common.validate_report(complete_report)
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        {},
+        {"exit_code": 2, "stdout": "", "stderr": "scanner input failed"},
+        {"exit_code": -9, "stdout": "", "stderr": "killed"},
+        {"exit_code": False, "stdout": "", "stderr": ""},
+        {"exit_code": 0, "stderr": ""},
+        {"exit_code": 1, "stdout": [], "stderr": ""},
+    ],
+)
+def test_malformed_preflight_cannot_be_published(monkeypatch, complete_report, output):
+    complete_report["stages"]["preflight:conventions"]["output"] = output
+    api = GitHub(complete_report)
+    monkeypatch.setattr(publisher, "gh", api)
+    with pytest.raises(ValueError, match="required stages"):
+        publisher.publish(complete_report, dry_run=False)
+    assert api.posts == []
+    assert common.build_report(complete_report)["status"] == "INCOMPLETE"
 
 
 def test_missing_stage_is_not_complete_even_with_empty_findings(complete_report):

--- a/tests/unit/test_review_legacy_spelling.py
+++ b/tests/unit/test_review_legacy_spelling.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""Offline CLI regressions; also runnable without pytest or a FlyDSL build."""
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import pytest
+except ImportError:
+    pass
+else:
+    pytestmark = pytest.mark.l0_backend_agnostic
+
+SCRIPT = Path(__file__).resolve().parents[2] / ".claude/skills/flydsl-code-review/scripts/scan_legacy_spelling.py"
+SPEC = importlib.util.spec_from_file_location("scan_legacy_spelling", SCRIPT)
+SCANNER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(SCANNER)
+
+
+def added_diff(source, path="kernels/example.py", start=1):
+    lines = source.splitlines()
+    return (
+        f"diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n"
+        f"@@ -{start - 1},0 +{start},{len(lines)} @@\n" + "".join(f"+{line}\n" for line in lines)
+    )
+
+
+class LegacySpellingTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="legacy-spelling-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.patch = self.root / "input.diff"
+        self.patch.write_text("", encoding="utf-8")
+
+    def cli(self, *args):
+        return subprocess.run([sys.executable, str(SCRIPT), *map(str, args)], capture_output=True, text=True)
+
+    def scan_cli(self, diff):
+        self.patch.write_text(diff, encoding="utf-8")
+        return self.cli("--diff", self.patch)
+
+    def test_invalid_arguments_report_usage(self):
+        for args in [
+            (),
+            ("--diff",),
+            ("--diff", self.patch, "extra"),
+        ]:
+            with self.subTest(args=args):
+                result = self.cli(*args)
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("usage:", result.stderr)
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_unreadable_and_invalid_text_diff_fail(self):
+        result = self.cli("--diff", self.root / "missing.diff")
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stdout, "")
+        self.patch.write_bytes(b"\xff")
+        result = self.cli("--diff", self.patch)
+        self.assertEqual(result.returncode, 2)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_empty_diff_and_clean_kernel_exit_zero(self):
+        for diff in ["", added_diff("value = fx.Float32(0.0)\nvalue = fx.max(value, peer)")]:
+            with self.subTest(diff=diff):
+                result = self.scan_cli(diff)
+                self.assertEqual(result.returncode, 0)
+                self.assertIn("no legacy spelling candidates", result.stdout)
+
+    def test_malformed_or_truncated_diff_fails(self):
+        for diff in [
+            "not a diff\n",
+            added_diff("value = ir.Type()").replace("+1,1", "+1,2"),
+            added_diff("value = ir.Type()").replace("@@ -0,0 +1,1 @@", "@@ broken @@"),
+            added_diff("value = ir.Type()").replace("+++ b/kernels/example.py\n", ""),
+            added_diff("value = ir.Type()").replace("+++ b/kernels/example.py", "+++ unknown.py"),
+            added_diff("value = ir.Type()") + "+unaccounted = ir.Type()\n",
+        ]:
+            with self.subTest(diff=diff):
+                result = self.scan_cli(diff)
+                self.assertEqual(result.returncode, 2)
+                self.assertEqual(result.stdout, "")
+                self.assertIn("error:", result.stderr)
+
+    def test_only_kernel_consumers_are_candidates(self):
+        for path in [
+            "python/flydsl/expr/example.py",
+            "tests/example.py",
+            ".claude/skills/flydsl-code-review/scripts/scan_legacy_spelling.py",
+            "kernels/common/buffer_ops.py",
+            "kernels/example.md",
+        ]:
+            with self.subTest(path=path):
+                self.assertEqual(SCANNER.scan(added_diff("value = buffer_ops.load()", path)), [])
+        hits = SCANNER.scan(added_diff("value = buffer_ops.load()", "kernels/subdir/example.py"))
+        self.assertEqual(len(hits), 1)
+
+    def test_all_five_rules_have_candidate_output(self):
+        source = "\n".join(
+            [
+                "i32_type = ir.IntegerType.get_signless(32)",
+                "if_op = scf.IfOp(cond_i1, [], has_else=False)",
+                "value = buffer_ops.buffer_load(rsrc, index, vec_width=1, dtype=fx.Int32)",
+                'allocator = SmemAllocator(None, arch="gfx942")',
+                "pointer = fx.make_ptr(pointer_type, [addr])",
+            ]
+        )
+        result = self.scan_cli(added_diff(source, start=9))
+        self.assertEqual(result.returncode, 1)
+        for line in range(9, 14):
+            self.assertIn(f"kernels/example.py:{line}:", result.stdout)
+        self.assertIn("coderfeli #33 #433 #540 #582", result.stdout)
+        self.assertIn("ordinary pointer construction is valid", result.stdout)
+
+    def test_scf_operation_wrappers_and_grouped_output(self):
+        source = "\n".join(
+            [
+                "if_op = scf.IfOp(cond_i1, [], has_else=False)",
+                "loop = scf.ForOp(lower, upper, step)",
+                "wait_loop = scf.WhileOp([T.i32], [init_cur])",
+                "scf.YieldOp([cur])",
+            ]
+        )
+        diff = added_diff(source, start=9)
+        self.assertEqual([hit[1] for hit in SCANNER.scan(diff)], [9, 10, 11, 12])
+        result = self.scan_cli(diff)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("kernels/example.py:9: scf.* control flow x4", result.stdout)
+        self.assertEqual(result.stdout.count("maintainers:"), 1)
+
+    def test_comments_strings_and_imports_are_ignored(self):
+        source = '''# ir.Type() SmemAllocator()
+value = fx.Float32(0)  # buffer_ops.load()
+example = "ir.Type() and make_ptr(value)"
+other = 'scf.For() and SmemAllocator()'
+text = """ir.Type()
+SmemAllocator()
+buffer_ops.load()
+"""
+from flydsl._mlir import ir
+from flydsl.utils.smem_allocator import (
+    SmemAllocator,
+)
+from flydsl.expr import make_ptr
+import flydsl._mlir.ir
+'''
+        self.assertEqual(SCANNER.scan(added_diff(source)), [])
+
+    def test_code_after_string_or_import_is_still_checked(self):
+        source = 'text = "ir.Type()"; value = ir.Type()\nimport flydsl._mlir.ir; scf.For()'
+        hits = SCANNER.scan(added_diff(source))
+        self.assertEqual([(hit[1], hit[2]) for hit in hits], [(1, "raw ir.* / ArithValue"), (2, "scf.* control flow")])
+
+    def test_fstring_literal_text_is_ignored(self):
+        source = 'message = f"prefer SmemAllocator and ir.Type() for {name}"'
+        self.assertEqual(SCANNER.scan(added_diff(source)), [])
+
+    @unittest.skipUnless(sys.version_info >= (3, 12), "f-string expression tokens require Python 3.12")
+    def test_fstring_interpolated_code_is_still_checked(self):
+        source = 'message = f"prefer SmemAllocator: {ir.Type()}"'
+        hits = SCANNER.scan(added_diff(source))
+        self.assertEqual([(hit[1], hit[2]) for hit in hits], [(1, "raw ir.* / ArithValue")])
+
+    def test_context_preserves_multiline_string_and_import_state(self):
+        diff = '''diff --git a/kernels/example.py b/kernels/example.py
+--- a/kernels/example.py
++++ b/kernels/example.py
+@@ -4,4 +4,6 @@
+ text = """
++ir.Type() and SmemAllocator()
+ """
+ from flydsl.utils.smem_allocator import (
++    SmemAllocator,
+ )
+'''
+        self.assertEqual(SCANNER.scan(diff), [])
+
+    def test_incomplete_hunk_statements_and_strings_are_supported(self):
+        self.assertEqual(SCANNER.scan(added_diff('text = """\nir.Type()\nSmemAllocator()')), [])
+        hits = SCANNER.scan(added_diff("result = function(\n    ir.Type(),"))
+        self.assertEqual([(hit[1], hit[2]) for hit in hits], [(2, "raw ir.* / ArithValue")])
+
+    def test_only_added_lines_are_reported_with_new_line_numbers(self):
+        diff = """diff --git a/kernels/example.py b/kernels/example.py
+--- a/kernels/example.py
++++ b/kernels/example.py
+@@ -7,4 +7,4 @@
+ old = ir.Type()
+-removed = buffer_ops.load()
++current = fx.Float32(0)
+ unchanged = SmemAllocator()
++new = scf.For()
+-removed = ir.Type()
+"""
+        hits = SCANNER.scan(diff)
+        self.assertEqual([(hit[0], hit[1], hit[2]) for hit in hits], [("kernels/example.py", 10, "scf.* control flow")])
+
+    def test_mixed_files_and_hunks_reset_paths_and_line_numbers(self):
+        diff = (
+            added_diff("ir.Type()", start=4)
+            + "@@ -20,0 +21 @@\n+scf.For()\n"
+            + added_diff("buffer_ops.load()", "docs/example.py", start=8)
+            + "diff --git a/kernels/deleted.py b/kernels/deleted.py\n--- a/kernels/deleted.py\n+++ /dev/null\n"
+            + "@@ -1 +0,0 @@\n-SmemAllocator()\n"
+            + added_diff("SmemAllocator()", "kernels/second.py", start=12)
+        )
+        hits = SCANNER.scan(diff)
+        self.assertEqual(
+            [(hit[0], hit[1]) for hit in hits],
+            [("kernels/example.py", 4), ("kernels/example.py", 21), ("kernels/second.py", 12)],
+        )
+
+    def test_source_lines_resembling_headers_remain_in_the_hunk(self):
+        diff = """diff --git a/kernels/example.py b/kernels/example.py
+--- a/kernels/example.py
++++ b/kernels/example.py
+@@ -1,2 +1 @@
+--- separator
+-old = 0
++++scf.For()
+\\ No newline at end of file
+"""
+        hits = SCANNER.scan(diff)
+        self.assertEqual([(hit[0], hit[1], hit[2]) for hit in hits], [("kernels/example.py", 1, "scf.* control flow")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_review_unreachable_tests.py
+++ b/tests/unit/test_review_unreachable_tests.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 FlyDSL Project Contributors
+
+"""CLI regression tests; run directly without FlyDSL, native libraries or pytest."""
+
+import difflib
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+try:
+    import pytest
+except ImportError:
+    pass
+else:
+    pytestmark = pytest.mark.l0_backend_agnostic
+
+
+_SCANNER = Path(__file__).resolve().parents[2] / ".claude/skills/flydsl-code-review/scripts/scan_unreachable_tests.py"
+
+
+class TestReviewUnreachableTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.source = self.root / "sample.py"
+        self.diff = self.root / "change.diff"
+
+    def scan(self, after, before="", *, diff=None, head=None, root=None):
+        after = textwrap.dedent(after).lstrip("\n")
+        before = textwrap.dedent(before).lstrip("\n")
+        self.source.write_text(after if head is None else head)
+        self.diff.write_text(
+            diff
+            if diff is not None
+            else "".join(
+                difflib.unified_diff(
+                    before.splitlines(keepends=True),
+                    after.splitlines(keepends=True),
+                    fromfile="a/sample.py",
+                    tofile="b/sample.py",
+                )
+            )
+        )
+        return subprocess.run(
+            [
+                sys.executable,
+                str(_SCANNER),
+                "--diff",
+                str(self.diff),
+                "--head",
+                str(root or self.root),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def assert_status(self, result, expected):
+        self.assertEqual(result.returncode, expected, result.stdout + result.stderr)
+
+    def test_pytest_whole_file_covers_functions_and_methods(self):
+        result = self.scan("""
+            import pytest
+            def test_added():
+                pass
+            class TestAdded:
+                def test_method(self):
+                    pass
+            if __name__ == "__main__":
+                pytest.main([__file__])
+        """)
+        self.assert_status(result, 0)
+        self.assertIn("2 added test definition line(s) have a statically visible", result.stdout)
+
+    def test_pytest_aliases_and_keyword_arguments(self):
+        for imports, call in [
+            ("import pytest as pt", "pt.main([__file__])"),
+            ("import pytest as pt, sys", "pt.main([__file__])"),
+            ("from pytest import main", "main([__file__])"),
+            ("from pytest import main as run_tests", "run_tests(args=[__file__])"),
+            ("import pytest", "pytest.main([__file__, '-q', '--tb=short'])"),
+        ]:
+            with self.subTest(call=call):
+                result = self.scan(
+                    f"{imports}\ndef test_added():\n    pass\n" f'if __name__ == "__main__":\n    {call}\n'
+                )
+                self.assert_status(result, 0)
+
+    def test_pytest_alias_in_called_helper(self):
+        result = self.scan("""
+            def test_added():
+                pass
+            def run():
+                import pytest as pt
+                return pt.main([__file__])
+            if __name__ == "__main__":
+                raise SystemExit(run())
+        """)
+        self.assert_status(result, 0)
+
+    def test_selectors_and_dynamic_pytest_arguments_are_unknown(self):
+        for call in [
+            "pytest.main([__file__, '-k', 'existing'])",
+            "pytest.main([__file__, '-m', 'slow'])",
+            "pytest.main([__file__ + '::test_existing'])",
+            "pytest.main(['other.py'])",
+            "pytest.main(sys.argv[1:])",
+            "pytest.main()",
+            "pytest.main([__file__], plugins=plugins)",
+        ]:
+            with self.subTest(call=call):
+                result = self.scan(
+                    "import pytest\ndef test_added():\n    pass\n" f'if __name__ == "__main__":\n    {call}\n'
+                )
+                self.assert_status(result, 1)
+                self.assertIn("whole-file coverage is unknown", result.stdout)
+                self.assertNotIn("have a statically visible", result.stdout)
+
+    def test_class_method_is_not_confused_with_reached_global_function(self):
+        before = """
+            def test_same():
+                pass
+            if __name__ == "__main__":
+                test_same()
+        """
+        result = self.scan(
+            """
+            class TestAdded:
+                def test_same(self):
+                    pass
+            def test_same():
+                pass
+            if __name__ == "__main__":
+                test_same()
+        """,
+            before,
+        )
+        self.assert_status(result, 1)
+        self.assertIn("TestAdded.test_same:2", result.stdout)
+        self.assertNotIn("have a statically visible", result.stdout)
+
+    def test_same_method_name_in_two_classes_keeps_both_candidates(self):
+        result = self.scan("""
+            class TestFirst:
+                def test_same(self):
+                    pass
+            class TestSecond:
+                def test_same(self):
+                    pass
+            if __name__ == "__main__":
+                pass
+        """)
+        self.assert_status(result, 1)
+        self.assertIn("TestFirst.test_same:2", result.stdout)
+        self.assertIn("TestSecond.test_same:5", result.stdout)
+
+    def test_only_added_definition_lines_are_reported(self):
+        before = """
+            class TestExisting:
+                def test_old(self):
+                    pass
+            def test_existing():
+                pass
+            if __name__ == "__main__":
+                test_existing()
+        """
+        result = self.scan(
+            """
+            class TestExisting:
+                def test_old(self):
+                    pass
+            def test_new():
+                pass
+            def test_existing():
+                pass
+            if __name__ == "__main__":
+                test_existing()
+        """,
+            before,
+        )
+        self.assert_status(result, 1)
+        self.assertIn("test_new:4", result.stdout)
+        self.assertNotIn("TestExisting.test_old", result.stdout)
+        self.assertIn("1 of 1 ADDED", result.stdout)
+
+    def test_multiline_string_is_not_a_test_definition(self):
+        result = self.scan('''
+            example = """
+            def test_fake():
+                pass
+            """
+            if __name__ == "__main__":
+                pass
+        ''')
+        self.assert_status(result, 0)
+        self.assertIn("no test definitions added", result.stdout)
+
+    def test_signature_edit_is_a_candidate_but_body_only_edit_is_not(self):
+        before = 'def test_existing():\n    pass\nif __name__ == "__main__":\n    pass\n'
+        result = self.scan(before.replace("test_existing()", "test_existing(value=1)"), before)
+        self.assert_status(result, 1)
+        self.assertIn("ADDED test definition line", result.stdout)
+        result = self.scan(before.replace("    pass", "    print('changed')", 1), before)
+        self.assert_status(result, 0)
+        self.assertIn("no test definitions added", result.stdout)
+
+    def test_empty_diff_and_deleted_files_have_no_candidates(self):
+        for diff in [
+            "",
+            "diff --git a/deleted.py b/deleted.py\n--- a/deleted.py\n+++ /dev/null\n"
+            "@@ -1,2 +0,0 @@\n-def test_old():\n-    pass\n",
+        ]:
+            with self.subTest(diff=diff):
+                result = self.scan("", diff=diff)
+                self.assert_status(result, 0)
+                self.assertIn("no test definitions added", result.stdout)
+
+    def test_transitive_calls_and_recursion(self):
+        result = self.scan("""
+            def test_added():
+                pass
+            def run_all():
+                wrapper()
+            def wrapper():
+                run_all()
+                test_added()
+            if "__main__" == __name__:
+                run_all()
+        """)
+        self.assert_status(result, 0)
+
+    def test_attribute_call_does_not_reach_same_named_global(self):
+        result = self.scan("""
+            def test_added():
+                pass
+            if __name__ == "__main__":
+                other.test_added()
+        """)
+        self.assert_status(result, 1)
+        self.assertIn("test_added:1", result.stdout)
+
+    def test_uncalled_nested_function_does_not_reach_tests(self):
+        result = self.scan("""
+            def test_added():
+                pass
+            def run():
+                def unused():
+                    test_added()
+            if __name__ == "__main__":
+                run()
+        """)
+        self.assert_status(result, 1)
+
+    def test_main_guard_requires_name_equality(self):
+        for guard in ['mode == "__main__"', '__name__ != "__main__"', '"__main__" in modes']:
+            with self.subTest(guard=guard):
+                result = self.scan(f"def test_added():\n    pass\nif {guard}:\n    test_added()\n")
+                self.assert_status(result, 0)
+                self.assertIn("no supported __main__ guard", result.stdout)
+                self.assertNotIn("have a statically visible", result.stdout)
+
+    def test_async_direct_call_needs_review(self):
+        result = self.scan("""
+            async def test_added():
+                pass
+            if __name__ == "__main__":
+                test_added()
+        """)
+        self.assert_status(result, 1)
+
+    def test_unconsumed_generator_does_not_reach_tests(self):
+        result = self.scan("""
+            def test_added():
+                pass
+            def run():
+                yield 1
+                test_added()
+            if __name__ == "__main__":
+                run()
+        """)
+        self.assert_status(result, 1)
+
+    def test_shadowed_function_or_pytest_alias_cannot_prove_coverage(self):
+        for source in [
+            """
+            def test_added():
+                pass
+            def run(test_added):
+                test_added()
+            if __name__ == "__main__":
+                run(other)
+        """,
+            """
+            import pytest as pt
+            def test_added():
+                pass
+            def run(pt):
+                pt.main([__file__])
+            if __name__ == "__main__":
+                run(other)
+        """,
+            """
+            import pytest
+            def test_added():
+                pass
+            __file__ = "other.py"
+            if __name__ == "__main__":
+                pytest.main([__file__])
+        """,
+        ]:
+            with self.subTest(source=source):
+                self.assert_status(self.scan(source), 1)
+
+    def test_unconsumed_generator_expression_does_not_reach_tests(self):
+        result = self.scan("""
+            def test_added():
+                pass
+            if __name__ == "__main__":
+                unused = (test_added() for _ in range(1))
+        """)
+        self.assert_status(result, 1)
+        self.assertIn("test_added:1", result.stdout)
+
+    def test_generator_expression_outer_iterable_is_evaluated(self):
+        result = self.scan("""
+            def test_added():
+                return [1]
+            if __name__ == "__main__":
+                unused = (value for value in test_added())
+        """)
+        self.assert_status(result, 0)
+
+    def test_match_capture_cannot_prove_original_function_called(self):
+        for pattern, value in [
+            ("test_added", "lambda: None"),
+            ("[*test_added]", "[]"),
+            ('{"other": _, **test_added}', '{"other": 1}'),
+        ]:
+            with self.subTest(pattern=pattern):
+                source = (
+                    "def test_added():\n    pass\n"
+                    'if __name__ == "__main__":\n'
+                    f"    match {value}:\n"
+                    f"        case {pattern}:\n"
+                    "            test_added()\n"
+                )
+                self.assert_status(self.scan(source), 1)
+
+    def test_pytest_cannot_cover_rebound_function_class_or_method(self):
+        for definition, rebind in [
+            ("def test_added():\n    pass\n", "test_added = None\n"),
+            ("class TestAdded:\n    def test_added(self):\n        pass\n", "TestAdded = None\n"),
+            ("class TestAdded:\n    def test_added(self):\n        pass\n", "    test_added = None\n"),
+        ]:
+            with self.subTest(rebind=rebind):
+                source = (
+                    "import pytest\n"
+                    + definition
+                    + rebind
+                    + 'if __name__ == "__main__":\n    pytest.main([__file__])\n'
+                )
+                self.assert_status(self.scan(source), 1)
+
+    def test_duplicate_global_definitions_do_not_collapse_line_identity(self):
+        result = self.scan("""
+            def test_same():
+                pass
+            def test_same():
+                pass
+            if __name__ == "__main__":
+                test_same()
+        """)
+        self.assert_status(result, 1)
+        self.assertIn("test_same:1", result.stdout)
+        self.assertIn("test_same:3", result.stdout)
+
+    def test_pytest_cannot_cover_overwritten_same_named_definitions(self):
+        result = self.scan("""
+            import pytest
+            def test_same():
+                pass
+            def test_same():
+                pass
+            if __name__ == "__main__":
+                pytest.main([__file__])
+        """)
+        self.assert_status(result, 1)
+        self.assertIn("test_same:2", result.stdout)
+        self.assertIn("test_same:4", result.stdout)
+
+    def test_source_that_looks_like_diff_metadata_remains_source(self):
+        result = self.scan('''
+            notes = """
+            ++ b/other.py
+            -- separator
+            """
+            def test_added():
+                pass
+            if __name__ == "__main__":
+                pass
+        ''')
+        self.assert_status(result, 1)
+        self.assertIn("test_added:5", result.stdout)
+
+    def test_invalid_input_is_exit_two(self):
+        for kwargs in [
+            {"head": "def test_different():\n    pass\n"},
+            {"root": self.root / "missing"},
+            {"root": self.source},
+            {"diff": "not a diff"},
+            {"diff": "--- a/sample.py\n+++ b/sample.py\n@@ -0,0 +1,2 @@\n+pass\n"},
+            {"diff": "diff --git a/sample.py b/sample.py\n@@ -0,0 +1 @@\n+pass\n"},
+            {"diff": "--- a/sample.py\n+++ b/sample.py\n@@ -0,0 +1 @@\n+pass\n+extra\n"},
+        ]:
+            with self.subTest(kwargs=kwargs):
+                result = self.scan("def test_added():\n    pass\n", **kwargs)
+                self.assert_status(result, 2)
+                self.assertIn("input error:", result.stderr)
+                self.assertNotIn("no test definitions", result.stdout)
+
+    def test_missing_head_and_diff_files_are_exit_two(self):
+        result = self.scan("def test_added():\n    pass\n")
+        self.assert_status(result, 0)
+        self.source.unlink()
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_SCANNER),
+                "--diff",
+                str(self.diff),
+                "--head",
+                str(self.root),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assert_status(result, 2)
+        self.diff.unlink()
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_SCANNER),
+                "--diff",
+                str(self.diff),
+                "--head",
+                str(self.root),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assert_status(result, 2)
+
+    def test_syntax_error_is_exit_two(self):
+        result = self.scan("def test_added(:\n    pass\n")
+        self.assert_status(result, 2)
+        self.assertIn("input error:", result.stderr)
+
+    def test_reviewed_source_is_never_executed(self):
+        result = self.scan("""
+            raise RuntimeError("reviewed code must not execute")
+            def test_added():
+                pass
+            if __name__ == "__main__":
+                test_added()
+        """)
+        self.assert_status(result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR targets #1106's `add-flydsl-code-review-skill` branch. It distills the two useful deterministic checks from #1047 into the existing review runner, so #1106 carries the combined review capability into `main`.

The pinned diff is scanned for added kernel legacy-API spellings and added tests without a statically visible script entry path. Raw observations go to Angles G and I for contextual adjudication; promoted candidates retain the existing independent verifier, challenger, and ranked-report path. Both preflight stages are checkpointed and required: exit 0/1 permits semantic review, while errors/timeouts yield `INCOMPLETE`. Scanner implementation changes invalidate resume, and the saved diff is checked against the pinned hash. Artifact schema v2 requires valid preflight outputs before publication.

The source scanners and 38 original regressions are adapted from #1047 at `2480f877aa7f74a24d1ce857b48ba92ff0699cf5`. The integration also fixes four reproduced scanner edge cases: Python 3.12 f-string literal false positives, unconsumed generator expressions, pattern-match shadowing, and rebound pytest test functions/classes/methods. The selection evidence stays linked to the source revision; no second review skill or combined standalone wrapper is added.

This also fixes #1106's [remaining CLI compatibility finding](https://github.com/ROCm/FlyDSL/pull/1106#discussion_r3978971740): verbose Claude Code output can be a transcript array. The runner consumes the last result record and preserves all error, permission-denial, and structured-output checks.

Validation:

- **111 CPU regressions passed**: 67 runner/publication tests and 44 scanner tests. Coverage includes G/I routing, scanner failure and resume, pinned-diff integrity, malformed artifact rejection, and verbose CLI success/failure shapes.
- Real Claude Code **2.1.263**, with the existing `verbose: true` setting: the exact `cli_agent` invocation returned an array-shaped transcript and completed successfully.
- Frozen #481 replay at `7e117e29c9c4582158aed33da4ee6dfe14d2c76e`: the entry-path scanner finds the three omitted fused/quant tests at lines 632, 884, and 924.
- `scripts/check_repo.py`, whole-tree agent-doc validation, the repository Python style gate, and explicit black/ruff checks on the skill scripts passed.
- Independent source and final integration reviews completed; all reproduced findings were corrected and retested.

These checks establish scanner and runner behavior. Full model-review corpus precision/recall and GPU execution were not measured. The existing per-angle candidate limit remains; raw scanner leads are preserved, not individually certified. Standard repository CI is configured for PRs targeting `main`, so the combined branch will run that CI through #1106 after this child PR merges.
